### PR TITLE
Thread safe replaced parallelStream with stream in MessageLoggerImpl.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/MessageLoggerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MessageLoggerImpl.java
@@ -45,7 +45,7 @@ public abstract class MessageLoggerImpl implements MessageLogger {
 
   protected Collection<MetadataElement> format(Collection<MetadataElement> set) {
     MetadataCollection metadata = new MetadataCollection();
-    set.parallelStream().forEach(e -> {
+    set.stream().forEach(e -> {
       metadata.add(wrap(e.getKey(), e.getValue()));
     });
     return metadata;

--- a/interlok-core/src/main/java/com/adaptris/core/MetadataCollection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MetadataCollection.java
@@ -16,13 +16,23 @@
 
 package com.adaptris.core;
 
-import java.util.*;
+
 
 import javax.validation.constraints.NotNull;
 
 import com.adaptris.core.util.MetadataHelper;
 import com.adaptris.util.KeyValuePairBag;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * A container class for handling a {@link Collection} of {@link MetadataElement} instance.
@@ -43,7 +53,7 @@ public class MetadataCollection extends ArrayList<MetadataElement> {
     super();
   }
 
-  public MetadataCollection(@NotNull Set<MetadataElement> elements) {   
+  public MetadataCollection(@NotNull Set<MetadataElement> elements) {
     super(Objects.requireNonNull(elements));
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/MetadataCollection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MetadataCollection.java
@@ -16,15 +16,7 @@
 
 package com.adaptris.core;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 import javax.validation.constraints.NotNull;
 

--- a/interlok-core/src/main/java/com/adaptris/core/metadata/DiscardValuesTooLongFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/metadata/DiscardValuesTooLongFilter.java
@@ -52,7 +52,7 @@ public class DiscardValuesTooLongFilter extends MetadataFilterImpl {
   public MetadataCollection filter(MetadataCollection original) {
     MetadataCollection result = new MetadataCollection();
     int maxLen = maxLength();
-    result.addAll(original.parallelStream().filter(e -> e.getValue().length() <= maxLen)
+    result.addAll(original.stream().filter(e -> e.getValue().length() <= maxLen)
         .collect(Collectors.toList()));
     return result;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/metadata/PasswordMetadataFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/metadata/PasswordMetadataFilter.java
@@ -57,7 +57,7 @@ public abstract class PasswordMetadataFilter extends MetadataFilterImpl {
     }
     patternPasswords = validatePatterns(getPasswordPatterns(), patternPasswords);
     MetadataCollection result = new MetadataCollection();
-    result.addAll(original.parallelStream().map(e -> {
+    result.addAll(original.stream().map(e -> {
       return matches(e, patternPasswords) ? rebuild(e) : e;
     }).collect(Collectors.toList()));
     return result;

--- a/interlok-core/src/main/java/com/adaptris/core/metadata/RegexMetadataFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/metadata/RegexMetadataFilter.java
@@ -101,7 +101,7 @@ public class RegexMetadataFilter extends MetadataFilterImpl {
     }
     initialisePatterns();
     MetadataCollection toBeRemoved = new MetadataCollection();
-    toBeRemoved.addAll(metadataCollection.parallelStream().filter(e -> matches(e, patternExcludes)).collect(Collectors.toList()));
+    toBeRemoved.addAll(metadataCollection.stream().filter(e -> matches(e, patternExcludes)).collect(Collectors.toList()));
     metadataCollection.removeAll(toBeRemoved);
     return metadataCollection;
   }
@@ -119,7 +119,7 @@ public class RegexMetadataFilter extends MetadataFilterImpl {
     }
     initialisePatterns();
     MetadataCollection result = new MetadataCollection();
-    result.addAll(metadataCollection.parallelStream().filter(e -> matches(e, patternIncludes)).collect(Collectors.toList()));
+    result.addAll(metadataCollection.stream().filter(e -> matches(e, patternIncludes)).collect(Collectors.toList()));
     return result;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/util/MetadataKeysOnly.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/MetadataKeysOnly.java
@@ -39,7 +39,7 @@ public class MetadataKeysOnly implements MetadataLogger {
 
   private Collection<MetadataElement> format(Collection<MetadataElement> set) {
     MetadataCollection metadata = new MetadataCollection();
-    set.parallelStream().forEach(e -> {
+    set.stream().forEach(e -> {
       metadata.add(new KeysOnly(e.getKey(), e.getValue()));
     });
     return metadata;


### PR DESCRIPTION
MessageLogger - AIOOB exception trace
Made thread safe by replacing parallelStream with stream.