### PR TITLE
INTERLOK-2675 add ParameterLogger interface.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/NoParameterLogging.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/NoParameterLogging.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.jdbc;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * 
+ * @config jdbc-no-parameter-logging
+ *
+ */
+@XStreamAlias("jdbc-no-parameter-logging")
+@ComponentProfile(summary="Never log parameters for JDBC Statement", since="3.8.4")
+public class NoParameterLogging implements ParameterLogger {
+
+  @Override
+  public void log(int paramterIndex, Object o) {
+    // Intentionally empty
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/ParameterLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/ParameterLogger.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.jdbc;
+
+/**
+ * @since 3.8.4
+ */
+@FunctionalInterface
+public interface ParameterLogger {
+  
+  void log(int paramterIndex, Object o);
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/StatementParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/StatementParameter.java
@@ -65,8 +65,9 @@ public class StatementParameter extends StatementParameterImpl {
 
   @Override
   public void apply(int parameterIndex, PreparedStatement statement, AdaptrisMessage msg) throws SQLException, ServiceException {
-    log.trace("Setting argument {} to [{}]", parameterIndex, getQueryValue(msg));
-    statement.setObject(parameterIndex, this.convertToQueryClass(getQueryValue(msg)));
+    Object queryValue = getQueryValue(msg);
+    logger().log(parameterIndex, queryValue);
+    statement.setObject(parameterIndex, this.convertToQueryClass(queryValue));
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/StatementParameterImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/StatementParameterImpl.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.jdbc;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.w3c.dom.Node;
 
 import com.adaptris.annotation.AdvancedConfig;
@@ -81,6 +82,9 @@ public abstract class StatementParameterImpl extends NamedStatementParameter {
   @InputFieldDefault(value = "false")
   @AdvancedConfig
   private Boolean convertNull;
+  @AdvancedConfig
+  @InputFieldDefault(value = "log everything")
+  private ParameterLogger parameterLogger;
 
   public StatementParameterImpl() {
     
@@ -160,7 +164,23 @@ public abstract class StatementParameterImpl extends NamedStatementParameter {
     return queryString;
   }
 
+  public ParameterLogger getParameterLogger() {
+    return parameterLogger;
+  }
 
+  /** Set the logger for non binary parameters.
+   * 
+   * @param parameterLogger
+   */
+  public void setParameterLogger(ParameterLogger parameterLogger) {
+    this.parameterLogger = parameterLogger;
+  }
+  
+  protected ParameterLogger logger() {
+    return ObjectUtils.defaultIfNull(getParameterLogger(), (i, o) -> {
+      log.trace("Setting argument {} to [{}]", i, o);
+    });
+  }
 
   public Object getQueryValue(AdaptrisMessage msg) {
     return getHandler(getQueryType()).getValue(msg, getQueryString());

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/TruncatedParameterLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/TruncatedParameterLogger.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.jdbc;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.util.NumberUtils;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * 
+ * @config jdbc-truncated-parameter-logging
+ *
+ */
+@XStreamAlias("jdbc-truncated-parameter-logging")
+@ComponentProfile(summary="Log parameters, but truncate them", since="3.8.4")
+public class TruncatedParameterLogger implements ParameterLogger {
+
+  private transient Logger log = LoggerFactory.getLogger(this.getClass());
+  
+  @InputFieldDefault(value = "50")
+  private Integer truncateLength;
+  
+  public TruncatedParameterLogger() {
+    
+  }
+  
+  public TruncatedParameterLogger(Integer length) {
+    this();
+    setTruncateLength(length);
+  }
+  
+  @Override
+  public void log(int paramterIndex, Object o) {
+    String s = o == null ? "(null)" : o.toString();
+    log.trace("Setting argument {} to [{}]", paramterIndex, StringUtils.abbreviate(s, truncateLength()));
+  }
+
+  public Integer getTruncateLength() {
+    return truncateLength;
+  }
+
+  public void setTruncateLength(Integer truncateLength) {
+    this.truncateLength = truncateLength;
+  }
+  
+
+  int truncateLength() {
+    return NumberUtils.toIntDefaultIfNull(getTruncateLength(), 50);
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/TypedStatementParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/TypedStatementParameter.java
@@ -51,7 +51,7 @@ public abstract class TypedStatementParameter<T> extends StatementParameterImpl 
       throws SQLException {
     Object o = getQueryValue(msg);
     T typedParam = convert(o);
-    log.trace("Setting argument {} to [{}]", parameterIndex, typedParam);
+    logger().log(parameterIndex, typedParam);   
     statement.setObject(parameterIndex, typedParam);
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/ParameterLoggerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/ParameterLoggerTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.jdbc;
+
+import org.junit.Test;
+
+public class ParameterLoggerTest {
+
+  @Test
+  public void testTruncatedLogger() {
+    TruncatedParameterLogger logger = new TruncatedParameterLogger(10);
+    logger.log(0, "");
+    logger.log(1, null);
+  }
+  
+  @Test
+  public void testNoLogging() {
+    NoParameterLogging logger = new NoParameterLogging();
+    logger.log(0, "");
+    logger.log(1, null);
+  }
+
+}


### PR DESCRIPTION
- Add ParameterLogger function interface.
- Default behaviour is to log the toString() on the object which was
the existing behaviour.
- Added a TruncatedParameterLogger and NoParamterLogging version.
- Add tests.