### PR TITLE
Feature/interlok 2624

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/AcknowledgementHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/AcknowledgementHandler.java
@@ -1,0 +1,12 @@
+package com.adaptris.core.jms;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+public interface AcknowledgementHandler {
+
+  void acknowledgeMessage(JmsActorConfig actor, Message message) throws JMSException;
+  
+  void rollbackMessage(JmsActorConfig actor, Message message);
+  
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jms/AsyncAcknowledgementHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/AsyncAcknowledgementHandler.java
@@ -1,0 +1,31 @@
+package com.adaptris.core.jms;
+
+import javax.jms.CompletionListener;
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+public class AsyncAcknowledgementHandler implements AcknowledgementHandler, CompletionListener {
+
+  @Override
+  public void acknowledgeMessage(JmsActorConfig actor, Message message) throws JMSException {
+    // do nothing
+  }
+
+  @Override
+  public void rollbackMessage(JmsActorConfig actor, Message message) {
+    // do nothing
+  }
+
+  @Override
+  public void onCompletion(Message message) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void onException(Message message, Exception exception) {
+    // TODO Auto-generated method stub
+    
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jms/ClientAcknowledgementHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/ClientAcknowledgementHandler.java
@@ -1,0 +1,34 @@
+package com.adaptris.core.jms;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+*
+* <p>
+* <code>AcknowledgementHandler</code> implementation that handles acknowledging messages when in CLIENT_ACKNOWLEDGE mode.
+* </p>
+*
+* @config client-acknowledgement-handler
+* @author amcgrath
+*/
+@XStreamAlias("client-acknowledgement-handler")
+@AdapterComponent
+@ComponentProfile(summary = "JMS Acknowledgement handler that handles CLIENT_ACKNOWLEDGE mode.", tag = "jms")
+public class ClientAcknowledgementHandler implements AcknowledgementHandler {
+
+  @Override
+  public void acknowledgeMessage(JmsActorConfig actor, Message message) throws JMSException {
+    message.acknowledge();
+  }
+
+  @Override
+  public void rollbackMessage(JmsActorConfig actor, Message message) {
+    //do nothing
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jms/ConsumerCreator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/ConsumerCreator.java
@@ -1,0 +1,12 @@
+package com.adaptris.core.jms;
+
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+
+@FunctionalInterface
+public interface ConsumerCreator {
+
+  public MessageConsumer createConsumer(Session session, JmsDestination destination, String filterExpression) throws JMSException;
+  
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -14,7 +14,8 @@ import com.adaptris.core.StandardProcessingExceptionHandler;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * JMS Producer implementation that extends all features of {@link JmsProducer}, but allows us to send messages asynchronously.
+ * JMS 2.0 Producer implementation that extends all features of {@link JmsProducer}, but allows us to send messages asynchronously. <br />
+ * Be aware, you must have a JMS 2.0 compatible broker, this producer is not backward compatible to JMS 1.1
  * <p>
  * Essentially the producer sending the message to the JMS provider will not wait for a response that would normally confirm the message
  * has been received and persisted.  Instead the producer sends the JMS message in a "fire-and-forget" manner. <br />

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -1,5 +1,7 @@
 package com.adaptris.core.jms;
 
+import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
+
 import javax.jms.CompletionListener;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -11,6 +13,9 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.StandardProcessingExceptionHandler;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -96,5 +101,14 @@ public class JmsAsyncProducer extends JmsProducer implements CompletionListener 
   public void setAsyncMessageErrorHandler(StandardProcessingExceptionHandler asyncMessageErrorHandler) {
     this.asyncMessageErrorHandler = asyncMessageErrorHandler;
   }
-  
+
+  @Override
+  public void init() throws CoreException {
+    try {
+      Args.notNull(getAsyncMessageErrorHandler(), "asyncMessageErrorHandler");
+      super.init();
+    } catch (IllegalArgumentException e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -1,0 +1,99 @@
+package com.adaptris.core.jms;
+
+import javax.jms.CompletionListener;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.validation.constraints.NotNull;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.StandardProcessingExceptionHandler;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * JMS Producer implementation that extends all features of {@link JmsProducer}, but allows us to send messages asynchronously.
+ * <p>
+ * Essentially the producer sending the message to the JMS provider will not wait for a response that would normally confirm the message
+ * has been received and persisted.  Instead the producer sends the JMS message in a "fire-and-forget" manner. <br />
+ * At some future point in time, the JMS provider will call us back with confirmation or inform us of an error for each sent message.
+ * </p>
+ * <p>
+ * Should the message have failed to be fully received or persisted, you can configure an async-message-error-handler.
+ * </p>
+ * <p>
+ * One of the benefits to sending messages asynchronously simply comes down to processing speed.  During any producer, it is generally the time waiting for the JMS provider
+ * to return control back to the client after the client submits a message that takes the most time.  With asynchronous message producing, we no longer have to wait for the JMS
+ * provider, allowing us to move onto the next message.
+ * </p>
+ * <p>
+ * <b>NOTE:</b> Once this producer has sent a message it is assumed to have succeeded, at least until a success or failure callback is received. <br />
+ * This means that if this producer is one of your workflow producers, the workflow itself will immediately deem this 
+ * message to have been processed and will move onto the next available message. <br/>
+ * Generally this may not be an issue, however if processing a message triggers a form of transaction committing or JMS acknowledging, 
+ * then the commit or ack could be completed regardless if the sent JMS message eventually succeeds or fails.
+ * </p>
+ * 
+ * @config jms-async-producer
+ * 
+ */
+@XStreamAlias("jms-async-producer")
+@AdapterComponent
+@ComponentProfile(summary = "Place message on a JMS queue or topic asynchronously", tag = "producer,jms", recommended = {JmsConnection.class})
+@DisplayOrder(order = {"destination", "asyncMessageErrorHandler", "messageTypeTranslator", "deliveryMode", "priority", "ttl", "acknowledgeMode"})
+public class JmsAsyncProducer extends JmsProducer implements CompletionListener {
+  
+  @NotNull
+  private StandardProcessingExceptionHandler asyncMessageErrorHandler;
+
+  protected void produce(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException, CoreException {
+    try {
+      setupSession(msg);
+      Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());
+      if (!perMessageProperties()) {
+        producerSession.getProducer().send(jmsDest.getDestination(), jmsMsg, this);
+      } else {
+        producerSession.getProducer().send(jmsDest.getDestination(), jmsMsg,
+            calculateDeliveryMode(msg, jmsDest.deliveryMode()),
+            calculatePriority(msg, jmsDest.priority()),
+            calculateTimeToLive(msg, jmsDest.timeToLive()),
+            this);
+      }
+      if (captureOutgoingMessageDetails()) {
+        captureOutgoingMessageDetails(jmsMsg, msg);
+      }
+      log.info("msg produced to destination [{}]", jmsDest);
+    } catch (Throwable ex) {
+      throw new CoreException("JMS runtime exception", ex);
+    }
+  }
+
+  @Override
+  public void onCompletion(Message message) {
+    try {
+      log.trace("Async message succesfully received with id {}", message.getJMSMessageID());
+    } catch (JMSException e) {}
+  }
+
+  @Override
+  public void onException(Message message, Exception exception) {
+    log.error("Async Message failed.", exception);
+    
+    try {
+      this.getAsyncMessageErrorHandler().handleProcessingException(this.getMessageTranslator().translate(message));
+    } catch (JMSException e) {
+      log.error("Failed to translate the failed JMS message to execute the exception handler.", e);
+    }
+  }
+
+  public StandardProcessingExceptionHandler getAsyncMessageErrorHandler() {
+    return asyncMessageErrorHandler;
+  }
+
+  public void setAsyncMessageErrorHandler(StandardProcessingExceptionHandler asyncMessageErrorHandler) {
+    this.asyncMessageErrorHandler = asyncMessageErrorHandler;
+  }
+  
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -1,7 +1,5 @@
 package com.adaptris.core.jms;
 
-import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-
 import javax.jms.CompletionListener;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -15,7 +13,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.StandardProcessingExceptionHandler;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -28,6 +25,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * </p>
  * <p>
  * Should the message have failed to be fully received or persisted, you can configure an async-message-error-handler.
+ * </p>
+ * <p>
+ * An important note about the async-message-error-handle, is that it will process the message in the state it was in just before the produce was attempted.
+ * If you have modified the message in the workflow before producing then attempting to "retry" this failed message through the same workflow may therefore be problematic.
  * </p>
  * <p>
  * One of the benefits to sending messages asynchronously simply comes down to processing speed.  During any producer, it is generally the time waiting for the JMS provider

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -108,7 +108,7 @@ public class JmsProducer extends JmsProducerImpl {
     }
   }
 
-  private void produce(AdaptrisMessage msg, JmsDestination jmsDest)
+  protected void produce(AdaptrisMessage msg, JmsDestination jmsDest)
       throws JMSException, CoreException {
     setupSession(msg);
     Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());

--- a/interlok-core/src/main/java/com/adaptris/core/jms/NoOpAcknowledgementHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/NoOpAcknowledgementHandler.java
@@ -1,0 +1,37 @@
+package com.adaptris.core.jms;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+*
+* <p>
+* <code>AcknowledgementHandler</code> implementation that does nothing.
+* </p>
+* <p>
+* Typically this implementation would be used when you're using managed JMS transactions such as XA or running in AUTO_ACKNOWLEDGE mode.
+* </p>
+*
+* @config no-op-acknowledgement-handler
+* @author amcgrath
+*/
+@XStreamAlias("no-op-acknowledgement-handler")
+@AdapterComponent
+@ComponentProfile(summary = "JMS Acknowledgement handler that skips all acknowledgements, rollbacks and commits.", tag = "jms")
+public class NoOpAcknowledgementHandler implements AcknowledgementHandler {
+
+  @Override
+  public void acknowledgeMessage(JmsActorConfig actor, Message message) throws JMSException {
+    //do nothing
+  }
+
+  @Override
+  public void rollbackMessage(JmsActorConfig actor, Message message) {
+    //do nothing
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BasicJmsProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BasicJmsProducerCase.java
@@ -94,7 +94,7 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
       activeMqBroker.start();
       AdaptrisMessage msg = createMessage();
       ServiceCase.execute(standaloneProducer, msg);
-      Map objectMetadata = msg.getObjectHeaders();
+      Map<Object, Object> objectMetadata = msg.getObjectHeaders();
       assertTrue(objectMetadata.containsKey(Message.class.getCanonicalName() + "." + JmsConstants.JMS_MESSAGE_ID));
       assertTrue(objectMetadata.containsKey(Message.class.getCanonicalName() + "." + JmsConstants.JMS_DESTINATION));
       assertTrue(objectMetadata.containsKey(Message.class.getCanonicalName() + "." + JmsConstants.JMS_PRIORITY));

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
@@ -17,12 +17,14 @@ import org.mockito.MockitoAnnotations;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardProcessingExceptionHandler;
 import com.adaptris.core.fs.FsProducer;
 import com.adaptris.core.jms.jndi.StandardJndiImplementation;
+import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.KeyValuePair;
 
 public class JmsAsyncProducerTest extends JmsProducerExample {
@@ -114,6 +116,25 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
     verify(mockMessage, times(0)).getJMSType();
     verify(mockMessage, times(0)).getJMSDeliveryMode();
     verify(mockMessage, times(0)).getJMSPriority();
+  }
+  
+  public void testInitWithoutExceptionHandlerFails() throws Exception {
+    producer.setAsyncMessageErrorHandler(null);
+    
+    try {
+      LifecycleHelper.init(producer);
+      fail("Should throw core exception without a configured exception handler.");
+    } catch (CoreException ex) {
+      //expected.
+    }
+  }
+  
+  public void testInitWithExceptionHandler() throws Exception {    
+    try {
+      LifecycleHelper.init(producer);
+    } catch (CoreException ex) {
+      fail("Shouldn't throw core exception with a configured exception handler.");
+    }
   }
   
   public void testExceptionHandler() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
@@ -1,0 +1,161 @@
+package com.adaptris.core.jms;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.jms.CompletionListener;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageProducer;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ConfiguredProduceDestination;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.NullConnection;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.StandardProcessingExceptionHandler;
+import com.adaptris.core.fs.FsProducer;
+import com.adaptris.core.jms.jndi.StandardJndiImplementation;
+import com.adaptris.util.KeyValuePair;
+
+public class JmsAsyncProducerTest extends JmsProducerExample {
+  
+  private JmsAsyncProducer producer;
+  
+  private AdaptrisMessage adaptrisMessage;
+
+  @Mock private ProducerSessionFactory mockSessionFactory;
+  @Mock private ProducerSession mockSession;
+  @Mock private MessageTypeTranslator mockTranslator;
+  @Mock private Message mockMessage;
+  @Mock private MessageProducer mockMessageProducer;
+  @Mock private JmsDestination mockJmsDestination;
+  @Mock private StandardProcessingExceptionHandler mockExceptionHandler;
+  
+  
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    
+    adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+    
+    producer = new JmsAsyncProducer();
+    
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setMessageTranslator(mockTranslator);
+    producer.setAsyncMessageErrorHandler(mockExceptionHandler);
+    
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockSession);
+    when(mockSession.getProducer())
+      .thenReturn(mockMessageProducer);
+    when(mockTranslator.translate(any(AdaptrisMessage.class)))
+      .thenReturn(mockMessage);
+    
+    when(mockJmsDestination.deliveryMode())
+      .thenReturn("PERSISTENT");
+    when(mockJmsDestination.priority())
+    .thenReturn(1);
+    when(mockJmsDestination.timeToLive())
+    .thenReturn(1l);
+  
+  }
+  
+  public JmsAsyncProducerTest(String name) {
+    super(name);
+  }
+  
+  public void testSendFails() throws Exception {
+    doThrow(new JMSException("expected"))
+      .when(mockMessageProducer).send(any(Destination.class), any(Message.class), any(CompletionListener.class));
+      
+    try {
+      producer.produce(adaptrisMessage, mockJmsDestination);
+      fail("Jms producer should have throw an exception on send()");
+    } catch (Throwable t) {
+      // expected;
+    }
+  }
+  
+  public void testSendPerMessageProperties() throws Exception {
+    producer.produce(adaptrisMessage, mockJmsDestination);
+    
+    verify(mockMessageProducer).send(any(Destination.class), any(Message.class), any(int.class), any(int.class), any(long.class), any(CompletionListener.class));
+  }
+  
+  public void testSendNotPerMessageProperties() throws Exception {
+    producer.setPerMessageProperties(false);
+    producer.produce(adaptrisMessage, mockJmsDestination);
+    
+    verify(mockMessageProducer).send(any(Destination.class), any(Message.class), any(CompletionListener.class));
+  }
+  
+  public void testCaptureOutgoingMessageProperties() throws Exception {
+    producer.setCaptureOutgoingMessageDetails(true);
+    producer.produce(adaptrisMessage, mockJmsDestination);
+    
+    verify(mockMessage).getJMSMessageID();
+    verify(mockMessage).getJMSType();
+    verify(mockMessage).getJMSDeliveryMode();
+    verify(mockMessage).getJMSPriority();
+  }
+  
+  public void testNotCaptureOutgoingMessageProperties() throws Exception {
+    producer.setCaptureOutgoingMessageDetails(false);
+    producer.produce(adaptrisMessage, mockJmsDestination);
+    
+    verify(mockMessage, times(0)).getJMSMessageID();
+    verify(mockMessage, times(0)).getJMSType();
+    verify(mockMessage, times(0)).getJMSDeliveryMode();
+    verify(mockMessage, times(0)).getJMSPriority();
+  }
+  
+  public void testExceptionHandler() throws Exception {
+    producer.onException(mockMessage, new Exception());
+    
+    verify(mockExceptionHandler).handleProcessingException(any(AdaptrisMessage.class));
+  }
+  
+  public void testSuccessHandler() throws Exception {
+    producer.onCompletion(mockMessage);
+    
+    verify(mockExceptionHandler, times(0)).handleProcessingException(any(AdaptrisMessage.class));
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    StandardJndiImplementation jndiImplementation = new StandardJndiImplementation();
+    jndiImplementation.setJndiName("ConnectionFactory");
+    jndiImplementation.getJndiParams().addKeyValuePair(new KeyValuePair("java.naming.factory.initial", "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory"));
+    jndiImplementation.getJndiParams().addKeyValuePair(new KeyValuePair("java.naming.provider.url", "tcp://localhost:61616?type=CF"));
+    
+    JmsConnection c = new JmsConnection(jndiImplementation);
+    ConfiguredProduceDestination dest = new ConfiguredProduceDestination("jms:topic:myTopicName?priority=4");
+
+    JmsAsyncProducer asyncProducer = new JmsAsyncProducer();
+    asyncProducer.setDestination(dest);
+    
+    FsProducer fsProducer = new FsProducer(new ConfiguredProduceDestination("my-failed-messages-dir"));
+    StandaloneProducer fsStandaloneProducer = new StandaloneProducer(new NullConnection(), fsProducer);
+    
+    asyncProducer.setAsyncMessageErrorHandler(new StandardProcessingExceptionHandler(fsStandaloneProducer));
+    
+    c.setConnectionErrorHandler(new JmsConnectionErrorHandler());
+    NullCorrelationIdSource mcs = new NullCorrelationIdSource();
+    asyncProducer.setCorrelationIdSource(mcs);
+
+    StandaloneProducer result = new StandaloneProducer();
+
+    result.setConnection(c);
+    result.setProducer(asyncProducer);
+
+    return result;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
@@ -19,18 +19,27 @@ package com.adaptris.core.jms;
 import static com.adaptris.core.jms.JmsConfig.DEFAULT_PAYLOAD;
 import static com.adaptris.core.jms.JmsConfig.MESSAGE_TRANSLATOR_LIST;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.jms.Destination;
+import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.jms.Topic;
 
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQSession;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -50,7 +59,17 @@ import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.util.TimeInterval;
 
 public class JmsProducerTest extends JmsProducerCase {
+  
+  @Mock private ProducerSessionFactory mockSessionFactory;
+  @Mock private ProducerSession mockProducerSession;
+  @Mock private Session mockSession;
+  @Mock private Message mockMessage;
 
+  public void setUp() throws Exception {
+    super.setUp();
+    MockitoAnnotations.initMocks(this);
+  }
+  
   public JmsProducerTest(String name) {
     super(name);
   }
@@ -81,6 +100,202 @@ public class JmsProducerTest extends JmsProducerCase {
     return session.createTopic(name);
   }
 
+  public void testTransactedCommit() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(true);
+    
+    JmsProducer producer = this.createProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.commit();
+    
+    verify(mockSession).commit();
+  }
+  
+  public void testNonTransactedNoCommit() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(false);
+    
+    JmsProducer producer = this.createProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.commit();
+    
+    verify(mockSession, times(0)).commit();
+  }
+  
+  public void testTransactedRollback() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(true);
+    
+    JmsProducer producer = this.createProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.rollback();
+    
+    verify(mockSession).rollback();
+  }
+  
+  public void testAttemptedTransactedRollback() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(true);
+    doThrow(new JMSException("expected"))
+      .when(mockSession).rollback();
+    
+    JmsProducer producer = this.createProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.rollback();
+    
+    verify(mockSession).rollback();
+  }
+  
+  public void testSessionDeadOnRollback() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenThrow(new JMSException("expected"));
+    
+    JmsProducer producer = this.createProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.rollback();
+    
+    verify(mockSession, times(0)).rollback();
+  }
+  
+  public void testNotTransactedNoRollback() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(false);
+    
+    JmsProducer producer = new JmsProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.rollback();
+    
+    verify(mockSession, times(0)).rollback();
+  }
+  
+  public void testNullMessageAck() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(false);
+  
+    JmsProducer producer = new JmsProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.acknowledge(null);
+    
+    verify(mockMessage, times(0)).acknowledge();
+  }
+  
+  public void testMessageAckNotTransacted() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(false);
+  
+    JmsProducer producer = new JmsProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.acknowledge(mockMessage);
+    
+    verify(mockMessage).acknowledge();
+  }
+  
+  public void testMessageAckTransacted() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(true);
+  
+    JmsProducer producer = new JmsProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.acknowledge(mockMessage);
+    
+    verify(mockMessage, times(0)).acknowledge();
+  }
+  
+  public void testMessageAckTransactedAutoMode() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(true);
+  
+    JmsProducer producer = new JmsProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.acknowledge(mockMessage);
+    
+    verify(mockMessage, times(0)).acknowledge();
+  }
+  
+  public void testMessageAckNonTransactedAutoMode() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(false);
+  
+    JmsProducer producer = new JmsProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.acknowledge(mockMessage);
+    
+    verify(mockMessage, times(0)).acknowledge();
+  }
+  
+  public void testMessageAckNonTransactedClientMode() throws Exception {
+    when(mockSessionFactory.createProducerSession(any(), any()))
+      .thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession())
+      .thenReturn(mockSession);
+    when(mockSession.getTransacted())
+      .thenReturn(false);
+  
+    JmsProducer producer = new JmsProducer(new ConfiguredProduceDestination("myDestination"));
+    producer.setSessionFactory(mockSessionFactory);
+    producer.setAcknowledgeMode("CLIENT_ACKNOWLEDGE");
+    producer.setupSession(AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx"));
+    producer.acknowledge(mockMessage);
+    
+    verify(mockMessage).acknowledge();
+  }
 
   public void testProduce_JmsReplyToDestination() throws Exception {
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();


### PR DESCRIPTION
A new JMS Async producer.
Doesn't really care about the jms bridge'ing consumer ack issues.
Just allows you to configure an exception handler when a message fails.

Also included is the beginnings of a configurable consumer ack handler, with the idea being that we will need it if we're worried about message loss when using async producers.