### PR TITLE
INTERLOK-2702 Merge functionality from DynamicServiceLocator into DynamicServiceExecutor

### DIFF
--- a/docs/adr/0003-deprecate-dynamicservicelocator.md
+++ b/docs/adr/0003-deprecate-dynamicservicelocator.md
@@ -1,19 +1,36 @@
-# 3. Deprecate DynamicServiceLocator
+---
+layout: page
+title: 0003-deprecate-dynamicservicelocator
+---
+# Deprecate DynamicServiceLocator in favour of DynamicServicExecutor
 
-Date: 2019-03-21
+* Status: Draft
+* Deciders: Aaron McGrath, Lewin Chan
+* Date: 2019-03-21
 
-## Status
+## Context and Problem Statement
 
-Accepted
+With the standard document trading network, there is a move towards centralised processing such that companies need only define their "mapping specification" and key information, and everything is handled centrally.
 
-## Context
+Traditionally, this was done via DynamicServiceLocator with files located on the fileystem named in the form : `SRC-DST-MSG_TYPE.xml`; recently, this has been done in a dedicated application which is now deprecated.
 
-The issue motivating this decision, and any context that influences or constrains the decision.
+The way that DynamicServiceLocator works contains a lot of extraneous configuration that only have a single implementation; it was designed for extensibility, but it's over complicated in terms of XML and coupling. It needs to be simplified so that it's more understandable in the UI.
 
 ## Decision
 
-The change that we're proposing or have agreed to implement.
+Deprecate DynamicServiceLocator, leave it available but marked as deprecated. Improve DynamicServiceExcutor so that it can be used instead.
+
+### Enhancing DynamicServiceExecutor.
+
+What this means is to implement additional ServiceExtractor implementations that allow the user to extract the _`_service-to-execute_ from an external location; currently the two supplied implementations simply use the _AdaptrisMessage_ object to extract the services.
+
+The additions required are :
+* Extract from a URL such that you can configure `http://my.server.com/%message{source}/%message{destination}/%message{messageType}.xml`. This would replace the existing DynamicServiceLocator functionality from _RemoteServiceStore_ and _LocalServiceStore_.
+* Extract from Database -> such that you can configure something like `SELECT dynamicService FROM services WHERE src='%message{source}' AND dest='%message{destination}' AND msgType='%message{messageType}'`
+  * The above would be quite "open" to SQL injection style attacks; so people should probably use _JdbcDataQueryService_ and then handle it from metadata.
+* Extract from a Cache -> similar to doing a RetrieveFromCache
+* Extract it from metadata.
 
 ## Consequences
 
-What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.
+DynamicServiceLocator and associated classes (such as TradingRelationship etc) are now marked as deprecated since 3.8.4, with a Removal notice for 3.11.0. This will show up in 3.8.4 releases on the UI page.

--- a/interlok-core/src/main/java/com/adaptris/core/ConfiguredTradingRelationshipCreator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfiguredTradingRelationshipCreator.java
@@ -17,20 +17,25 @@
 package com.adaptris.core;
 
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.services.dynamic.DynamicServiceLocator;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 
 /**
  * <p>
- * Implementation of <code>TradingRelationshipCreator</code> which creates a <code>TradingRelationship</code> with the configured
- * values.
+ * Implementation of <code>TradingRelationshipCreator</code> which creates a
+ * <code>TradingRelationship</code> with the configured values.
  * </p>
  * 
  * @config configured-trading-relationship-creator
+ * @deprecated since 3.8.4 since only {@link DynamicServiceLocator} uses this.
  */
+@Deprecated
 @XStreamAlias("configured-trading-relationship-creator")
 @DisplayOrder(order = {"source", "destination", "type"})
