### PR TITLE
INTERLOK-2472 Make TestCompositeKeystore use a unique keystore

### DIFF
--- a/interlok-core/src/test/java/com/adaptris/core/PortManager.java
+++ b/interlok-core/src/test/java/com/adaptris/core/PortManager.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
-
 import com.adaptris.security.util.SecurityUtil;
 
 /**
@@ -58,10 +57,8 @@ public class PortManager {
     if (usedPorts.contains(port)) {
       return result;
     }
-    try {
-      ServerSocket srv = new ServerSocket(port);
-      srv.close();
-      srv = null;
+    try (ServerSocket srv = new ServerSocket(port)) {
+      srv.setReuseAddress(true);
       result = true;
     }
     catch (IOException e) {

--- a/interlok-core/src/test/java/com/adaptris/security/SingleEntryKeystoreBase.java
+++ b/interlok-core/src/test/java/com/adaptris/security/SingleEntryKeystoreBase.java
@@ -16,42 +16,39 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.InputStream;
 import java.security.cert.Certificate;
-import java.util.Properties;
 import java.util.Random;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.security.exc.KeystoreException;
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
 import com.adaptris.security.keystore.KeystoreProxy;
-
 import junit.framework.TestCase;
 
 /**
  * Test Keystore Functionality wrapping a single KEYSTORE_PKCS12 certificate
  * 
- * @author lchan
  */
