### PR TITLE
INTERLOK-2668 - Add Cache to SchemaValidator

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
@@ -59,17 +59,23 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 /**
  * Used with {@link XmlValidationService} to validate an XML message against a schema.
  * <p>
- * This validates an input XML document against a schema. After first use, it caches the schema for
- * re-use against the URL that was resolved as an expression or as
+ * This validates an input XML document against a schema. After first use, it caches the schema for re-use against the URL that was
+ * resolved as an expression or from static configuration. This means that until first use, no attempt is made to access the schema
+ * URL.
  * </p>
  * 
  * @config xml-schema-validator
  * 
  */
 @XStreamAlias("xml-schema-validator")
-@DisplayOrder(order = {"schema", "schemaCache"})
-@ComponentProfile(summary = "Validate an XML document against a schema",
-    recommended = {CacheConnection.class})
+@DisplayOrder(order =
+{
+    "schema", "schemaCache"
+})
+@ComponentProfile(summary = "Validate an XML document against a schema", recommended =
+{
+    CacheConnection.class
+})
 public class XmlSchemaValidator extends MessageValidatorImpl {
 
   private static final int DEFAULT_CACHE_SIZE = 16;
@@ -94,8 +100,8 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
   private transient boolean warningLogged;
 
   public XmlSchemaValidator() {
-    setSchemaCache(new CacheConnection(new ExpiringMapCache()
-        .withExpiration(new TimeInterval(2L, TimeUnit.HOURS)).withMaxEntries(DEFAULT_CACHE_SIZE)));
+    setSchemaCache(new CacheConnection(
+        new ExpiringMapCache().withExpiration(new TimeInterval(2L, TimeUnit.HOURS)).withMaxEntries(DEFAULT_CACHE_SIZE)));
   }
 
   public XmlSchemaValidator(String schema) {
@@ -109,7 +115,6 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
     setSchemaMetadataKey(metadataKey);
   }
 
-
   @Override
   public void validate(AdaptrisMessage msg) throws CoreException {
     try (InputStream in = msg.getInputStream()) {
@@ -118,9 +123,8 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
       validator.validate(new SAXSource(new InputSource(in)));
     }
     catch (SAXParseException e) {
-      throw new ServiceException("Error validating message [" + e.getMessage() + "] line ["
-          + e.getLineNumber() + "] column ["
-          + e.getColumnNumber() + "]", e);
+      throw new ServiceException(String.format("Error validating message[%s] line [%s] column[%s]", e.getMessage(),
+          e.getLineNumber(), e.getColumnNumber()), e);
     }
     catch (Exception e) {
       throw ExceptionHelper.wrapServiceException("Failed to validate message", e);
@@ -174,7 +178,7 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
     Schema schema = (Schema) cache.get(urlString);
     if (schema == null) {
       schema = schemaFactory.newSchema(toURL(urlString));
-      cache.put(urlString,  schema);
+      cache.put(urlString, schema);
     }
     return schema;
   }
@@ -183,7 +187,8 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
   private URL toURL(String urlString) throws IOException, URISyntaxException {
     try {
       return new URL(urlString);
-    } catch (MalformedURLException e) {
+    }
+    catch (MalformedURLException e) {
       return FsHelper.createUrlFromString(urlString, true);
     }
   }
@@ -260,11 +265,10 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
   /**
    * Configure the internal cache for schemas.
    * <p>
-   * While it is possible to configure a distributed cache (a-la ehcache or JSR107) the
-   * {@link javax.xml.validation.Schema} object isn't serializable, so you may run into issues. It
-   * will be best to stick with {@link ExpiringMapCache} if you want to enable caching. The default
-   * behaviour is to cache 16 schemas for a max of 2 hours (last-access) if you don't explicitly
-   * configure it differently.
+   * While it is possible to configure a distributed cache (a-la ehcache or JSR107) the {@link javax.xml.validation.Schema} object
+   * isn't serializable, so you may run into issues. It will be best to stick with {@link ExpiringMapCache} if you want to enable
+   * caching. The default behaviour is to cache 16 schemas for a max of 2 hours (last-access) if you don't explicitly configure it
+   * differently.
    * </p>
    * 
    * @param cache the cache, generally a {@link CacheConnection} or {@link SharedConnection}.

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
@@ -16,64 +16,99 @@
 
 package com.adaptris.core.transform;
 
-import static org.apache.commons.lang.StringUtils.isEmpty;
-
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
-
+import java.util.concurrent.TimeUnit;
+import javax.validation.constraints.NotNull;
 import javax.xml.XMLConstants;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-
+import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-
 import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.SharedConnection;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.cache.ExpiringMapCache;
+import com.adaptris.core.fs.FsHelper;
+import com.adaptris.core.services.cache.CacheConnection;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.util.TimeInterval;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Used with {@link XmlValidationService} to validate an XML message against a schema.
  * <p>
- * This validates an input XML document against a schema. The schema may either be configured or obtained at runtime from a
- * configured metadata key. If a schema and a schemaMetadata key are configured, and a value is stored against the metadata key,
- * this value will be used. If no value is stored against the metadata key the configured schema will be used.
+ * This validates an input XML document against a schema. After first use, it caches the schema for
+ * re-use against the URL that was resolved as an expression or as
  * </p>
  * 
  * @config xml-schema-validator
  * 
- * @author lchan
- * 
  */
 @XStreamAlias("xml-schema-validator")
-@DisplayOrder(order = {"schema", "schemaMetadataKey"})
+@DisplayOrder(order = {"schema", "schemaCache"})
+@ComponentProfile(summary = "Validate an XML document against a schema",
+    recommended = {CacheConnection.class})
 public class XmlSchemaValidator extends MessageValidatorImpl {
 
-  // marshalled
+  private static final int DEFAULT_CACHE_SIZE = 16;
+
+  @InputFieldHint(expression = true)
+  // this will force rfc2396 style validation but we don't know how many people are using
+  // file:./relative/path which isn't truly rfc2396 compliant...
+  // @UrlExpression
   private String schema;
   @AdvancedConfig
+  @Deprecated
+  @Removal(version = "3.11.0")
   private String schemaMetadataKey;
+  @InputFieldDefault(value = "expiring-map-cache, 16 entries, 2 hours")
+  @NotNull
+  @AutoPopulated
+  @AdvancedConfig
+  private AdaptrisConnection schemaCache;
 
   // transient
   private transient SchemaFactory schemaFactory;
-  private transient Schema schemaObject;
+  private transient boolean warningLogged;
 
   public XmlSchemaValidator() {
-
+    setSchemaCache(new CacheConnection(new ExpiringMapCache()
+        .withExpiration(new TimeInterval(2L, TimeUnit.HOURS)).withMaxEntries(DEFAULT_CACHE_SIZE)));
   }
 
-  public XmlSchemaValidator(String schema, String metadataKey) {
+  public XmlSchemaValidator(String schema) {
     this();
     setSchema(schema);
+  }
+
+  @Deprecated
+  public XmlSchemaValidator(String schema, String metadataKey) {
+    this(schema);
     setSchemaMetadataKey(metadataKey);
   }
+
 
   @Override
   public void validate(AdaptrisMessage msg) throws CoreException {
@@ -83,50 +118,74 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
       validator.validate(new SAXSource(new InputSource(in)));
     }
     catch (SAXParseException e) {
-      throw new ServiceException("error validating message [" + e.getMessage() + "] line [" + e.getLineNumber() + "] column ["
+      throw new ServiceException("Error validating message [" + e.getMessage() + "] line ["
+          + e.getLineNumber() + "] column ["
           + e.getColumnNumber() + "]", e);
     }
     catch (Exception e) {
-      throw new ServiceException("Failed to validate message", e);
+      throw ExceptionHelper.wrapServiceException("Failed to validate message", e);
     }
   }
 
   @Override
   public void init() throws CoreException {
-    if (this.getSchema() == null) {
-      if (this.getSchemaMetadataKey() == null) {
-        throw new CoreException("no schema or schemaMetadataKey set");
-      }
-      else {
-        log.info("no schema configured, schema must be set against metadata key [" + this.getSchemaMetadataKey() + "]");
-      }
-    }
     try {
-      schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-      if (this.getSchema() != null) {
-        this.schemaObject = schemaFactory.newSchema(new URL(this.getSchema()));
+      if (StringUtils.isBlank(getSchema()) && StringUtils.isBlank(getSchemaMetadataKey())) {
+        throw new CoreException("metadata-key & schema are blank");
       }
+      LifecycleHelper.init(getSchemaCache());
+      schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
     }
     catch (Exception e) {
-      throw new CoreException(e);
+      throw ExceptionHelper.wrapCoreException(e);
     }
   }
 
-  private Schema obtainSchemaToUse(AdaptrisMessage msg) throws Exception {
-    Schema result = null;
+  @Override
+  public void start() throws CoreException {
+    LifecycleHelper.start(getSchemaCache());
+  }
 
-    if (isEmpty(getSchemaMetadataKey())) {
-      result = this.schemaObject;
-    }
-    else {
+  @Override
+  public void stop() {
+    LifecycleHelper.stop(getSchemaCache());
+  }
+
+  @Override
+  public void close() {
+    LifecycleHelper.close(getSchemaCache());
+  }
+
+  private Schema obtainSchemaToUse(AdaptrisMessage msg) throws Exception {
+    String schemaUrl = msg.resolve(getSchema());
+    if (StringUtils.isNotBlank(getSchemaMetadataKey())) {
+      LoggingHelper.logWarning(warningLogged, () -> {
+        warningLogged = true;
+      }, "schema-metadata-metadata is deprecated, use expression based schema URL instead.");
       if (msg.containsKey(getSchemaMetadataKey())) {
-        result = schemaFactory.newSchema(new URL(msg.getMetadataValue(this.getSchemaMetadataKey())));
-      }
-      else {
-        result = this.schemaObject;
+        schemaUrl = msg.getMetadataValue(getSchemaMetadataKey());
       }
     }
-    return result;
+    return resolve(schemaUrl);
+  }
+
+  private Schema resolve(String urlString) throws Exception {
+    Cache cache = getSchemaCache().retrieveConnection(CacheConnection.class).retrieveCache();
+    Schema schema = (Schema) cache.get(urlString);
+    if (schema == null) {
+      schema = schemaFactory.newSchema(toURL(urlString));
+      cache.put(urlString,  schema);
+    }
+    return schema;
+  }
+
+  // This should cope with when people type in c:/a/b/c instead of a URL.
+  private URL toURL(String urlString) throws IOException, URISyntaxException {
+    try {
+      return new URL(urlString);
+    } catch (MalformedURLException e) {
+      return FsHelper.createUrlFromString(urlString, true);
+    }
   }
 
   /**
@@ -153,23 +212,16 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
   // properties
 
   /**
-   * <p>
    * Sets the schema to validate against. May not be null or empty.
-   * </p>
    * 
-   * @param s the schema to validate against
+   * @param s the schema to validate against, normally a URL.
    */
   public void setSchema(String s) {
-    if ("".equals(s)) {
-      throw new IllegalArgumentException("setSchema() may not be empty");
-    }
     this.schema = s;
   }
 
   /**
-   * <p>
    * Returns the schema to validate against.
-   * </p>
    * 
    * @return the schema to validate against
    */
@@ -181,7 +233,10 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
    * Returns the (optional) metadata key against which a schema can be provided at run time.
    * 
    * @return the (optional) metadata key against which a schema can be provided at run time
+   * @deprecated since 3.8.4 use an expression based {@link setSchema(String)} instead.
    */
+  @Deprecated
+  @Removal(version = "3.11.0", message = "use an expression based schema value instead.")
   public String getSchemaMetadataKey() {
     return schemaMetadataKey;
   }
@@ -190,11 +245,36 @@ public class XmlSchemaValidator extends MessageValidatorImpl {
    * Sets the (optional) metadata key against which a schema can be provided at run time
    * 
    * @param s the (optional) metadata key against which a schema can be provided at run time
+   * @deprecated since 3.8.4 use an expression based {@link setSchema(String)} instead.
    */
+  @Deprecated
+  @Removal(version = "3.11.0", message = "use an expression based schema value instead.")
   public void setSchemaMetadataKey(String s) {
-    if ("".equals(s)) {
-      throw new IllegalArgumentException("setSchemaMetadataKey() may not have an empty param");
-    }
     this.schemaMetadataKey = s;
+  }
+
+  public AdaptrisConnection getSchemaCache() {
+    return schemaCache;
+  }
+
+  /**
+   * Configure the internal cache for schemas.
+   * <p>
+   * While it is possible to configure a distributed cache (a-la ehcache or JSR107) the
+   * {@link javax.xml.validation.Schema} object isn't serializable, so you may run into issues. It
+   * will be best to stick with {@link ExpiringMapCache} if you want to enable caching. The default
+   * behaviour is to cache 16 schemas for a max of 2 hours (last-access) if you don't explicitly
+   * configure it differently.
+   * </p>
+   * 
+   * @param cache the cache, generally a {@link CacheConnection} or {@link SharedConnection}.
+   */
+  public void setSchemaCache(AdaptrisConnection cache) {
+    this.schemaCache = Args.notNull(cache, "schemaCache");
+  }
+
+  public XmlSchemaValidator withSchemaCache(AdaptrisConnection c) {
+    setSchemaCache(c);
+    return this;
   }
 }


### PR DESCRIPTION
- Schema is not created until first use, and then cached which means we needed to change some of the tests.
- Deprecate schema-metadata-key and make schema %message{}
- Add protection for if people have configured c:/x/y/z as their schema via FsHelper (it wouldn't have worked anyway, but now it could...)