### PR TITLE
INTERLOK-2681 Make read-file-service support URLs

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
@@ -20,11 +20,9 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
-
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -37,7 +35,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.util.Args;
 import com.adaptris.fs.FsException;
-import com.adaptris.fs.FsFilenameExistsException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -153,16 +150,7 @@ public class FsConsumer extends FsConsumerImpl {
   }
 
   protected File renameFile(File file) throws FsException {
-    File newFile = new File(file.getAbsolutePath() + wipSuffix);
-
-    try {
-      fsWorker.rename(file, newFile);
-    }
-    catch (FsFilenameExistsException e) {
-      newFile = new File(file.getParentFile(), System.currentTimeMillis() + "." + file.getName() + wipSuffix);
-      fsWorker.rename(file, newFile);
-    }
-    return newFile;
+    return FsHelper.renameFile(file, wipSuffix, fsWorker);
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -142,7 +142,7 @@ public abstract class FsHelper {
     }
     else {
       if (scheme == null) {
-        return relativeConfig(configuredUri);
+        return new URL("file:///" + configuredUri.toString());
       }
       else {
         throw new IllegalArgumentException("Illegal URL [" + s + "]");
@@ -197,21 +197,22 @@ public abstract class FsHelper {
     return newFile;
   }
 
-  /**
-   * 
-   * @param uri the relative <code>URI</code> to process
-   * @return a <code>file:/// URL</code> based on the current working directory (obtained by calling
-   *         <code>System.getProperty("user.dir")</code>) plus the passed relative <code>uri</code>
-   * @throws Exception wrapping any underlying <code>Exception</code>
-   */
-  private static URL relativeConfig(URI uri) throws IOException {
-    String pwd = System.getProperty("user.dir");
-
-    String path = pwd + "/" + uri; // ok even if uri starts with a /
-    URL result = new URL("file:///" + path);
-
-    return result;
-  }
+  // /**
+  // *
+  // * @param uri the relative <code>URI</code> to process
+  // * @return a <code>file:/// URL</code> based on the current working directory (obtained by
+  // calling
+  // * <code>System.getProperty("user.dir")</code>) plus the passed relative <code>uri</code>
+  // * @throws Exception wrapping any underlying <code>Exception</code>
+  // */
+  // private static URL relativeConfig(URI uri) throws IOException {
+  // String pwd = System.getProperty("user.dir");
+  //
+  // String path = pwd + "/" + uri; // ok even if uri starts with a /
+  // URL result = new URL("file:///" + path);
+  //
+  // return result;
+  // }
 
   private static String backslashToSlash(String url) {
     if (!isEmpty(url)) {

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -16,8 +16,7 @@
 
 package com.adaptris.core.fs;
 
-import static org.apache.commons.lang.StringUtils.isEmpty;
-
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -28,10 +27,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.fs.FsException;
 import com.adaptris.fs.FsFilenameExistsException;
 import com.adaptris.fs.FsWorker;
@@ -47,7 +45,12 @@ public abstract class FsHelper {
    * 
    */
   public static File toFile(String s) throws IOException, URISyntaxException {
-    return createFileReference(createUrlFromString(s, true));
+    try {
+      return createFileReference(createUrlFromString(s, true));
+    } catch (IllegalArgumentException e) {
+      // Catch it from createUrlFromString(), since it's probably c:/file.
+      return new File(s);
+    }
   }
 
   /**
@@ -68,7 +71,7 @@ public abstract class FsHelper {
    * @throws UnsupportedEncodingException if the encoding was not supported.
    */
   public static File createFileReference(URL url, String charset) throws UnsupportedEncodingException {
-    String charSetToUse = charset == null ? System.getProperty("file.encoding") : charset;
+    String charSetToUse = StringUtils.defaultIfBlank(charset, System.getProperty("file.encoding"));
     String filename = URLDecoder.decode(url.getPath(), charSetToUse);
     // Cope with file://localhost/./config/blah -> /./config/blah is the result of getPath()
     // Munge that properly.
@@ -142,7 +145,7 @@ public abstract class FsHelper {
         return relativeConfig(configuredUri);
       }
       else {
-        throw new IllegalArgumentException("illegal destination [" + s + "]");
+        throw new IllegalArgumentException("Illegal URL [" + s + "]");
       }
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/ReadFileService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/ReadFileService.java
@@ -1,17 +1,17 @@
 package com.adaptris.core.services;
 
+import static com.adaptris.fs.FsWorker.checkReadable;
+import static com.adaptris.fs.FsWorker.isFile;
+import static org.apache.commons.io.IOUtils.copy;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
-
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import org.apache.commons.lang3.StringUtils;
-
+import org.hibernate.validator.constraints.NotBlank;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AffectsMetadata;
@@ -22,9 +22,9 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.fs.FsHelper;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.util.stream.StreamUtil;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -33,130 +33,100 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @config read-file-service
  */
 @AdapterComponent
-@ComponentProfile(summary = "Read a file from a specific path into the message payload", tag = "service,read,file")
+@ComponentProfile(summary = "Read a file from a specific path into the message payload",
+    tag = "service,file")
 @XStreamAlias("read-file-service")
-public class ReadFileService extends ServiceImp
-{
-	private static final String ERROR = "File Path has not been set, this service will not execute.";
+public class ReadFileService extends ServiceImp {
 
-	/**
-	 * The parameter for the path to the file to read.
-	 */
-	@NotNull
-	@Valid
-	@InputFieldHint(expression = true)
-	private String filePath;
+  /**
+   * The parameter for the path to the file to read.
+   */
+  @NotBlank
+  @InputFieldHint(expression = true)
+  private String filePath;
 
-	@AffectsMetadata
-	@AdvancedConfig
-	@InputFieldDefault(value = "null")
-	private String contentTypeMetadataKey;
+  @AffectsMetadata
+  @AdvancedConfig
+  @InputFieldDefault(value = "null")
+  private String contentTypeMetadataKey;
 
-	@AdvancedConfig
-	@Valid
-	@InputFieldDefault(value = "Files.probeContentType(Path)")
-	private ContentTypeProbe contentTypeProbe;
+  @AdvancedConfig
+  @Valid
+  @InputFieldDefault(value = "Files.probeContentType(Path)")
+  private ContentTypeProbe contentTypeProbe;
 
-	@Override
-	public void doService(final AdaptrisMessage message) throws ServiceException
-	{
-		try
-		{
-			final File file = new File(message.resolve(getFilePath()));
-			if (file.exists() && file.isFile())
-			{
-				log.info("Reading file : {}", file.getAbsolutePath());
-        try (FileInputStream in = new FileInputStream(file); OutputStream out = message.getOutputStream()) {
-          StreamUtil.copyAndClose(in, out);
-          if (StringUtils.isNotBlank(getContentTypeMetadataKey())) {
-            message.addMetadata(getContentTypeMetadataKey(), probeContentType(file));
-          }
-        }
-			}
-			else
-			{
-				log.error("File path does not exist or is a directory : {}", file.getAbsolutePath());
-				throw new FileNotFoundException("File " + file.getAbsolutePath() + " does not exist or is a directory!");
-			}
-		}
-		catch (final IOException e)
-		{
-		  throw ExceptionHelper.wrapServiceException(e);
-		}
-	}
+  @Override
+  public void doService(final AdaptrisMessage message) throws ServiceException {
+    try {
+      final File file = isFile(checkReadable(FsHelper.toFile(message.resolve(getFilePath()))));
+      log.debug("Reading file : {}", file.getCanonicalPath());
+      try (FileInputStream in = new FileInputStream(file);
+          OutputStream out = message.getOutputStream()) {
+        copy(in, out);
+      }
+      if (isNotBlank(getContentTypeMetadataKey())) {
+        message.addMetadata(getContentTypeMetadataKey(), probeContentType(file));
+      }
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
 
-	private String probeContentType(File file) throws IOException {
-	  return StringUtils.defaultIfBlank(contentTypeProbe().probeContentType(file), "");
-	}
+  private String probeContentType(File file) throws IOException {
+    return defaultIfBlank(contentTypeProbe().probeContentType(file), "");
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	public void prepare() throws CoreException
-	{
-		/* empty method */
-	}
+  @Override
+  public void prepare() throws CoreException {
+    /* empty method */
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	protected void closeService()
-	{
-		/* empty method */
-	}
+  @Override
+  protected void closeService() {
+    /* empty method */
+  }
 
-	/**
-	 * {@inheritDoc}.
-	 */
-	@Override
-	protected void initService() throws CoreException
-	{
-		try
-		{
-			Args.notNull(getFilePath(), "filePath");
-		}
-		catch (Exception e)
-		{
-			throw ExceptionHelper.wrapCoreException(e);
-		}
-	}
+  @Override
+  protected void initService() throws CoreException {
+    try {
+      Args.notBlank(getFilePath(), "filePath");
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
+  }
 
-	/**
-	 * Get the file path parameter.
-	 * 
-	 * @return The file path parameter.
-	 */
-	public String getFilePath()
-	{
-		return filePath;
-	}
+  /**
+   * Get the file path parameter.
+   * 
+   * @return The file path parameter.
+   */
+  public String getFilePath() {
+    return filePath;
+  }
 
-	/**
-	 * Set the file path parameter.
-	 * 
-	 * @param filePath
-	 *            The file path parameter.
-	 */
-	public void setFilePath(final String filePath)
-	{
-		this.filePath = Args.notBlank(filePath, "filePath");
-	}
+  /**
+   * Set the file path parameter.
+   * 
+   * @param filePath The file path parameter.
+   */
+  public void setFilePath(final String filePath) {
+    this.filePath = Args.notBlank(filePath, "filePath");
+  }
 
-	public String getContentTypeMetadataKey() {
-		return contentTypeMetadataKey;
-	}
+  public String getContentTypeMetadataKey() {
+    return contentTypeMetadataKey;
+  }
 
-	/**
-	 * Sets the metadata key set the content type as, if not provided will not be set. (default: null)
-	 * @param contentTypeMetadataKey
-	 */
-	public void setContentTypeMetadataKey(String contentTypeMetadataKey) {
-		this.contentTypeMetadataKey =  Args.notBlank(contentTypeMetadataKey, "contentTypeMetadataKey");
-	}
-	
-	 
+  /**
+   * Sets the metadata key set the content type as, if not provided will not be set. (default: null)
+   * 
+   * @param contentTypeMetadataKey
+   */
+  public void setContentTypeMetadataKey(String contentTypeMetadataKey) {
+    this.contentTypeMetadataKey = contentTypeMetadataKey;
+  }
+
+
   public ContentTypeProbe getContentTypeProbe() {
     return contentTypeProbe;
   }
@@ -164,13 +134,15 @@ public class ReadFileService extends ServiceImp
   public void setContentTypeProbe(ContentTypeProbe contentTypeProbe) {
     this.contentTypeProbe = contentTypeProbe;
   }
-  
+
   protected ContentTypeProbe contentTypeProbe() {
-    return getContentTypeProbe() != null ? getContentTypeProbe() : e -> { return Files.probeContentType(e.toPath()); };
+    return getContentTypeProbe() != null ? getContentTypeProbe() : e -> {
+      return Files.probeContentType(e.toPath());
+    };
   }
 
   @FunctionalInterface
-	public interface ContentTypeProbe {
-	  String probeContentType(File f) throws IOException ;
-	}
+  public interface ContentTypeProbe {
+    String probeContentType(File f) throws IOException;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/ReadFileService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/ReadFileService.java
@@ -25,6 +25,7 @@ import com.adaptris.core.ServiceImp;
 import com.adaptris.core.fs.FsHelper;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.fs.FsException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -58,7 +59,8 @@ public class ReadFileService extends ServiceImp {
   @Override
   public void doService(final AdaptrisMessage message) throws ServiceException {
     try {
-      final File file = isFile(checkReadable(FsHelper.toFile(message.resolve(getFilePath()))));
+      final File file = convertToFile(message.resolve(getFilePath()));
+      System.err.println("Attempting to read : " + file.getCanonicalPath());
       log.debug("Reading file : {}", file.getCanonicalPath());
       try (FileInputStream in = new FileInputStream(file);
           OutputStream out = message.getOutputStream()) {
@@ -69,6 +71,14 @@ public class ReadFileService extends ServiceImp {
       }
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+  
+  private static File convertToFile(String filepath) throws FsException {
+    try {
+      return isFile(checkReadable(FsHelper.toFile(filepath)));
+    } catch (Exception e) {
+      return isFile(checkReadable(new File(filepath)));
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
@@ -17,15 +17,12 @@
 package com.adaptris.core.services.metadata;
 
 import static com.adaptris.core.util.MetadataHelper.convertFromProperties;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.Properties;
 import java.util.Set;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.BooleanUtils;
@@ -117,14 +114,13 @@ public class ReadMetadataFromFilesystem extends ServiceImp {
     String filenameToRead = "[could not create filename]";
     try {
       String baseUrl = getDestination().getDestination(msg);
-      URL url = FsHelper.createUrlFromString(baseUrl, true);
-      File parentFile = FsHelper.createFileReference(url);
-      File fileToRead = new File(FsHelper.createFileReference(url), filenameCreator().createName(msg));
+      File parentFile = FsHelper.toFile(baseUrl);
+      File fileToRead = new File(parentFile, filenameCreator().createName(msg));
       if (parentFile.isFile()) {
         fileToRead = parentFile;
       }
       filenameToRead = fileToRead.getCanonicalPath();
-      log.trace("Reading " + filenameToRead);
+      log.trace("Reading {}", filenameToRead);
       try (InputStream in = new FileInputStream(fileToRead)) {
         Set<MetadataElement> set = getStyle(getInputStyle()).load(in);
         for (MetadataElement e : set) {

--- a/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
@@ -106,6 +106,18 @@ public class FsHelperTest extends FsHelper {
     // should be "/"
     assertNotNull(f3.getParentFile().getParentFile());
     assertNull(f3.getParentFile().getParentFile().getParentFile());
+
+    File f4 = FsHelper.toFile("build.gradle");
+    assertEquals("build.gradle", f4.getName());
+    // will be "/"
+    assertNotNull(f4.getParentFile());
+    assertNull(f4.getParentFile().getParentFile());
+
+    File f5 = FsHelper.toFile("./build.gradle");
+    assertEquals("build.gradle", f4.getName());
+    // will be "."
+    assertNotNull(f4.getParentFile());
+    assertNull(f4.getParentFile().getParentFile());
   }
 
 

--- a/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
@@ -17,12 +17,11 @@
 package com.adaptris.core.fs;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.net.URL;
-
 import org.junit.Test;
 
 @SuppressWarnings("deprecation")
@@ -84,10 +83,22 @@ public class FsHelperTest extends FsHelper {
   }
 
   @Test
+  public void testToFile() throws Exception {
+    File f = FsHelper.toFile("file://localhost/./fred");
+    assertEquals("fred", f.getName());
+    assertEquals("." + File.separator + "fred", f.getPath());
+    File f2 = FsHelper.toFile("c:/home/fred");
+    assertEquals("fred", f2.getName());
+    assertNotNull(f2.getParentFile());
+  }
+
+
+  @Test
   public void testRelativeURL() throws Exception {
     File f = FsHelper.toFile("file://localhost/./fred");
     assertEquals("fred", f.getName());
     assertEquals("." + File.separator + "fred", f.getPath());
+    File f2 = FsHelper.toFile("c:/home/fred");
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
@@ -17,19 +17,28 @@
 package com.adaptris.core.fs;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.File;
+import java.io.FileFilter;
 import java.net.URL;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.apache.oro.io.AwkFilenameFilter;
 import org.junit.Test;
+import com.adaptris.core.stubs.TempFileUtils;
+import com.adaptris.fs.FsWorker;
+import com.adaptris.fs.StandardWorker;
 
 @SuppressWarnings("deprecation")
 public class FsHelperTest extends FsHelper {
 
   @Test
   public void testUnixStyleFullURI() throws Exception {
-    FsHelper.createUrlFromString("file:////home/fred");
+    assertNotNull(FsHelper.createUrlFromString("file:////home/fred"));
   }
 
   @Test
@@ -90,6 +99,13 @@ public class FsHelperTest extends FsHelper {
     File f2 = FsHelper.toFile("c:/home/fred");
     assertEquals("fred", f2.getName());
     assertNotNull(f2.getParentFile());
+    File f3 = FsHelper.toFile("/home/fred");
+    assertEquals("fred", f3.getName());
+    // "/home"
+    assertNotNull(f3.getParentFile());
+    // should be "/"
+    assertNotNull(f3.getParentFile().getParentFile());
+    assertNull(f3.getParentFile().getParentFile().getParentFile());
   }
 
 
@@ -98,77 +114,99 @@ public class FsHelperTest extends FsHelper {
     File f = FsHelper.toFile("file://localhost/./fred");
     assertEquals("fred", f.getName());
     assertEquals("." + File.separator + "fred", f.getPath());
-    File f2 = FsHelper.toFile("c:/home/fred");
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testCreateUrlFromString() throws Exception {
-    // 1 - valid absolute URL...
-    String urlString = "file:///c:/tmp/";
-    URL url = FsHelper.createUrlFromString(urlString);
 
-    // can't use this - the number of slashes changes to one...
-    // assertTrue(urlString.equals(url.toString()));
+    String urlString = "file:///c:/tmp/";
+    URL url = FsHelper.createUrlFromString(urlString, true);
 
     assertTrue("protocol", "file".equals(url.getProtocol()));
     assertTrue("path " + url.getPath(), "/c:/tmp/".equals(url.getPath()));
 
-    // 2 - valid absolute URL with 1 slash...
     String urlString2 = "file:/c:/tmp/";
-    URL url2 = FsHelper.createUrlFromString(urlString2);
-
+    URL url2 = FsHelper.createUrlFromString(urlString2, true);
     assertTrue("protocol", "file".equals(url2.getProtocol()));
     assertTrue("path " + url.getPath(), "/c:/tmp/".equals(url2.getPath()));
 
-    // 3 - valid relative URI...
     String urlString3 = "../dir/";
-    URL url3 = FsHelper.createUrlFromString(urlString3);
-
+    URL url3 = FsHelper.createUrlFromString(urlString3, true);
     assertTrue("protocol", "file".equals(url3.getProtocol()));
 
-    // either configure where you are running or rewrite method to obtain sthg
-    // to test against!
-    // assertTrue("path " + url.getPath(),
-    // "/c:/tmp/dir/".equals(url3.getPath()));
+    tryExpectingException(() -> {
+      FsHelper.createUrlFromString("..\\dir\\");
+    });
+    tryExpectingException(() -> {
+      FsHelper.createUrlFromString("c:\\dir\\");
+    });
+    tryExpectingException(() -> {
+      FsHelper.createUrlFromString("http://file/");
+    });
+    tryExpectingException(() -> {
+      FsHelper.createUrlFromString("file:\\\file\\");
+    });
+    tryExpectingException(() -> {
+      FsHelper.createUrlFromString(null, true);
+    });
+  }
 
-    // 4 - invalid relative URI...
-    String urlString4 = "..\\dir\\";
 
+  @Test
+  public void testCreateFilter() throws Exception {
+    FileFilter filter = createFilter("", RegexFileFilter.class.getCanonicalName());
+    // no op filter.
+    assertTrue(filter.accept(new File("build.gradle")));
+    assertNotEquals(RegexFileFilter.class, filter.getClass());
+    filter = createFilter(".*", RegexFileFilter.class.getCanonicalName());
+    assertEquals(RegexFileFilter.class, filter.getClass());
+    assertTrue(filter.accept(new File("build.gradle")));
+
+    // Just to fire the warning.
+    assertEquals(AwkFilenameFilter.class,
+        createFilter(".*", AwkFilenameFilter.class.getCanonicalName()).getClass());
+  }
+
+  @Test
+  public void testRenameFile() throws Exception {
+    FsWorker worker = new StandardWorker();
+    File src = TempFileUtils.createTrackedFile(this);
+    src.createNewFile();
+    File renamed = renameFile(src, ".wip", new StandardWorker());
+    assertTrue(renamed.exists());
+    assertFalse(src.exists());
+  }
+
+  @Test
+  public void testRenameFile_AlreadyExists() throws Exception {
+    File src = TempFileUtils.createTrackedFile(this);
+    src.createNewFile();
+
+    File wipFile = new File(src.getCanonicalPath() + ".wip");
+    wipFile.createNewFile();
+    TempFileUtils.trackFile(wipFile, this);
+
+    File renamed = renameFile(src, ".wip", new StandardWorker());
+    // Should have a timestamp addition.
+    assertNotEquals(wipFile, renamed);
+    assertFalse(src.exists());
+    assertTrue(wipFile.exists());
+    assertTrue(renamed.exists());
+  }
+
+
+  private void tryExpectingException(Attempt t) {
     try {
-      FsHelper.createUrlFromString(urlString4);
-      fail("no Exc. from invalid URI " + urlString4);
-    }
-    catch (Exception e) { /* okay */
-    }
+      t.tryIt();
+      fail();
+    } catch (Exception expected) {
 
-    // 5 - invalid relative URI...
-    String urlString5 = "c:\\dir\\";
+    }
+  }
 
-    try {
-      FsHelper.createUrlFromString(urlString5);
-      fail("no Exc. from invalid URI " + urlString5);
-    }
-    catch (Exception e) { /* okay */
-    }
-
-    // 6 - invalid absolute URL...
-    String urlString6 = "http://file/";
-
-    try {
-      FsHelper.createUrlFromString(urlString6);
-      fail("no Exc. from invalid URI " + urlString6);
-    }
-    catch (Exception e) { /* okay */
-    }
-
-    // 7 - invalid absolute URL...
-    String urlString7 = "file:\\\file\\";
-
-    try {
-      FsHelper.createUrlFromString(urlString7);
-      fail("no Exc. from invalid URI " + urlString7);
-    }
-    catch (Exception e) { /* okay */
-    }
+  @FunctionalInterface
+  private interface Attempt {
+    void tryIt() throws Exception;
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/ReadFileServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/ReadFileServiceTest.java
@@ -1,108 +1,97 @@
 /*
  * Copyright 2015 Adaptris Ltd.
  * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * 
  * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.adaptris.core.services;
 
 import static org.junit.Assert.assertArrayEquals;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Files;
-
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.GeneralServiceExample;
 
-public class ReadFileServiceTest extends GeneralServiceExample
-{
-	private static final String FILE = "build.gradle";
+public class ReadFileServiceTest extends GeneralServiceExample {
+  private static final String FILE = "build.gradle";
 
-	public ReadFileServiceTest(final String testName)
-	{
-		super(testName);
-	}
 
-	@Override
-	protected void setUp() throws Exception
-	{
-		/* empty method */
-	}
+
+  @Override
+  protected void setUp() throws Exception {
+    /* empty method */
+  }
 
 
   @Test
   public void testProbeContentType() throws Exception {
     final ReadFileService service = new ReadFileService();
     assertNotNull(service.contentTypeProbe());
-    ReadFileService.ContentTypeProbe myProbe = e-> { return Files.probeContentType(e.toPath()); };
+    ReadFileService.ContentTypeProbe myProbe = e -> {
+      return Files.probeContentType(e.toPath());
+    };
     service.setContentTypeProbe(myProbe);
     assertEquals(myProbe, service.getContentTypeProbe());
     assertEquals(myProbe, service.contentTypeProbe());
   }
-  
-	@Test
-	public void testService() throws Exception
-	{
-		final AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-		final ReadFileService service = retrieveObjectForSampleConfig();
 
-		execute(service, message);
+  @Test
+  public void testService() throws Exception {
+    final AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    final ReadFileService service = new ReadFileService();
+    service.setFilePath(FILE);
 
-		final byte[] actual = message.getPayload();
+    execute(service, message);
 
-		final File file = new File(FILE);
-		final byte[] expected = new byte[(int)file.length()];
-		try (final FileInputStream fir = new FileInputStream(file))
-		{
-			fir.read(expected);
-		}
+    final byte[] actual = message.getPayload();
 
-		assertArrayEquals(expected, actual);
-	}
+    final File file = new File(FILE);
+    final byte[] expected = new byte[(int) file.length()];
+    try (final FileInputStream fir = new FileInputStream(file)) {
+      fir.read(expected);
+    }
 
-	 
-	@Test
-	public void testServiceContentType() throws Exception
-	{
-		final AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-		final ReadFileService service = new ReadFileService();
-		service.setFilePath(PROPERTIES.getProperty("XmlTransformService.outputTestMessage"));
-		service.setContentTypeMetadataKey("contentType");
+    assertArrayEquals(expected, actual);
+  }
 
-		execute(service, message);
 
-		final byte[] actual = message.getPayload();
+  @Test
+  public void testServiceContentType() throws Exception {
+    final AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    final ReadFileService service = new ReadFileService();
+    service.setFilePath(PROPERTIES.getProperty("XmlTransformService.outputTestMessage"));
+    service.setContentTypeMetadataKey("contentType");
 
-		final File file = new File(PROPERTIES.getProperty("XmlTransformService.outputTestMessage"));
-		final byte[] expected = new byte[(int)file.length()];
-		try (final FileInputStream fir = new FileInputStream(file))
-		{
-			fir.read(expected);
-		}
+    execute(service, message);
 
-		assertArrayEquals(expected, actual);
-		assertTrue(message.containsKey("contentType"));
-		// Macs don't seem to be able to probe content type by default.
-		if (StringUtils.isNotBlank(message.getMetadataValue("contentType"))) {
-		  assertTrue(message.getMetadataValue("contentType").endsWith("/xml"));
-		}
-	}
+    final byte[] actual = message.getPayload();
+
+    final File file = new File(PROPERTIES.getProperty("XmlTransformService.outputTestMessage"));
+    final byte[] expected = new byte[(int) file.length()];
+    try (final FileInputStream fir = new FileInputStream(file)) {
+      fir.read(expected);
+    }
+
+    assertArrayEquals(expected, actual);
+    assertTrue(message.containsKey("contentType"));
+    // Macs don't seem to be able to probe content type by default.
+    if (StringUtils.isNotBlank(message.getMetadataValue("contentType"))) {
+      assertTrue(message.getMetadataValue("contentType").endsWith("/xml"));
+    }
+  }
 
   @Test
   public void testService_NoContentType() throws Exception {
@@ -118,29 +107,24 @@ public class ReadFileServiceTest extends GeneralServiceExample
     }
     assertArrayEquals(expected, actual);
   }
-  
-	@Test
-	public void testServiceFailedInit() throws Exception
-	{
-		try
-		{
-			final AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-			final ReadFileService service = new ReadFileService();
 
-			execute(service, message);
-			fail();
-		}
-    catch (@SuppressWarnings("unused") final CoreException expected)
-		{
-			/* expected result */
-		}
-	}
+  @Test
+  public void testServiceFailedInit() throws Exception {
+    try {
+      final AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      final ReadFileService service = new ReadFileService();
 
-	@Override
-	protected ReadFileService retrieveObjectForSampleConfig()
-	{
-		final ReadFileService service = new ReadFileService();
-    service.setFilePath(FILE);
-		return service;
-	}
+      execute(service, message);
+      fail();
+    } catch (@SuppressWarnings("unused") final CoreException expected) {
+      /* expected result */
+    }
+  }
+
+  @Override
+  protected ReadFileService retrieveObjectForSampleConfig() {
+    final ReadFileService service = new ReadFileService();
+    service.setFilePath("%message{pathToFile}, or a file path");
+    return service;
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/TempFileUtils.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/TempFileUtils.java
@@ -18,10 +18,8 @@ package com.adaptris.core.stubs;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
-
 import com.adaptris.util.GuidGenerator;
 
 public class TempFileUtils {
@@ -36,7 +34,10 @@ public class TempFileUtils {
   public static File createTrackedFile(String prefix, String suffix, File baseDir, Object tracker) throws IOException {
     File f = File.createTempFile(prefix, suffix, baseDir);
     f.delete();
-    f.deleteOnExit();
+    return trackFile(f, tracker);
+  }
+
+  public static File trackFile(File f, Object tracker) {
     cleaner.track(f, tracker, FileDeleteStrategy.FORCE);
     return f;
   }
@@ -53,9 +54,8 @@ public class TempFileUtils {
     File f = File.createTempFile(prefix, suffix, baseDir);
     f.delete();
     f.mkdirs();
-    f.deleteOnExit();
     cleaner.track(f, tracker, FileDeleteStrategy.FORCE);
-    return f;
+    return trackFile(f, tracker);
   }
 
 }


### PR DESCRIPTION
Support strings are now
* %message{metadata-key}
* file:///c:/blah/blah/blah
* c:/blah/blah/blah

The second makes it consistent with message-driven-destination.