-public abstract class SingleEntryKeystoreBase extends TestCase {
+public abstract class SingleEntryKeystoreBase {
   protected KeystoreLocation kloc = null;
-  protected Properties cfg;
   protected Config config;
-  protected transient Log logR = null;
+  protected transient Logger logR = null;
 
   /** @see TestCase */
-  public SingleEntryKeystoreBase(String testName) {
-    super(testName);
-    logR = LogFactory.getLog(this.getClass());
+  public SingleEntryKeystoreBase() {
+    logR = LoggerFactory.getLogger(this.getClass());
   }
 
-  /**
-   * Get a certificate out of the keystore.
-   */
+  protected abstract void setUp() throws Exception;
+
+  @Test
   public void testContainsNonExistentAlias() throws Exception {
     KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
     ksp.load();
@@ -62,9 +59,7 @@ public abstract class SingleEntryKeystoreBase extends TestCase {
     }
   }
 
-  /**
-   * Get the underlying keystore object
-   */
+  @Test
   public void testKeystoreGetKeyStore() {
     try {
       KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
@@ -77,6 +72,7 @@ public abstract class SingleEntryKeystoreBase extends TestCase {
     }
   }
 
+  @Test
   public void testImportCertificate() throws Exception {
     KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
     ksp.load();
@@ -110,6 +106,7 @@ public abstract class SingleEntryKeystoreBase extends TestCase {
     }
   }
 
+  @Test
   public void testImportCertificateChain() throws Exception {
     KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
     ksp.load();
@@ -136,6 +133,7 @@ public abstract class SingleEntryKeystoreBase extends TestCase {
     }
   }
 
+  @Test
   public void testImportPrivateKey() throws Exception {
     KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
     ksp.load();

--- a/interlok-core/src/test/java/com/adaptris/security/TestCertificateGeneration.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestCertificateGeneration.java
@@ -16,15 +16,17 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.util.Properties;
 import java.util.Random;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.security.certificate.CertRequestHandler;
 import com.adaptris.security.certificate.CertificateBuilder;
 import com.adaptris.security.certificate.CertificateHandler;
@@ -33,47 +35,25 @@ import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
 import com.adaptris.security.keystore.KeystoreProxy;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 /**
  * Test Certificate Generation.
  * <p>
  * This will also test the write capabilities of the keystore manager
  *
- * @author $Author: lchan $
  */
-public class TestCertificateGeneration extends TestCase {
+public class TestCertificateGeneration {
 
   private KeystoreProxy ksp = null;
   private KeystoreLocation ksc = null;
   private Properties cfg;
-  private static Log logR = LogFactory.getLog(TestCertificateGeneration.class);
+  private static Logger logR = LoggerFactory.getLogger(TestCertificateGeneration.class);
   private static final Random random = new Random();
 
-  /**
-   * @see TestCase
-   */
-  public TestCertificateGeneration(String testName) {
-    super(testName);
+  public TestCertificateGeneration() {
   }
 
-  /** Main Class. */
-  public static void main(java.lang.String[] args) {
-    junit.textui.TestRunner.run(suite());
-  }
-
-  public static Test suite() {
-
-    TestSuite suite = new TestSuite(TestCertificateGeneration.class);
-    return suite;
-  }
-
-  /** @see TestCase#setUp() */
-  @Override
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     cfg = Config.getInstance().getProperties();
     if (cfg == null) {
       fail("No Configuration(!) available");
@@ -86,15 +66,7 @@ public class TestCertificateGeneration extends TestCase {
         cfg.getProperty(Config.KEYSTORE_TEST_URL), null, true);
   }
 
-  /** @see TestCase#tearDown() */
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-
-  /**
-   * Test the generation of a certificate.
-   */
+  @Test
   public void testCertificateGeneration() throws Exception {
     String commonName = String.valueOf(random.nextInt(1000));
     CertificateBuilder builder = Config.getInstance().getBuilder(commonName);
@@ -116,9 +88,7 @@ public class TestCertificateGeneration extends TestCase {
 
   }
 
-  /**
-   * Test writing the newly generated certificate to a keystore.
-   */
+  @Test
   public void testCertificateAndPrivateKeyToKeystore() throws Exception {
     String commonName = String.valueOf(random.nextInt(1000));
     CertificateBuilder builder = Config.getInstance().getBuilder(commonName);
@@ -141,9 +111,7 @@ public class TestCertificateGeneration extends TestCase {
     ksp.commit();
   }
 
-  /**
-   * Test writing the newly generated certificate to a keystore.
-   */
+  @Test
   public void testCertificateToKeystore() throws Exception {
     String commonName = String.valueOf(random.nextInt(1000));
     CertificateBuilder builder = Config.getInstance().getBuilder(commonName);
@@ -161,6 +129,7 @@ public class TestCertificateGeneration extends TestCase {
     ksp.commit();
   }
 
+  @Test
   public void testEncodedCertificateToKeystore() throws Exception {
     String commonName = String.valueOf(random.nextInt(1000));
     CertificateBuilder builder = Config.getInstance().getBuilder(commonName);
@@ -179,6 +148,7 @@ public class TestCertificateGeneration extends TestCase {
     ksp.commit();
   }
 
+  @Test
   public void testCreateCertificateRequest() {
     try {
       String commonName = String.valueOf(random.nextInt(1000));

--- a/interlok-core/src/test/java/com/adaptris/security/TestCertificateHandler.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestCertificateHandler.java
@@ -16,60 +16,35 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.UnknownHostException;
 import java.util.Calendar;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.security.certificate.CertificateHandler;
 import com.adaptris.security.certificate.CertificateHandlerFactory;
 import com.adaptris.security.exc.CertException;
 import com.adaptris.security.keystore.KeystoreFactory;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 /**
  * Test Certificate Handling.
- *
- * @author $Author: lchan $
  */
-public class TestCertificateHandler extends TestCase {
+public class TestCertificateHandler {
   private Config config;
-  private static Log logR = null;
+  private Logger logR = LoggerFactory.getLogger(this.getClass());
 
-  /**
-   * @see TestCase
-   */
-  public TestCertificateHandler(String testName) {
-    super(testName);
-    if (logR == null) {
-      logR = LogFactory.getLog(TestCertificateHandler.class);
-    }
+  public TestCertificateHandler() {
   }
 
-  /**
-   * Main class.
-   */
-  public static void main(java.lang.String[] args) {
-    junit.textui.TestRunner.run(suite());
-  }
-
-  public static Test suite() {
-    TestSuite suite = new TestSuite(TestCertificateHandler.class);
-    return suite;
-  }
-
-  /**
-   * @see TestCase#setUp()
-   */
-  @Override
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     config = Config.getInstance();
     if (config == null) {
       fail("No Configuration(!) available");
@@ -79,17 +54,7 @@ public class TestCertificateHandler extends TestCase {
     config.buildKeystore(config.getProperties().getProperty(Config.KEYSTORE_TEST_URL), null, true);
   }
 
-  /**
-   * @see TestCase#tearDown()
-   */
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-
-  /**
-   * Test a un-expired certificate for expiry.
-   */
+  @Test
   public void testGoodCertificateExpiry() throws Exception {
     InputStream input = new FileInputStream(config.getProperties().getProperty(Config.CERTHANDLER_GOOD));
 
@@ -100,11 +65,7 @@ public class TestCertificateHandler extends TestCase {
     assertTrue("Expiry on \n" + handler.getCertificate().toString(), !handler.isExpired());
   }
 
-  /**
-   * Test that the good cert hasn't been revoked.
-   * <p>
-   * If we log a failure against this, then this dupont cert has been revoked
-   */
+  @Test
   public void testGoodCertificateRevocation() throws Exception {
     InputStream input = new FileInputStream(config.getProperties().getProperty(Config.CERTHANDLER_GOOD));
 
@@ -116,9 +77,7 @@ public class TestCertificateHandler extends TestCase {
 
   }
 
-  /**
-   * Check again. but check the getLastRevocationCheck() is the same as one we stored previously
-   */
+  @Test
   public void testGoodCertificateRevocationCache() throws Exception {
     InputStream input = new FileInputStream(config.getProperties().getProperty(Config.CERTHANDLER_GOOD));
 
@@ -132,9 +91,7 @@ public class TestCertificateHandler extends TestCase {
 
   }
 
-  /**
-   * This certificate we know is expired...
-   */
+  @Test
   public void testExpiredCertificateExpiry() throws Exception {
     InputStream input = new FileInputStream(config.getProperties().getProperty(Config.CERTHANDLER_EXPIRED));
 
@@ -146,9 +103,7 @@ public class TestCertificateHandler extends TestCase {
 
   }
 
-  /**
-   * Expired Certis should still be good. If we log a failure against this, then this dupont cert has been revoked
-   */
+  @Test
   public void testExpiredCertificateRevocation() throws Exception {
     try {
       InputStream input = new FileInputStream(config.getProperties().getProperty(Config.CERTHANDLER_EXPIRED));
@@ -167,9 +122,7 @@ public class TestCertificateHandler extends TestCase {
 
   }
 
-  /*
-   * Check again..., but check the getLastRevocationCheck() is the same as one we stored previously
-   */
+  @Test
   public void testExpiredCertificateRevocationCache() throws Exception {
     try {
       InputStream input = new FileInputStream(config.getProperties().getProperty(Config.CERTHANDLER_EXPIRED));

--- a/interlok-core/src/test/java/com/adaptris/security/TestConfiguredUrl.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestConfiguredUrl.java
@@ -16,54 +16,37 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
 import java.util.Properties;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.security.keystore.ConfiguredUrl;
 import com.adaptris.security.util.Constants;
-
-import junit.framework.Test;
 import junit.framework.TestCase;
-import junit.framework.TestSuite;
 
 /**
- * Test Inline Keystore Functionality wrapping a single KEYSTORE_X509
- * certificate
- *
- * @author $Author: lchan $
+ * Test Inline Keystore Functionality wrapping a single KEYSTORE_X509 certificate
  */
-public class TestConfiguredUrl extends TestCase {
+public class TestConfiguredUrl {
 
   private Properties cfg;
   private ConfiguredUrl url, copy;
-  private static Log logR = null;
+  private Logger logR = LoggerFactory.getLogger(this.getClass());
 
-  /** @see TestCase */
-  public TestConfiguredUrl(String testName) {
-    super(testName);
-    if (logR == null) {
-      logR = LogFactory.getLog(TestConfiguredUrl.class);
-    }
-  }
+  public TestConfiguredUrl() {
 
-  /** main. */
-  public static void main(java.lang.String[] args) {
-    junit.textui.TestRunner.run(suite());
-  }
-
-  public static Test suite() {
-    TestSuite suite = new TestSuite(TestConfiguredUrl.class);
-    return suite;
   }
 
   /**
    * @see TestCase#setUp()
    */
-  @Override
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     Config config = Config.getInstance();
     cfg = config.getProperties();
 
@@ -80,24 +63,19 @@ public class TestConfiguredUrl extends TestCase {
     config.buildKeystore(cfg.getProperty(Config.KEYSTORE_TEST_URL), null, true);
   }
 
-  /**
-   * @see TestCase#tearDown()
-   */
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-
+  @Test
   public void testAsKeystoreLocation() throws Exception {
     assertNotNull(url.asKeystoreLocation());
     assertEquals(url.asKeystoreLocation(), copy.asKeystoreLocation());
     assertEquals(url.asKeystoreLocation().hashCode(), copy.asKeystoreLocation().hashCode());
   }
 
+  @Test
   public void testAsKeystoreProxy() throws Exception {
     assertNotNull(url.asKeystoreProxy());
   }
 
+  @Test
   public void testEquality() throws Exception {
     assertNotSame(url, new Object());
     assertEquals(url, copy);

--- a/interlok-core/src/test/java/com/adaptris/security/TestDefaultSecurityService.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestDefaultSecurityService.java
@@ -19,16 +19,13 @@ package com.adaptris.security;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-
 import java.util.Properties;
 import java.util.Random;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.security.keystore.Alias;
 import com.adaptris.security.keystore.ConfiguredUrl;
 import com.adaptris.security.keystore.KeystoreLocation;
@@ -43,7 +40,7 @@ public class TestDefaultSecurityService {
   private KeystoreProxy ksm = null;
   private KeystoreLocation ksi = null;
   private Properties config;
-  private static Logger logR = null;
+  private Logger logR = LoggerFactory.getLogger(this.getClass());
   private SecurityService service = null;
   private Alias us;
   private Alias them;
@@ -51,9 +48,6 @@ public class TestDefaultSecurityService {
   private static final String RAW_DATA = "The quick brown fox " + "jumps over the lazy dog";
 
   public TestDefaultSecurityService() {
-    if (logR == null) {
-      logR = LoggerFactory.getLogger(TestDefaultSecurityService.class);
-    }
   }
 
   @Before

--- a/interlok-core/src/test/java/com/adaptris/security/TestInlineKeystore.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestInlineKeystore.java
@@ -16,16 +16,20 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
 import com.adaptris.security.keystore.InlineKeystore;
 import com.adaptris.security.util.Constants;
-
-import junit.framework.TestCase;
 
 /**
  * Test Inline Keystore Functionality wrapping a single KEYSTORE_X509
  * certificate
  *
- * @author $Author: lchan $
  */
 public class TestInlineKeystore extends SingleEntryKeystoreBase {
   private static final String EXAMPLE_KEYINFO = "<KeyInfo xmlns=\"http://www.w3.org/2000/09/xmldsig#\""
@@ -63,23 +67,13 @@ public class TestInlineKeystore extends SingleEntryKeystoreBase {
 
   private InlineKeystore inline, copy;
 
-  /** @see TestCase */
-  public TestInlineKeystore(String testName) {
-    super(testName);
+  public TestInlineKeystore() {
   }
 
-  /**
-   * @see TestCase#setUp()
-   */
   @Override
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     config = Config.getInstance();
-    cfg = config.getProperties();
-
-    if (cfg == null) {
-      fail("No Configuration(!) available");
-    }
     inline = new InlineKeystore();
     inline.setCertificate(EXAMPLE_KEYINFO);
     inline.setType(Constants.KEYSTORE_XMLKEYINFO);
@@ -92,14 +86,8 @@ public class TestInlineKeystore extends SingleEntryKeystoreBase {
     kloc = inline.asKeystoreLocation();
   }
 
-  /**
-   * @see TestCase#tearDown()
-   */
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
 
+  @Test
   public void testEquality() throws Exception {
     assertNotSame(inline, new Object());
     assertEquals(inline, copy);
@@ -108,16 +96,19 @@ public class TestInlineKeystore extends SingleEntryKeystoreBase {
     assertNotNull(inline.toString());
   }
 
+  @Test
   public void testAsKeystoreLocation() throws Exception {
     assertNotNull(inline.asKeystoreLocation());
     assertEquals(inline.asKeystoreLocation(), copy.asKeystoreLocation());
     assertEquals(inline.asKeystoreLocation().hashCode(), copy.asKeystoreLocation().hashCode());
   }
 
+  @Test
   public void testAsKeystoreProxy() throws Exception {
     assertNotNull(inline.asKeystoreProxy());
   }
 
+  @Test
   public void testWriteable() throws Exception {
     assertTrue(!inline.asKeystoreLocation().isWriteable());
     try {

--- a/interlok-core/src/test/java/com/adaptris/security/TestKeyStore.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestKeyStore.java
@@ -16,58 +16,38 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.util.Properties;
 import java.util.Random;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
 import com.adaptris.security.keystore.KeystoreProxy;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 /**
  * Test Keystore Functionality.
  * 
- * @author $Author: lchan $
  */
-public class TestKeyStore extends TestCase {
+public class TestKeyStore {
   private KeystoreProxy ksp = null;
   private KeystoreLocation kloc = null;
   private Properties cfg;
   private Config config;
-  private static Log logR = null;
+  private Logger logR = LoggerFactory.getLogger(this.getClass());
 
-  /** @see TestCase */
-  public TestKeyStore(String testName) {
-    super(testName);
-    if (logR == null) {
-      logR = LogFactory.getLog(TestKeyStore.class);
-    }
+  public TestKeyStore() {
   }
 
-  /** main. */
-  public static void main(java.lang.String[] args) {
-    junit.textui.TestRunner.run(suite());
-  }
 
-  public static Test suite() {
-    TestSuite suite = new TestSuite(TestKeyStore.class);
-    return suite;
-  }
-
-  /**
-   * @see TestCase#setUp()
-   */
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     config = Config.getInstance();
     cfg = config.getProperties();
 
@@ -81,16 +61,8 @@ public class TestKeyStore extends TestCase {
         .buildKeystore(cfg.getProperty(Config.KEYSTORE_TEST_URL), null, false);
   }
 
-  /**
-   * @see TestCase#tearDown()
-   */
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
 
-  /**
-   * Get a certificate out of the keystore.
-   */
+  @Test
   public void testKeystoreGetCertificate() throws Exception {
     Certificate thisCert;
     ksp = KeystoreFactory.getDefault().create(kloc);
@@ -99,13 +71,13 @@ public class TestKeyStore extends TestCase {
     if (ksp.containsAlias(alias)) {
       thisCert = ksp.getCertificate(alias);
       assertNotNull("Certificate is not null", thisCert);
-      logR.trace(thisCert);
     }
     else {
       fail(alias + " does not exist in the specified keystore");
     }
   }
 
+  @Test
   public void testKeystoreImportCertificate() throws Exception {
     ksp = KeystoreFactory.getDefault().create(kloc);
     ksp.load();
@@ -113,6 +85,7 @@ public class TestKeyStore extends TestCase {
         .getProperty(Config.KEYSTORE_IMPORT_X509_FILE));
   }
 
+  @Test
   public void testKeystoreImportCertificateInvalidFilename() throws Exception {
     ksp = KeystoreFactory.getDefault().create(kloc);
     ksp.load();
@@ -125,9 +98,7 @@ public class TestKeyStore extends TestCase {
     }
   }
 
-  /**
-   * Get the private key out off the keystore.
-   */
+  @Test
   public void testKeystoreGetPrivateKey() throws Exception {
     ksp = KeystoreFactory.getDefault().create(kloc);
     ksp.load();
@@ -136,13 +107,13 @@ public class TestKeyStore extends TestCase {
       PrivateKey pk = ksp.getPrivateKey(alias, cfg.getProperty(
           Config.KEYSTORE_COMMON_PRIVKEY_PW).toCharArray());
       assertNotNull("PrivateKey is not null", pk);
-      logR.trace(pk);
     }
     else {
       fail(alias + " does not exist in the specified keystore");
     }
   }
 
+  @Test
   public void testKeystoreNoPrivateKeyPassword() throws Exception {
     ksp = KeystoreFactory.getDefault().create(kloc);
     ksp.load();
@@ -150,13 +121,13 @@ public class TestKeyStore extends TestCase {
     if (ksp.containsAlias(alias)) {
       PrivateKey pk = ksp.getPrivateKey(alias, null);
       assertNotNull("PrivateKey is not null", pk);
-      logR.trace(pk);
     }
     else {
       fail(alias + " does not exist in the specified keystore");
     }
   }
 
+  @Test
   public void testKeystoreImportPrivateKey() throws Exception {
     config.importPrivateKey(cfg.getProperty(Config.KEYSTORE_TEST_URL), cfg
         .getProperty(Config.KEYSTORE_IMPORT_PKCS12_FILE), false);
@@ -167,13 +138,13 @@ public class TestKeyStore extends TestCase {
       PrivateKey pk = ksp.getPrivateKey(alias, cfg.getProperty(
           Config.KEYSTORE_COMMON_PRIVKEY_PW).toCharArray());
       assertNotNull("PrivateKey is not null", pk);
-      logR.trace(pk);
     }
     else {
       fail(alias + " does not exist in the specified keystore");
     }
   }
 
+  @Test
   public void testKeystoreImportInvalidPrivateKey() throws Exception {
     try {
       config.importPrivateKey(cfg.getProperty(Config.KEYSTORE_TEST_URL),
@@ -185,6 +156,7 @@ public class TestKeyStore extends TestCase {
     }
   }
 
+  @Test
   public void testKeystoreImportCertificateChain() throws Exception {
     config.importPrivateKey(cfg.getProperty(Config.KEYSTORE_TEST_URL), cfg
         .getProperty(Config.KEYSTORE_IMPORT_PKCS12_FILE), false);
@@ -197,6 +169,7 @@ public class TestKeyStore extends TestCase {
     ksp.commit();
   }
 
+  @Test
   public void testKeystoreImportCertificateChainInvalidFile() throws Exception {
     config.importPrivateKey(cfg.getProperty(Config.KEYSTORE_TEST_URL), cfg
         .getProperty(Config.KEYSTORE_IMPORT_PKCS12_FILE), true);
@@ -214,6 +187,7 @@ public class TestKeyStore extends TestCase {
     ksp.commit();
   }
 
+  @Test
   public void testKeystoreImportCertificateChainInvalidAlias() throws Exception {
     config.importPrivateKey(cfg.getProperty(Config.KEYSTORE_TEST_URL), cfg
         .getProperty(Config.KEYSTORE_IMPORT_PKCS12_FILE), true);

--- a/interlok-core/src/test/java/com/adaptris/security/TestKeyStoreInfoChange.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestKeyStoreInfoChange.java
@@ -16,56 +16,38 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import java.security.cert.Certificate;
 import java.util.Properties;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
 import com.adaptris.security.keystore.KeystoreProxy;
-
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 
 /**
  * Test Keystore Functionality.
  * 
  * @author $Author: lchan $
  */
-public class TestKeyStoreInfoChange extends TestCase {
+public class TestKeyStoreInfoChange {
   private KeystoreProxy ksm = null;
   private KeystoreLocation ksi = null;
   private KeystoreLocation pwKsi = null;
   private KeystoreLocation newKsi = null;
   private Properties config;
-  private static Log logR = null;
+  private Logger logR = LoggerFactory.getLogger(this.getClass());
 
-  /** @see TestCase */
-  public TestKeyStoreInfoChange(String testName) {
-    super(testName);
-    if (logR == null) {
-      logR = LogFactory.getLog(TestKeyStoreInfoChange.class);
-    }
+  public TestKeyStoreInfoChange() {
+
   }
 
-  /** main. */
-  public static void main(java.lang.String[] args) {
-    junit.textui.TestRunner.run(suite());
-  }
 
-  public static Test suite() {
-    TestSuite suite = new TestSuite(TestKeyStoreInfoChange.class);
-    return suite;
-  }
-
-  /**
-   * @see TestCase#setUp()
-   */
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     config = Config.getInstance().getProperties();
     if (config == null) {
       fail("No Configuration(!) available");
@@ -83,17 +65,7 @@ public class TestKeyStoreInfoChange extends TestCase {
         config.getProperty(Config.KEYSTORE_TEST_URL), null, false);
   }
 
-  /**
-   * @see TestCase#tearDown()
-   */
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-
-  /**
-   * This tests a generic change of the keystore info to a new location and
-   * password.
-   */
+  @Test
   public void testChangeKeyStoreInfo() {
     Certificate thisCert;
     try {
@@ -106,7 +78,7 @@ public class TestKeyStoreInfoChange extends TestCase {
       tempKsm.load();
       if (tempKsm.containsAlias(alias)) {
         thisCert = tempKsm.getCertificate(alias);
-        logR.trace(thisCert);
+        assertNotNull(thisCert);
       }
       else {
         fail(alias + " does not exist in the specified keystore");
@@ -118,9 +90,7 @@ public class TestKeyStoreInfoChange extends TestCase {
     }
   }
 
-  /**
-   * Test the change of the kestore password
-   */
+  @Test
   public void testChangeKeyStorePassword() {
     Certificate thisCert;
     try {
@@ -138,7 +108,7 @@ public class TestKeyStoreInfoChange extends TestCase {
       // we should be able to reread the certificate information...
       if (tempKsm.containsAlias(alias)) {
         thisCert = tempKsm.getCertificate(alias);
-        logR.trace(thisCert);
+        assertNotNull(thisCert);
       }
       else {
         fail(alias + " does not exist in the specified keystore");

--- a/interlok-core/src/test/java/com/adaptris/security/TestKeystoreLocation.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestKeystoreLocation.java
@@ -16,45 +16,38 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Properties;
-
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreLocation;
-
 import junit.framework.TestCase;
 
 /**
  * Test Keystore Functionality.
  *
- * @author $Author: lchan $
  */
-public class TestKeystoreLocation extends TestCase {
+public class TestKeystoreLocation {
   private Properties cfg;
   private Config config;
-  private static Log logR = null;
+  private Logger logR = LoggerFactory.getLogger(this.getClass());
 
   /** @see TestCase */
-  public TestKeystoreLocation(String testName) {
-    super(testName);
-    if (logR == null) {
-      logR = LogFactory.getLog(TestKeystoreLocation.class);
-    }
+  public TestKeystoreLocation() {
   }
 
-  /**
-   * @see TestCase#setUp()
-   */
-  @Override
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     config = Config.getInstance();
     cfg = config.getProperties();
 
@@ -65,14 +58,8 @@ public class TestKeystoreLocation extends TestCase {
         .buildKeystore(cfg.getProperty(Config.KEYSTORE_TEST_URL), null, false);
   }
 
-  /**
-   * @see TestCase#tearDown()
-   */
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
 
+  @Test
   public void testKeystoreEquality() {
     try {
       KeystoreLocation ksi = KeystoreFactory.getDefault().create(
@@ -87,6 +74,7 @@ public class TestKeystoreLocation extends TestCase {
     }
   }
 
+  @Test
   public void testKeystoreFactory() {
     try {
       KeystoreLocation ksi = KeystoreFactory.getDefault().create(
@@ -101,6 +89,7 @@ public class TestKeystoreLocation extends TestCase {
     }
   }
 
+  @Test
   public void testLocalKeystore() {
     try {
       KeystoreLocation k = KeystoreFactory.getDefault().create(
@@ -116,6 +105,7 @@ public class TestKeystoreLocation extends TestCase {
     }
   }
 
+  @Test
   public void testNonExistentLocalKeystore() {
     try {
       KeystoreLocation k = KeystoreFactory.getDefault().create(
@@ -129,6 +119,7 @@ public class TestKeystoreLocation extends TestCase {
     }
   }
 
+  @Test
   public void testRemoteKeystore() throws Exception {
     if (Boolean.parseBoolean(cfg.getProperty(Config.REMOTE_TESTS_ENABLED,
         "false"))) {
@@ -167,6 +158,7 @@ public class TestKeystoreLocation extends TestCase {
     }
   }
 
+  @Test
   public void testNonExistentRemoteKeystore() {
     if (Boolean.parseBoolean(cfg.getProperty(Config.REMOTE_TESTS_ENABLED,
         "false"))) {

--- a/interlok-core/src/test/java/com/adaptris/security/TestPassword.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestPassword.java
@@ -17,20 +17,15 @@
 package com.adaptris.security;
 
 import static org.junit.Assert.assertEquals;
-
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
-
 import org.junit.Test;
-
 import com.adaptris.security.certificate.CertificateBuilder;
 import com.adaptris.security.password.Password;
 import com.adaptris.security.password.PasswordCodec;
 import com.adaptris.util.system.Os;
 
 /**
- * @author lchan
- *
  */
 public class TestPassword {
   private static final String CHARSET = "ISO-8859-1";

--- a/interlok-core/src/test/java/com/adaptris/security/TestSecurityUtil.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestSecurityUtil.java
@@ -19,18 +19,14 @@ package com.adaptris.security;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 import java.security.SecureRandom;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.security.util.SecurityUtil;
 
 /**
- * @author lchan
- *
+*
  */
 public class TestSecurityUtil extends SecurityUtil {
 

--- a/interlok-core/src/test/java/com/adaptris/security/TestSingleX509Keystore.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestSingleX509Keystore.java
@@ -16,57 +16,45 @@
 
 package com.adaptris.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
-
+import org.junit.Before;
+import org.junit.Test;
 import com.adaptris.security.keystore.KeystoreFactory;
 import com.adaptris.security.keystore.KeystoreProxy;
-
-import junit.framework.TestCase;
 
 /**
  * Test Keystore Functionality wrapping a single KEYSTORE_X509 certificate
  * 
- * @author $Author: lchan $
+ * 
  */
 public class TestSingleX509Keystore extends SingleEntryKeystoreBase {
-  /** @see TestCase */
-  public TestSingleX509Keystore(String testName) {
-    super(testName);
+
+  public TestSingleX509Keystore() {
+    super();
   }
 
-  /**
-   * @see TestCase#setUp()
-   */
+  @Override
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     config = Config.getInstance();
-    cfg = config.getProperties();
-
-    if (cfg == null) {
-      fail("No Configuration(!) available");
-    }
     kloc = KeystoreFactory.getDefault().create(
-        cfg.getProperty(Config.KEYSTORE_SINGLE_X509_URL),
-        cfg.getProperty(Config.KEYSTORE_COMMON_KEYSTORE_PW).toCharArray());
+        config.getProperty(Config.KEYSTORE_SINGLE_X509_URL),
+        config.getProperty(Config.KEYSTORE_COMMON_KEYSTORE_PW).toCharArray());
   }
 
-  /**
-   * @see TestCase#tearDown()
-   */
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
 
-  /**
-   * Get a certificate out of the keystore.
-   */
+  @Test
   public void testContainsAlias() {
     try {
       KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
       ksp.load();
 
-      String alias = cfg.getProperty(Config.KEYSTORE_SINGLE_X509_ALIAS);
+      String alias = config.getProperty(Config.KEYSTORE_SINGLE_X509_ALIAS);
       if (!ksp.containsAlias(alias)) {
         fail(alias + " doesn't exist in the specified keystore!");
       }
@@ -77,17 +65,15 @@ public class TestSingleX509Keystore extends SingleEntryKeystoreBase {
     }
   }
 
-  /**
-   * Get a certificate out of the keystore.
-   */
+  @Test
   public void testKeystoreGetCertificate() {
     try {
       KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
       ksp.load();
-      String alias = cfg.getProperty(Config.KEYSTORE_SINGLE_X509_ALIAS);
+      String alias = config.getProperty(Config.KEYSTORE_SINGLE_X509_ALIAS);
       if (ksp.containsAlias(alias)) {
         Certificate thisCert = ksp.getCertificate(alias);
-        logR.trace(thisCert);
+        assertNotNull(thisCert);
       }
       else {
         fail(alias + " does not exist in the specified keystore");
@@ -99,11 +85,12 @@ public class TestSingleX509Keystore extends SingleEntryKeystoreBase {
     }
   }
 
+  @Test
   public void testKeystoreGetCertificateChain() {
     try {
       KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
       ksp.load();
-      String alias = cfg.getProperty(Config.KEYSTORE_SINGLE_X509_ALIAS);
+      String alias = config.getProperty(Config.KEYSTORE_SINGLE_X509_ALIAS);
       if (ksp.containsAlias(alias)) {
         Certificate[] thisCert = ksp.getCertificateChain(alias);
         assertEquals(1, thisCert.length);
@@ -118,14 +105,12 @@ public class TestSingleX509Keystore extends SingleEntryKeystoreBase {
     }
   }
 
-  /**
-   * Get the private key out off the keystore.
-   */
+  @Test
   public void testKeystoreGetPrivateKey() {
     try {
       KeystoreProxy ksp = KeystoreFactory.getDefault().create(kloc);
       ksp.load();
-      String alias = cfg.getProperty(Config.KEYSTORE_SINGLE_X509_ALIAS);
+      String alias = config.getProperty(Config.KEYSTORE_SINGLE_X509_ALIAS);
       if (ksp.containsAlias(alias)) {
         PrivateKey pk = ksp.getPrivateKey(alias, "".toCharArray());
         assertNull(pk);

--- a/interlok-core/src/test/resources/security-test.properties.template
+++ b/interlok-core/src/test/resources/security-test.properties.template
@@ -44,9 +44,8 @@ junitsecurity.keystore.import.pkcs12.file=@BASE_DIR@/src/test/resources/security
 junitsecurity.keystore.import.certchain.file=@BASE_DIR@/src/test/resources/security/pkey.certchain.p7b
 junitsecurity.keystore.import.x509.file=@BASE_DIR@/src/test/resources/security/good.cer
 
-junitsecurity.keystore.composite.1=${junitsecurity.keystore.keystoreUrl}
-junitsecurity.keystore.composite.2=${junitsecurity.keystore.single.x509url}
-junitsecurity.keystore.composite.3=${junitsecurity.keystore.single.pkcs12url}
+junitsecurity.keystore.composite.1=${junitsecurity.keystore.single.x509url}
+junitsecurity.keystore.composite.2=${junitsecurity.keystore.single.pkcs12url}
 
 # The algorithm to use when testing encryption/decryption
 junitsecurity.security.algorithm=DESede/CBC/PKCS5Padding


### PR DESCRIPTION
- Reviewed the tests, made classes annotation based.
- Switch out clogger for slf4j
- TestCompositeKeystore now uses a unique keystore rather than
the same keystore every test...