### PR TITLE
INTERLOK-2707 Modify ServiceExtractor Interface to return a Service

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DefaultServiceExtractor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DefaultServiceExtractor.java
@@ -27,11 +27,11 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Default {@link ServiceExtractor} implementation that treats the entire payload as the service.
  * 
  * @config dynamic-default-service-extractor
- * @author lchan
  * 
  */
 @XStreamAlias("dynamic-default-service-extractor")
 @ComponentProfile(summary = "Treat the message body as the service to execute.")
+// intentionally doesn't extend ServiceExtratorImpl because _coverage_
 public class DefaultServiceExtractor implements ServiceExtractor {
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceExecutor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/DynamicServiceExecutor.java
@@ -17,7 +17,6 @@
 package com.adaptris.core.services.dynamic;
 
 import static com.adaptris.core.util.LoggingHelper.friendlyName;
-import java.io.InputStream;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.BooleanUtils;
@@ -104,8 +103,8 @@ public class DynamicServiceExecutor extends ServiceImp implements EventHandlerAw
   }
 
   private Service createService(AdaptrisMessage msg) throws Exception {
-    try (InputStream in = serviceExtractor.getInputStream(msg)) {
-      return (Service) currentMarshaller().unmarshal(in);
+    try {
+      return getServiceExtractor().getService(msg, currentMarshaller());
     } catch (Exception e) {
       return onException(e);
     }
@@ -172,7 +171,8 @@ public class DynamicServiceExecutor extends ServiceImp implements EventHandlerAw
   /**
    * Set the marshaller to use to unmarshal the service.
    * 
-   * @param m the marshaller, if not configured will default to {@link DefaultMarshaller#getDefaultMarshaller()}
+   * @param m the marshaller, if not configured will default to
+   *        {@link DefaultMarshaller#getDefaultMarshaller()}
    */
   public void setMarshaller(AdaptrisMarshaller m) {
     this.marshaller = m;

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ExtractorWithConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ExtractorWithConnection.java
@@ -23,7 +23,7 @@ import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 
-public abstract class ExtractorWithConnection implements ServiceExtractor {
+public abstract class ExtractorWithConnection extends ServiceExtractorImpl {
   @NotNull
   @Valid
   private AdaptrisConnection connection;

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/MimeServiceExtractor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/MimeServiceExtractor.java
@@ -25,6 +25,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
@@ -45,7 +46,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("dynamic-mime-service-extractor")
 @ComponentProfile(
     summary = "Select the service to executed based on a MIME selector on the message")
-public class MimeServiceExtractor implements ServiceExtractor {
+@DisplayOrder(order = {"selector"})
+public class MimeServiceExtractor extends ServiceExtractorImpl {
 
   @NotNull
   @Valid

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractor.java
@@ -17,8 +17,11 @@
 package com.adaptris.core.services.dynamic;
 
 import java.io.InputStream;
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ComponentLifecycle;
+import com.adaptris.core.Service;
 
 /**
  * Interface for use with {@link DynamicServiceExecutor}.
@@ -31,6 +34,28 @@ public interface ServiceExtractor extends ComponentLifecycle {
    * 
    * @param m the adaptris message.
    * @return an input stream.
+   * @deprecated since 3.8.4 use {@link #getService(AdaptrisMessage)} or
+   *             {@link #getService(AdaptrisMessage, AdaptrisMarshaller)} instead.
    */
+  @Deprecated
+  @Removal(version = "3.11.0")
   InputStream getInputStream(AdaptrisMessage m) throws Exception;
+
+  /**
+   * Build a service from the message.
+   * 
+   * @param msg the message
+   * @param m the marshaller
+   * @return a service
+   * @throws Exception if no service could be created
+   * @implSpec The default implementation still uses {@link #getInputStream(AdaptrisMessage)} for
+   *           expediency but will be removed in 3.11.0
+   */
+  @SuppressWarnings("deprecation")
+  default Service getService(AdaptrisMessage msg, AdaptrisMarshaller m) throws Exception {
+    try (InputStream in = getInputStream(msg)) {
+      return (Service) m.unmarshal(in);
+    }
+  }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractor.java
@@ -48,8 +48,10 @@ public interface ServiceExtractor extends ComponentLifecycle {
    * @param m the marshaller
    * @return a service
    * @throws Exception if no service could be created
+   * @since 3.8.4
    * @implSpec The default implementation still uses {@link #getInputStream(AdaptrisMessage)} for
-   *           expediency but will be removed in 3.11.0
+   *           expediency but will be removed in 3.11.0. Just extend {@link ServiceExtractorImpl}
+   *           for future compatibility.
    */
   @SuppressWarnings("deprecation")
   default Service getService(AdaptrisMessage msg, AdaptrisMarshaller m) throws Exception {

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceExtractorImpl.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.dynamic;
+
+import java.io.InputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.adaptris.core.AdaptrisMarshaller;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.Service;
+
+public abstract class ServiceExtractorImpl implements ServiceExtractor {
+
+  protected transient Logger log = LoggerFactory.getLogger(this.getClass());
+
+  public ServiceExtractorImpl() {
+
+  }
+
+  // We intentionally override getInputStream() since it's deprecated, so that
+  // if people choose to extend this class, they don't get broken.
+  @Override
+  public abstract InputStream getInputStream(AdaptrisMessage msg) throws Exception;
+
+  @Override
+  public Service getService(AdaptrisMessage msg, AdaptrisMarshaller m) throws Exception {
+    try (InputStream in = getInputStream(msg)) {
+      return (Service) m.unmarshal(in);
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDataInputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDataInputParameter.java
@@ -20,6 +20,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.io.IOUtils;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.MetadataDataInputParameter;
@@ -46,7 +47,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("dynamic-service-from-data-input")
 @ComponentProfile(summary = "Extract the service to execute from a DataInputParameter",
     since = "3.8.4")
-public class ServiceFromDataInputParameter implements ServiceExtractor {
+@DisplayOrder(order = {"input"})
+public class ServiceFromDataInputParameter extends ServiceExtractorImpl {
 
   @NotNull
   @Valid

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromUrl.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.dynamic;
 import java.io.InputStream;
 import org.hibernate.validator.constraints.NotBlank;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.util.Args;
@@ -34,7 +35,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("dynamic-service-from-url")
 @ComponentProfile(summary = "Extract the service to execute from a URL (file/http etc)",
     since = "3.8.4")
-public class ServiceFromUrl implements ServiceExtractor {
+@DisplayOrder(order = {"url"})
+public class ServiceFromUrl extends ServiceExtractorImpl {
 
   @NotBlank
   @InputFieldHint(expression = true)


### PR DESCRIPTION
- Added a `getService(AdaptrisMessage, AdaptrisMarshaller)` method; it is a default interface method with appropriate javadocs saying how you should just extend ServiceExtractorImpl if you can't be bothered
to change your impl.
- Added ServiceExtractorImpl
- DefaultServiceExtractor doesn't extend it, so we get coverage...
- Switch DynamicServiceExecutor to use the new method.

Tests still pass with no changes (and still give 100% 👍 ).