### PR TITLE
INTERLOK-2725 Add MetadataLogger interface

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/MessageLoggerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MessageLoggerImpl.java
@@ -16,7 +16,6 @@
 package com.adaptris.core;
 
 import java.util.Collection;
-import java.util.Set;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
@@ -44,7 +43,7 @@ public abstract class MessageLoggerImpl implements MessageLogger {
   }
 
 
-  protected Collection<MetadataElement> format(Set<MetadataElement> set) {
+  protected Collection<MetadataElement> format(Collection<MetadataElement> set) {
     MetadataCollection metadata = new MetadataCollection();
     set.parallelStream().forEach(e -> {
       metadata.add(wrap(e.getKey(), e.getValue()));
@@ -57,6 +56,7 @@ public abstract class MessageLoggerImpl implements MessageLogger {
   }
 
   private static class FormattedElement extends MetadataElement {
+    private static final long serialVersionUID = 2019040201L;
 
     public FormattedElement(String key, String value) {
       super(key, value);

--- a/interlok-core/src/main/java/com/adaptris/core/MetadataLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MetadataLogger.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@FunctionalInterface
+public interface MetadataLogger {
+
+  default String toString(MetadataElement... elements) {
+    return toString(Arrays.asList(elements));
+  }
+
+  String toString(Collection<MetadataElement> elements);
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddMetadataService.java
@@ -36,10 +36,8 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
@@ -65,11 +63,8 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @XStreamAlias("add-metadata-service")
 @AdapterComponent
 @ComponentProfile(summary = "Add Static Metadata to a Message", tag = "service,metadata")
-@DisplayOrder(order =
-{
-    "metadataElements", "overwrite"
-})
-public class AddMetadataService extends ServiceImp {
+@DisplayOrder(order = {"metadataElements", "overwrite", "metadataLogger"})
+public class AddMetadataService extends MetadataServiceImpl {
 
   private static final String UNIQUE_ID_MNENOMIC = "$UNIQUE_ID$";
   private static final String FILE_SIZE_MNEMONIC = "$MSG_SIZE$";
@@ -147,6 +142,7 @@ public class AddMetadataService extends ServiceImp {
    *
    * @param msg the message to process
    */
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     Set<MetadataElement> addedMetadata = new HashSet<MetadataElement>();
     for (MetadataElement e : metadataElements) {
@@ -156,16 +152,7 @@ public class AddMetadataService extends ServiceImp {
         addedMetadata.add(addMe);
       }
     }
-    log.debug("metadata added {}", addedMetadata);
-  }
-
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-
+    logMetadata("metadata added : {}", addedMetadata);
   }
 
   /**
@@ -212,10 +199,6 @@ public class AddMetadataService extends ServiceImp {
    */
   public void addMetadataElement(String key, String value) {
     metadataElements.add(new MetadataElement(key, value));
-  }
-
-  @Override
-  public void prepare() throws CoreException {
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64DecodeMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64DecodeMetadataService.java
@@ -45,7 +45,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-base64-decode")
 @AdapterComponent
 @ComponentProfile(summary = "Base64 decode an item of metadata", tag = "service,metadata,base64")
-@DisplayOrder(order = {"metadataKeyRegexp"})
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class Base64DecodeMetadataService extends ReformatMetadata {
 
   private transient ByteTranslator byteTranslator = new Base64ByteTranslator();

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64EncodeMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64EncodeMetadataService.java
@@ -42,7 +42,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-base64-encode")
 @AdapterComponent
 @ComponentProfile(summary = "Base64 encode an item of metadata", tag = "service,metadata,base64")
-@DisplayOrder(order = {"metadataKeyRegexp"})
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class Base64EncodeMetadataService extends ReformatMetadata {
 
   private transient ByteTranslator byteTranslator = new Base64ByteTranslator();

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ConvertObjectMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ConvertObjectMetadataService.java
@@ -32,7 +32,6 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -53,8 +52,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("convert-object-metadata-service")
 @AdapterComponent
 @ComponentProfile(summary = "Convert object metadata into normal metadata", tag = "service,metadata")
-@DisplayOrder(order = {"objectMetadataKeyRegexp"})
-public class ConvertObjectMetadataService extends ServiceImp {
+@DisplayOrder(order = {"objectMetadataKeyRegexp", "metadataLogger"})
+public class ConvertObjectMetadataService extends MetadataServiceImpl {
 
   @NotBlank
   @AffectsMetadata
@@ -71,6 +70,7 @@ public class ConvertObjectMetadataService extends ServiceImp {
     setObjectMetadataKeyRegexp(regexp);
   }
 
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     Set<MetadataElement> metadataToAdd = new HashSet<MetadataElement>();
     for (Iterator i = msg.getObjectHeaders().entrySet().iterator(); i.hasNext();) {
@@ -82,7 +82,7 @@ public class ConvertObjectMetadataService extends ServiceImp {
         metadataToAdd.add(e);
       }
     }
-    log.trace("metadata added " + metadataToAdd);
+    logMetadata("Metadata Added : {}", metadataToAdd);
   }
 
   @Override
@@ -90,12 +90,6 @@ public class ConvertObjectMetadataService extends ServiceImp {
     objectMetadataKeyPattern = Pattern.compile(getObjectMetadataKeyRegexp());
 
   }
-
-  @Override
-  protected void closeService() {
-
-  }
-
 
   public String getObjectMetadataKeyRegexp() {
     return objectMetadataKeyRegexp;
@@ -111,8 +105,5 @@ public class ConvertObjectMetadataService extends ServiceImp {
     this.objectMetadataKeyRegexp = s;
   }
 
-  @Override
-  public void prepare() throws CoreException {
-  }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/CopyMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/CopyMetadataService.java
@@ -16,6 +16,9 @@
 
 package com.adaptris.core.services.metadata;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -25,9 +28,8 @@ import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
+import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.Args;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairCollection;
@@ -53,8 +55,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("copy-metadata-service")
 @AdapterComponent
 @ComponentProfile(summary = "Copy metadata values to other metadata keys", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeys"})
-public class CopyMetadataService extends ServiceImp {
+@DisplayOrder(order = {"metadataKeys", "metadataLogger"})
+public class CopyMetadataService extends MetadataServiceImpl {
 
   @NotNull
   @AutoPopulated
@@ -69,28 +71,18 @@ public class CopyMetadataService extends ServiceImp {
   /**
    * {@inheritDoc}
    */
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
+    List<MetadataElement> copied = new ArrayList<>();
     for (KeyValuePair k : getMetadataKeys()) {
       String value = msg.getMetadataValue(k.getKey());
       if (value != null) {
-        msg.addMetadata(k.getValue(), value);
-        log.debug("found metadata [" + value + "] against key [" + k.getKey()
-            + "] copied to key [" + k.getValue() + "]");
+        MetadataElement e = new MetadataElement(k.getValue(), value);
+        msg.addMetadata(e);
       }
     }
+    logMetadata("Copied Metadata : {}", copied);
   }
-
-
-  @Override
-  protected void initService() throws CoreException {
-
-  }
-
-  @Override
-  protected void closeService() {
-
-  }
-
 
   /**
    * <p>
@@ -115,10 +107,6 @@ public class CopyMetadataService extends ServiceImp {
    */
   public void setMetadataKeys(KeyValuePairCollection m) {
     this.metadataKeys = Args.notNull(m, "metadataKeys");
-  }
-
-  @Override
-  public void prepare() throws CoreException {
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/GenerateUniqueMetadataValueService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/GenerateUniqueMetadataValueService.java
@@ -26,9 +26,8 @@ import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
+import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.Args;
 import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.IdGenerator;
@@ -49,8 +48,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("generate-unique-metadata-value-service")
 @AdapterComponent
 @ComponentProfile(summary = "Generate a unique value and attach it as metadata", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKey", "generator"})
-public class GenerateUniqueMetadataValueService extends ServiceImp {
+@DisplayOrder(order = {"metadataKey", "generator", "metadataLogger"})
+public class GenerateUniqueMetadataValueService extends MetadataServiceImpl {
 
   @AffectsMetadata
   private String metadataKey;
@@ -71,23 +70,13 @@ public class GenerateUniqueMetadataValueService extends ServiceImp {
     setGenerator(generator);
   }
 
-
-  @Override
-  protected void initService() throws CoreException {
-
-  }
-
-  @Override
-  protected void closeService() {
-
-  }
-
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     String metadataKey = metadataKey(msg);
     String metadataValue = getGenerator().create(msg);
-    log.trace("Adding [" + metadataValue + "] to metadata key [" + metadataKey + "]");
-    msg.addMetadata(metadataKey, metadataValue);
+    MetadataElement e = new MetadataElement(metadataKey, metadataValue);
+    msg.addMetadata(e);
+    logMetadata("Added {}", e);
   }
 
   /**
@@ -126,10 +115,6 @@ public class GenerateUniqueMetadataValueService extends ServiceImp {
    */
   public void setGenerator(IdGenerator idg) {
     generator = Args.notNull(idg, "generator");
-  }
-
-  @Override
-  public void prepare() throws CoreException {
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/HexToStringService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/HexToStringService.java
@@ -21,7 +21,6 @@ import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.core.CoreException;
 import com.adaptris.util.text.ByteTranslator;
 import com.adaptris.util.text.CharsetByteTranslator;
 import com.adaptris.util.text.HexStringByteTranslator;
@@ -39,7 +38,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Turn a hex encoded string into a java string using the specified character encoding",
     tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp", "charset"})
+@DisplayOrder(order = {"metadataKeyRegexp", "charset", "metadataLogger"})
 public class HexToStringService extends ReformatMetadata {
 
   private String charset;
@@ -54,14 +53,6 @@ public class HexToStringService extends ReformatMetadata {
     setCharset(UTF_8);
   }
 
-
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-  }
   public String getCharset() {
     return charset;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataAppenderService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataAppenderService.java
@@ -29,8 +29,7 @@ import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.ServiceImp;
+import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
@@ -48,8 +47,8 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @XStreamAlias("metadata-appender-service")
 @AdapterComponent
 @ComponentProfile(summary = "Concatenate various metadata values into one", tag = "service,metadata")
-@DisplayOrder(order = {"appendKeys", "resultKey"})
-public class MetadataAppenderService extends ServiceImp {
+@DisplayOrder(order = {"appendKeys", "resultKey", "metadataLogger"})
+public class MetadataAppenderService extends MetadataServiceImpl {
 
   @NotNull
   @AutoPopulated
@@ -79,9 +78,9 @@ public class MetadataAppenderService extends ServiceImp {
         result.append(msg.getMetadataValue(key));
       }
     }
-    msg.addMetadata(resultKey, result.toString());
-    log.debug("added metadata key [" + resultKey + "] value ["
-      + result.toString() + "]");
+    MetadataElement e = new MetadataElement(resultKey, result.toString());
+    logMetadata("Added {}", e);
+    msg.addMetadata(e);
   }
 
   /**
@@ -141,19 +140,6 @@ public class MetadataAppenderService extends ServiceImp {
    */
   public void setResultKey(String string) {
     resultKey = Args.notBlank(string, "resultKey");
-  }
-
-
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-  }
-
-  @Override
-  public void prepare() throws CoreException {
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataFilterService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataFilterService.java
@@ -25,10 +25,7 @@ import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataCollection;
-import com.adaptris.core.MetadataElement;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.util.Args;
@@ -47,8 +44,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-filter-service")
 @AdapterComponent
 @ComponentProfile(summary = "Filter and remove metadata", tag = "service,metadata")
-@DisplayOrder(order = {"filter"})
-public class MetadataFilterService extends ServiceImp {
+@DisplayOrder(order = {"filter", "metadataLogger"})
+public class MetadataFilterService extends MetadataServiceImpl {
 
   @NotNull
   @AutoPopulated
@@ -62,28 +59,13 @@ public class MetadataFilterService extends ServiceImp {
 
   @Override
   public void doService(AdaptrisMessage msg) {
-    log.trace("Filtering metadata using [" + filter.getClass().getCanonicalName() + "]");
+    log.trace("Filtering metadata using [{}]", filter.getClass().getCanonicalName());
     MetadataCollection filtered = filter.filter(msg);
     msg.clearMetadata();
-    StringBuffer filteredKeys = new StringBuffer("Metadata keys preserved:");
-    for (MetadataElement e : filtered) {
-      filteredKeys.append(" ");
-      filteredKeys.append(e.getKey());
-      msg.addMetadata(e);
-    }
-    log.trace(filteredKeys.toString());
+    msg.setMetadata(filtered.toSet());
+    logMetadata("Metadata preserved : {}", filtered);
   }
 
-
-  @Override
-  protected void initService() throws CoreException {
-
-  }
-
-  @Override
-  protected void closeService() {
-
-  }
   public MetadataFilter getFilter() {
     return filter;
   }
@@ -96,9 +78,4 @@ public class MetadataFilterService extends ServiceImp {
     setFilter(mf);
     return this;
   }
-
-  @Override
-  public void prepare() throws CoreException {
-  }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java
@@ -52,7 +52,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-hashing-service")
 @AdapterComponent
 @ComponentProfile(summary = "Hash a metadata value, and store it", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp", "hashAlgorithm", "byteTranslator"})
+@DisplayOrder(order = {"metadataKeyRegexp", "hashAlgorithm", "byteTranslator", "metadataLogger"})
 public class MetadataHashingService extends ReformatMetadata {
   private static final String DEFAULT_HASH_ALG = "SHA1";
   @NotBlank
@@ -90,11 +90,6 @@ public class MetadataHashingService extends ReformatMetadata {
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
-  }
-
-  @Override
-  protected void closeService() {
-    super.closeService();
   }
 
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataKeyToCapitalCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataKeyToCapitalCase.java
@@ -35,7 +35,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-key-to-capital-case")
 @AdapterComponent
 @ComponentProfile(summary = "Changes matching metadata keys to capital case", tag = "service,metadata")
-@DisplayOrder(order = {"keysToModify"})
+@DisplayOrder(order = {"keysToModify", "metadataLogger"})
 public class MetadataKeyToCapitalCase extends ReformatMetadataKey {
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataKeyToLowerCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataKeyToLowerCase.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-key-to-lower-case")
 @AdapterComponent
 @ComponentProfile(summary = "Changes matching metadata keys to lowercase", tag = "service,metadata")
-@DisplayOrder(order = {"keysToModify"})
+@DisplayOrder(order = {"keysToModify", "metadataLogger"})
 public class MetadataKeyToLowerCase extends ReformatMetadataKey {
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataKeyToUpperCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataKeyToUpperCase.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-key-to-upper-case")
 @AdapterComponent
 @ComponentProfile(summary = "Changes matching metadata keys to uppercase", tag = "service,metadata")
-@DisplayOrder(order = {"keysToModify"})
+@DisplayOrder(order = {"keysToModify", "metadataLogger"})
 public class MetadataKeyToUpperCase extends ReformatMetadataKey {
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataServiceImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.metadata;
+
+import java.util.Collection;
+
+import javax.validation.Valid;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.MetadataElement;
+import com.adaptris.core.MetadataLogger;
+import com.adaptris.core.ServiceImp;
+
+public abstract class MetadataServiceImpl extends ServiceImp {
+
+  private static final MetadataLogger DEFAULT_LOGGER = (list) -> {
+    return list.toString();
+  };
+
+  @AdvancedConfig
+  @InputFieldDefault(value = "full key and value")
+  @Valid
+  private MetadataLogger metadataLogger;
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+
+  }
+
+  protected void logMetadata(String logMsg, MetadataElement... elements) {
+    log.trace(logMsg, metadataLogger().toString(elements));
+  }
+
+  protected void logMetadata(String logMsg, Collection<MetadataElement> list) {
+    log.trace(logMsg, metadataLogger().toString(list));
+  }
+
+  public MetadataLogger getMetadataLogger() {
+    return metadataLogger;
+  }
+
+  public void setMetadataLogger(MetadataLogger metadataLogger) {
+    this.metadataLogger = metadataLogger;
+  }
+
+  public <T extends MetadataServiceImpl> T withMetadataLogger(MetadataLogger logger) {
+    setMetadataLogger(logger);
+    return (T) this;
+  }
+
+  private MetadataLogger metadataLogger() {
+    return ObjectUtils.defaultIfNull(getMetadataLogger(), DEFAULT_LOGGER);
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataServiceImpl.java
@@ -16,11 +16,9 @@
 package com.adaptris.core.services.metadata;
 
 import java.util.Collection;
-
 import javax.validation.Valid;
-
 import org.apache.commons.lang3.ObjectUtils;
-
+import org.slf4j.Logger;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.CoreException;
@@ -33,6 +31,12 @@ public abstract class MetadataServiceImpl extends ServiceImp {
   private static final MetadataLogger DEFAULT_LOGGER = (list) -> {
     return list.toString();
   };
+
+  protected static final LogWrapper TRACE = (logger, msg, metadata) -> logger.trace(msg, metadata);
+  protected static final LogWrapper DEBUG = (logger, msg, metadata) -> logger.debug(msg, metadata);
+  protected static final LogWrapper INFO = (logger, msg, metadata) -> logger.info(msg, metadata);
+  protected static final LogWrapper WARN = (logger, msg, metadata) -> logger.warn(msg, metadata);
+  protected static final LogWrapper ERROR = (logger, msg, metadata) -> logger.error(msg, metadata);
 
   @AdvancedConfig
   @InputFieldDefault(value = "full key and value")
@@ -54,11 +58,19 @@ public abstract class MetadataServiceImpl extends ServiceImp {
   }
 
   protected void logMetadata(String logMsg, MetadataElement... elements) {
-    log.trace(logMsg, metadataLogger().toString(elements));
+    logMetadata(TRACE, logMsg, elements);
   }
 
   protected void logMetadata(String logMsg, Collection<MetadataElement> list) {
-    log.trace(logMsg, metadataLogger().toString(list));
+    logMetadata(TRACE, logMsg, list);
+  }
+
+  protected void logMetadata(LogWrapper lvl, String logMsg, MetadataElement... elements) {
+    lvl.log(log, logMsg, metadataLogger().toString(elements));
+  }
+
+  protected void logMetadata(LogWrapper lvl, String logMsg, Collection<MetadataElement> list) {
+    lvl.log(log, logMsg, metadataLogger().toString(list));
   }
 
   public MetadataLogger getMetadataLogger() {
@@ -76,5 +88,10 @@ public abstract class MetadataServiceImpl extends ServiceImp {
 
   private MetadataLogger metadataLogger() {
     return ObjectUtils.defaultIfNull(getMetadataLogger(), DEFAULT_LOGGER);
+  }
+  
+  @FunctionalInterface
+  protected interface LogWrapper {
+    void log(Logger logger, String logMsg, String stringifiedMetadata);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueToLowerCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueToLowerCase.java
@@ -34,7 +34,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-value-to-lower-case")
 @AdapterComponent
 @ComponentProfile(summary = "Changes matching metadata into lowercase", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp"})
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class MetadataValueToLowerCase extends ReformatMetadata {
 
   public MetadataValueToLowerCase() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueToUpperCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueToUpperCase.java
@@ -34,7 +34,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-value-to-upper-case")
 @AdapterComponent
 @ComponentProfile(summary = "Changes matching metadata to uppercase", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp"})
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class MetadataValueToUpperCase extends ReformatMetadata {
 
   public MetadataValueToUpperCase() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
@@ -42,7 +42,6 @@ import com.adaptris.core.FormattedFilenameCreator;
 import com.adaptris.core.MessageDrivenDestination;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.fs.FsHelper;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
@@ -67,9 +66,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Read a set of metadata from the filesystem and add/replace current metadata", tag = "service,metadata")
 @DisplayOrder(order =
 {
-    "destination", "inputStyle", "overwriteExistingMetadata", "filenameCreator"
+    "destination", "inputStyle", "overwriteExistingMetadata", "filenameCreator", "metadataLogger"
 })
-public class ReadMetadataFromFilesystem extends ServiceImp {
+public class ReadMetadataFromFilesystem extends MetadataServiceImpl {
 
   private InputStyle inputStyle;
   @NotNull
@@ -132,7 +131,7 @@ public class ReadMetadataFromFilesystem extends ServiceImp {
             msg.addMetadata(e);
           }
         }
-        log.trace("New Metadata for message {}", msg.getMetadata());
+        logMetadata("New Metadata for message {}", msg.getMetadata());
       }
     }
     catch (Exception e) {
@@ -150,11 +149,6 @@ public class ReadMetadataFromFilesystem extends ServiceImp {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }
-
-  @Override
-  protected void closeService() {
-  }
-
 
   public InputStyle getInputStyle() {
     return inputStyle;
@@ -224,10 +218,5 @@ public class ReadMetadataFromFilesystem extends ServiceImp {
   FileNameCreator filenameCreator() {
     return getFilenameCreator() != null ? getFilenameCreator() : new FormattedFilenameCreator();
   }
-
-  @Override
-  public void prepare() throws CoreException {
-  }
-
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReformatDateService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReformatDateService.java
@@ -53,7 +53,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("reformat-date-service")
 @AdapterComponent
 @ComponentProfile(summary = "Reformat a data value stored in metadata", tag = "service,metadata,timestamp,datetime")
-@DisplayOrder(order = {"metadataKeyRegexp", "sourceDateFormat", "sourceFormatBuilder", "destinationDateFormat", "destinationFormatBuilder"})
+@DisplayOrder(order = {"metadataKeyRegexp", "sourceDateFormat", "sourceFormatBuilder", "destinationDateFormat",
+    "destinationFormatBuilder", "metadataLogger"})
 public class ReformatDateService extends ReformatMetadata {
 
   private static final DateFormatBuilder DEFAULT_FORMAT_BUILDER = new DateFormatBuilder();
@@ -100,11 +101,6 @@ public class ReformatDateService extends ReformatMetadata {
     if (!isBlank(getDestinationDateFormat())) {
       log.warn("destination-date-format is deprecated, use destination-format-builder instead");
     }
-  }
-
-  @Override
-  protected void closeService() {
-    super.closeService();
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReformatMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReformatMetadata.java
@@ -25,10 +25,8 @@ import org.hibernate.validator.constraints.NotBlank;
 
 import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.ExceptionHelper;
 
 /**
@@ -45,7 +43,7 @@ import com.adaptris.core.util.ExceptionHelper;
  * @see TrimMetadataService
  * @see ReplaceMetadataValue
  */
-public abstract class ReformatMetadata extends ServiceImp implements MetadataReformatter {
+public abstract class ReformatMetadata extends MetadataServiceImpl implements MetadataReformatter {
 
   @NotBlank
   @AffectsMetadata
@@ -58,15 +56,6 @@ public abstract class ReformatMetadata extends ServiceImp implements MetadataRef
     this();
     setMetadataKeyRegexp(regexp);
   }
-
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-  }
-
 
   /**
    * <p>
@@ -88,7 +77,7 @@ public abstract class ReformatMetadata extends ServiceImp implements MetadataRef
           modifiedMetadata.add(new MetadataElement(e.getKey(), reformat(e.getValue(), msg)));
         }
       }
-      log.trace("Modified metadata : " + modifiedMetadata);
+      logMetadata("Modified metadata : {}", modifiedMetadata);
       msg.setMetadata(modifiedMetadata);
     }
     catch (Exception e) {
@@ -113,9 +102,6 @@ public abstract class ReformatMetadata extends ServiceImp implements MetadataRef
     metadataKeyRegexp = s;
   }
 
-  @Override
-  public void prepare() throws CoreException {
-  }
 
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReformatMetadataKey.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReformatMetadataKey.java
@@ -21,11 +21,9 @@ import javax.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.RemoveAllMetadataFilter;
 
@@ -34,7 +32,7 @@ import com.adaptris.core.metadata.RemoveAllMetadataFilter;
  * 
  * 
  */
-public abstract class ReformatMetadataKey extends ServiceImp {
+public abstract class ReformatMetadataKey extends MetadataServiceImpl {
 
   @AutoPopulated
   @NotNull
@@ -45,21 +43,7 @@ public abstract class ReformatMetadataKey extends ServiceImp {
     setKeysToModify(new RemoveAllMetadataFilter());
   }
 
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-  }
-
-
   protected abstract String reformatKey(String s) throws ServiceException;
-
-
-  @Override
-  public void prepare() throws CoreException {
-  }
 
   public MetadataFilter getKeysToModify() {
     return keysToModify;
@@ -76,9 +60,9 @@ public abstract class ReformatMetadataKey extends ServiceImp {
     MetadataCollection replacements = buildReplacements(toFilter);
     // toFilter.forEach(e -> { msg.removeMetadata(e); });
     // replacements.forEach(e -> { msg.addMetadata(e); });
-    log.trace("Removing {}", toFilter.toString());
+    logMetadata("Removing {}", toFilter);
     removeMetadata(msg, toFilter);
-    log.trace("Adding {}", replacements.toString());
+    logMetadata("Adding {}", replacements);
     addMetadata(msg, replacements);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/RegexpMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/RegexpMetadataService.java
@@ -36,7 +36,6 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
@@ -55,8 +54,8 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @AdapterComponent
 @ComponentProfile(summary = "Extract data from the message via a regular expression and store it as metadata",
     tag = "service,metadata")
-@DisplayOrder(order = {"regexpMetadataQueries"})
-public class RegexpMetadataService extends ServiceImp {
+@DisplayOrder(order = {"regexpMetadataQueries", "addNullValues", "metadataLogger"})
+public class RegexpMetadataService extends MetadataServiceImpl {
 
   @NotNull
   @AutoPopulated
@@ -77,23 +76,26 @@ public class RegexpMetadataService extends ServiceImp {
     setRegexpMetadataQueries(list);
   }
 
+  @Override
   public void doService(AdaptrisMessage msg)
     throws ServiceException {
 
     String message = msg.getContent();
-
+    List<MetadataElement> added = new ArrayList<>();
     try {
       for (int i = 0; i < regexpMetadataQueries.size(); i++) {
         RegexpMetadataQuery q = regexpMetadataQueries.get(i);
         MetadataElement elem = q.doQuery(message);
         if (!isEmpty(elem.getValue()) || addNullValues()) {
           msg.addMetadata(elem);
+          added.add(elem);
         }
       }
     }
     catch (CoreException e) {
       throw new ServiceException(e);
     }
+    logMetadata("Added metadata : {}", added);
   }
 
   /**
@@ -113,19 +115,6 @@ public class RegexpMetadataService extends ServiceImp {
    */
   public void setRegexpMetadataQueries(List<RegexpMetadataQuery> l) {
     regexpMetadataQueries = Args.notNull(l, "regexp-metadata-queries");
-  }
-
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-
-  }
-
-  @Override
-  public void prepare() throws CoreException {
   }
 
   public Boolean getAddNullValues() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/RegexpMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/RegexpMetadataService.java
@@ -83,8 +83,7 @@ public class RegexpMetadataService extends MetadataServiceImpl {
     String message = msg.getContent();
     List<MetadataElement> added = new ArrayList<>();
     try {
-      for (int i = 0; i < regexpMetadataQueries.size(); i++) {
-        RegexpMetadataQuery q = regexpMetadataQueries.get(i);
+      for (RegexpMetadataQuery q : getRegexpMetadataQueries()) {
         MetadataElement elem = q.doQuery(message);
         if (!isEmpty(elem.getValue()) || addNullValues()) {
           msg.addMetadata(elem);

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReplaceMetadataValue.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReplaceMetadataValue.java
@@ -56,7 +56,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("replace-metadata-value")
 @AdapterComponent
 @ComponentProfile(summary = "Perform a find and replace on metadata", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp", "searchValue", "replacementValue", "replaceAll"})
+@DisplayOrder(order = {"metadataKeyRegexp", "searchValue", "replacementValue", "replaceAll", "metadataLogger"})
 public class ReplaceMetadataValue extends ReformatMetadata {
 
   @NotBlank

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/StringToHexService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/StringToHexService.java
@@ -35,7 +35,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("string-to-hex-metadata-service")
 @ComponentProfile(summary = "Turn a metadata value into a hex string using the specified character encoding",
     tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp", "charset"})
+@DisplayOrder(order = {"metadataKeyRegexp", "charset", "metadataLogger"})
 public class StringToHexService extends HexToStringService {
 
   public StringToHexService() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/TrimMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/TrimMetadataService.java
@@ -37,7 +37,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("trim-metadata-service")
 @AdapterComponent
 @ComponentProfile(summary = "Trim leading/trailing spaces from metadata", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp"})
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class TrimMetadataService extends ReformatMetadata {
 
   public TrimMetadataService() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/UrlDecodeMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/UrlDecodeMetadataService.java
@@ -34,7 +34,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("url-decode-metadata-service")
 @AdapterComponent
 @ComponentProfile(summary = "URL Decode some metadata", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp"})
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class UrlDecodeMetadataService extends ReformatMetadata {
 
   public UrlDecodeMetadataService() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/UrlEncodeMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/UrlEncodeMetadataService.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("url-encode-metadata-service")
 @AdapterComponent
 @ComponentProfile(summary = "URL Encode some metadata", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp"})
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class UrlEncodeMetadataService extends ReformatMetadata {
 
   public UrlEncodeMetadataService() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/XpathMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/XpathMetadataService.java
@@ -36,7 +36,6 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
 import com.adaptris.core.services.metadata.xpath.XpathQuery;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
@@ -63,8 +62,8 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @XStreamAlias("xpath-metadata-service")
 @AdapterComponent
 @ComponentProfile(summary = "Extract data via XPath and store it as metadata", tag = "service,metadata,xml,xpath")
-@DisplayOrder(order = {"xpathQueries", "namespaceContext", "xmlDocumentFactoryConfig"})
-public class XpathMetadataService extends ServiceImp {
+@DisplayOrder(order = {"xpathQueries", "namespaceContext", "xmlDocumentFactoryConfig", "metadataLogger"})
+public class XpathMetadataService extends MetadataServiceImpl {
 
   @NotNull
   @AutoPopulated
@@ -99,11 +98,6 @@ public class XpathMetadataService extends ServiceImp {
   }
 
   @Override
-  protected void closeService() {
-
-  }
-
-
   public void doService(AdaptrisMessage msg) throws ServiceException {
 
     Set<MetadataElement> metadataElements = new HashSet<MetadataElement>();
@@ -118,7 +112,7 @@ public class XpathMetadataService extends ServiceImp {
       for (XpathQuery query : queriesToExecute) {
         metadataElements.add(query.resolveXpath(doc, xpathToUse, query.createXpathQuery(msg)));
       }
-      log.debug("Xpath Metadata resolved {}", metadataElements);
+      logMetadata("Xpath Metadata resolved {}", metadataElements);
       msg.setMetadata(metadataElements);
     }
     catch (Exception e) {
@@ -161,11 +155,6 @@ public class XpathMetadataService extends ServiceImp {
   public void addXpathQuery(XpathQuery query) {
     xpathQueries.add(Args.notNull(query, "query"));
   }
-
-  @Override
-  public void prepare() throws CoreException {
-  }
-
 
   public DocumentBuilderFactoryBuilder getXmlDocumentFactoryConfig() {
     return xmlDocumentFactoryConfig;

--- a/interlok-core/src/main/java/com/adaptris/core/util/MetadataKeysOnly.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/MetadataKeysOnly.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.util;
+
+import java.util.Collection;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.MetadataElement;
+import com.adaptris.core.MetadataLogger;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * MetadataLogger implementation that that logs metadata keys only
+ * 
+ * @config message-logging-with-metadata-keys-only
+ */
+@ComponentProfile(summary = "Log metadata keys only", since = "3.8.4")
+@XStreamAlias("message-logging-with-metadata-keys-only")
+public class MetadataKeysOnly implements MetadataLogger {
+
+  @Override
+  public String toString(Collection<MetadataElement> elements) {
+    return String.format("Metadata Keys : %s", format(elements).toString());
+  }
+
+  private Collection<MetadataElement> format(Collection<MetadataElement> set) {
+    MetadataCollection metadata = new MetadataCollection();
+    set.parallelStream().forEach(e -> {
+      metadata.add(new KeysOnly(e.getKey(), e.getValue()));
+    });
+    return metadata;
+  }
+
+  private class KeysOnly extends MetadataElement {
+
+    private static final long serialVersionUID = 2019040201L;
+
+    public KeysOnly(String key, String value) {
+      super(key, value);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("[%s]", getKey());
+    }
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/util/TruncateMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/TruncateMetadata.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package com.adaptris.core.util;
 
+import java.util.Collection;
+
 import org.apache.commons.lang.StringUtils;
 
 import com.adaptris.annotation.ComponentProfile;
@@ -22,18 +24,21 @@ import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MessageLoggerImpl;
 import com.adaptris.core.MetadataElement;
+import com.adaptris.core.MetadataLogger;
 import com.adaptris.util.NumberUtils;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * MessageLogger implementation that that logs unique-id and metadata but truncates metadata at the
+ * MessageLogger & MetadataLogger implementation that that logs unique-id and metadata but truncates metadata at the
  * configured length.
  * 
  * @config message-logging-with-truncated-metadata
+ * @see MessageLogger
+ * @see MetadataLogger
  */
 @XStreamAlias("message-logging-with-truncated-metadata")
 @ComponentProfile(summary = "Log unique-id & metadata (values are truncated) only", since = "3.8.4")
-public class TruncateMetadata extends MessageLoggerImpl {
+public class TruncateMetadata extends MessageLoggerImpl implements MetadataLogger {
 
   private static final int DEFAULT_MAX_LENGTH = 256;
 
@@ -68,16 +73,22 @@ public class TruncateMetadata extends MessageLoggerImpl {
     this.maxLength = bytes;
   }
 
+  @Override
+  public String toString(Collection<MetadataElement> elements) {
+    return format(elements).toString();
+  }
 
   private int maxLength() {
     return NumberUtils.toIntDefaultIfNull(getMaxLength(), DEFAULT_MAX_LENGTH);
   }
 
+  @Override
   protected MetadataElement wrap(String key, String value) {
     return new TruncateValue(key, value);
   }
 
   private class TruncateValue extends MetadataElement {
+    private static final long serialVersionUID = 2019040201L;
 
     public TruncateValue(String key, String value) {
       super(key, value);
@@ -89,4 +100,5 @@ public class TruncateMetadata extends MessageLoggerImpl {
           StringUtils.abbreviate(getValue(), maxLength()));
     }
   }
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataServiceImplTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataServiceImplTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.metadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.MetadataElement;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.TruncateMetadata;
+
+public class MetadataServiceImplTest extends MetadataServiceImpl {
+
+
+  @Test
+  public void testMetadataLogger() {
+    TruncateMetadata logger = new TruncateMetadata(10);
+    withMetadataLogger(logger);
+    assertNotNull(getMetadataLogger());
+    assertEquals(logger, getMetadataLogger());
+    assertEquals(TruncateMetadata.class, getMetadataLogger().getClass());
+  }
+
+  @Test
+  public void testLogMetadata_TRACE() {
+    logMetadata(TRACE, "{}", array());
+    logMetadata(TRACE, "{}", list());
+  }
+
+  @Test
+  public void testLogMetadata_DEBUG() {
+    logMetadata(DEBUG, "{}", array());
+    logMetadata(DEBUG, "{}", list());
+  }
+
+  @Test
+  public void testLogMetadata_INFO() {
+    logMetadata(INFO, "{}", array());
+    logMetadata(INFO, "{}", list());
+  }
+
+  @Test
+  public void testLogMetadata_WARN() {
+    logMetadata(WARN, "{}", array());
+    logMetadata(WARN, "{}", list());
+  }
+
+  @Test
+  public void testLogMetadata_ERROR() {
+    logMetadata(ERROR, "{}", array());
+    logMetadata(ERROR, "{}", list());
+  }
+
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    // dummy method
+  }
+
+  private static MetadataElement[] array() {
+    return new MetadataElement[] {
+        new MetadataElement("key1", "val1"), new MetadataElement("key2", "val2")
+    };
+  }
+
+  private static MetadataCollection list() {
+    return new MetadataCollection(array());
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/XpathMetadataServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/XpathMetadataServiceTest.java
@@ -30,6 +30,7 @@ import com.adaptris.core.services.metadata.xpath.MultiItemConfiguredXpathQuery;
 import com.adaptris.core.services.metadata.xpath.MultiItemMetadataXpathQuery;
 import com.adaptris.core.services.metadata.xpath.XpathQuery;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+import com.adaptris.core.util.TruncateMetadata;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
@@ -78,7 +79,7 @@ public class XpathMetadataServiceTest extends MetadataServiceExample {
 
   public void testDoService_NotXML() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEFG");
-    XpathMetadataService service = new XpathMetadataService();
+    XpathMetadataService service = new XpathMetadataService().withMetadataLogger(new TruncateMetadata(20));
     service.setXpathQueries(new ArrayList<XpathQuery>(Arrays.asList(new ConfiguredXpathQuery("source",
         "//source-id"), new ConfiguredXpathQuery("destination", "//destination-id"))));
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/util/MetadataLoggerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/MetadataLoggerTest.java
@@ -1,0 +1,46 @@
+package com.adaptris.core.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.MetadataElement;
+
+public class MetadataLoggerTest {
+
+  @Test
+  public void testDefaultMethods() {
+    AdaptrisMessage msg = MessageLoggerTest.createMessage();
+    MetadataElement e1 = msg.getMetadata("LENGTH_39");
+    MetadataElement e2 = msg.getMetadata("LENGTH_43");
+    String s = new MetadataKeysOnly().toString(e1, e2);
+    System.err.println("testDefaultMethods:: " + s);
+    assertNotNull(s);
+    assertFalse(s.contains("The quick brown fox jumps over the lazy dog"));
+    assertFalse(s.contains("Pack my box with five dozen liquor jugs"));
+  }
+
+  @Test
+  public void testMetadataKeysOnly() {
+    AdaptrisMessage msg = MessageLoggerTest.createMessage();
+    String s = new MetadataKeysOnly().toString(msg.getMetadata());
+    System.err.println("testMinimalLogger:: " + s);
+    assertNotNull(s);
+    assertFalse(s.contains("The quick brown fox jumps over the lazy dog"));
+    assertFalse(s.contains("Pack my box with five dozen liquor jugs"));
+  }
+
+  @Test
+  public void testTruncatedLogger() {
+    AdaptrisMessage msg = MessageLoggerTest.createMessage();
+    // all the metadata should be truncated @ 20 characters
+    String s = new TruncateMetadata(20).toString(msg.getMetadata());
+    System.err.println("testTruncatedLogger:: " + s);
+    assertNotNull(s);
+    assertFalse(s.contains("The quick brown fox jumps over the lazy dog"));
+    assertTrue(s.contains("The quick brown f..."));
+  }
+}


### PR DESCRIPTION
- Add MetadataLogger interface
- Add MetadataServiceImpl that provides logging behaviour
- Changed services to extend MetadataServiceImpl and use new logging behaviour.
- Remove redundant methods provided by MetadataServiceImpl
- Add 2 implementations TruncateMetadata + MetadataKeysOnly; the default impl is just a lambda.