### PR TITLE
INTERLOK-2625 Add XmlExceptionReport / XmlExceptionWithStacktrace

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionAsXml.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionAsXml.java
@@ -16,18 +16,18 @@
 package com.adaptris.core.services.exception;
 
 import javax.validation.Valid;
-
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
+import com.adaptris.core.Workflow;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.XmlHelper;
@@ -96,7 +96,9 @@ public class ExceptionAsXml implements ExceptionSerializer {
   @Override
   public void serialize(Exception exception, AdaptrisMessage msg) throws CoreException {
     try {
-      Document newDoc = exceptionGenerator().create(exception);
+      Document newDoc =
+          exceptionGenerator().create(exception, msg.getMetadataValue(Workflow.WORKFLOW_ID_KEY),
+              (String) msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION_CAUSE));
       documentFactoryBuilder().build().newDocumentBuilder().newDocument();
       Document result = documentMerge().merge(XmlHelper.createDocument(msg, documentFactoryBuilder(), ignoreXmlParseExceptions()),
           newDoc);

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionReport.java
@@ -1,0 +1,57 @@
+package com.adaptris.core.services.exception;
+
+import java.util.Map;
+import java.util.TreeMap;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Object that wraps all the information for an exception report.
+ */
+@XStreamAlias("exception-report")
+public class ExceptionReport {
+
+  public static final String STACKTRACE = "stacktrace";
+  public static final String EXCEPTION_MESSAGE = "exceptionMessage";
+  public static final String EXCEPTION_LOCATION = "exceptionLocation";
+  public static final String WORKFLOW = "workflow";
+
+  private String exceptionMessage;
+  private StackTraceElement[] stacktrace;
+  private String exceptionLocation;
+  private String workflow;
+
+
+  public ExceptionReport() {
+
+  }
+
+  public ExceptionReport(Exception e, boolean withStackTrace) {
+    this();
+    exceptionMessage = e.getMessage();
+    if (withStackTrace) {
+      stacktrace = e.getStackTrace();
+    }
+  }
+
+  public ExceptionReport withExceptionLocation(String s) {
+    exceptionLocation = s;
+    return this;
+  }
+
+  public ExceptionReport withWorkflow(String s) {
+    workflow = s;
+    return this;
+  }
+
+  // Refactor so that we can just use this in ExceptionAsJson etc.
+  public Map<String, Object> asMap() {
+    Map<String, Object> result = new TreeMap<String, Object>();
+    result.put(WORKFLOW, workflow);
+    result.put(EXCEPTION_LOCATION, exceptionLocation);
+    result.put(EXCEPTION_MESSAGE, exceptionMessage);
+    if (stacktrace != null) {
+      result.put(STACKTRACE, stacktrace);
+    }
+    return result;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionReportGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionReportGenerator.java
@@ -29,8 +29,10 @@ public interface ExceptionReportGenerator {
    * Create a Document from the exception.
    *
    * @param e the exception
+   * @param workflow the workflow where it happened
+   * @param location where in the workflow it happened.
    * @return a document ready to be merged.
    * @throws Exception on error.
    */
-  Document create(Exception e) throws Exception;
+  Document create(Exception e, String workflow, String location) throws Exception;
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/SimpleExceptionReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/SimpleExceptionReport.java
@@ -17,15 +17,12 @@
 package com.adaptris.core.services.exception;
 
 import static com.adaptris.core.util.XmlHelper.createDocument;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
-
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
@@ -60,7 +57,7 @@ public class SimpleExceptionReport implements ExceptionReportGenerator {
     setElementName(elementName);
   }
 
-  public Document create(Exception e) throws Exception {
+  public Document create(Exception e, String workflow, String location) throws Exception {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw, true);
     pw.println("<" + elementName() + ">");

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/XmlExceptionReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/XmlExceptionReport.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.exception;
+
+import static com.adaptris.core.util.XmlHelper.createDocument;
+import org.w3c.dom.Document;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMarshaller;
+import com.adaptris.core.XStreamMarshaller;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * {@link ExceptionReportGenerator} implementation that renders the exception as XML.
+ * 
+ * 
+ * @config xml-exception-report
+ */
+@XStreamAlias("xml-exception-report")
+@ComponentProfile(
+    summary = "ExceptionReportGenerator implementation that produces XML (without the stacktrace)",
+    since = "3.8.4")
+public class XmlExceptionReport implements ExceptionReportGenerator {
+
+  public XmlExceptionReport() {
+  }
+
+  @Override
+  public Document create(Exception e, String workflow, String location) throws Exception {
+    // Just use XStream as the marshaller, if we let them configure it, someone might configure
+    // a XStreamJSON which would be quite bad.
+    AdaptrisMarshaller m = new XStreamMarshaller();
+    ExceptionReport report = createReportObject(e, workflow, location);
+    return createDocument(m.marshal(report), (DocumentBuilderFactoryBuilder) null);
+  }
+
+  protected ExceptionReport createReportObject(Exception e, String workflow, String location) {
+    return new ExceptionReport(e, false).withWorkflow(workflow).withExceptionLocation(location);
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/XmlReportWithStacktrace.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/XmlReportWithStacktrace.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.exception;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * {@link ExceptionReportGenerator} implementation that renders the exception as XML including the
+ * stacktrace
+ * 
+ * 
+ * @config xml-with-stacktrace-exception-report
+ */
+@XStreamAlias("xml-with-stacktrace-exception-report")
+@ComponentProfile(
+    summary = "ExceptionReportGenerator implementation that produces XML (includes the stacktrace)",
+    since = "3.8.4")
+public class XmlReportWithStacktrace extends XmlExceptionReport {
+
+  public XmlReportWithStacktrace() {
+  }
+
+  protected ExceptionReport createReportObject(Exception e, String workflow, String location) {
+    // Note that XStream does have a custom handler for StacktraceElements so they will
+    // come out as <trace>class.method(class.java:lineno)</trace>
+    return new ExceptionReport(e, true).withWorkflow(workflow).withExceptionLocation(location);
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/exception/XmlExceptionReportTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/exception/XmlExceptionReportTest.java
@@ -1,0 +1,70 @@
+package com.adaptris.core.services.exception;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import com.adaptris.util.XmlUtils;
+
+public class XmlExceptionReportTest {
+
+  @Before
+  public void setUp() throws Exception {
+
+  }
+
+  @After
+  public void tearDown() throws Exception {
+
+  }
+
+  @Test
+  public void testNoStacktrace() throws Exception {
+    XmlExceptionReport reporter = new XmlExceptionReport();
+    Document d =
+        reporter.create(new Exception("testNoStacktrace"), "myWorkflow", "ThrowExceptionService");
+    assertNotNull(d);
+    new XmlUtils().writeDocument(d, System.err);
+  }
+
+  @Test
+  public void testWithStacktrace() throws Exception {
+    XmlReportWithStacktrace reporter = new XmlReportWithStacktrace();
+    Document d =
+        reporter.create(new Exception("testWithStacktrace"), "myWorkflow", "ThrowExceptionService");
+    assertNotNull(d);
+    new XmlUtils().writeDocument(d, System.err);
+  }
+
+  @Test
+  public void testExceptionReport_NoStacktrace() throws Exception {
+    ExceptionReport report =
+        new ExceptionReport(new Exception("testExceptionReport_NoStacktrace"), false)
+        .withWorkflow("myWorkflow").withExceptionLocation("ThrowExceptionService");
+    Map<String, Object> map = report.asMap();
+    assertTrue(map.containsKey(ExceptionReport.EXCEPTION_LOCATION));
+    assertTrue(map.containsKey(ExceptionReport.WORKFLOW));
+    assertTrue(map.containsKey(ExceptionReport.EXCEPTION_MESSAGE));
+    assertFalse(map.containsKey(ExceptionReport.STACKTRACE));
+    assertEquals("myWorkflow", map.get(ExceptionReport.WORKFLOW));
+  }
+
+  @Test
+  public void testExceptionReport_Stacktrace() throws Exception {
+    ExceptionReport report =
+        new ExceptionReport(new Exception("testExceptionReport_Stacktrace"), true)
+        .withWorkflow("myWorkflow").withExceptionLocation("ThrowExceptionService");
+    Map<String, Object> map = report.asMap();
+    assertTrue(map.containsKey(ExceptionReport.EXCEPTION_LOCATION));
+    assertTrue(map.containsKey(ExceptionReport.WORKFLOW));
+    assertTrue(map.containsKey(ExceptionReport.EXCEPTION_MESSAGE));
+    assertTrue(map.containsKey(ExceptionReport.STACKTRACE));
+    assertEquals("myWorkflow", map.get(ExceptionReport.WORKFLOW));
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/exception/XmlExceptionReportTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/exception/XmlExceptionReportTest.java
@@ -31,12 +31,30 @@ public class XmlExceptionReportTest {
     assertNotNull(d);
     new XmlUtils().writeDocument(d, System.err);
   }
+  
+  @Test
+  public void testNoStacktraceNoWorkflow() throws Exception {
+    XmlExceptionReport reporter = new XmlExceptionReport();
+    Document d =
+        reporter.create(new Exception("testNoStacktraceNoWorkflow"), null, "ThrowExceptionService");
+    assertNotNull(d);
+    new XmlUtils().writeDocument(d, System.err);
+  }
 
   @Test
   public void testWithStacktrace() throws Exception {
     XmlReportWithStacktrace reporter = new XmlReportWithStacktrace();
     Document d =
         reporter.create(new Exception("testWithStacktrace"), "myWorkflow", "ThrowExceptionService");
+    assertNotNull(d);
+    new XmlUtils().writeDocument(d, System.err);
+  }
+  
+  @Test
+  public void testWithStacktraceNoWorkflow() throws Exception {
+    XmlReportWithStacktrace reporter = new XmlReportWithStacktrace();
+    Document d =
+        reporter.create(new Exception("testWithStacktraceNoWorkflow"), null, "ThrowExceptionService");
     assertNotNull(d);
     new XmlUtils().writeDocument(d, System.err);
   }
@@ -52,6 +70,19 @@ public class XmlExceptionReportTest {
     assertTrue(map.containsKey(ExceptionReport.EXCEPTION_MESSAGE));
     assertFalse(map.containsKey(ExceptionReport.STACKTRACE));
     assertEquals("myWorkflow", map.get(ExceptionReport.WORKFLOW));
+  }
+  
+  @Test
+  public void testExceptionReport_NoStacktrace_NoWorkflow() throws Exception {
+    ExceptionReport report =
+        new ExceptionReport(new Exception("testExceptionReport_NoStacktrace_NoWorkflow"), false)
+        .withWorkflow(null).withExceptionLocation("ThrowExceptionService");
+    Map<String, Object> map = report.asMap();
+    assertTrue(map.containsKey(ExceptionReport.EXCEPTION_LOCATION));
+    assertTrue(map.containsKey(ExceptionReport.WORKFLOW));
+    assertTrue(map.containsKey(ExceptionReport.EXCEPTION_MESSAGE));
+    assertFalse(map.containsKey(ExceptionReport.STACKTRACE));
+    assertEquals(null, map.get(ExceptionReport.WORKFLOW));
   }
 
   @Test


### PR DESCRIPTION
- Change the create() interface method (which is a breaking change).
- Create a new ExceptionReport object with an asMap() method so that it could be reused later by ExceptionAsJson et. al.
- XML uses XStream, which has the side effect of serializing the stacktrace as <trace>...
- Should we deprecate "SimpleExceptionReport"?
(run the tests, check standard-error output from ExceptionReportTest, to see the XML).