### PR TITLE
Step one: Mass organise imports to reduce warnings.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdapterXStreamMarshallerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdapterXStreamMarshallerFactory.java
@@ -22,6 +22,7 @@ import static com.adaptris.annotation.AnnotationConstants.XSTREAM_ALIAS_PROPERTI
 import static com.adaptris.annotation.AnnotationConstants.XSTREAM_IMPLICIT_PROPERTIES_FILE;
 import static com.adaptris.core.marshaller.xstream.XStreamUtils.getClasses;
 import static com.adaptris.core.marshaller.xstream.XStreamUtils.readResource;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -30,8 +31,10 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.marshaller.xstream.LowerCaseHyphenatedMapper;
 import com.adaptris.core.marshaller.xstream.PrettyStaxDriver;
 import com.thoughtworks.xstream.XStream;

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
@@ -19,10 +19,13 @@ package com.adaptris.core;
 import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.LifecycleHelper;

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessage.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessage.java
@@ -18,6 +18,7 @@ package com.adaptris.core;
 
 import java.util.Map;
 import java.util.Set;
+
 import com.adaptris.annotation.Removal;
 import com.adaptris.interlok.types.InterlokMessage;
 

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageImp.java
@@ -18,6 +18,7 @@ package com.adaptris.core;
 
 import static com.adaptris.core.metadata.MetadataResolver.resolveKey;
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -32,11 +33,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.util.Args;
 import com.adaptris.util.IdGenerator;
 import com.adaptris.util.stream.StreamUtil;

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisPollingConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisPollingConsumer.java
@@ -18,7 +18,9 @@ package com.adaptris.core;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/AllowsRetriesConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AllowsRetriesConnection.java
@@ -17,7 +17,9 @@
 package com.adaptris.core;
 
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.util.NumberUtils;
 import com.adaptris.util.TimeInterval;

--- a/interlok-core/src/main/java/com/adaptris/core/Channel.java
+++ b/interlok-core/src/main/java/com/adaptris/core/Channel.java
@@ -24,8 +24,9 @@ import java.util.Date;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import org.apache.commons.lang3.BooleanUtils;
+
 import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/interlok-core/src/main/java/com/adaptris/core/DefaultAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DefaultAdaptrisMessageImp.java
@@ -17,6 +17,7 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FilterOutputStream;
@@ -25,7 +26,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
+
 import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.util.IdGenerator;
 
 /**

--- a/interlok-core/src/main/java/com/adaptris/core/DynamicSharedService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DynamicSharedService.java
@@ -16,6 +16,7 @@ import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.NumberUtils;
 import com.adaptris.util.TimeInterval;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import net.jodah.expiringmap.ExpirationListener;
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;

--- a/interlok-core/src/main/java/com/adaptris/core/EventHandlerBase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/EventHandlerBase.java
@@ -21,11 +21,14 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.LifecycleHelper;

--- a/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
@@ -21,10 +21,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.LifecycleHelper;

--- a/interlok-core/src/main/java/com/adaptris/core/FileLogHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FileLogHandler.java
@@ -21,10 +21,13 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
+
 import javax.management.MalformedObjectNameException;
+
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.runtime.AdapterManager;
 import com.adaptris.core.runtime.ParentRuntimeInfoComponent;
 import com.adaptris.core.runtime.RuntimeInfoComponent;

--- a/interlok-core/src/main/java/com/adaptris/core/GaussianIntervalPoller.java
+++ b/interlok-core/src/main/java/com/adaptris/core/GaussianIntervalPoller.java
@@ -1,12 +1,13 @@
 package com.adaptris.core;
 
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.Valid;
+
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.util.TimeInterval;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import javax.validation.Valid;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 
 /**
  * <p>

--- a/interlok-core/src/main/java/com/adaptris/core/MessageLoggerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MessageLoggerImpl.java
@@ -17,6 +17,7 @@ package com.adaptris.core;
 
 import java.util.Collection;
 import java.util.Set;
+
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 

--- a/interlok-core/src/main/java/com/adaptris/core/MimeEncoderImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MimeEncoderImpl.java
@@ -36,6 +36,7 @@ import javax.validation.constraints.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.Args;

--- a/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
@@ -21,7 +21,9 @@ import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -25,14 +25,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+
 import org.apache.commons.lang3.Range;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPool;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/RequestReplyProducerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RequestReplyProducerImp.java
@@ -17,7 +17,9 @@
 package com.adaptris.core;
 
 import java.io.IOException;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.lms.FileBackedMessage;

--- a/interlok-core/src/main/java/com/adaptris/core/RequestReplyWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RequestReplyWorkflow.java
@@ -20,7 +20,9 @@ import java.util.concurrent.TimeUnit;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
@@ -17,6 +17,7 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceList.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceList.java
@@ -24,7 +24,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.ListIterator;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/SharedComponentList.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedComponentList.java
@@ -31,7 +31,9 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/StandaloneConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandaloneConsumer.java
@@ -17,6 +17,7 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/interlok-core/src/main/java/com/adaptris/core/StandardProcessingExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardProcessingExceptionHandler.java
@@ -18,7 +18,9 @@ package com.adaptris.core;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.validation.Valid;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.util.LifecycleHelper;

--- a/interlok-core/src/main/java/com/adaptris/core/WaitingOutOfStateHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WaitingOutOfStateHandler.java
@@ -18,7 +18,9 @@ package com.adaptris.core;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
+
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.LifecycleHelper;

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -21,19 +21,23 @@ import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION_CAUSE;
 import static com.adaptris.core.CoreConstants.UNIQUE_ID_JMX_PATTERN;
 import static org.apache.commons.lang.StringUtils.isBlank;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hibernate.validator.constraints.NotBlank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/cache/ExpiringMapCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/cache/ExpiringMapCache.java
@@ -19,8 +19,10 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
@@ -31,6 +33,7 @@ import com.adaptris.core.util.Args;
 import com.adaptris.util.NumberUtils;
 import com.adaptris.util.TimeInterval;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
 

--- a/interlok-core/src/main/java/com/adaptris/core/cache/RetryingCacheProxy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/cache/RetryingCacheProxy.java
@@ -18,10 +18,13 @@ package com.adaptris.core.cache;
 import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataFileInputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataFileInputParameter.java
@@ -17,7 +17,9 @@
 package com.adaptris.core.common;
 
 import java.io.IOException;
+
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.Removal;

--- a/interlok-core/src/main/java/com/adaptris/core/common/PayloadStreamInputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/PayloadStreamInputParameter.java
@@ -18,6 +18,7 @@ package com.adaptris.core.common;
 
 import java.io.IOException;
 import java.io.InputStream;
+
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;

--- a/interlok-core/src/main/java/com/adaptris/core/config/DefaultPreProcessorLoader.java
+++ b/interlok-core/src/main/java/com/adaptris/core/config/DefaultPreProcessorLoader.java
@@ -17,10 +17,13 @@
 package com.adaptris.core.config;
 import static com.adaptris.core.util.PropertyHelper.getPropertyIgnoringCase;
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import java.lang.reflect.Constructor;
 import java.util.Properties;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.management.AdapterConfigManager;
 import com.adaptris.core.management.BootstrapProperties;

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
@@ -20,9 +20,11 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
+
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
@@ -22,6 +22,7 @@ import static com.adaptris.core.CoreConstants.FS_CONSUME_PARENT_DIR;
 import static com.adaptris.core.CoreConstants.FS_FILE_SIZE;
 import static com.adaptris.core.CoreConstants.ORIGINAL_NAME_KEY;
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -29,10 +30,13 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import javax.management.MalformedObjectNameException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerMonitor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerMonitor.java
@@ -15,8 +15,6 @@
 */
 package com.adaptris.core.fs;
 