+@Removal(version = "3.11.0")
 public final class ConfiguredTradingRelationshipCreator implements
     TradingRelationshipCreator {
 

--- a/interlok-core/src/main/java/com/adaptris/core/MetadataTradingRelationshipCreator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MetadataTradingRelationshipCreator.java
@@ -19,21 +19,25 @@ package com.adaptris.core;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.services.dynamic.DynamicServiceLocator;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * Implementation of <code>TradingRelationshipCreator</code> which populates the <code>TradingRelationship</code> with values
- * returned from configurable metadata keys.
+ * Implementation of <code>TradingRelationshipCreator</code> which populates the
+ * <code>TradingRelationship</code> with values returned from configurable metadata keys.
  * </p>
  * 
  * @config metadata-trading-relationship-creator
+ * @deprecated since 3.8.4 since only {@link DynamicServiceLocator} uses this.
  */
+@Deprecated
 @XStreamAlias("metadata-trading-relationship-creator")
 @DisplayOrder(order = {"sourceKey", "destinationKey", "typeKey"})
+@Removal(version = "3.11.0")
 public class MetadataTradingRelationshipCreator
   implements TradingRelationshipCreator {
 

--- a/interlok-core/src/main/java/com/adaptris/core/TradingRelationship.java
+++ b/interlok-core/src/main/java/com/adaptris/core/TradingRelationship.java
@@ -16,14 +16,20 @@
 
 package com.adaptris.core;
 
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.services.dynamic.DynamicServiceLocator;
 import com.adaptris.core.util.Args;
 
 /**
  * <p>
- * Encapsulates a source, destination and type <i>trading relationship</i>.  A
- * wild card identifier may be used for any or all of the three components.
+ * Encapsulates a source, destination and type <i>trading relationship</i>. A wild card identifier
+ * may be used for any or all of the three components.
  * </p>
+ * 
+ * @deprecated since 3.8.4 since only {@link DynamicServiceLocator} uses this.
  */
+@Deprecated
+@Removal(version = "3.11.0")
 public class TradingRelationship implements Cloneable {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/TradingRelationshipCreator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/TradingRelationshipCreator.java
@@ -16,14 +16,18 @@
 
 package com.adaptris.core;
 
-
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.services.dynamic.DynamicServiceLocator;
 
 /**
- * <p> 
- * Create a <code>TradingRelationship</code> from an 
- * <code>AdaptrisMessage</code>.
+ * <p>
+ * Create a <code>TradingRelationship</code> from an <code>AdaptrisMessage</code>.
  * </p>
+ * 
+ * @deprecated since 3.8.4 since only {@link DynamicServiceLocator} uses this.
  */
+@Deprecated
+@Removal(version = "3.11.0")
 public interface TradingRelationshipCreator {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/XpathTradingRelationshipCreator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/XpathTradingRelationshipCreator.java
@@ -19,17 +19,16 @@ package com.adaptris.core;
 import static com.adaptris.core.util.XmlHelper.createDocument;
 import static com.adaptris.util.text.xml.XPath.newXPathInstance;
 import static org.apache.commons.lang.StringUtils.isEmpty;
-
 import javax.validation.Valid;
 import javax.xml.namespace.NamespaceContext;
-
 import org.hibernate.validator.constraints.NotBlank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.services.dynamic.DynamicServiceLocator;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.KeyValuePairSet;
@@ -39,21 +38,25 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * Implementation of <code>TradingRelationshipCreator</code> which populates the <code>TradingRelationship</code> with values
- * returned from configurable xpaths.
+ * Implementation of <code>TradingRelationshipCreator</code> which populates the
+ * <code>TradingRelationship</code> with values returned from configurable xpaths.
  * </p>
  *
  * <p>
- * If the {@code DocumentBuilderFactoryBuilder} has been explicitly set to be not namespace aware and the document does in fact
- * contain namespaces, then Saxon can cause merry havoc in the sense that {@code //NonNamespaceXpath} doesn't work if the document
- * has namespaces in it. We have included a shim so that behaviour can be toggled based on what you have configured.
+ * If the {@code DocumentBuilderFactoryBuilder} has been explicitly set to be not namespace aware
+ * and the document does in fact contain namespaces, then Saxon can cause merry havoc in the sense
+ * that {@code //NonNamespaceXpath} doesn't work if the document has namespaces in it. We have
+ * included a shim so that behaviour can be toggled based on what you have configured.
  * </p>
  * 
  * @see XPath#newXPathInstance(DocumentBuilderFactoryBuilder, NamespaceContext)
  * @config xpath-trading-relationship-creator
+ * @deprecated since 3.8.4 since only {@link DynamicServiceLocator} uses this.
  */
+@Deprecated
 @XStreamAlias("xpath-trading-relationship-creator")
 @DisplayOrder(order = {"sourceXpath", "destinationXpath", "typeXpath", "namespaceContext"})
+@Removal(version = "3.11.0")
 public class XpathTradingRelationshipCreator implements
     TradingRelationshipCreator {
 

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcService.java
@@ -20,9 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
-
 import javax.validation.Valid;
-
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConnectedService;
@@ -135,13 +133,7 @@ public abstract class JdbcService extends ServiceImp implements ConnectedService
    * @return the connection either from the adaptris message or from configuration.
    */
   protected Connection getConnection(AdaptrisMessage msg) throws SQLException {
-    Connection conn = (Connection) msg.getObjectHeaders().get(JdbcConstants.OBJ_METADATA_DATABASE_CONNECTION_KEY);
-    
-    if (conn != null && !conn.isClosed()){
-      return conn;
-    } else {
-      return getConnection().retrieveConnection(DatabaseConnection.class).connect();
-    }
+    return JdbcUtil.getConnection(msg, getConnection());
   }
 
   /**
@@ -155,10 +147,7 @@ public abstract class JdbcService extends ServiceImp implements ConnectedService
    * @param msg the AdaptrisMessage
    */
   protected void rollback(Connection sqlConnection, AdaptrisMessage msg) {
-    if (msg.getObjectHeaders().containsKey(JdbcConstants.OBJ_METADATA_DATABASE_CONNECTION_KEY)) {
-      return;
-    }
-    JdbcUtil.rollback(sqlConnection);
+    JdbcUtil.rollback(sqlConnection, msg);
   }
 
   /**
@@ -172,11 +161,9 @@ public abstract class JdbcService extends ServiceImp implements ConnectedService
    * @param msg the AdaptrisMessage currently being processed.
    * @throws SQLException if the commit fails.
    */
+  @Deprecated
   protected void commit(Connection sqlConnection, AdaptrisMessage msg) throws SQLException {
-    if (msg.getObjectHeaders().containsKey(JdbcConstants.OBJ_METADATA_DATABASE_CONNECTION_KEY)) {
-      return;
-    }
-    JdbcUtil.commit(sqlConnection);
+    JdbcUtil.commit(sqlConnection, msg);
   }
 
   public TimeInterval getStatementTimeout() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ConfiguredServiceNameProvider.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ConfiguredServiceNameProvider.java
@@ -18,21 +18,27 @@ package com.adaptris.core.services.dynamic;
 
 import java.util.HashSet;
 import java.util.Set;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.TradingRelationship;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Implementation of {@link ServiceNameProvider} that has static mappings for trading relationships and service names
+ * Implementation of {@link ServiceNameProvider} that has static mappings for trading relationships
+ * and service names
  * <p>
- * This is primiarily a basic implementation of <code>ServiceNameProvider</code> for testing. We do not recommend it for production
- * use as additional dynamic services will require you to restart the adapter every time you add one.
+ * This is primiarily a basic implementation of <code>ServiceNameProvider</code> for testing. We do
+ * not recommend it for production use as additional dynamic services will require you to restart
+ * the adapter every time you add one.
  * </p>
  * 
  * @config configured-service-name-provider
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
 @XStreamAlias("configured-service-name-provider")
+@Deprecated
+@Removal(version = "3.11.0")
 public class ConfiguredServiceNameProvider extends ServiceNameProviderImp {
 
   private Set<ServiceNameMapper> serviceNameMappers;

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DefaultServiceExtractor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DefaultServiceExtractor.java
@@ -18,7 +18,7 @@ package com.adaptris.core.services.dynamic;
 
 import java.io.IOException;
 import java.io.InputStream;
-
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -31,6 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("dynamic-default-service-extractor")
+@ComponentProfile(summary = "Treat the message body as the service to execute.")
 public class DefaultServiceExtractor implements ServiceExtractor {
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DefaultServiceNameProvider.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DefaultServiceNameProvider.java
@@ -17,11 +17,11 @@
 package com.adaptris.core.services.dynamic;
 
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.TradingRelationship;
 import com.adaptris.core.util.Args;
@@ -29,14 +29,20 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * Implementation of {@link ServiceNameProvider} which returns the passed {@link TradingRelationship} source, destination and type
- * separated by an (optional) configurable character.
+ * Implementation of {@link ServiceNameProvider} which returns the passed
+ * {@link TradingRelationship} source, destination and type separated by an (optional) configurable
+ * character.
  * </p>
  * 
  * @config default-service-name-provider
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
+ * 
  */
+@Deprecated
 @XStreamAlias("default-service-name-provider")
 @DisplayOrder(order = {"separator"})
+@Removal(version = "3.11.0")
 public class DefaultServiceNameProvider extends ServiceNameProviderImp {
 
   @AutoPopulated

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceExecutor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceExecutor.java
@@ -43,27 +43,27 @@ import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Implementation of {@link com.adaptris.core.Service} which dynamically obtains and applies a {@link com.adaptris.core.Service} to
- * an {@link com.adaptris.core.AdaptrisMessage} based on
- * the contents of the message.
+ * Implementation of {@link com.adaptris.core.Service} which dynamically obtains and applies a
+ * {@link com.adaptris.core.Service} to an {@link com.adaptris.core.AdaptrisMessage} based on the
+ * contents of the message.
  * 
  * <p>
- * This class will attempt to extract a marshalled service (roughly analagous to {@link DynamicServiceLocator}) from the payload of
- * the current message, unmarshal that service, and then execute that service against the current message. The use of this type of
- * service is discouraged from a supportability perspective; however there will be use cases where it is appropriate. No checks are
- * performed on the {@link com.adaptris.core.Service} that is unmarshalled other than license verification; any exceptions thrown by
- * unmarshalled
- * service are simply rethrown back to the workflow for standard message error handling.
+ * This class will attempt to extract a marshalled service (roughly analagous to
+ * {@link DynamicServiceLocator}) from the specified location (which might be the current message),
+ * unmarshal that service, and then execute that service against the current message. The use of
+ * this type of service is discouraged from a supportability perspective; however there will be use
+ * cases where it is appropriate. No checks are performed on the {@link com.adaptris.core.Service}
+ * that is unmarshalled; any exceptions thrown by unmarshalled service are simply rethrown back to
+ * the workflow for standard message error handling.
  * </p>
  * 
  * @config dynamic-service-executor
  * 
- * @author lchan
  * @see ServiceExtractor
  */
 @XStreamAlias("dynamic-service-executor")
 @AdapterComponent
-@ComponentProfile(summary = "Execute a service definition which is defined in the message itself", tag = "service,dynamic")
+@ComponentProfile(summary = "Lookup and execute a dynamic service", tag = "service,dynamic")
 @DisplayOrder(order = {"serviceExtractor", "marshaller", "treatNotFoundAsError"})
 public class DynamicServiceExecutor extends ServiceImp implements EventHandlerAware {
 
@@ -125,10 +125,12 @@ public class DynamicServiceExecutor extends ServiceImp implements EventHandlerAw
     LifecycleHelper.init(getServiceExtractor());
   }
 
+  @Override
   public void start() throws CoreException {
     LifecycleHelper.start(getServiceExtractor());
   }
 
+  @Override
   public void stop() {
     LifecycleHelper.stop(getServiceExtractor());
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceLocator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceLocator.java
@@ -40,6 +40,7 @@ import com.adaptris.core.TradingRelationshipCreator;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -82,6 +83,7 @@ public class DynamicServiceLocator extends ServiceImp implements EventHandlerAwa
 
   private transient EventHandler eventHandler;
 
+  private static transient boolean warningLogged = false;
   /**
    * Creates a new Instance.
    * <p>
@@ -92,6 +94,9 @@ public class DynamicServiceLocator extends ServiceImp implements EventHandlerAwa
    * </p>
    */
   public DynamicServiceLocator() {
+    LoggingHelper.logDeprecation(warningLogged, () -> {
+      warningLogged = true;
+    }, this.getClass().getSimpleName(), DynamicServiceExecutor.class.getName());
     // defaults...
     setMatchingStrategy(new ExactMatchingStrategy());
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceLocator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceLocator.java
@@ -17,18 +17,16 @@
 package com.adaptris.core.services.dynamic;
 
 import static com.adaptris.core.util.LoggingHelper.friendlyName;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.BooleanUtils;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -46,17 +44,22 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * Implementation of {@link com.adaptris.core.Service} which dynamically obtains and applies a {@link com.adaptris.core.Service} to an {@link com.adaptris.core.AdaptrisMessage} based on
- * its {@link TradingRelationship}.
+ * Implementation of {@link com.adaptris.core.Service} which dynamically obtains and applies a
+ * {@link com.adaptris.core.Service} to an {@link com.adaptris.core.AdaptrisMessage} based on its
+ * {@link TradingRelationship}.
  * </p>
  * 
  * @config dynamic-service-locator
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  * 
  */
+@Deprecated
 @XStreamAlias("dynamic-service-locator")
 @AdapterComponent
 @ComponentProfile(summary = "Locate and execute a service definition based on attributes of the message", tag = "service,dynamic")
 @DisplayOrder(order = {"treatNotFoundAsError"})
+@Removal(version = "3.11.0")
 public class DynamicServiceLocator extends ServiceImp implements EventHandlerAware {
 
   @NotNull

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ExactMatchingStrategy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ExactMatchingStrategy.java
@@ -16,19 +16,24 @@
 
 package com.adaptris.core.services.dynamic;
 
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.TradingRelationship;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * <code>ExactMatchingStrategy</code> returns a <code>TradingRelationship[]</code> containing the passed
- * <code>TradingRelationship</code> only, or an empty array if the parameter is null.
+ * <code>ExactMatchingStrategy</code> returns a <code>TradingRelationship[]</code> containing the
+ * passed <code>TradingRelationship</code> only, or an empty array if the parameter is null.
  * </p>
  * 
  * @config exact-matching-strategy
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
 @XStreamAlias("exact-matching-strategy")
+@Removal(version = "3.11.0")
 public class ExactMatchingStrategy implements MatchingStrategy {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ExtractorWithConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ExtractorWithConnection.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.LifecycleHelper;
+
+public abstract class ExtractorWithConnection implements ServiceExtractor {
+  @NotNull
+  @Valid
+  private AdaptrisConnection connection;
+
+
+  public ExtractorWithConnection() {
+
+  }
+
+  @Override
+  public void init() throws CoreException {
+    LifecycleHelper.prepare(getConnection());
+    LifecycleHelper.init(getConnection());
+  }
+
+  @Override
+  public void start() throws CoreException {
+    LifecycleHelper.start(getConnection());
+  }
+
+  @Override
+  public void stop() {
+    LifecycleHelper.stop(getConnection());
+  }
+
+  @Override
+  public void close() {
+    LifecycleHelper.close(getConnection());
+  }
+
+  public AdaptrisConnection getConnection() {
+    return connection;
+  }
+
+  public void setConnection(AdaptrisConnection c) {
+    this.connection = Args.notNull(c, "connection");
+  }
+
+  public <T extends ExtractorWithConnection> T withConnection(AdaptrisConnection c) {
+    setConnection(c);
+    return (T) this;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ExtractorWithConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ExtractorWithConnection.java
@@ -20,6 +20,7 @@ import javax.validation.constraints.NotNull;
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 
 public abstract class ExtractorWithConnection implements ServiceExtractor {
@@ -34,8 +35,13 @@ public abstract class ExtractorWithConnection implements ServiceExtractor {
 
   @Override
   public void init() throws CoreException {
-    LifecycleHelper.prepare(getConnection());
-    LifecycleHelper.init(getConnection());
+    try {
+      Args.notNull(getConnection(), "connection");
+      LifecycleHelper.prepare(getConnection());
+      LifecycleHelper.init(getConnection());
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/LocalMarshallServiceStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/LocalMarshallServiceStore.java
@@ -20,12 +20,10 @@ import static com.adaptris.fs.FsWorker.checkReadable;
 import static com.adaptris.fs.FsWorker.isDirectory;
 import static com.adaptris.fs.FsWorker.isFile;
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
-
 import java.io.File;
-
 import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.Service;
 import com.adaptris.core.fs.FsHelper;
@@ -35,12 +33,17 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * Implementation of <code>ServiceStore</code> which uses the local file system to store marshalled <code>Service</code>s.
+ * Implementation of <code>ServiceStore</code> which uses the local file system to store marshalled
+ * <code>Service</code>s.
  * </p>
  * 
  * @config local-marshall-service-store
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
 @XStreamAlias("local-marshall-service-store")
+@Removal(version = "3.11.0")
 public class LocalMarshallServiceStore extends MarshallFileServiceStore {
 
   @NotBlank

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/MarshallFileServiceStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/MarshallFileServiceStore.java
@@ -17,21 +17,23 @@
 package com.adaptris.core.services.dynamic;
 
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.Service;
 import com.adaptris.core.util.Args;
 
 /**
- * Abstract base implementation of a file based service store that uses your choice of 
- * marshalling technology.
+ * Abstract base implementation of a file based service store that uses your choice of marshalling
+ * technology.
  *
- * @author lchan
- * @author $Author: lchan $
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
+@Removal(version = "3.11.0")
 public abstract class MarshallFileServiceStore extends MarshallServiceStore {
   @NotNull
   @InputFieldDefault(value = "")

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/MarshallServiceStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/MarshallServiceStore.java
@@ -18,7 +18,7 @@ package com.adaptris.core.services.dynamic;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMarshaller;
@@ -27,7 +27,12 @@ import com.adaptris.core.DefaultMarshaller;
  * <p>
  * Implementation of {@link ServiceStore} which uses an XML marshaller for Services.
  * </p>
+ * 
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
+@Removal(version = "3.11.0")
 public abstract class MarshallServiceStore implements ServiceStore {
 
   private AdaptrisMarshaller marshaller;

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/MatchingStrategy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/MatchingStrategy.java
@@ -16,16 +16,22 @@
 
 package com.adaptris.core.services.dynamic;
 
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.TradingRelationship;
 
 /**
  * <p>
- * Implementations of <code>MatchingStrategy</code> provide alternative 
- * <code>TradingRelationship</code>'s for <code>ServiceNameProvider</code>'s 
- * to look for if there is no exact match.
+ * Implementations of <code>MatchingStrategy</code> provide alternative
+ * <code>TradingRelationship</code>'s for <code>ServiceNameProvider</code>'s to look for if there is
+ * no exact match.
  * </p>
+ * 
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
+@Removal(version = "3.11.0")
 public interface MatchingStrategy {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/RemoteMarshallServiceStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/RemoteMarshallServiceStore.java
@@ -17,17 +17,15 @@
 package com.adaptris.core.services.dynamic;
 
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
-
 import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.Service;
 import com.adaptris.core.util.Args;
@@ -36,13 +34,18 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * Implementation of <code>ServiceStore</code> which uses a remote URL to store marshalled <code>Service</code>s.
+ * Implementation of <code>ServiceStore</code> which uses a remote URL to store marshalled
+ * <code>Service</code>s.
  * </p>
  * 
  * @config remote-marshall-service-store
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
 @XStreamAlias("remote-marshall-service-store")
 @DisplayOrder(order = {"baseUrl"})
+@Removal(version = "3.11.0")
 public class RemoteMarshallServiceStore extends MarshallFileServiceStore {
 
   @NotBlank

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/SafeServiceNameProvider.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/SafeServiceNameProvider.java
@@ -16,24 +16,31 @@
 
 package com.adaptris.core.services.dynamic;
 
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.TradingRelationship;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Extension of <code>DefaultServiceNameProvider</code> which strips the following characters from any component of the Trading
- * Relationship:
+ * Extension of <code>DefaultServiceNameProvider</code> which strips the following characters from
+ * any component of the Trading Relationship:
  * <p>
  * <code>/,\,?,*,:,|, ,&,",&lt;,&gt;,'</code>
  * </p>
- * Of particular use for ebXML where it is feasible that URLs might be used to identify the parties or message type.
+ * Of particular use for ebXML where it is feasible that URLs might be used to identify the parties
+ * or message type.
  * 
  * @config safe-service-name-provider
  * 
  * @author Stuart Ellidge
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
+ * 
  */
+@Deprecated
 @XStreamAlias("safe-service-name-provider")
+@Removal(version = "3.11.0")
 public final class SafeServiceNameProvider extends DefaultServiceNameProvider {
   public SafeServiceNameProvider() {
 	super();

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractor.java
@@ -24,7 +24,6 @@ import com.adaptris.core.ComponentLifecycle;
  * Interface for use with {@link DynamicServiceExecutor}.
  * 
  */
-@FunctionalInterface
 public interface ServiceExtractor extends ComponentLifecycle {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractor.java
@@ -16,27 +16,22 @@
 
 package com.adaptris.core.services.dynamic;
 
-import java.io.IOException;
 import java.io.InputStream;
-
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.ServiceException;
+import com.adaptris.core.ComponentLifecycle;
 
 /**
  * Interface for use with {@link DynamicServiceExecutor}.
  * 
- * @author lchan
- * 
  */
-public interface ServiceExtractor {
+@FunctionalInterface
+public interface ServiceExtractor extends ComponentLifecycle {
 
   /**
    * Get an {@link InputStream} that can be unmarshalled into a service.
    * 
    * @param m the adaptris message.
    * @return an input stream.
-   * @throws IOException on IO errors.
-   * @throws ServiceException wrapping any other exceptions.
    */
-  InputStream getInputStream(AdaptrisMessage m) throws ServiceException, IOException;
+  InputStream getInputStream(AdaptrisMessage m) throws Exception;
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromCache.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.services.cache.CacheConnection;
+import com.adaptris.core.services.cache.RetrieveFromCacheService;
+import com.adaptris.core.util.Args;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Extract the service to execute from a cache
+ * 
+ * <p>
+ * This allows you to retrieve a service (stored as a String) from a configured {@link Cache}
+ * instance; it supports the expression syntax so you can build up the key for the cache from
+ * metadata or similar. It will not remove the cache entry.
+ * </p>
+ * <p>
+ * The alternative to this would be to use {@link RetrieveFromCacheService} and subsequently a
+ * {@link ServiceFromDataInputParameter} (from metadata). How the dynamic services are inserted into
+ * the cache is up to you.
+ * </p>
+ * 
+ * @config dynamic-service-from-cache
+ * @see DynamicServiceExecutor
+ * 
+ */
+@XStreamAlias("dynamic-service-from-cache")
+@ComponentProfile(summary = "Extract the service to execute from a cache",
+    recommended = {CacheConnection.class})
+@DisplayOrder(order = {"key", "connection"})
+public class ServiceFromCache extends ExtractorWithConnection {
+
+  @NotBlank
+  @InputFieldHint(expression = true)
+  private String key;
+
+  public ServiceFromCache() {
+
+  }
+
+  @Override
+  public InputStream getInputStream(AdaptrisMessage msg) throws Exception {
+    Args.notBlank(getKey(), "key");
+    Cache cache = getConnection().retrieveConnection(CacheConnection.class).retrieveCache();
+    String service = (String) cache.get(msg.resolve(getKey()));
+    return IOUtils.toInputStream(service, msg.getContentEncoding());
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String query) {
+    this.key = Args.notBlank(query, "query");
+  }
+
+  public ServiceFromCache withKey(String q) {
+    setKey(q);
+    return this;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromCache.java
@@ -48,7 +48,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("dynamic-service-from-cache")
 @ComponentProfile(summary = "Extract the service to execute from a cache",
-    recommended = {CacheConnection.class})
+    recommended = {CacheConnection.class}, since = "3.8.4")
 @DisplayOrder(order = {"key", "connection"})
 public class ServiceFromCache extends ExtractorWithConnection {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDataInputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDataInputParameter.java
@@ -44,7 +44,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *
  */
 @XStreamAlias("dynamic-service-from-data-input")
-@ComponentProfile(summary = "Extract the service to execute from a DataInputParameter")
+@ComponentProfile(summary = "Extract the service to execute from a DataInputParameter",
+    since = "3.8.4")
 public class ServiceFromDataInputParameter implements ServiceExtractor {
 
   @NotNull

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDataInputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDataInputParameter.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import java.io.InputStream;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.io.IOUtils;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.MetadataDataInputParameter;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
+import com.adaptris.core.util.Args;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Extract the service to execute based on the configured {@link DataInputParameter}
+ * 
+ * <p>
+ * Wraps {@code DataInputParameter<String>} so you can use any of those implementations as the
+ * source of your executable service.
+ * </p>
+ * 
+ * @config dynamic-service-from-data-input
+ * @see DynamicServiceExecutor
+ * @see ConstantDataInputParameter
+ * @see StringPayloadDataInputParameter
+ * @see MetadataDataInputParameter
+ *
+ */
+@XStreamAlias("dynamic-service-from-data-input")
+@ComponentProfile(summary = "Extract the service to execute from a DataInputParameter")
+public class ServiceFromDataInputParameter implements ServiceExtractor {
+
+  @NotNull
+  @Valid
+  private DataInputParameter<String> input;
+
+  public ServiceFromDataInputParameter() {
+
+  }
+
+  public ServiceFromDataInputParameter(DataInputParameter<String> input) {
+    this();
+    setInput(input);
+  }
+
+  @Override
+  public InputStream getInputStream(AdaptrisMessage m) throws Exception {
+    Args.notNull(input, "input");
+    return IOUtils.toInputStream(input.extract(m), m.getContentEncoding());
+  }
+
+  public DataInputParameter<String> getInput() {
+    return input;
+  }
+
+  public void setInput(DataInputParameter<String> input) {
+    this.input = Args.notNull(input, "input");
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
@@ -85,6 +85,7 @@ public class ServiceFromDatabase extends ExtractorWithConnection {
 
   @Override
   public InputStream getInputStream(AdaptrisMessage m) throws Exception {
+    Args.notBlank(getQuery(), "query");
     Connection jdbcCon = getConnection().retrieveConnection(DatabaseConnection.class).connect();
     String jdbcQuery = m.resolve(getQuery());
     ResultSet resultSet = null;

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
@@ -87,7 +87,8 @@ public class ServiceFromDatabase extends ExtractorWithConnection {
   public InputStream getInputStream(AdaptrisMessage m) throws Exception {
     Args.notBlank(getQuery(), "query");
     Connection jdbcCon = getConnection().retrieveConnection(DatabaseConnection.class).connect();
-    String jdbcQuery = m.resolve(getQuery());
+    // needs multi-line mode.
+    String jdbcQuery = m.resolve(getQuery(), true);
     ResultSet resultSet = null;
     Statement statement = null;
     InputStream result = null;

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
@@ -68,7 +68,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("dynamic-service-from-database")
 @ComponentProfile(summary = "Extract the service to execute from a database",
-    recommended = {DatabaseConnection.class})
+    recommended = {DatabaseConnection.class}, since = "3.8.4")
 @DisplayOrder(order = {"key", "connection"})
 public class ServiceFromDatabase extends ExtractorWithConnection {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.jdbc.DatabaseConnection;
+import com.adaptris.core.services.jdbc.FirstRowMetadataTranslator;
+import com.adaptris.core.services.jdbc.JdbcDataQueryService;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.JdbcUtil;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Extract the service to execute from a database
+ * 
+ * <p>
+ * This executes the configured query, takes the first column of the first ResultSet and uses that
+ * as the source for the dynamic service.
+ * </p>
+ * <p>
+ * Since it supports the expression syntax; this is perfectly acceptable; It is up to you to protect
+ * against SQL injection attacks.
+ * 
+ * <pre>
+ * {@code SELECT dynamicService FROM services 
+ *        WHERE src='%message{source}' 
+ *              AND dest='%message{destination}' 
+ *              AND msgType='%message{messageType}'}
+ * </pre>
+ * </p>
+ * <p>
+ * The alternative to this would be to use {@link JdbcDataQueryService} with a
+ * {@link FirstRowMetadataTranslator} and subsequently a {@link ServiceFromDataInputParameter} (from
+ * metadata). That might be more performant as you would benefit from prepared statement caching and
+ * mitigate against SQL injection style attacks.
+ * </p>
+ * 
+ * @config dynamic-service-from-database
+ * @see DynamicServiceExecutor
+ * 
+ */
+@XStreamAlias("dynamic-service-from-database")
+@ComponentProfile(summary = "Extract the service to execute from a database",
+    recommended = {DatabaseConnection.class})
+@DisplayOrder(order = {"key", "connection"})
+public class ServiceFromDatabase extends ExtractorWithConnection {
+
+  @NotBlank
+  @InputFieldHint(expression = true)
+  private String query;
+  @NotNull
+  @Valid
+  private AdaptrisConnection connection;
+
+  public ServiceFromDatabase() {
+
+  }
+
+  @Override
+  public InputStream getInputStream(AdaptrisMessage m) throws Exception {
+    Connection jdbcCon = getConnection().retrieveConnection(DatabaseConnection.class).connect();
+    String jdbcQuery = m.resolve(getQuery());
+    ResultSet resultSet = null;
+    Statement statement = null;
+    InputStream result = null;
+    try {
+      statement = jdbcCon.createStatement();
+      resultSet = statement.executeQuery(jdbcQuery);
+      if (resultSet.next()) {
+        result = new ServiceInputStream(resultSet, statement);
+      } else {
+        throw new ServiceException("No results from [" + jdbcQuery + "]");
+      }
+    } catch (Exception e) {
+      JdbcUtil.closeQuietly(resultSet, statement);
+      throw e;
+    }
+    return result;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setQuery(String query) {
+    this.query = Args.notBlank(query, "query");
+  }
+
+  public ServiceFromDatabase withQuery(String q) {
+    setQuery(q);
+    return this;
+  }
+
+  private class ServiceInputStream extends FilterInputStream {
+    private ResultSet result;
+    private Statement statement;
+
+    ServiceInputStream(ResultSet rs, Statement stmt) throws Exception {
+      super(rs.getAsciiStream(1));
+      result = rs;
+      statement = stmt;
+    }
+
+    @Override
+    public void close() throws IOException {
+      super.close();
+      JdbcUtil.closeQuietly(result, statement);
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import java.io.InputStream;
+import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.util.URLHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Extract the service to execute based on the configured URL.
+ * 
+ * @config dynamic-service-from-url
+ *
+ */
+@XStreamAlias("dynamic-service-from-url")
+@ComponentProfile(summary = "Extract the service to execute from a URL (file/http etc)")
+public class ServiceFromUrl implements ServiceExtractor {
+
+  @NotBlank
+  @InputFieldHint(expression = true)
+  private String url;
+
+  public ServiceFromUrl() {
+
+  }
+
+  public ServiceFromUrl(String url) {
+    this();
+    setUrl(url);
+  }
+
+  @Override
+  public InputStream getInputStream(AdaptrisMessage m) throws Exception {
+    String urlToConnectTo = m.resolve(getUrl());
+    return URLHelper.connect(urlToConnectTo);
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
@@ -27,7 +27,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Extract the service to execute based on the configured URL.
  * 
  * @config dynamic-service-from-url
- *
+ * @see DynamicServiceExecutor
+ * 
  */
 @XStreamAlias("dynamic-service-from-url")
 @ComponentProfile(summary = "Extract the service to execute from a URL (file/http etc)")

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
@@ -20,6 +20,7 @@ import org.hibernate.validator.constraints.NotBlank;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.util.Args;
 import com.adaptris.util.URLHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -49,6 +50,7 @@ public class ServiceFromUrl implements ServiceExtractor {
 
   @Override
   public InputStream getInputStream(AdaptrisMessage m) throws Exception {
+    Args.notBlank(getUrl(), "url");
     String urlToConnectTo = m.resolve(getUrl());
     return URLHelper.connect(urlToConnectTo);
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
@@ -32,7 +32,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("dynamic-service-from-url")
-@ComponentProfile(summary = "Extract the service to execute from a URL (file/http etc)")
+@ComponentProfile(summary = "Extract the service to execute from a URL (file/http etc)",
+    since = "3.8.4")
 public class ServiceFromUrl implements ServiceExtractor {
 
   @NotBlank

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceNameMapper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceNameMapper.java
@@ -17,23 +17,27 @@
 package com.adaptris.core.services.dynamic;
 
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.TradingRelationship;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * Maps a name for a <code>Service</code> to a <code>TradingRelationship</code>. Used by {@link ConfiguredServiceNameProvider}.
+ * Maps a name for a <code>Service</code> to a <code>TradingRelationship</code>. Used by
+ * {@link ConfiguredServiceNameProvider}.
  * </p>
  * 
  * @config configured-service-name-mapper
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
 @XStreamAlias("configured-service-name-mapper")
 @DisplayOrder(order = {"serviceName", "tradingRelationship"})
+@Removal(version = "3.11.0")
 public class ServiceNameMapper {
 
   @NotNull

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceNameProvider.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceNameProvider.java
@@ -16,15 +16,21 @@
 
 package com.adaptris.core.services.dynamic;
 
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.TradingRelationship;
 
 /**
- * <p> 
+ * <p>
  * Returns a logical name for a passed <code>TradingRelationship</code> or
  * <code>TradingRelationship[]</code>.
  * </p>
+ * 
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
+@Removal(version = "3.11.0")
 public interface ServiceNameProvider {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceNameProviderImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceNameProviderImp.java
@@ -18,7 +18,7 @@ package com.adaptris.core.services.dynamic;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.TradingRelationship;
 import com.adaptris.core.util.Args;
@@ -27,7 +27,12 @@ import com.adaptris.core.util.Args;
  * <p>
  * Partial implementation of <code>ServiceNameProvider</code>.
  * </p>
+ * 
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
+@Removal(version = "3.11.0")
 public abstract class ServiceNameProviderImp implements ServiceNameProvider {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass());

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceStore.java
@@ -16,15 +16,20 @@
 
 package com.adaptris.core.services.dynamic;
 
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.Service;
 
 /**
- * <p> 
- * Implementations provide a store of <code>Service</code>s which may be 
- * retrieved by name.  
+ * <p>
+ * Implementations provide a store of <code>Service</code>s which may be retrieved by name.
  * </p>
+ * 
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
+@Removal(version = "3.11.0")
 public interface ServiceStore {
   
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/StandardMatchingStrategy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/StandardMatchingStrategy.java
@@ -18,15 +18,16 @@ package com.adaptris.core.services.dynamic;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.TradingRelationship;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * <code>StandardMatchingStrategy</code> creates a <code>TradingRelationship[]</code> which substitutes
- * <code>TradingRelationship.WILD_CARD</code>s in the progressively more generic order described below.
+ * <code>StandardMatchingStrategy</code> creates a <code>TradingRelationship[]</code> which
+ * substitutes <code>TradingRelationship.WILD_CARD</code>s in the progressively more generic order
+ * described below.
  * <ul>
  * <li>source</li>
  * <li>destination</li>
@@ -42,8 +43,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * </p>
  * 
  * @config standard-matching-strategy
+ * @deprecated since 3.8.4 use {@link DynamicServiceExecutor} with a URL based
+ *             {@link ServiceExtractor} instead.
  */
+@Deprecated
 @XStreamAlias("standard-matching-strategy")
+@Removal(version = "3.11.0")
 public class StandardMatchingStrategy implements MatchingStrategy {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass());

--- a/interlok-core/src/test/java/com/adaptris/core/ConfiguredTradingRelationshipCreatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConfiguredTradingRelationshipCreatorTest.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+@SuppressWarnings("deprecation")
 public class ConfiguredTradingRelationshipCreatorTest extends BaseCase {
 
   private static final String TYPE = "type";

--- a/interlok-core/src/test/java/com/adaptris/core/MetadataTradingRelationshipCreatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MetadataTradingRelationshipCreatorTest.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+@SuppressWarnings("deprecation")
 public class MetadataTradingRelationshipCreatorTest extends BaseCase {
   private static final String TYPE = "type";
   private static final String DEST = "dest";

--- a/interlok-core/src/test/java/com/adaptris/core/TradingRelationshipTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/TradingRelationshipTest.java
@@ -18,6 +18,7 @@ package com.adaptris.core;
 
 import junit.framework.TestCase;
 
+@SuppressWarnings("deprecation")
 public class TradingRelationshipTest extends TestCase {
 
   public TradingRelationshipTest(String name) {

--- a/interlok-core/src/test/java/com/adaptris/core/XpathTradingRelationshipCreatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/XpathTradingRelationshipCreatorTest.java
@@ -19,6 +19,7 @@ package com.adaptris.core;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
+@SuppressWarnings("deprecation")
 public class XpathTradingRelationshipCreatorTest extends BaseCase {
 
   private static final String TYPE = "type";

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ConfiguredServiceNameProviderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ConfiguredServiceNameProviderTest.java
@@ -18,12 +18,12 @@ package com.adaptris.core.services.dynamic;
 
 import java.util.Arrays;
 import java.util.HashSet;
-
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.BaseCase;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.TradingRelationship;
 
+@SuppressWarnings("deprecation")
 public class ConfiguredServiceNameProviderTest extends BaseCase {
 
   private ConfiguredServiceNameProvider provider;

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/DefaultServiceNameProviderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/DefaultServiceNameProviderTest.java
@@ -17,9 +17,9 @@
 package com.adaptris.core.services.dynamic;
 
 import com.adaptris.core.TradingRelationship;
-
 import junit.framework.TestCase;
 
+@SuppressWarnings("deprecation")
 public class DefaultServiceNameProviderTest extends TestCase {
 
   private DefaultServiceNameProvider provider;

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/DynamicServiceExecutorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/DynamicServiceExecutorTest.java
@@ -30,6 +30,7 @@ import com.adaptris.core.Service;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.XStreamMarshaller;
+import com.adaptris.core.common.MetadataDataInputParameter;
 import com.adaptris.core.services.LogMessageService;
 import com.adaptris.core.services.metadata.AddMetadataService;
 import com.adaptris.util.GuidGenerator;
@@ -89,6 +90,30 @@ public class DynamicServiceExecutorTest extends DynamicServiceExample {
             })).getContent() + "\n-->\n";
       }
       
+    },
+    DATA_INPUT {
+      @Override
+      boolean matches(ServiceExtractor e) {
+        return e instanceof ServiceFromDataInputParameter;
+      }
+
+      @Override
+      ServiceExtractor create() {
+        return new ServiceFromDataInputParameter(new MetadataDataInputParameter("metadataKey"));
+      }
+
+      @Override
+      String getExampleCommentHeader() throws Exception {
+        return "\n<!--"
+            + "\nUsing this extractor implementation, the expectation is that the configured"
+            + "\nDataInputParameter<String> will resolve to a "
+            + "\nwill contain a well formed service that can be unmarshalled and executed."
+            + "\ne.g. something like:\n"
+            + createMessage(new ServiceList(new Service[]
+            {
+              new LogMessageService()
+            })).getContent() + "\n-->\n";
+      }
     },
     MIME {
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/DynamicServiceLocatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/DynamicServiceLocatorTest.java
@@ -21,9 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-
 import org.apache.commons.io.FileUtils;
-
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ClosedState;
@@ -41,6 +39,7 @@ import com.adaptris.core.XpathTradingRelationshipCreator;
 import com.adaptris.core.services.dynamic.DynamicFailingService.WhenToFail;
 import com.adaptris.core.util.LifecycleHelper;
 
+@SuppressWarnings("deprecation")
 public class DynamicServiceLocatorTest extends DynamicServiceExample {
 
   private static final String DEFAULT_DEST = "TheDestination";

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ExactMatchingStrategyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ExactMatchingStrategyTest.java
@@ -17,9 +17,9 @@
 package com.adaptris.core.services.dynamic;
 
 import com.adaptris.core.TradingRelationship;
-
 import junit.framework.TestCase;
 
+@SuppressWarnings("deprecation")
 public class ExactMatchingStrategyTest extends TestCase {
 
   private ExactMatchingStrategy exactMatchingStrategy;

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/LocalMarshallServiceStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/LocalMarshallServiceStoreTest.java
@@ -17,11 +17,11 @@
 package com.adaptris.core.services.dynamic;
 
 import java.io.File;
-
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.stubs.TempFileUtils;
 
+@SuppressWarnings("deprecation")
 public class LocalMarshallServiceStoreTest extends MarshallServiceStoreCase {
 
   public LocalMarshallServiceStoreTest(String s) {

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/MarshallServiceStoreCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/MarshallServiceStoreCase.java
@@ -18,10 +18,8 @@ package com.adaptris.core.services.dynamic;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
-
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.BaseCase;
 import com.adaptris.core.DefaultMarshaller;
@@ -30,6 +28,7 @@ import com.adaptris.core.ServiceList;
 import com.adaptris.core.services.WaitService;
 import com.adaptris.util.TimeInterval;
 
+@SuppressWarnings("deprecation")
 public abstract class MarshallServiceStoreCase extends BaseCase {
 
   private static FileCleaningTracker cleaner = new FileCleaningTracker();

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/RemoteCastorserviceStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/RemoteCastorserviceStoreTest.java
@@ -17,10 +17,10 @@
 package com.adaptris.core.services.dynamic;
 
 import java.io.File;
-
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceList;
 
+@SuppressWarnings("deprecation")
 public class RemoteCastorserviceStoreTest extends MarshallServiceStoreCase {
 
   public RemoteCastorserviceStoreTest(String s) {

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/SafeServiceNameProviderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/SafeServiceNameProviderTest.java
@@ -17,9 +17,9 @@
 package com.adaptris.core.services.dynamic;
 
 import com.adaptris.core.TradingRelationship;
-
 import junit.framework.TestCase;
 
+@SuppressWarnings("deprecation")
 public class SafeServiceNameProviderTest extends TestCase {
 
   private DefaultServiceNameProvider provider;

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromCacheTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromCacheTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.io.InputStream;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.ServiceList;
+import com.adaptris.core.cache.ExpiringMapCache;
+import com.adaptris.core.services.LogMessageService;
+import com.adaptris.core.services.cache.CacheConnection;
+import com.adaptris.core.util.LifecycleHelper;
+
+public class ServiceFromCacheTest {
+
+
+  @Test
+  public void testGetInputStream() throws Exception {
+    CacheConnection conn = createCache("actualCacheKey");
+
+    ServiceFromCache extractor =
+        new ServiceFromCache().withKey("%message{myKey}").withConnection(conn);
+    
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata("myKey", "actualCacheKey");
+    try {
+      LifecycleHelper.initAndStart(extractor);
+      try (InputStream in = extractor.getInputStream(msg)) {
+        assertNotNull(in);
+        assertEquals(ServiceList.class,
+            DefaultMarshaller.getDefaultMarshaller().unmarshal(in).getClass());
+      }
+    } finally {
+      LifecycleHelper.stopAndClose(extractor);
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNotFound() throws Exception {
+    CacheConnection conn = createCache("actualCacheKey");
+
+    ServiceFromCache extractor =
+        new ServiceFromCache().withKey("%message{myKey}").withConnection(conn);
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata("myKey", "nonExistentKey");
+    try {
+      LifecycleHelper.initAndStart(extractor);
+      // NPE will be thrown by IOUtils.toInputStream() since it's not in the cache.
+      InputStream in = extractor.getInputStream(msg);
+    } finally {
+      LifecycleHelper.stopAndClose(extractor);
+    }
+  }
+
+  private CacheConnection createCache(String key) throws Exception {
+    ExpiringMapCache cacheInstance = new ExpiringMapCache();
+    CacheConnection conn = new CacheConnection();
+    conn.setCacheInstance(cacheInstance);
+    LifecycleHelper.initAndStart(conn);
+    conn.retrieveCache().put(key,
+        DynamicServiceExecutorTest.createMessage(new ServiceList(new LogMessageService()))
+            .getContent());
+    return conn;
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromDataInputTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromDataInputTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.io.InputStream;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceList;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.services.LogMessageService;
+import com.adaptris.core.util.LifecycleHelper;
+
+public class ServiceFromDataInputTest {
+
+  @Test
+  public void testGetInputStream() throws Exception {
+    String xml = DynamicServiceExecutorTest
+        .createMessage(new ServiceList(new Service[] {new LogMessageService()})).getContent();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    ServiceFromDataInputParameter serviceExtractor =
+        new ServiceFromDataInputParameter(new ConstantDataInputParameter(xml));
+    try {
+      LifecycleHelper.initAndStart(serviceExtractor);
+      try (InputStream in = serviceExtractor.getInputStream(msg)) {
+        assertNotNull(in);
+        assertEquals(ServiceList.class,
+            DefaultMarshaller.getDefaultMarshaller().unmarshal(in).getClass());
+      }
+    } finally {
+      LifecycleHelper.stopAndClose(serviceExtractor);
+    }
+  }
+
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromDatabaseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromDatabaseTest.java
@@ -49,7 +49,9 @@ public class ServiceFromDatabaseTest {
   private static final String INSERT_STMT = String.format(
       "INSERT INTO %s (source, destination, dynamicService)" + "values (?,?,?)", TABLE_NAME);
   private static final String SELECT_STMT = String.format(
-      "SELECT dynamicService FROM %s WHERE source='%%message{source}' AND destination='%%message{destination}'",
+      "SELECT dynamicService FROM %s "
+      + "\nWHERE source='%%message{source}' "
+      + "\nAND destination='%%message{destination}'",
       TABLE_NAME);
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromDatabaseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromDatabaseTest.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceList;
+import com.adaptris.core.jdbc.JdbcConnection;
+import com.adaptris.core.services.LogMessageService;
+import com.adaptris.core.util.LifecycleHelper;
+
+public class ServiceFromDatabaseTest {
+
+  private static final String JDBC_DRIVER = "org.apache.derby.jdbc.EmbeddedDriver";
+  private static final String JDBC_URL = "jdbc:derby:memory:DSL_FROM_DB;create=true";
+  private static final String TABLE_NAME = "services";
+  private static final String DROP_STMT = String.format("DROP TABLE %s", TABLE_NAME);
+  private static final String CREATE_STMT = String.format(
+      "CREATE TABLE %s (source VARCHAR(128) NOT NULL, "
+      + "destination VARCHAR(128) NOT NULL, "
+          + "dynamicService CLOB NOT NULL)",
+      TABLE_NAME);
+  private static final String INSERT_STMT = String.format(
+      "INSERT INTO %s (source, destination, dynamicService)" + "values (?,?,?)", TABLE_NAME);
+  private static final String SELECT_STMT = String.format(
+      "SELECT dynamicService FROM %s WHERE source='%%message{source}' AND destination='%%message{destination}'",
+      TABLE_NAME);
+
+
+  @Test
+  public void testGetInputStream() throws Exception {
+    DatabaseEntry entry = new DatabaseEntry("mySourcePartner", "myDestinationPartner");
+    createDatabase(Arrays.asList(entry));
+    JdbcConnection jdbcConn = configure(new JdbcConnection());
+
+    ServiceFromDatabase extractor =
+        new ServiceFromDatabase().withQuery(SELECT_STMT).withConnection(jdbcConn);
+    
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata("source", "mySourcePartner");
+    msg.addMetadata("destination", "myDestinationPartner");
+    try {
+      LifecycleHelper.initAndStart(extractor);
+      try (InputStream in = extractor.getInputStream(msg)) {
+        assertNotNull(in);
+        assertEquals(ServiceList.class,
+            DefaultMarshaller.getDefaultMarshaller().unmarshal(in).getClass());
+      }
+    } finally {
+      LifecycleHelper.stopAndClose(extractor);
+    }
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testNotFound() throws Exception {
+    DatabaseEntry entry = new DatabaseEntry("mySourcePartner", "myDestinationPartner");
+    createDatabase(Arrays.asList(entry));
+    JdbcConnection jdbcConn = configure(new JdbcConnection());
+    ServiceFromDatabase extractor =
+        new ServiceFromDatabase().withQuery(SELECT_STMT).withConnection(jdbcConn);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata("source", "anotherSourcePartner");
+    msg.addMetadata("destination", "anotherDestinationPartner");
+    try {
+      LifecycleHelper.initAndStart(extractor);
+      // Since there's no resultSet.next(), should throw a ServiceException.
+      InputStream in = extractor.getInputStream(msg);
+    } finally {
+      LifecycleHelper.stopAndClose(extractor);
+    }
+  }
+
+
+  protected static Connection createConnection() throws Exception {
+    Class.forName(JDBC_DRIVER);
+    Connection c = DriverManager.getConnection(JDBC_URL);
+    c.setAutoCommit(true);
+    return c;
+  }
+
+  protected static JdbcConnection configure(JdbcConnection c) {
+    c.setDriverImp(JDBC_DRIVER);
+    c.setConnectUrl(JDBC_URL);
+    c.setAutoCommit(true);
+    return c;
+  }
+
+  protected static void createDatabase(List<DatabaseEntry> list) throws Exception {
+    createDatabase();
+    try (Connection c = createConnection();
+        PreparedStatement insert = c.prepareStatement(INSERT_STMT);) {
+      for (DatabaseEntry entry : list) {
+        insert.clearParameters();
+        insert.setString(1, entry.source);
+        insert.setString(2, entry.destination);
+        insert.setString(3, entry.service);
+        insert.executeUpdate();
+      }
+    }
+  }
+
+  protected static void createDatabase() throws Exception {
+    try (Connection c = createConnection(); Statement s = c.createStatement()) {
+      executeQuietly(s, DROP_STMT);
+      s.execute(CREATE_STMT);
+    }
+  }
+
+  protected static void executeQuietly(Statement s, String sql) {
+    try {
+      s.execute(sql);
+    } catch (Exception e) {
+      ;
+    }
+  }
+
+
+  private class DatabaseEntry {
+    String source;
+    String destination;
+    String service;
+
+    public DatabaseEntry(String src, String dest) throws Exception {
+      source = src;
+      destination = dest;
+      service = DynamicServiceExecutorTest.createMessage(new ServiceList(new LogMessageService()))
+          .getContent();
+    }
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromDatabaseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromDatabaseTest.java
@@ -17,6 +17,7 @@ package com.adaptris.core.services.dynamic;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -51,6 +52,26 @@ public class ServiceFromDatabaseTest {
       "SELECT dynamicService FROM %s WHERE source='%%message{source}' AND destination='%%message{destination}'",
       TABLE_NAME);
 
+  @Test
+  public void testLifecycle() throws Exception {
+    JdbcConnection jdbcConn = configure(new JdbcConnection());
+    ServiceFromDatabase extractor =
+        new ServiceFromDatabase().withQuery(SELECT_STMT);
+    try {
+      LifecycleHelper.initAndStart(extractor);
+      fail();
+    } catch (Exception expected) {
+
+    } finally {
+      LifecycleHelper.stopAndClose(extractor);
+    }
+    extractor.setConnection(jdbcConn);
+    try {
+      LifecycleHelper.initAndStart(extractor);
+    } finally {
+      LifecycleHelper.stopAndClose(extractor);
+    }
+  }
 
   @Test
   public void testGetInputStream() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromUrlTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceFromUrlTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.InputStream;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceList;
+import com.adaptris.core.services.LogMessageService;
+import com.adaptris.core.stubs.TempFileUtils;
+import com.adaptris.core.util.LifecycleHelper;
+
+public class ServiceFromUrlTest {
+
+  @Test
+  public void testGetInputStream() throws Exception {
+    File f = createService();
+    String urlStyle = f.getCanonicalPath().replaceAll("\\\\", "/");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata("location", urlStyle);
+    ServiceFromUrl serviceExtractor = new ServiceFromUrl("file:///%message{location}");
+    try {
+      LifecycleHelper.initAndStart(serviceExtractor);
+      try (InputStream in = serviceExtractor.getInputStream(msg)) {
+        assertNotNull(in);
+        assertEquals(ServiceList.class,
+            DefaultMarshaller.getDefaultMarshaller().unmarshal(in).getClass());
+      }
+    } finally {
+      LifecycleHelper.stopAndClose(serviceExtractor);
+    }
+  }
+
+
+  private File createService() throws Exception {
+    File f = TempFileUtils.createTrackedFile(this);
+    String xml = DynamicServiceExecutorTest
+        .createMessage(new ServiceList(new Service[] {new LogMessageService()})).getContent();
+    try (FileWriter w = new FileWriter(f, false)) {
+      w.write(xml);
+    }
+    return f;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceNameMapperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/ServiceNameMapperTest.java
@@ -19,9 +19,9 @@ package com.adaptris.core.services.dynamic;
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.TradingRelationship;
-
 import junit.framework.TestCase;
 
+@SuppressWarnings("deprecation")
 public class ServiceNameMapperTest extends TestCase {
 
   public ServiceNameMapperTest(String arg0) {

--- a/interlok-core/src/test/java/com/adaptris/core/services/dynamic/StandardMatchingStrategyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/dynamic/StandardMatchingStrategyTest.java
@@ -17,9 +17,9 @@
 package com.adaptris.core.services.dynamic;
 
 import com.adaptris.core.TradingRelationship;
-
 import junit.framework.TestCase;
 
+@SuppressWarnings("deprecation")
 public class StandardMatchingStrategyTest extends TestCase {
   
   private StandardMatchingStrategy strategy;


### PR DESCRIPTION
* Deprecate all of DynamicServiceLocator and associated classes (@Removal for 3.11.0)
* Add in new ServiceExtractor implementations to replicate the existing functionality
   * URL (which replicates)
   * Database
   * Cache
   * Any DataInputParameter<String> 

https://github.com/adaptris/interlok/blob/feature/INTERLOK-2702/docs/adr/0003-deprecate-dynamicservicelocator.md
