### PR TITLE
Feature/interlok 2790 - make symmetricKeyCrypto work with metadata as well as payload

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/interlok/types/InterlokMessage.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/types/InterlokMessage.java
@@ -192,4 +192,21 @@ public interface InterlokMessage {
    * @return the original string, an item of metadata, or null (if the metadata key does not exist).
    */
   String resolve(String s, boolean multiline);
+
+
+  /**
+   * Wrap the interlok message as another type of thing.
+   * 
+   * @param wrapper an implementation of {@link MessageWrapper}
+   * @return the wrapped object
+   * @throws Exception
+   */
+  default <T extends Object> T wrap(MessageWrapper<T> wrapper) throws Exception {
+    return wrapper.wrap(this);
+  }
+
+  @FunctionalInterface
+  public interface MessageWrapper<T> {
+    T wrap(InterlokMessage m) throws Exception;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataDataOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataDataOutputParameter.java
@@ -17,7 +17,6 @@
 package com.adaptris.core.common;
 
 import org.hibernate.validator.constraints.NotBlank;
-import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.util.Args;
@@ -35,17 +34,13 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("metadata-data-output-parameter")
 @DisplayOrder(order = {"metadataKey"})
-public class MetadataDataOutputParameter
-    implements DataOutputParameter<String> {
+public class MetadataDataOutputParameter implements DataOutputParameter<String> {
   
   static final String DEFAULT_METADATA_KEY = "destinationKey";
 
   @NotBlank
   @AutoPopulated
   private String metadataKey;
-  
-  @AdvancedConfig
-  private String contentEncoding;
   
   public MetadataDataOutputParameter() {
     this.setMetadataKey(DEFAULT_METADATA_KEY);

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataDataOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataDataOutputParameter.java
@@ -17,7 +17,7 @@
 package com.adaptris.core.common;
 
 import org.hibernate.validator.constraints.NotBlank;
-
+import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.util.Args;
@@ -35,13 +35,17 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("metadata-data-output-parameter")
 @DisplayOrder(order = {"metadataKey"})
-public class MetadataDataOutputParameter implements DataOutputParameter<String> {
+public class MetadataDataOutputParameter
+    implements DataOutputParameter<String> {
   
   static final String DEFAULT_METADATA_KEY = "destinationKey";
 
   @NotBlank
   @AutoPopulated
   private String metadataKey;
+  
+  @AdvancedConfig
+  private String contentEncoding;
   
   public MetadataDataOutputParameter() {
     this.setMetadataKey(DEFAULT_METADATA_KEY);
@@ -64,5 +68,4 @@ public class MetadataDataOutputParameter implements DataOutputParameter<String> 
   public void setMetadataKey(String key) {
     this.metadataKey = Args.notBlank(key, "metadata key");
   }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamInputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamInputParameter.java
@@ -16,9 +16,12 @@
 
 package com.adaptris.core.common;
 
-import java.io.IOException;
+import static com.adaptris.core.common.MetadataDataInputParameter.DEFAULT_METADATA_KEY;
 import java.io.InputStream;
-import com.adaptris.core.util.ExceptionHelper;
+import java.io.StringReader;
+import org.apache.commons.io.input.ReaderInputStream;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.util.Args;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.types.InterlokMessage;
@@ -26,30 +29,30 @@ import com.adaptris.interlok.types.InterlokMessage.MessageWrapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * This {@code DataInputParameter} is used when you want to source data from the {@link com.adaptris.core.AdaptrisMessage} payload.
+ * This {@code DataInputParameter} is used when you want to read some data from metadata.
  * 
- * 
- * @author amcgrath
- * @config stream-payload-input-parameter
+ * @config metadata-stream-input-parameter
  * 
  */
-@XStreamAlias("stream-payload-input-parameter")
-public class PayloadStreamInputParameter
+@XStreamAlias("metadata-stream-input-parameter")
+@DisplayOrder(order = {"metadataKey", "contentEncoding"})
+public class MetadataStreamInputParameter extends MetadataStreamParameter
     implements DataInputParameter<InputStream>, MessageWrapper<InputStream> {
 
-  public PayloadStreamInputParameter() {
-    
+  public MetadataStreamInputParameter() {
+    this.setMetadataKey(DEFAULT_METADATA_KEY);
   }
   
+  public MetadataStreamInputParameter(String key) {
+    this();
+    setMetadataKey(key);
+  }
+
   @Override
-  public InputStream extract(InterlokMessage message) throws InterlokException {
-    InputStream result = null;
-    try {
-      result = message.getInputStream();
-    } catch (IOException e) {
-      throw ExceptionHelper.wrapCoreException(e);
-    }
-    return result;
+  public InputStream extract(InterlokMessage m) throws InterlokException {
+    Args.notBlank(getMetadataKey(), "metadataKey");
+    String data= m.getMessageHeaders().get(getMetadataKey());
+    return new ReaderInputStream(new StringReader(data), charset(getContentEncoding()));
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamOutputParameter.java
@@ -16,26 +16,23 @@
 
 package com.adaptris.core.common;
 
+import static com.adaptris.core.common.MetadataDataOutputParameter.DEFAULT_METADATA_KEY;
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
-
+import java.io.FilterOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-
+import java.io.StringWriter;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.StringBuilderWriter;
-import org.hibernate.validator.constraints.NotBlank;
-
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AutoPopulated;
+import org.apache.commons.io.output.WriterOutputStream;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataOutputParameter;
 import com.adaptris.interlok.types.InterlokMessage;
+import com.adaptris.interlok.types.InterlokMessage.MessageWrapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -47,17 +44,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("metadata-stream-output-parameter")
 @DisplayOrder(order = {"metadataKey", "contentEncoding"})
-public class MetadataStreamOutputParameter implements DataOutputParameter<InputStreamWithEncoding> {
-  
-  static final String DEFAULT_METADATA_KEY = "destinationKey";
-
-  @NotBlank
-  @AutoPopulated
-  private String metadataKey;
-  @AdvancedConfig
-  private String contentEncoding;
-  
+public class MetadataStreamOutputParameter extends MetadataStreamParameter
+    implements DataOutputParameter<InputStreamWithEncoding>,
+    MessageWrapper<OutputStream> {
+    
   public MetadataStreamOutputParameter() {
+    super();
     this.setMetadataKey(DEFAULT_METADATA_KEY);
   }
   
@@ -70,7 +62,9 @@ public class MetadataStreamOutputParameter implements DataOutputParameter<InputS
   public void insert(InputStreamWithEncoding data, InterlokMessage message) throws InterlokException {
     try {
       StringBuilder builder = new StringBuilder();
-      try (Reader in = getReader(data.inputStream, defaultIfEmpty(getContentEncoding(), data.encoding));
+      try (
+          Reader in = new InputStreamReader(data.inputStream,
+              charset(defaultIfEmpty(getContentEncoding(), data.encoding)));
           StringBuilderWriter out = new StringBuilderWriter(builder)) {
         IOUtils.copy(in, out);
       }
@@ -80,31 +74,26 @@ public class MetadataStreamOutputParameter implements DataOutputParameter<InputS
     }
   }
 
-  private InputStreamReader getReader(InputStream in, String encoding) throws UnsupportedEncodingException {
-    InputStreamReader reader = null;
-    if (encoding == null) {
-      reader = new InputStreamReader(in);
-    } else {
-      reader = new InputStreamReader(in, encoding);
+  @Override
+  public OutputStream wrap(InterlokMessage m) throws Exception {
+    return new MetadataOutputStream(m, new StringWriter());
+  }
+
+  private class MetadataOutputStream extends FilterOutputStream {
+
+    private InterlokMessage msg;
+    private StringWriter writer;
+
+    public MetadataOutputStream(InterlokMessage msg, StringWriter writer) {
+      super(new WriterOutputStream(writer, charset(getContentEncoding())));
+      this.msg = msg;
+      this.writer = writer;
     }
-    return reader;
+
+    @Override
+    public void close() throws IOException {
+      super.close();
+      msg.addMessageHeader(getMetadataKey(), writer.toString());
+    }
   }
-
-
-  public String getMetadataKey() {
-    return metadataKey;
-  }
-
-  public void setMetadataKey(String key) {
-    this.metadataKey = Args.notBlank(key, "metadata key");
-  }
-
-  public String getContentEncoding() {
-    return contentEncoding;
-  }
-
-  public void setContentEncoding(String contentEncoding) {
-    this.contentEncoding = contentEncoding;
-  }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamParameter.java
@@ -1,0 +1,49 @@
+package com.adaptris.core.common;
+
+import java.nio.charset.Charset;
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.core.util.Args;
+
+public abstract class MetadataStreamParameter {
+
+  @NotBlank
+  private String metadataKey;
+  @AdvancedConfig
+  private String contentEncoding;
+
+  public MetadataStreamParameter() {
+
+  }
+
+  public String getMetadataKey() {
+    return metadataKey;
+  }
+
+  public void setMetadataKey(String key) {
+    this.metadataKey = Args.notBlank(key, "metadata key");
+  }
+
+  public <T extends MetadataStreamParameter> T withMetadataKey(String e) {
+    setMetadataKey(e);
+    return (T) this;
+  }
+
+  public String getContentEncoding() {
+    return contentEncoding;
+  }
+
+  public void setContentEncoding(String contentEncoding) {
+    this.contentEncoding = contentEncoding;
+  }
+
+  public <T extends MetadataStreamParameter> T withContentEncoding(String e) {
+    setContentEncoding(e);
+    return (T) this;
+  }
+
+  public static Charset charset(String charset) {
+    return StringUtils.isBlank(charset) ? Charset.defaultCharset() : Charset.forName(charset);
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/common/PayloadStreamOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/PayloadStreamOutputParameter.java
@@ -19,15 +19,15 @@ package com.adaptris.core.common;
 import static com.adaptris.util.stream.StreamUtil.copyAndClose;
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang.StringUtils.isEmpty;
-
 import java.io.IOException;
-
+import java.io.OutputStream;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataOutputParameter;
 import com.adaptris.interlok.types.InterlokMessage;
+import com.adaptris.interlok.types.InterlokMessage.MessageWrapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -39,7 +39,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("stream-payload-output-parameter")
 @DisplayOrder(order = {"contentEncoding"})
-public class PayloadStreamOutputParameter implements DataOutputParameter<InputStreamWithEncoding> {
+public class PayloadStreamOutputParameter implements DataOutputParameter<InputStreamWithEncoding>,
+    MessageWrapper<OutputStream> {
 
   @AdvancedConfig
   private String contentEncoding;
@@ -65,5 +66,10 @@ public class PayloadStreamOutputParameter implements DataOutputParameter<InputSt
 
   public void setContentEncoding(String contentEncoding) {
     this.contentEncoding = contentEncoding;
+  }
+
+  @Override
+  public OutputStream wrap(InterlokMessage m) throws Exception {
+    return m.getOutputStream();
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/security/SymmetricKeyCryptographyService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/SymmetricKeyCryptographyService.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
-
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
 import javax.crypto.CipherOutputStream;
@@ -13,18 +12,24 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
+import org.apache.commons.lang3.ObjectUtils;
 import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.adaptris.interlok.types.InterlokMessage.MessageWrapper;
 import com.adaptris.security.password.Password;
 import com.adaptris.util.stream.StreamUtil;
 import com.adaptris.util.text.Conversion;
@@ -37,20 +42,24 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("symmetric-key-cryptography-service")
 @AdapterComponent
 @ComponentProfile(summary = "Encrypts or Decrypts payload using key and initial vector", tag = "service,cryptography")
-@DisplayOrder(order = {"algorithm", "cipherTransformation", "operationMode", "key", "initialVector"})
+@DisplayOrder(order = {"algorithm", "cipherTransformation", "operationMode", "key", "initialVector", "source", "target"})
 public class SymmetricKeyCryptographyService extends ServiceImp {
 
   @NotBlank
   @Valid
+  @InputFieldHint(expression = true)
   private String algorithm;
 
   @NotBlank
   @Valid
+  @InputFieldHint(expression = true)
   private String cipherTransformation;
 
   @NotNull
   @Valid
-  private OpMode operationMode = OpMode.DECRYPT;
+  @AutoPopulated
+  @InputFieldDefault(value = "DECRYPT")
+  private OpMode operationMode;
   
   @NotNull
   @Valid
@@ -60,44 +69,65 @@ public class SymmetricKeyCryptographyService extends ServiceImp {
   @Valid
   private DataInputParameter<String> initialVector;
 
+  @Valid
+  @InputFieldDefault(value = "the payload")
+  private MessageWrapper<InputStream> source;
+
+  @Valid
+  @InputFieldDefault(value = "the payload")
+  private MessageWrapper<OutputStream> target;
 
   public enum OpMode {
     DECRYPT {
       @Override
-      void execute(Cipher cipher, SecretKeySpec secretKeySpec, IvParameterSpec ivParameterSpec, AdaptrisMessage msg) throws InvalidAlgorithmParameterException, InvalidKeyException, IOException {
+      void execute(Cipher cipher, SecretKeySpec secretKeySpec, IvParameterSpec ivParameterSpec,
+          InputStream msgIn, OutputStream msgOut)
+          throws InvalidAlgorithmParameterException, InvalidKeyException, IOException {
         cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
-        try (InputStream msgIn = msg.getInputStream();
-            CipherInputStream in = new CipherInputStream(msgIn, cipher);
-            OutputStream out = msg.getOutputStream()) {
+        try (CipherInputStream in = new CipherInputStream(msgIn, cipher);
+            OutputStream out = msgOut) {
           StreamUtil.copyAndClose(in, out);
         }
       }
     },
     ENCRYPT {
       @Override
-      void execute(Cipher cipher, SecretKeySpec secretKeySpec, IvParameterSpec ivParameterSpec, AdaptrisMessage msg) throws InvalidAlgorithmParameterException, InvalidKeyException, IOException {
+      void execute(Cipher cipher, SecretKeySpec secretKeySpec, IvParameterSpec ivParameterSpec,
+          InputStream msgIn, OutputStream msgOut)
+          throws InvalidAlgorithmParameterException, InvalidKeyException, IOException {
         cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
-        try (InputStream in = msg.getInputStream();
-            OutputStream msgOut = msg.getOutputStream();
+        try (InputStream in = msgIn;
             CipherOutputStream out = new CipherOutputStream(msgOut, cipher)) {
           StreamUtil.copyAndClose(in, out);
         }
       }
     };
-    abstract void execute(Cipher cipher, SecretKeySpec secretKeySpec, IvParameterSpec ivParameterSpec, AdaptrisMessage msg) throws InvalidAlgorithmParameterException, InvalidKeyException, IOException;
+    abstract void execute(Cipher cipher, SecretKeySpec secretKeySpec,
+        IvParameterSpec ivParameterSpec, InputStream msgIn, OutputStream msgOut)
+        throws InvalidAlgorithmParameterException, InvalidKeyException, IOException;
   }
+
+
+  public SymmetricKeyCryptographyService() {
+    setOperationMode(OpMode.DECRYPT);
+  }
+
 
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     try {
-      byte[] keyBytes =  Conversion.base64StringToByteArray(Password.decode(getKey().extract(msg)));
+      String algToUse = msg.resolve(getAlgorithm());
+      String cipherToUse = msg.resolve(getCipherTransformation());
+      byte[] keyBytes = Conversion.base64StringToByteArray(
+          Password.decode(ExternalResolver.resolve(getKey().extract(msg))));
       byte[] initialVectorBytes =  Conversion.base64StringToByteArray(getInitialVector().extract(msg));
-      Cipher cipher = Cipher.getInstance(getCipherTransformation());
-      SecretKeySpec secretKeySpec = new SecretKeySpec(keyBytes, getAlgorithm());
+      Cipher cipher = Cipher.getInstance(cipherToUse);
+      SecretKeySpec secretKeySpec = new SecretKeySpec(keyBytes, algToUse);
       IvParameterSpec ivParameterSpec = new IvParameterSpec(initialVectorBytes);
-      getOperationMode().execute(cipher, secretKeySpec, ivParameterSpec, msg);
+      getOperationMode().execute(cipher, secretKeySpec, ivParameterSpec, source().wrap(msg),
+          target().wrap(msg));
     } catch (Exception e) {
-      ExceptionHelper.rethrowServiceException(e);
+      throw ExceptionHelper.wrapServiceException(e);
     }
   }
 
@@ -113,11 +143,20 @@ public class SymmetricKeyCryptographyService extends ServiceImp {
 
   @Override
   public void prepare() throws CoreException {
-
+    Args.notBlank(getAlgorithm(), "algorithm");
+    Args.notBlank(getCipherTransformation(), "cipherTransformation");
+    Args.notNull(getKey(), "key");
+    Args.notNull(getInitialVector(), "initalVector");
   }
 
   /**
-   *
+   * Set the name of the secret-key algorithm.
+   * <p>
+   * This value is passed in as one of the parameters to
+   * {@link SecretKeySpec#SecretKeySpec(byte[], String)}; while it is free text, the correct value
+   * will depend on what you have agreed with the remote party and support within your JVM.
+   * </p>
+   * 
    * @param algorithm the name of the secret-key algorithm to be associated with the given key.
    */
   public void setAlgorithm(String algorithm) {
@@ -134,8 +173,14 @@ public class SymmetricKeyCryptographyService extends ServiceImp {
   }
 
   /**
+   * Set the cipher transformation to be applied
+   * <p>
+   * This value is passed into {@link Cipher#getInstance(String)}; while it is free text, the
+   * correct value will depend on what you have agreed with the remote party and support within your
+   * JVM.
+   * </p>
    *
-   * @param cipherTransformation the name of the transformation, e.g., AES/CBC/PKCS5Padding.
+   * @param cipherTransformation the name of the transformation, e.g. {@code AES/CBC/PKCS5Padding}.
    */
   public void setCipherTransformation(String cipherTransformation) {
     this.cipherTransformation = cipherTransformation;
@@ -151,8 +196,14 @@ public class SymmetricKeyCryptographyService extends ServiceImp {
   }
 
   /**
-   *
-   * @param initialVector Base64 encoded string of initial vector bytes.
+   * Set the initial vector for the algorithm
+   * 
+   * <p>
+   * Depending on the algorithm you have chosen, then size of the initial vector will vary. For
+   * instance, for AES, it needs to be 16 bytes
+   * </p>
+   * 
+   * @param initialVector the Base64 encoded string of initial vector bytes.
    */
   public void setInitialVector(DataInputParameter<String> initialVector) {
     this.initialVector = initialVector;
@@ -168,8 +219,14 @@ public class SymmetricKeyCryptographyService extends ServiceImp {
   }
 
   /**
-   *
-   * @param key  Base64 encoded string of key bytes.
+   * Set the initial key the service
+   * 
+   * <p>
+   * Depending on the algorithm you have chosen, then size of the key will vary. For instance, for
+   * AES, it needs to be 32 bytes
+   * </p>
+   * 
+   * @param key Base64 encoded string of key bytes.
    */
   public void setKey(DataInputParameter<String> key) {
     this.key = key;
@@ -195,5 +252,56 @@ public class SymmetricKeyCryptographyService extends ServiceImp {
   public OpMode getOperationMode() {
     return operationMode;
   }
+
+  public MessageWrapper<InputStream> getSource() {
+    return source;
+  }
+
+  /**
+   * Set the source for the input of the crypto service.
+   * 
+   * @param source the source.
+   */
+  public void setSource(InterlokMessage.MessageWrapper<InputStream> source) {
+    this.source = source;
+  }
+
+  public SymmetricKeyCryptographyService withSource(
+      MessageWrapper<InputStream> source) {
+    setSource(source);
+    return this;
+  }
+
+  private MessageWrapper<InputStream> source() {
+    return ObjectUtils.defaultIfNull(getSource(), (msg) -> {
+      return msg.getInputStream();
+    });
+  }
+
+  public MessageWrapper<OutputStream> getTarget() {
+    return target;
+  }
+
+  /**
+   * Set the target for the output of the crypto service.
+   * 
+   * @param target the target.
+   */
+  public void setTarget(MessageWrapper<OutputStream> target) {
+    this.target = target;
+  }
+
+  public SymmetricKeyCryptographyService withTarget(
+      InterlokMessage.MessageWrapper<OutputStream> target) {
+    setTarget(target);
+    return this;
+  }
+
+  private MessageWrapper<OutputStream> target() {
+    return ObjectUtils.defaultIfNull(getTarget(), (msg) -> {
+      return msg.getOutputStream();
+    });
+  }
+
 }
 

--- a/interlok-core/src/main/java/com/adaptris/core/security/SymmetricKeyCryptographyService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/SymmetricKeyCryptographyService.java
@@ -143,10 +143,14 @@ public class SymmetricKeyCryptographyService extends ServiceImp {
 
   @Override
   public void prepare() throws CoreException {
-    Args.notBlank(getAlgorithm(), "algorithm");
-    Args.notBlank(getCipherTransformation(), "cipherTransformation");
-    Args.notNull(getKey(), "key");
-    Args.notNull(getInitialVector(), "initalVector");
+    try {
+      Args.notBlank(getAlgorithm(), "algorithm");
+      Args.notBlank(getCipherTransformation(), "cipherTransformation");
+      Args.notNull(getKey(), "key");
+      Args.notNull(getInitialVector(), "initalVector");
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceWorkerPool.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceWorkerPool.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
@@ -32,7 +31,6 @@ import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMarshaller;
@@ -51,7 +49,7 @@ public class ServiceWorkerPool {
   private transient EventHandler eventHandler;
   private transient int maxThreads;
   private transient Logger log = LoggerFactory.getLogger(this.getClass());
-  private static transient boolean warningLogged = false;
+
   public ServiceWorkerPool(Service s, EventHandler eh, int maxThreads) throws CoreException {
     try {
       this.wrappedService = Args.notNull(s, "service");

--- a/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataInputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataInputParameterTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.adaptris.core.common;
+
+import static com.adaptris.core.common.MetadataDataInputParameter.DEFAULT_METADATA_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+
+public class MetadataStreamDataInputParameterTest {
+  private static final String METADATA_KEY = "myMetadataKey";
+  private static final String UTF_8 = "UTF-8";
+  private static final String TEXT = "Hello World";
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Test
+  public void testMetadataKey() throws Exception {
+    MetadataStreamInputParameter p = new MetadataStreamInputParameter();
+    assertEquals(DEFAULT_METADATA_KEY, p.getMetadataKey());
+    p.setMetadataKey("myKey");
+    assertEquals("myKey", p.getMetadataKey());
+    try {
+      p.setMetadataKey("");
+      fail();
+    } catch (IllegalArgumentException e) {
+
+    }
+    assertEquals("myKey", p.getMetadataKey());
+  }
+
+  @Test
+  public void testExtract() throws Exception {
+    MetadataStreamInputParameter p = new MetadataStreamInputParameter(METADATA_KEY);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata(METADATA_KEY, TEXT);
+    try (InputStream in = p.extract(msg)) {
+      List<String> strings = IOUtils.readLines(in, Charset.defaultCharset());
+      assertEquals(1, strings.size());
+      assertEquals(TEXT, strings.get(0));
+    }
+  }
+
+  @Test
+  public void testExtract_WithContentEncoding() throws Exception {
+    MetadataStreamInputParameter p =
+        new MetadataStreamInputParameter().withMetadataKey(METADATA_KEY).withContentEncoding(UTF_8);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata(METADATA_KEY, TEXT);
+    try (InputStream in = p.extract(msg)) {
+      List<String> strings = IOUtils.readLines(in, Charset.defaultCharset());
+      assertEquals(1, strings.size());
+      assertEquals(TEXT, strings.get(0));
+    }
+  }
+
+  @Test
+  public void testWrap() throws Exception {
+    MetadataStreamInputParameter p = new MetadataStreamInputParameter(METADATA_KEY);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata(METADATA_KEY, TEXT);
+    try (InputStream in = msg.wrap(p)) {
+      List<String> strings = IOUtils.readLines(in, Charset.defaultCharset());
+      assertEquals(1, strings.size());
+      assertEquals(TEXT, strings.get(0));
+    }
+  }
+
+  @Test
+  public void testWrap_WithContentEncoding() throws Exception {
+    MetadataStreamInputParameter p =
+        new MetadataStreamInputParameter().withMetadataKey(METADATA_KEY).withContentEncoding(UTF_8);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata(METADATA_KEY, TEXT);
+    try (InputStream in = msg.wrap(p)) {
+      List<String> strings = IOUtils.readLines(in, Charset.defaultCharset());
+      assertEquals(1, strings.size());
+      assertEquals(TEXT, strings.get(0));
+    }
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataOutputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataOutputParameterTest.java
@@ -15,20 +15,19 @@
  */
 package com.adaptris.core.common;
 
-import static com.adaptris.core.common.MetadataStreamOutputParameter.DEFAULT_METADATA_KEY;
+import static com.adaptris.core.common.MetadataDataOutputParameter.DEFAULT_METADATA_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
-
+import java.io.OutputStream;
+import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
@@ -110,4 +109,28 @@ public class MetadataStreamDataOutputParameterTest {
     };
     p.insert(new InputStreamWithEncoding(in, null), msg);
   }
+
+  @Test
+  public void testWrap() throws Exception {
+    MetadataStreamOutputParameter p =
+        new MetadataStreamOutputParameter().withMetadataKey("myMetadataKey");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try (OutputStream out = msg.wrap(p)) {
+      IOUtils.write(TEXT, out);
+    }
+    assertEquals(TEXT, msg.getMetadataValue("myMetadataKey"));
+  }
+
+  @Test
+  public void testWrap_WithCharset() throws Exception {
+    MetadataStreamOutputParameter p =
+        new MetadataStreamOutputParameter().withMetadataKey("myMetadataKey")
+            .withContentEncoding(UTF_8);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try (OutputStream out = msg.wrap(p)) {
+      IOUtils.write(TEXT, out, UTF_8);
+    }
+    assertEquals(TEXT, msg.getMetadataValue("myMetadataKey"));
+  }
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/common/PayloadStreamInputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/PayloadStreamInputParameterTest.java
@@ -16,18 +16,15 @@
 package com.adaptris.core.common;
 
 import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.List;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
@@ -53,6 +50,18 @@ public class PayloadStreamInputParameterTest {
     }
   }
 
+  @Test
+  public void testWrap() throws Exception {
+    PayloadStreamInputParameter p = new PayloadStreamInputParameter();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT.getBytes());
+    try (InputStream in = p.wrap(msg)) {
+      List<String> strings = IOUtils.readLines(in, Charset.defaultCharset());
+      assertEquals(1, strings.size());
+      assertEquals(TEXT, strings.get(0));
+    }
+  }
+
+
   @Test(expected = CoreException.class)
   public void testExtractWithException() throws Exception {
     PayloadStreamInputParameter p = new PayloadStreamInputParameter();
@@ -66,6 +75,7 @@ public class PayloadStreamInputParameterTest {
       super(new GuidGenerator(), new DefectiveMessageFactory());
     }
 
+    @Override
     public InputStream getInputStream() throws IOException {
       throw new IOException("broken");
     }

--- a/interlok-core/src/test/java/com/adaptris/core/common/PayloadStreamOutputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/PayloadStreamOutputParameterTest.java
@@ -17,14 +17,12 @@ package com.adaptris.core.common;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
-
+import java.io.OutputStream;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
@@ -136,5 +134,14 @@ public class PayloadStreamOutputParameterTest {
       }
     };
     p.insert(new InputStreamWithEncoding(in, null), msg);
+  }
+
+  @Test
+  public void testWrap() throws Exception {
+    PayloadStreamOutputParameter p = new PayloadStreamOutputParameter();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try (OutputStream out = p.wrap(msg)) {
+
+    }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/security/SecurityServiceExample.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/SecurityServiceExample.java
@@ -26,12 +26,16 @@ public abstract class SecurityServiceExample extends ServiceCase {
    */
   public static final String BASE_DIR_KEY = "SecurityServiceExamples.baseDir";
 
-  public SecurityServiceExample(String name) {
-    super(name);
+  public SecurityServiceExample() {
+    super();
     if (PROPERTIES.getProperty(BASE_DIR_KEY) != null) {
       setBaseDir(PROPERTIES.getProperty(BASE_DIR_KEY));
     }
   }
 
+  public SecurityServiceExample(String name) {
+    this();
+    setName(name);
+  }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/security/SymmetricKeyCryptographyServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/SymmetricKeyCryptographyServiceTest.java
@@ -9,9 +9,13 @@ import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceCase;
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.PayloadStreamInputParameter;
 import com.adaptris.core.common.PayloadStreamOutputParameter;
+import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.text.Conversion;
 
 /**
@@ -36,6 +40,28 @@ public class SymmetricKeyCryptographyServiceTest extends SecurityServiceExample 
     encryptedPayload = encrypt(PAYLOAD, key, iv);
   }
 
+  @Test
+  public void testDoService_BadConfig() throws Exception {
+    try {
+      LifecycleHelper.initAndStart(new SymmetricKeyCryptographyService());
+      fail();
+    } catch (CoreException expected) {
+
+    }
+    SymmetricKeyCryptographyService service = new SymmetricKeyCryptographyService()
+        .withAlgorithm("BLAH").withCipherTransformation("AES/Blah/Blah")
+        .withKey(new ConstantDataInputParameter("123"))
+        .withInitialVector(new ConstantDataInputParameter("123"));
+    AdaptrisMessage message =
+        AdaptrisMessageFactory.getDefaultInstance().newMessage(encryptedPayload);
+    try {
+      ServiceCase.execute(service, message);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
 
   @Test
   public void testDoService() throws Exception {
@@ -45,7 +71,7 @@ public class SymmetricKeyCryptographyServiceTest extends SecurityServiceExample 
     service.setKey(new ConstantDataInputParameter(Conversion.byteArrayToBase64String(key)));
     service.setInitialVector(new ConstantDataInputParameter(Conversion.byteArrayToBase64String(iv)));
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(encryptedPayload);
-    service.doService(message);
+    ServiceCase.execute(service, message);
     assertEquals(PAYLOAD, message.getContent());
   }
 
@@ -58,7 +84,7 @@ public class SymmetricKeyCryptographyServiceTest extends SecurityServiceExample 
     service.setKey(new ConstantDataInputParameter(Conversion.byteArrayToBase64String(key)));
     service.setInitialVector(new ConstantDataInputParameter(Conversion.byteArrayToBase64String(iv)));
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD);
-    service.doService(message);
+    ServiceCase.execute(service, message);
     assertTrue(Arrays.equals(encryptedPayload, message.getPayload()));
   }
 
@@ -73,7 +99,7 @@ public class SymmetricKeyCryptographyServiceTest extends SecurityServiceExample 
     service.setSource(new PayloadStreamInputParameter());
     service.setTarget(new PayloadStreamOutputParameter());
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD);
-    service.doService(message);
+    ServiceCase.execute(service, message);
     assertTrue(Arrays.equals(encryptedPayload, message.getPayload()));
   }
 


### PR DESCRIPTION
- Add a MessageWrapper interface to InterlokMessage
- Add a MetadataStreamInputParameter which gives us a metadata value as a stream.
- Add additional docs for each of the setters alg/vector/cipher
- Made Payload/Metadata outputs implement MessageWrapper.
- Could be used to support INTERLOK-2762 with the intention that we might do something like  (since TypedAdaptrisMessage would implement AdaptrisMessage but provide improved resolution capabilities).

```
TypedAdaptrisMessage eMsg = msg.wrap(new TypedWrapper());
for (Service s : services) {
  s.doService(eMsg);
}
```