-import static com.adaptris.core.runtime.AdapterComponentMBean.JMX_FS_MONITOR_TYPE;
-
 import com.adaptris.core.runtime.ConsumerMonitorImpl;
 import com.adaptris.core.runtime.WorkflowManager;
 

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.fs;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -27,9 +28,11 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.fs.FsException;
 import com.adaptris.fs.FsFilenameExistsException;
 import com.adaptris.fs.FsWorker;

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsProducer.java
@@ -25,7 +25,9 @@ import java.net.URL;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/fs/InlineItemCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/InlineItemCache.java
@@ -21,8 +21,10 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisComponent;

--- a/interlok-core/src/main/java/com/adaptris/core/fs/LastModifiedFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/LastModifiedFilter.java
@@ -18,8 +18,10 @@ package com.adaptris.core.fs;
 
 import java.io.FileFilter;
 import java.util.Date;
+
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
+
 import org.apache.commons.lang.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/AggregatingFtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/AggregatingFtpConsumer.java
@@ -24,7 +24,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FileTransferConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FileTransferConnection.java
@@ -38,6 +38,7 @@ import com.adaptris.filetransfer.FileTransferException;
 import com.adaptris.security.exc.PasswordException;
 import com.adaptris.util.NumberUtils;
 import com.adaptris.util.TimeInterval;
+
 import net.jodah.expiringmap.ExpirationListener;
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConnectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConnectionImp.java
@@ -17,9 +17,12 @@
 package com.adaptris.core.ftp;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import java.io.IOException;
 import java.util.TimeZone;
+
 import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpProducer.java
@@ -22,7 +22,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/RelaxedFtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/RelaxedFtpConsumer.java
@@ -17,7 +17,9 @@
 package com.adaptris.core.ftp;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/SftpConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/SftpConnection.java
@@ -28,7 +28,6 @@ import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.Removal;
-import com.adaptris.core.common.FileDataInputParameter;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.filetransfer.FileTransferClient;

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/StandardSftpConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/StandardSftpConnection.java
@@ -18,8 +18,10 @@ package com.adaptris.core.ftp;
 
 import java.io.File;
 import java.io.IOException;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/http/auth/ConfiguredAuthorizationHeader.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/auth/ConfiguredAuthorizationHeader.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adaptris.annotation.Removal;
