### PR TITLE
INTERLOK-2687 Switch to using setSoftMinEvictableTimeMillis

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -25,14 +25,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+
 import org.apache.commons.lang3.Range;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPool;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -399,7 +402,7 @@ public class PoolingWorkflow extends WorkflowImp {
     pool.setMaxIdle(maxIdle());
     pool.setMaxWaitMillis(-1L);
     pool.setBlockWhenExhausted(true);
-    pool.setMinEvictableIdleTimeMillis(lifetime);
+    pool.setSoftMinEvictableIdleTimeMillis(lifetime);
     pool.setTimeBetweenEvictionRunsMillis(
         lifetime + ThreadLocalRandom.current().nextLong(lifetime));
     return pool;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceWorkerPool.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceWorkerPool.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
@@ -31,6 +32,7 @@ import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -76,7 +78,7 @@ public class ServiceWorkerPool {
     pool.setMaxIdle(maxThreads);
     pool.setMaxWaitMillis(-1L);
     pool.setBlockWhenExhausted(true);
-    pool.setMinEvictableIdleTimeMillis(EVICT_RUN);
+    pool.setSoftMinEvictableIdleTimeMillis(EVICT_RUN);
     pool.setTimeBetweenEvictionRunsMillis(
         EVICT_RUN + ThreadLocalRandom.current().nextLong(EVICT_RUN));
     return pool;


### PR DESCRIPTION
- According to the javadocs, SoftMinEvictable means that it will
only evict if there are already min-idle instances available. This
is the more appropriate check rather than MinEvictable