### PR TITLE
Replace outdated FastClasspathScanner with ClassGraph

### DIFF
--- a/adapter/src/main/java/com/adaptris/core/runtime/AdapterRegistry.java
+++ b/adapter/src/main/java/com/adaptris/core/runtime/AdapterRegistry.java
@@ -514,9 +514,9 @@ public class AdapterRegistry implements AdapterRegistryMBean {
       }
 
       ScanResult result = new ClassGraph()
-          .enableAllInfo();
-      .blacklistPackages(FCS_BLACKLIST);
-      .scan();
+        .enableAllInfo()
+        .blacklistPackages(FCS_BLACKLIST)
+        .scan();
 
       List<String> subclassNames = result.getSubclasses(className).getNames();
 

--- a/adapter/src/main/java/com/adaptris/core/runtime/AdapterRegistry.java
+++ b/adapter/src/main/java/com/adaptris/core/runtime/AdapterRegistry.java
@@ -62,8 +62,8 @@ import com.adaptris.core.util.JmxHelper;
 import com.adaptris.util.URLString;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
-import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
-import io.github.lukehutch.fastclasspathscanner.matchprocessor.SubclassMatchProcessor;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
 
 @SuppressWarnings("deprecation")
 public class AdapterRegistry implements AdapterRegistryMBean {
@@ -73,7 +73,7 @@ public class AdapterRegistry implements AdapterRegistryMBean {
   private static final String[] FCS_BLACKLIST = {
       "-javax", "-java", "-org.apache", "-org.codehaus", "-org.hibernate", "-org.springframework", "-com.mchange", "-com.sun",
       "-org.bouncycastle", "-org.eclipse", "-org.jboss", "-org.slf4j", "-net.sf.saxon", "-com.google.guava", "-com.fasterxml",
-      "-io.github.lukehutch", "-com.jcraft", "-com.thoughtworks", "-org.quartz"
+      "-io.github.classgraph", "-com.jcraft", "-com.thoughtworks", "-org.quartz"
   };
   private static final String EXCEPTION_MSG_XML_NULL = "XML String is null";
   private static final String EXCEPTION_MSG_URL_NULL = "URL is null";
@@ -512,14 +512,18 @@ public class AdapterRegistry implements AdapterRegistryMBean {
           classDescriptor.getClassDescriptorProperties().add(fieldProperty);
         }
       }
-      new FastClasspathScanner(FCS_BLACKLIST).matchSubclassesOf(clazz, new SubclassMatchProcessor() {
 
-        @Override
-        public void processMatch(Class subclass) {
-          classDescriptor.getSubTypes().add(subclass.getName());
-        }
+      ScanResult result = new ClassGraph()
+          .enableAllInfo();
+      .blacklistPackages(FCS_BLACKLIST);
+      .scan();
 
-      }).scan();
+      List<String> subclassNames = result.getSubclasses(className).getNames();
+
+      for (String subclassName : subclassNames) {
+          classDescriptor.getSubTypes().add(subclassName);
+      }
+
     } catch (ClassNotFoundException e) {
       throw new CoreException(e);
     }

--- a/ivy/build.gradle
+++ b/ivy/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   compile ("com.adaptris:interlok-common:$adpCoreVersion") { changing= true}
   compile ("com.thoughtworks.xstream:xstream:1.4.10")
   compile ("org.codehaus.jettison:jettison:1.2")
-  compile ("io.github.lukehutch:fast-classpath-scanner:2.9.4")
+  compile ("io.github.classgraph:classgraph:4.1.5")
   compile ("net.jodah:expiringmap:0.5.8")
   compile ("javax.activation:activation:1.1.1")
   compile ("org.apache.activemq:activemq-client:5.15.2")

--- a/ivy/ivy-adapter.xml
+++ b/ivy/ivy-adapter.xml
@@ -34,7 +34,7 @@
     <!-- switch to fast-classpath-scanner
     <dependency org="org.reflections" name="reflections" rev="0.9.11" conf="compile->default"/>
     -->
-    <dependency org="io.github.lukehutch" name="fast-classpath-scanner" rev="2.9.4" conf="compile->default"/>
+    <dependency org="io.github.classgraph" name="classgraph" rev="4.1.5" conf="compile->default"/>
     <dependency org="net.jodah" name="expiringmap" rev="0.5.8" conf="compile->default"/>
 
     <dependency org="javax.activation" name="activation" rev="1.1.1"  conf="compile->default" />


### PR DESCRIPTION
This replaces the outdated FastClasspathScanner with its successor ClassGraph, which is more reliable and future-proof, as reported in #19.

I've run `ant test`, but after running for about an hour and a half, the tests are still not complete (StandardHTTPProducerTest took 1,732 seconds!), so I've decided to just submit this as-is.