-import com.adaptris.core.ftp.StandardSftpConnection;
 import com.adaptris.core.http.HttpConstants;
 import com.adaptris.core.util.LoggingHelper;
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/auth/ThreadLocalCredentials.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/auth/ThreadLocalCredentials.java
@@ -19,9 +19,11 @@ import java.net.PasswordAuthentication;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.http.ResourceAuthenticator;
 
 public class ThreadLocalCredentials implements ResourceAuthenticator {

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpProducer.java
@@ -24,7 +24,9 @@ import java.util.Set;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpURLConnectionAuthenticator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpURLConnectionAuthenticator.java
@@ -16,6 +16,7 @@
 package com.adaptris.core.http.client.net;
 
 import java.net.HttpURLConnection;
+
 import com.adaptris.core.http.auth.HttpAuthenticator;
 
 /**

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/MetadataRequestHeaders.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/MetadataRequestHeaders.java
@@ -20,6 +20,7 @@ import java.net.HttpURLConnection;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/StandardHttpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/StandardHttpProducer.java
@@ -41,6 +41,7 @@ import javax.validation.constraints.NotNull;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
@@ -46,6 +46,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/HashUserRealmProxy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/HashUserRealmProxy.java
@@ -19,8 +19,10 @@ package com.adaptris.core.http.jetty;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
@@ -30,6 +32,7 @@ import org.eclipse.jetty.util.security.Constraint;
 import org.hibernate.validator.constraints.NotBlank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.Removal;

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyResponseService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyResponseService.java
@@ -16,10 +16,13 @@
 package com.adaptris.core.http.jetty;
 
 import java.net.HttpURLConnection;
+
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/interceptor/MetadataStatistic.java
+++ b/interlok-core/src/main/java/com/adaptris/core/interceptor/MetadataStatistic.java
@@ -23,8 +23,10 @@ import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Properties;
+
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
+
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**

--- a/interlok-core/src/main/java/com/adaptris/core/interceptor/MetadataTotalsInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/interceptor/MetadataTotalsInterceptor.java
@@ -17,10 +17,13 @@
 package com.adaptris.core.interceptor;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.management.MalformedObjectNameException;
 import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisComponent;

--- a/interlok-core/src/main/java/com/adaptris/core/interceptor/MetricsInterceptorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/interceptor/MetricsInterceptorImpl.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.interceptor;
 
 import java.util.concurrent.TimeUnit;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.util.NumberUtils;
 import com.adaptris.util.TimeInterval;

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/DatabaseConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/DatabaseConnection.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import javax.sql.DataSource;
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/DebugPoolFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/DebugPoolFactory.java
@@ -2,7 +2,9 @@ package com.adaptris.core.jdbc;
 
 import java.io.PrintWriter;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcPooledConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcPooledConnection.java
@@ -18,9 +18,12 @@ package com.adaptris.core.jdbc;
 
 import java.sql.SQLException;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcService.java
@@ -20,7 +20,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+
 import javax.validation.Valid;
+
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConnectedService;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/ActiveJmsConnectionErrorHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/ActiveJmsConnectionErrorHandler.java
@@ -26,7 +26,9 @@ import javax.jms.Message;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TemporaryTopic;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/FailoverJmsConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/FailoverJmsConnection.java
@@ -25,7 +25,9 @@ import javax.jms.JMSException;
 import javax.jms.Session;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnection.java
@@ -23,7 +23,9 @@ import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 import javax.jms.Session;
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnectionErrorHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnectionErrorHandler.java
@@ -20,7 +20,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -24,7 +24,9 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsReplyToWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsReplyToWorkflow.java
@@ -28,7 +28,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandardWorkflow;
-import com.adaptris.core.http.jetty.JettyMessageConsumer;
 import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/MessageCountProducerSessionFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/MessageCountProducerSessionFactory.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.jms;
 
 import javax.jms.JMSException;
+
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/MessageSizeProducerSessionFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/MessageSizeProducerSessionFactory.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.jms;
 
 import javax.jms.JMSException;
+
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/MessageTypeTranslatorImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/MessageTypeTranslatorImp.java
@@ -23,6 +23,7 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/MetadataHandlerContext.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/MetadataHandlerContext.java
@@ -16,9 +16,9 @@
 
 package com.adaptris.core.jms;
 
-import com.adaptris.core.metadata.MetadataFilter;
-
 import java.util.List;
+
+import com.adaptris.core.metadata.MetadataFilter;
 
 /**
  * Interface that abstracts the handling of AdaptrisMessage metadata and JMS

--- a/interlok-core/src/main/java/com/adaptris/core/jms/OnMessageHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/OnMessageHandler.java
@@ -19,8 +19,10 @@ package com.adaptris.core.jms;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/activemq/AdvancedActiveMqImplementation.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/activemq/AdvancedActiveMqImplementation.java
@@ -18,7 +18,9 @@ package com.adaptris.core.jms.activemq;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.activemq.ActiveMQConnectionFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/jndi/BaseJndiImplementation.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/jndi/BaseJndiImplementation.java
@@ -12,6 +12,7 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/jndi/CachedDestinationJndiImplementation.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/jndi/CachedDestinationJndiImplementation.java
@@ -19,9 +19,11 @@ package com.adaptris.core.jms.jndi;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import javax.jms.JMSException;
 import javax.jms.Queue;
 import javax.jms.Topic;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.jms.JmsActorConfig;

--- a/interlok-core/src/main/java/com/adaptris/core/jmx/JmxConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jmx/JmxConnection.java
@@ -28,6 +28,7 @@ import javax.validation.Valid;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/jmx/JmxNotificationConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jmx/JmxNotificationConsumer.java
@@ -27,7 +27,9 @@ import javax.management.NotificationListener;
 import javax.management.ObjectName;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/lifecycle/FilteredSharedComponentStart.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lifecycle/FilteredSharedComponentStart.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMessageImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMessageImpl.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.lms;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -27,10 +28,12 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.channels.FileLock;
 import java.nio.charset.Charset;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageImp;
 import com.adaptris.util.IdGenerator;

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsProducer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/lms/ZipFileBackedMessageFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/ZipFileBackedMessageFactory.java
@@ -17,7 +17,9 @@
 package com.adaptris.core.lms;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/mail/DefaultSmtpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/mail/DefaultSmtpProducer.java
@@ -17,7 +17,9 @@
 package com.adaptris.core.mail;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/mail/MailConsumerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/mail/MailConsumerImp.java
@@ -28,8 +28,9 @@ import java.util.Map;
 import javax.mail.internet.MimeMessage;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.BooleanUtils;
+
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/mail/RawMailConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/mail/RawMailConsumer.java
@@ -25,8 +25,9 @@ import java.util.List;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
-import org.apache.commons.lang3.BooleanUtils;
+
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;

--- a/interlok-core/src/main/java/com/adaptris/core/management/jmx/JmxComponentImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/jmx/JmxComponentImpl.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.management.jmx;
 
 import java.util.Properties;
+
 import com.adaptris.core.management.MgmtComponentImpl;
 
 abstract class JmxComponentImpl extends MgmtComponentImpl {

--- a/interlok-core/src/main/java/com/adaptris/core/metadata/DiscardValuesTooLongFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/metadata/DiscardValuesTooLongFilter.java
@@ -15,6 +15,7 @@
 package com.adaptris.core.metadata;
 
 import java.util.stream.Collectors;
+
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.MetadataCollection;

--- a/interlok-core/src/main/java/com/adaptris/core/metadata/ElementKeyAndValueFormatter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/metadata/ElementKeyAndValueFormatter.java
@@ -1,8 +1,10 @@
 package com.adaptris.core.metadata;
 
 import javax.validation.constraints.NotNull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;

--- a/interlok-core/src/main/java/com/adaptris/core/metadata/OrderedItemMetadataFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/metadata/OrderedItemMetadataFilter.java
@@ -1,17 +1,18 @@
 package com.adaptris.core.metadata;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Metadata Filter implementation that returns keys in order defined.

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ConsumerMonitorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ConsumerMonitorImpl.java
@@ -15,9 +15,9 @@
  */
 package com.adaptris.core.runtime;
 
-import com.adaptris.core.AdaptrisMessageConsumer;
-
 import static com.adaptris.core.runtime.AdapterComponentMBean.JMX_CONSUMER_MONITOR_TYPE;
+
+import com.adaptris.core.AdaptrisMessageConsumer;
 
 public abstract class ConsumerMonitorImpl<T extends AdaptrisMessageConsumer> extends ChildRuntimeInfoComponentImpl implements ConsumerMonitorMBean {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/LogMessageService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/LogMessageService.java
@@ -17,9 +17,11 @@
 package com.adaptris.core.services;
 
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/services/ReadFileService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/ReadFileService.java
@@ -5,13 +5,17 @@ import static com.adaptris.fs.FsWorker.isFile;
 import static org.apache.commons.io.IOUtils.copy;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+
 import javax.validation.Valid;
+
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AffectsMetadata;

--- a/interlok-core/src/main/java/com/adaptris/core/services/RetryingServiceWrapper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/RetryingServiceWrapper.java
@@ -22,7 +22,9 @@ import java.util.concurrent.TimeUnit;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/services/WaitService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/WaitService.java
@@ -20,7 +20,9 @@ import java.text.DateFormat;
 import java.util.Date;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/MessageAggregatorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/MessageAggregatorImpl.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.services.aggregator;
 
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceLocator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceLocator.java
@@ -20,7 +20,9 @@ import static com.adaptris.core.util.LoggingHelper.friendlyName;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/LocalMarshallServiceStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/LocalMarshallServiceStore.java
@@ -16,7 +16,9 @@
 
 package com.adaptris.core.services.dynamic;
 
-import static com.adaptris.fs.FsWorker.*;
+import static com.adaptris.fs.FsWorker.checkReadable;
+import static com.adaptris.fs.FsWorker.isDirectory;
+import static com.adaptris.fs.FsWorker.isFile;
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 
 import java.io.File;
@@ -29,8 +31,6 @@ import com.adaptris.core.Service;
 import com.adaptris.core.fs.FsHelper;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.fs.FsException;
-import com.adaptris.fs.FsWorker;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionAsXml.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionAsXml.java
@@ -16,11 +16,13 @@
 package com.adaptris.core.services.exception;
 
 import javax.validation.Valid;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionReport.java
@@ -2,6 +2,7 @@ package com.adaptris.core.services.exception;
 
 import java.util.Map;
 import java.util.TreeMap;
+
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/SimpleExceptionReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/SimpleExceptionReport.java
@@ -17,12 +17,15 @@
 package com.adaptris.core.services.exception;
 
 import static com.adaptris.core.util.XmlHelper.createDocument;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/XmlExceptionReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/XmlExceptionReport.java
@@ -17,7 +17,9 @@
 package com.adaptris.core.services.exception;
 
 import static com.adaptris.core.util.XmlHelper.createDocument;
+
 import org.w3c.dom.Document;
+
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.XStreamMarshaller;

--- a/interlok-core/src/main/java/com/adaptris/core/services/findreplace/FindAndReplaceService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/findreplace/FindAndReplaceService.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcBatchingDataCaptureService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcBatchingDataCaptureService.java
@@ -22,8 +22,11 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.xml.namespace.NamespaceContext;
+
 import org.apache.commons.lang.ArrayUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcDataCaptureService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcDataCaptureService.java
@@ -18,7 +18,9 @@ package com.adaptris.core.services.jdbc;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+
 import javax.xml.namespace.NamespaceContext;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcDataCaptureServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcDataCaptureServiceImpl.java
@@ -17,14 +17,18 @@
 package com.adaptris.core.services.jdbc;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcDataQueryService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcDataQueryService.java
@@ -27,7 +27,9 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcIteratingDataCaptureServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcIteratingDataCaptureServiceImpl.java
@@ -19,15 +19,18 @@ package com.adaptris.core.services.jdbc;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+
 import javax.validation.Valid;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcMapInsert.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcMapInsert.java
@@ -22,11 +22,14 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.CharUtils;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcMapUpsert.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcMapUpsert.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.ExceptionHelper;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/ResultSetTranslatorImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/ResultSetTranslatorImp.java
@@ -20,10 +20,13 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/SimplePayloadResultSetTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/SimplePayloadResultSetTranslator.java
@@ -17,12 +17,15 @@
 package com.adaptris.core.services.jdbc;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Iterator;
+
 import javax.validation.Valid;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.jdbc.types.ColumnWriter;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/StatementParameterImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/StatementParameterImpl.java
@@ -17,6 +17,7 @@ package com.adaptris.core.services.jdbc;
 
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.w3c.dom.Node;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/StyledResultTranslatorImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/StyledResultTranslatorImp.java
@@ -17,7 +17,9 @@
 package com.adaptris.core.services.jdbc;
 
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang.StringUtils;
+
 import com.adaptris.annotation.AutoPopulated;
 
 /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/XmlPayloadTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/XmlPayloadTranslator.java
@@ -18,13 +18,16 @@ package com.adaptris.core.services.jdbc;
 
 import java.sql.SQLException;
 import java.util.List;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/raw/JdbcRawDataCaptureService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/raw/JdbcRawDataCaptureService.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.jdbc.raw;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/BlobColumnTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/BlobColumnTranslator.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.services.jdbc.types;
 
 import static org.apache.commons.io.IOUtils.copy;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,6 +26,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.sql.Blob;
 import java.sql.SQLException;
+
 import com.adaptris.jdbc.JdbcResultRow;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ByteArrayColumnTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ByteArrayColumnTranslator.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.services.jdbc.types;
 
 import static org.apache.commons.io.IOUtils.copy;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -24,7 +25,9 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.sql.SQLException;
+
 import org.apache.commons.io.IOUtils;
+
 import com.adaptris.jdbc.JdbcResultRow;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ClobColumnTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ClobColumnTranslator.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.services.jdbc.types;
 
 import static org.apache.commons.io.IOUtils.copy;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,6 +26,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.sql.Clob;
 import java.sql.SQLException;
+
 import com.adaptris.jdbc.JdbcResultRow;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ColumnHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ColumnHelper.java
@@ -3,6 +3,7 @@ package com.adaptris.core.services.jdbc.types;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
 import com.adaptris.jdbc.JdbcResultRow;
 import com.adaptris.jdbc.ParameterValueType;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ColumnWriter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ColumnWriter.java
@@ -19,6 +19,7 @@ package com.adaptris.core.services.jdbc.types;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.SQLException;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ColumnWriterWithCharEncoding.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/ColumnWriterWithCharEncoding.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/StringColumnTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/StringColumnTranslator.java
@@ -19,7 +19,9 @@ package com.adaptris.core.services.jdbc.types;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.SQLException;
+
 import org.apache.commons.io.IOUtils;
+
 import com.adaptris.jdbc.JdbcResultRow;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jmx/ConstantValueTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jmx/ConstantValueTranslator.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.services.jmx;
 
 import java.util.Date;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jmx/JmxWaitService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jmx/JmxWaitService.java
@@ -21,7 +21,9 @@ import java.util.concurrent.TimeUnit;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddTimestampMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddTimestampMetadataService.java
@@ -21,6 +21,7 @@ import static org.apache.commons.lang.StringUtils.isBlank;
 import java.util.Date;
 
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/CreateQueryStringFromMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/CreateQueryStringFromMetadata.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/DateFormatBuilderWithOptionalFractionAndOffset.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/DateFormatBuilderWithOptionalFractionAndOffset.java
@@ -1,8 +1,6 @@
 package com.adaptris.core.services.metadata;
 
-import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.core.AdaptrisMessage;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import static org.apache.commons.lang.StringUtils.isBlank;
 
 import java.text.ParseException;
 import java.time.Instant;
@@ -16,7 +14,9 @@ import java.time.temporal.ChronoField;
 import java.util.Date;
 import java.util.Locale;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Builds a DateFormat instance for use with {@link ReformatDateService} and {@link AddTimestampMetadataService}.

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MapMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MapMetadataService.java
@@ -19,9 +19,12 @@ package com.adaptris.core.services.metadata;
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
@@ -17,15 +17,19 @@
 package com.adaptris.core.services.metadata;
 
 import static com.adaptris.core.util.MetadataHelper.convertFromProperties;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.Set;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/RegexpMetadataQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/RegexpMetadataQuery.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.metadata;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 import org.slf4j.Logger;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/RegexpMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/RegexpMetadataService.java
@@ -23,7 +23,9 @@ import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReplaceMetadataValue.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReplaceMetadataValue.java
@@ -17,10 +17,13 @@
 package com.adaptris.core.services.metadata;
 
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/SimpleSequenceNumberService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/SimpleSequenceNumberService.java
@@ -23,8 +23,10 @@ import java.io.OutputStream;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Properties;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AffectsMetadata;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystem.java
@@ -30,6 +30,7 @@ import javax.validation.constraints.NotNull;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelector.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelector.java
@@ -24,7 +24,9 @@ import javax.mail.Header;
 import javax.mail.internet.MimeBodyPart;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/XpathNodeIdentifier.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/XpathNodeIdentifier.java
@@ -19,6 +19,7 @@ package com.adaptris.core.services.routing;
 import java.util.List;
 
 import javax.xml.xpath.XPathConstants;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.w3c.dom.Document;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/LineCountSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/LineCountSplitter.java
@@ -21,7 +21,9 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/MimePartSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/MimePartSplitter.java
@@ -26,7 +26,9 @@ import java.util.List;
 import javax.mail.Header;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeBodyPart;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingMessageSplitterService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingMessageSplitterService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingSplitJoinService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingSplitJoinService.java
@@ -20,8 +20,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.pool2.impl.GenericObjectPool;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceWorkerPool.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceWorkerPool.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
@@ -31,6 +32,7 @@ import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/SimpleRegexpMessageSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/SimpleRegexpMessageSplitter.java
@@ -21,6 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/SizeBasedSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/SizeBasedSplitter.java
@@ -19,6 +19,7 @@ package com.adaptris.core.services.splitter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/SplitByMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/SplitByMetadata.java
@@ -17,8 +17,10 @@
 package com.adaptris.core.services.splitter;
 
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.NotBlank;
+
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-core/src/main/java/com/adaptris/core/services/system/AddMetaDataValue.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/system/AddMetaDataValue.java
@@ -22,8 +22,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.BooleanUtils;
+
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/transform/TransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/TransformService.java
@@ -21,7 +21,9 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlRuleValidator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlRuleValidator.java
@@ -15,16 +15,20 @@
 package com.adaptris.core.transform;
 
 import static com.adaptris.core.util.XmlHelper.createDocument;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
@@ -22,17 +22,20 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.constraints.NotNull;
 import javax.xml.XMLConstants;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+
 import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.transform.Transformer;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 

--- a/interlok-core/src/main/java/com/adaptris/core/util/DocumentBuilderFactoryBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/DocumentBuilderFactoryBuilder.java
@@ -1,14 +1,17 @@
 package com.adaptris.core.util;
 
 import java.util.Map;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.xml.sax.EntityResolver;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/core/util/TruncateMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/TruncateMetadata.java
@@ -16,6 +16,7 @@
 package com.adaptris.core.util;
 
 import org.apache.commons.lang.StringUtils;
+
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;

--- a/interlok-core/src/main/java/com/adaptris/fs/FsWorker.java
+++ b/interlok-core/src/main/java/com/adaptris/fs/FsWorker.java
@@ -16,13 +16,9 @@
 
 package com.adaptris.fs;
 
-import static com.adaptris.fs.FsWorker.checkWriteable;
-import static com.adaptris.fs.FsWorker.isDirectory;
-
 import java.io.File;
 import java.io.FileFilter;
 
-import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
 
 /**

--- a/interlok-core/src/main/java/com/adaptris/fs/StandardWorker.java
+++ b/interlok-core/src/main/java/com/adaptris/fs/StandardWorker.java
@@ -18,10 +18,8 @@ package com.adaptris.fs;
 
 import static com.adaptris.fs.FsWorker.checkNonExistent;
 import static com.adaptris.fs.FsWorker.checkWriteable;
-import static com.adaptris.fs.FsWorker.isDirectory;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.RandomAccessFile;
 
 import org.slf4j.Logger;

--- a/interlok-core/src/main/java/com/adaptris/jdbc/CallableStatementExecutorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/jdbc/CallableStatementExecutorImpl.java
@@ -16,7 +16,9 @@
 package com.adaptris.jdbc;
 
 import java.sql.Statement;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.InputFieldDefault;
 
 public abstract class CallableStatementExecutorImpl implements CallableStatementExecutor {

--- a/interlok-core/src/main/java/com/adaptris/jdbc/JdbcResultRow.java
+++ b/interlok-core/src/main/java/com/adaptris/jdbc/JdbcResultRow.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.adaptris.annotation.Removal;
 
 public class JdbcResultRow {

--- a/interlok-core/src/main/java/com/adaptris/jdbc/JdbcResultSetImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/jdbc/JdbcResultSetImpl.java
@@ -21,7 +21,9 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
 import org.apache.commons.lang.StringUtils;
+
 import com.adaptris.core.util.JdbcUtil;
 
 public class JdbcResultSetImpl implements JdbcResultSet {

--- a/interlok-core/src/main/java/com/adaptris/mail/Pop3sReceiverFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/mail/Pop3sReceiverFactory.java
@@ -26,6 +26,7 @@ import java.util.StringTokenizer;
 
 import javax.mail.URLName;
 import javax.net.ssl.SSLContext;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.net.pop3.POP3Client;
 import org.apache.commons.net.pop3.POP3SClient;

--- a/interlok-core/src/main/java/com/adaptris/naming/adapter/NamingContext.java
+++ b/interlok-core/src/main/java/com/adaptris/naming/adapter/NamingContext.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
+
 import javax.naming.Binding;
 import javax.naming.CompositeName;
 import javax.naming.Context;
@@ -36,6 +37,7 @@ import javax.naming.NamingException;
 import javax.naming.NotContextException;
 import javax.naming.Reference;
 import javax.naming.spi.NamingManager;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/interlok-core/src/main/java/com/adaptris/transform/ff/StreamParser.java
+++ b/interlok-core/src/main/java/com/adaptris/transform/ff/StreamParser.java
@@ -16,7 +16,11 @@
 
 package com.adaptris.transform.ff;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.PushbackReader;
+import java.io.Reader;
+import java.io.StreamTokenizer;
+import java.io.StringReader;
 
 /**
  * 

--- a/interlok-core/src/main/java/com/adaptris/transform/validate/ValidationStage.java
+++ b/interlok-core/src/main/java/com/adaptris/transform/validate/ValidationStage.java
@@ -22,7 +22,9 @@ import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;

--- a/interlok-core/src/main/java/com/adaptris/util/GetServiceByName.java
+++ b/interlok-core/src/main/java/com/adaptris/util/GetServiceByName.java
@@ -25,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.StringTokenizer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/interlok-core/src/main/java/com/adaptris/util/PseudoRandomIdGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/util/PseudoRandomIdGenerator.java
@@ -21,7 +21,9 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 import java.security.SecureRandom;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.util.text.Conversion;

--- a/interlok-core/src/main/java/com/adaptris/util/TimeInterval.java
+++ b/interlok-core/src/main/java/com/adaptris/util/TimeInterval.java
@@ -17,6 +17,7 @@
 package com.adaptris.util;
 
 import java.util.concurrent.TimeUnit;
+
 import com.adaptris.annotation.DisplayOrder;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 

--- a/interlok-core/src/main/java/com/adaptris/util/URLHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/util/URLHelper.java
@@ -29,6 +29,7 @@ import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
+
 import com.adaptris.core.fs.FsHelper;
 
 public abstract class URLHelper {

--- a/interlok-core/src/main/java/com/adaptris/util/text/mime/MultipartIterator.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/mime/MultipartIterator.java
@@ -19,12 +19,15 @@ import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+
 import javax.activation.DataSource;
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetHeaders;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.IdGenerator;
 

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/Resolver.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/Resolver.java
@@ -23,16 +23,19 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.util.NumberUtils;

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleWorkflowCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleWorkflowCase.java
@@ -19,6 +19,7 @@ package com.adaptris.core;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+
 import com.adaptris.core.stubs.MockChannel;
 import com.adaptris.core.stubs.MockWorkflowInterceptor;
 import com.adaptris.core.stubs.StubAdapterStartUpEvent;

--- a/interlok-core/src/test/java/com/adaptris/core/GaussianIntervalPollerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/GaussianIntervalPollerTest.java
@@ -1,10 +1,10 @@
 package com.adaptris.core;
 
+import java.util.concurrent.TimeUnit;
+
 import com.adaptris.core.stubs.MockChannel;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.util.TimeInterval;
-
-import java.util.concurrent.TimeUnit;
 
 public class GaussianIntervalPollerTest extends BaseCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/JndiContextFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/JndiContextFactoryTest.java
@@ -24,8 +24,6 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.ftp.FtpConnection;
 import com.adaptris.core.http.jetty.HttpConnection;
 import com.adaptris.core.jdbc.MockJdbcConnection;
@@ -34,6 +32,8 @@ import com.adaptris.core.management.Constants;
 import com.adaptris.core.management.SystemPropertiesUtil;
 import com.adaptris.core.util.JndiHelper;
 import com.adaptris.naming.adapter.NamingContext;
+
+import junit.framework.TestCase;
 
 public class JndiContextFactoryTest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/StandardWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/StandardWorkflowTest.java
@@ -24,8 +24,10 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.services.exception.ConfiguredException;
 import com.adaptris.core.services.exception.ThrowExceptionService;
 import com.adaptris.core.services.metadata.AddMetadataService;

--- a/interlok-core/src/test/java/com/adaptris/core/cache/CacheDefaultMethodsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/cache/CacheDefaultMethodsTest.java
@@ -1,7 +1,9 @@
 package com.adaptris.core.cache;
 
 import java.io.Serializable;
+
 import org.junit.Test;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
 

--- a/interlok-core/src/test/java/com/adaptris/core/common/PayloadStreamInputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/PayloadStreamInputParameterTest.java
@@ -16,15 +16,18 @@
 package com.adaptris.core.common;
 
 import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.List;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/test/java/com/adaptris/core/config/ConfigPreProcessorImplTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/config/ConfigPreProcessorImplTest.java
@@ -2,8 +2,11 @@ package com.adaptris.core.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+
 import java.util.Properties;
+
 import org.junit.Test;
+
 import com.adaptris.core.management.BootstrapProperties;
 import com.adaptris.core.stubs.JunitBootstrapProperties;
 

--- a/interlok-core/src/test/java/com/adaptris/core/config/ConfigPreProcessorsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/config/ConfigPreProcessorsTest.java
@@ -3,8 +3,11 @@ package com.adaptris.core.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+
 import java.net.URL;
+
 import org.junit.Test;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.util.KeyValuePairSet;
 

--- a/interlok-core/src/test/java/com/adaptris/core/config/ConfigurationPreProcessorFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/config/ConfigurationPreProcessorFactoryTest.java
@@ -18,12 +18,16 @@ package com.adaptris.core.config;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
+
 import java.util.Properties;
+
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import com.adaptris.core.config.DefaultPreProcessorLoader.PropertyLoader;
 import com.adaptris.core.stubs.JunitBootstrapProperties;
 import com.adaptris.util.KeyValuePairSet;
+
 import junit.framework.TestCase;
 
 public class ConfigurationPreProcessorFactoryTest extends TestCase {

--- a/interlok-core/src/test/java/com/adaptris/core/config/PreProcessingXStreamMarshallerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/config/PreProcessingXStreamMarshallerTest.java
@@ -20,7 +20,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import org.mockito.Mockito;
+
 import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.MarshallingBaseCase;

--- a/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
@@ -23,12 +23,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
+
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.oro.io.AwkFilenameFilter;
 import org.junit.Test;
+
 import com.adaptris.core.stubs.TempFileUtils;
 import com.adaptris.fs.FsWorker;
 import com.adaptris.fs.StandardWorker;

--- a/interlok-core/src/test/java/com/adaptris/core/http/JdkHttpProducer.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/JdkHttpProducer.java
@@ -61,7 +61,6 @@ import com.adaptris.core.http.auth.ThreadLocalCredentials;
 import com.adaptris.core.http.client.RequestMethodProvider;
 import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
 import com.adaptris.core.http.client.net.StandardHttpProducer;
-import com.adaptris.core.http.jetty.StandardResponseProducer;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.util.stream.StreamUtil;

--- a/interlok-core/src/test/java/com/adaptris/core/http/RawStatusProviderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/RawStatusProviderTest.java
@@ -27,8 +27,8 @@ import org.junit.Test;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.http.server.RawStatusProvider;
 import com.adaptris.core.http.server.HttpStatusProvider.HttpStatus;
+import com.adaptris.core.http.server.RawStatusProvider;
 
 public class RawStatusProviderTest {
 

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/ResponseProducer.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/ResponseProducer.java
@@ -40,7 +40,6 @@ import com.adaptris.core.NullConnection;
 import com.adaptris.core.ProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ProduceOnlyProducerImp;
-import com.adaptris.core.ftp.StandardSftpConnection;
 import com.adaptris.core.http.server.HttpStatusBuilder;
 import com.adaptris.core.http.server.HttpStatusProvider.HttpStatus;
 import com.adaptris.core.http.server.HttpStatusProvider.Status;

--- a/interlok-core/src/test/java/com/adaptris/core/interceptor/MetadataCountInterceptorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/interceptor/MetadataCountInterceptorTest.java
@@ -25,8 +25,6 @@ import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -36,6 +34,8 @@ import com.adaptris.core.MetadataElement;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.TimeInterval;
+
+import junit.framework.TestCase;
 
 public class MetadataCountInterceptorTest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/interceptor/ThrottlingInterceptorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/interceptor/ThrottlingInterceptorTest.java
@@ -19,12 +19,12 @@ package com.adaptris.core.interceptor;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.TimeInterval;
+
+import junit.framework.TestCase;
 
 public class ThrottlingInterceptorTest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcConstantParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcConstantParameterTest.java
@@ -16,10 +16,10 @@
 
 package com.adaptris.core.jdbc;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
+
+import junit.framework.TestCase;
 
 public class JdbcConstantParameterTest extends TestCase {
   

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcStatementCreatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcStatementCreatorTest.java
@@ -16,12 +16,12 @@
 
 package com.adaptris.core.jdbc;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.services.jdbc.ConfiguredSQLStatement;
 import com.adaptris.core.services.jdbc.MetadataSQLStatement;
+
+import junit.framework.TestCase;
 
 public class JdbcStatementCreatorTest extends TestCase {
   

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/NullableParameterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/NullableParameterCase.java
@@ -16,10 +16,10 @@
 
 package com.adaptris.core.jdbc;
 
-import junit.framework.TestCase;
-
 import com.adaptris.util.text.NullPassThroughConverter;
 import com.adaptris.util.text.NullsNotSupportedConverter;
+
+import junit.framework.TestCase;
 
 public abstract class NullableParameterCase extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
@@ -18,12 +18,11 @@ package com.adaptris.core.jms;
 
 import static com.adaptris.core.jms.JmsConfig.DEFAULT_PAYLOAD;
 import static com.adaptris.core.jms.JmsConfig.MESSAGE_TRANSLATOR_LIST;
-
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/interlok-core/src/test/java/com/adaptris/core/jms/StringMetadataConverterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/StringMetadataConverterTest.java
@@ -1,15 +1,10 @@
 package com.adaptris.core.jms;
 
-import com.adaptris.core.BaseCase;
-import com.adaptris.core.MetadataCollection;
-import com.adaptris.core.MetadataElement;
-import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
-import com.adaptris.core.metadata.NoOpMetadataFilter;
-import com.adaptris.core.metadata.RegexMetadataFilter;
-
 import javax.jms.JMSException;
 import javax.jms.Message;
-import javax.jms.Session;
+
+import com.adaptris.core.metadata.NoOpMetadataFilter;
+import com.adaptris.core.metadata.RegexMetadataFilter;
 
 /**
  * @author mwarman

--- a/interlok-core/src/test/java/com/adaptris/core/metadata/DiscardValuesTooLongFilterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/metadata/DiscardValuesTooLongFilterTest.java
@@ -17,7 +17,9 @@
 package com.adaptris.core.metadata;
 
 import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.MetadataCollection;

--- a/interlok-core/src/test/java/com/adaptris/core/metadata/OrderedItemMetadataFilterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/metadata/OrderedItemMetadataFilterTest.java
@@ -1,13 +1,14 @@
 package com.adaptris.core.metadata;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.MetadataCollection;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.MetadataCollection;
 
 /**
  * @author mwarman

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/MessageErrorDigestTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/MessageErrorDigestTest.java
@@ -19,10 +19,10 @@ package com.adaptris.core.runtime;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.DefaultMessageFactory;
+
+import junit.framework.TestCase;
 
 public class MessageErrorDigestTest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/security/SymmetricKeyCryptographyServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/SymmetricKeyCryptographyServiceTest.java
@@ -1,18 +1,20 @@
 package com.adaptris.core.security;
 
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.util.text.Conversion;
-import org.junit.Before;
-import org.junit.Test;
-
-import javax.crypto.Cipher;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
-import java.security.SecureRandom;
-import java.util.Arrays;
 
 /**
  * @author mwarman

--- a/interlok-core/src/test/java/com/adaptris/core/services/LogMessageServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/LogMessageServiceTest.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.services;
 
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.GeneralServiceExample;
 import com.adaptris.core.services.LoggingServiceImpl.LoggingLevel;

--- a/interlok-core/src/test/java/com/adaptris/core/services/ReadFileServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/ReadFileServiceTest.java
@@ -15,11 +15,14 @@
 package com.adaptris.core.services;
 
 import static org.junit.Assert.assertArrayEquals;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Files;
+
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/test/java/com/adaptris/core/services/RetryingServiceWrapperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/RetryingServiceWrapperTest.java
@@ -24,9 +24,7 @@ import static org.mockito.Mockito.verify;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MetadataConsumeDestinationGeneratorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MetadataConsumeDestinationGeneratorTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConsumeDestination;
 import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.services.aggregator.ConsumeDestinationFromMetadata;
 
 public class MetadataConsumeDestinationGeneratorTest {
   private static final String DEFAULT_FILTER_KEY = "metadataFilterKey";

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/XmlAggregatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/XmlAggregatorCase.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.services.aggregator.XmlDocumentAggregator;
 import com.adaptris.core.services.splitter.SplitJoinServiceTest;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.util.text.xml.InsertNode;

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/DefaultServiceNameProviderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/DefaultServiceNameProviderTest.java
@@ -16,9 +16,9 @@
 
 package com.adaptris.core.services.dynamic;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.TradingRelationship;
+
+import junit.framework.TestCase;
 
 public class DefaultServiceNameProviderTest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceNameMapperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceNameMapperTest.java
@@ -16,11 +16,11 @@
 
 package com.adaptris.core.services.dynamic;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.TradingRelationship;
+
+import junit.framework.TestCase;
 
 public class ServiceNameMapperTest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/exception/XmlExceptionReportTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/exception/XmlExceptionReportTest.java
@@ -4,11 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
+
 import com.adaptris.util.XmlUtils;
 
 public class XmlExceptionReportTest {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/JdbcDataCaptureServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/JdbcDataCaptureServiceCase.java
@@ -24,6 +24,7 @@ import java.sql.Statement;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ComponentLifecycle;

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/JdbcQueryServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/JdbcQueryServiceCase.java
@@ -28,6 +28,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/NamedParameterApplicatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/NamedParameterApplicatorTest.java
@@ -25,14 +25,14 @@ import static org.mockito.Mockito.verify;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import junit.framework.TestCase;
-
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceException;
+
+import junit.framework.TestCase;
 
 public class NamedParameterApplicatorTest extends TestCase {
   

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/SequentialParameterApplicatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/SequentialParameterApplicatorTest.java
@@ -25,14 +25,14 @@ import static org.mockito.Mockito.verify;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import junit.framework.TestCase;
-
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceException;
+
+import junit.framework.TestCase;
 
 public class SequentialParameterApplicatorTest extends TestCase {
   

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/XmlPayloadTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/XmlPayloadTranslatorTest.java
@@ -19,7 +19,9 @@ package com.adaptris.core.services.jdbc;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.List;
+
 import org.w3c.dom.Document;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.services.jdbc.StyledResultTranslatorImp.ColumnStyle;
 import com.adaptris.core.services.jdbc.types.IntegerColumnTranslator;

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/raw/JdbcRawDataCaptureServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/raw/JdbcRawDataCaptureServiceTest.java
@@ -27,6 +27,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Random;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ComponentLifecycle;

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/BlobColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/BlobColumnTranslatorTest.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.jdbc.types;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -26,8 +27,10 @@ import java.io.StringWriter;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
+
 import org.apache.commons.io.output.WriterOutputStream;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 @SuppressWarnings("deprecation")

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/BooleanColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/BooleanColumnTranslatorTest.java
@@ -16,9 +16,12 @@
 
 package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
+
 import java.sql.Types;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class BooleanColumnTranslatorTest {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ByteArrayColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ByteArrayColumnTranslatorTest.java
@@ -18,12 +18,15 @@ package com.adaptris.core.services.jdbc.types;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.sql.Types;
+
 import org.apache.commons.io.output.WriterOutputStream;
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 @SuppressWarnings("deprecation")

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ClobColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ClobColumnTranslatorTest.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.jdbc.types;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
@@ -27,11 +28,14 @@ import java.io.Writer;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.Types;
+
 import javax.sql.rowset.serial.SerialClob;
+
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 @SuppressWarnings("deprecation")

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ColumnHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ColumnHelperTest.java
@@ -1,8 +1,11 @@
 package com.adaptris.core.services.jdbc.types;
 
 import static org.junit.Assert.assertEquals;
+
 import java.sql.Types;
+
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class ColumnHelperTest extends ColumnHelper {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/DateColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/DateColumnTranslatorTest.java
@@ -17,12 +17,15 @@
 package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.sql.Types;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class DateColumnTranslatorTest {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/DoubleColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/DoubleColumnTranslatorTest.java
@@ -17,9 +17,12 @@
 package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.sql.Types;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class DoubleColumnTranslatorTest {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/FloatColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/FloatColumnTranslatorTest.java
@@ -18,9 +18,12 @@ package com.adaptris.core.services.jdbc.types;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.sql.Types;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class FloatColumnTranslatorTest {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/IntegerColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/IntegerColumnTranslatorTest.java
@@ -17,9 +17,12 @@
 package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.sql.Types;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class IntegerColumnTranslatorTest {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/StringColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/StringColumnTranslatorTest.java
@@ -17,12 +17,15 @@
 package com.adaptris.core.services.jdbc.types;
 
 import static org.junit.Assert.assertEquals;
+
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.sql.Types;
+
 import org.apache.commons.io.output.WriterOutputStream;
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 @SuppressWarnings("deprecation")

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/TimeColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/TimeColumnTranslatorTest.java
@@ -18,12 +18,15 @@ package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.sql.Types;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class TimeColumnTranslatorTest {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/TimestampColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/TimestampColumnTranslatorTest.java
@@ -18,12 +18,15 @@ package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.sql.Types;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class TimestampColumnTranslatorTest {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jmx/ObjectMetadataValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jmx/ObjectMetadataValueTranslatorTest.java
@@ -18,10 +18,10 @@ package com.adaptris.core.services.jmx;
 
 import java.util.Date;
 
-import junit.framework.TestCase;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
+
+import junit.framework.TestCase;
 
 public class ObjectMetadataValueTranslatorTest extends TestCase {
   

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/DateFormatBuilderWithOptionalFractionAndOffsetTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/DateFormatBuilderWithOptionalFractionAndOffsetTest.java
@@ -1,13 +1,15 @@
 package com.adaptris.core.services.metadata;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 import java.util.Date;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
 
 /**
  * @author mwarman

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/XpathQueryCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/XpathQueryCase.java
@@ -26,12 +26,12 @@ import java.util.Set;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.adaptris.core.CoreException;
+
+import junit.framework.TestCase;
 
 public abstract class XpathQueryCase extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/path/XPathServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/path/XPathServiceTest.java
@@ -29,7 +29,6 @@ import com.adaptris.core.common.MetadataDataInputParameter;
 import com.adaptris.core.common.MetadataDataOutputParameter;
 import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.common.StringPayloadDataOutputParameter;
-import com.adaptris.core.services.path.XPathService;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitJoinServiceExceptionStrategyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitJoinServiceExceptionStrategyTest.java
@@ -16,23 +16,24 @@
 
 package com.adaptris.core.services.splitter;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.ServiceException;
-import com.adaptris.core.services.aggregator.MimeAggregator;
-import com.adaptris.core.services.exception.ConfiguredException;
-import com.adaptris.core.services.exception.ThrowExceptionService;
-import com.adaptris.util.TimeInterval;
+import static com.adaptris.core.ServiceCase.asCollection;
+import static com.adaptris.core.ServiceCase.execute;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-import java.util.concurrent.TimeUnit;
-
-import static com.adaptris.core.ServiceCase.asCollection;
-import static com.adaptris.core.ServiceCase.execute;
-import static org.junit.Assert.fail;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.aggregator.MimeAggregator;
+import com.adaptris.core.services.exception.ConfiguredException;
+import com.adaptris.core.services.exception.ThrowExceptionService;
+import com.adaptris.util.TimeInterval;
 
 @SuppressWarnings("deprecation")
 public class SplitJoinServiceExceptionStrategyTest {

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/MockService.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/MockService.java
@@ -4,8 +4,6 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
-import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
-import com.adaptris.core.util.ExceptionHelper;
 
 public class MockService extends ServiceImp {
 

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/TempFileUtils.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/TempFileUtils.java
@@ -18,8 +18,10 @@ package com.adaptris.core.stubs;
 
 import java.io.File;
 import java.io.IOException;
+
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
+
 import com.adaptris.util.GuidGenerator;
 
 public class TempFileUtils {

--- a/interlok-core/src/test/java/com/adaptris/core/transform/XmlRuleValidatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/XmlRuleValidatorTest.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.transform;
 
 import java.util.Arrays;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.BaseCase;
 import com.adaptris.core.DefaultMessageFactory;

--- a/interlok-core/src/test/java/com/adaptris/core/transform/XmlValidationServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/XmlValidationServiceTest.java
@@ -18,6 +18,7 @@ package com.adaptris.core.transform;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;

--- a/interlok-core/src/test/java/com/adaptris/core/util/MessageLoggerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/MessageLoggerTest.java
@@ -3,7 +3,9 @@ package com.adaptris.core.util;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.DefaultMessageLogger;

--- a/interlok-core/src/test/java/com/adaptris/http/legacy/HttpConsumeConnection.java
+++ b/interlok-core/src/test/java/com/adaptris/http/legacy/HttpConsumeConnection.java
@@ -17,10 +17,10 @@
 package com.adaptris.http.legacy;
 
 import com.adaptris.core.CoreException;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.adaptris.http.HttpException;
 import com.adaptris.http.HttpListener;
 import com.adaptris.http.Listener;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * The Consume Connection for vanilla Http.

--- a/interlok-core/src/test/java/com/adaptris/http/legacy/HttpsConsumeConnection.java
+++ b/interlok-core/src/test/java/com/adaptris/http/legacy/HttpsConsumeConnection.java
@@ -17,7 +17,6 @@
 package com.adaptris.http.legacy;
 
 import com.adaptris.core.CoreException;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.adaptris.core.security.ConfiguredPrivateKeyPasswordProvider;
 import com.adaptris.core.security.PrivateKeyPasswordProvider;
 import com.adaptris.http.HttpException;
@@ -28,6 +27,7 @@ import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
 import com.adaptris.security.password.Password;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * The consume connection for HTTPs.

--- a/interlok-core/src/test/java/com/adaptris/http/test/BaseRequestProcessor.java
+++ b/interlok-core/src/test/java/com/adaptris/http/test/BaseRequestProcessor.java
@@ -20,13 +20,8 @@ package com.adaptris.http.test;
 
 import java.util.Properties;
 
-
-
 import org.apache.commons.logging.Log;
-
 import org.apache.commons.logging.LogFactory;
-
-
 
 import com.adaptris.http.RequestProcessor;
 

--- a/interlok-core/src/test/java/com/adaptris/http/test/TestHttpRequest.java
+++ b/interlok-core/src/test/java/com/adaptris/http/test/TestHttpRequest.java
@@ -19,9 +19,9 @@ package com.adaptris.http.test;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
 import com.adaptris.http.HttpRequest;
+
+import junit.framework.TestCase;
 
 public class TestHttpRequest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/jdbc/JdbcResultRowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/jdbc/JdbcResultRowTest.java
@@ -2,7 +2,9 @@ package com.adaptris.jdbc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
 import java.sql.Types;
+
 import org.junit.Test;
 
 public class JdbcResultRowTest {

--- a/interlok-core/src/test/java/com/adaptris/jdbc/MysqlStatementCreatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/jdbc/MysqlStatementCreatorTest.java
@@ -19,8 +19,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import com.adaptris.jdbc.MysqlStatementCreator;
-
 public class MysqlStatementCreatorTest {
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/jdbc/PostgresStatementCreatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/jdbc/PostgresStatementCreatorTest.java
@@ -19,8 +19,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import com.adaptris.jdbc.PostgresStatementCreator;
-
 public class PostgresStatementCreatorTest {
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/security/Config.java
+++ b/interlok-core/src/test/java/com/adaptris/security/Config.java
@@ -18,10 +18,8 @@ package com.adaptris.security;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
-import java.util.Iterator;
 import java.util.Properties;
 
 import org.apache.commons.logging.Log;

--- a/interlok-core/src/test/java/com/adaptris/security/TestCertificateGeneration.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestCertificateGeneration.java
@@ -22,10 +22,6 @@ import java.security.cert.Certificate;
 import java.util.Properties;
 import java.util.Random;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -36,6 +32,10 @@ import com.adaptris.security.certificate.CertificateHandlerFactory;
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
 import com.adaptris.security.keystore.KeystoreProxy;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Test Certificate Generation.

--- a/interlok-core/src/test/java/com/adaptris/security/TestCertificateHandler.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestCertificateHandler.java
@@ -21,10 +21,6 @@ import java.io.InputStream;
 import java.net.UnknownHostException;
 import java.util.Calendar;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -32,6 +28,10 @@ import com.adaptris.security.certificate.CertificateHandler;
 import com.adaptris.security.certificate.CertificateHandlerFactory;
 import com.adaptris.security.exc.CertException;
 import com.adaptris.security.keystore.KeystoreFactory;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Test Certificate Handling.

--- a/interlok-core/src/test/java/com/adaptris/security/TestConfiguredUrl.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestConfiguredUrl.java
@@ -18,15 +18,15 @@ package com.adaptris.security;
 
 import java.util.Properties;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.adaptris.security.keystore.ConfiguredUrl;
 import com.adaptris.security.util.Constants;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Test Inline Keystore Functionality wrapping a single KEYSTORE_X509

--- a/interlok-core/src/test/java/com/adaptris/security/TestInlineKeystore.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestInlineKeystore.java
@@ -16,10 +16,10 @@
 
 package com.adaptris.security;
 
-import junit.framework.TestCase;
-
 import com.adaptris.security.keystore.InlineKeystore;
 import com.adaptris.security.util.Constants;
+
+import junit.framework.TestCase;
 
 /**
  * Test Inline Keystore Functionality wrapping a single KEYSTORE_X509

--- a/interlok-core/src/test/java/com/adaptris/security/TestKeyStore.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestKeyStore.java
@@ -21,10 +21,6 @@ import java.security.cert.Certificate;
 import java.util.Properties;
 import java.util.Random;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -32,6 +28,10 @@ import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
 import com.adaptris.security.keystore.KeystoreProxy;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Test Keystore Functionality.

--- a/interlok-core/src/test/java/com/adaptris/security/TestKeyStoreInfoChange.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestKeyStoreInfoChange.java
@@ -19,16 +19,16 @@ package com.adaptris.security;
 import java.security.cert.Certificate;
 import java.util.Properties;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
 import com.adaptris.security.keystore.KeystoreProxy;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Test Keystore Functionality.

--- a/interlok-core/src/test/java/com/adaptris/security/TestKeystoreLocation.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestKeystoreLocation.java
@@ -22,14 +22,14 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.Properties;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
+
+import junit.framework.TestCase;
 
 /**
  * Test Keystore Functionality.

--- a/interlok-core/src/test/java/com/adaptris/security/TestSingleX509Keystore.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestSingleX509Keystore.java
@@ -19,10 +19,10 @@ package com.adaptris.security;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 
-import junit.framework.TestCase;
-
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreProxy;
+
+import junit.framework.TestCase;
 
 /**
  * Test Keystore Functionality wrapping a single KEYSTORE_X509 certificate

--- a/interlok-core/src/test/java/com/adaptris/transform/ff/StreamParserTest.java
+++ b/interlok-core/src/test/java/com/adaptris/transform/ff/StreamParserTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.transform.ff;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 public class StreamParserTest {

--- a/interlok-core/src/test/java/com/adaptris/util/ByteArrayDataSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/ByteArrayDataSourceTest.java
@@ -18,12 +18,12 @@ package com.adaptris.util;
 
 import java.io.ByteArrayOutputStream;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.adaptris.util.text.mime.ByteArrayDataSource;
+
+import junit.framework.TestCase;
 
 public class ByteArrayDataSourceTest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/util/FifoMutexLockTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/FifoMutexLockTest.java
@@ -16,10 +16,10 @@
 
 package com.adaptris.util;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import junit.framework.TestCase;
 
 public class FifoMutexLockTest extends TestCase {
 

--- a/interlok-core/src/test/java/com/adaptris/util/NumberUtilsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/NumberUtilsTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 public class NumberUtilsTest extends NumberUtils {

--- a/interlok-core/src/test/java/com/adaptris/util/TestURLName.java
+++ b/interlok-core/src/test/java/com/adaptris/util/TestURLName.java
@@ -18,10 +18,10 @@ package com.adaptris.util;
 
 import javax.mail.URLName;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import junit.framework.TestCase;
 
 /**
  *

--- a/interlok-core/src/test/java/com/adaptris/util/text/ByteTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/ByteTranslatorTest.java
@@ -16,9 +16,9 @@
 
 package com.adaptris.util.text;
 
-import junit.framework.TestCase;
-
 import com.adaptris.util.GuidGenerator;
+
+import junit.framework.TestCase;
 
 public class ByteTranslatorTest extends TestCase {
 


### PR DESCRIPTION
Step one: Just a mass organize imports.
Maybe 20 unused imports have been removed, the rest if the modified files will all be re-ordering.

Next step to follow, replace deprecated calls...