### PR TITLE
INTERLOK 2795

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageConsumer.java
@@ -16,7 +16,6 @@
 
 package com.adaptris.core;
 
-
 /**
  * <p>
  * Implementations of <code>AdaptrisMessageConsumer</code>
@@ -49,4 +48,23 @@ public interface AdaptrisMessageConsumer extends AdaptrisMessageWorker {
    * @param destination the name of the destination
    */
   void setDestination(ConsumeDestination destination);
+
+  /**
+   * Return the specific metadata key that contains the consume location.
+   * <p>
+   * if specified; then the workflow will attempt to set
+   * {@value CoreConstants#MESSAGE_CONSUME_LOCATION} as a standard metadata key. If not explicitly
+   * overriden, then this metadata key is not available.
+   * </p>
+   * 
+   * @implSpec The default implementation returns null, indicating there is no way to standardise
+   *           the consume location.
+   * 
+   * @return the metadata key;
+   * @since 3.9.0
+   */
+  default String consumeLocationKey() {
+    return null;
+  }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -388,5 +388,20 @@ public abstract class CoreConstants {
    */
   public static final String UNIQUE_ID_JMX_PATTERN = "[^,\\*\\?=:\"\\\\@]+";
 
+  /**
+   * Metadata key that stores the location where the message was consumed from if available.
+   * <p>
+   * This will have different meanings based on the consumer; for JMS consumers it might be
+   * {@link javax.jms.Message#getJMSDestination()}; for a file system consumer, it will be the
+   * directory from which it was consumed from.
+   * </p>
+   * <p>
+   * Note that this metadata key may not always be populated and is reliant on the
+   * {@link AdaptrisMessageConsumer#consumeLocationKey()} returning a non-null value.
+   * </p>
+   * 
+   * @since 3.9.0
+   */
+  public static final String MESSAGE_CONSUME_LOCATION = "_interlokMessageConsumedFrom";
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
@@ -92,7 +92,7 @@ public class MultiProducerWorkflow extends StandardWorkflow {
   }
 
   private void onMessage(final AdaptrisMessage msg) {
-    AdaptrisMessage wip = null;
+    AdaptrisMessage wip = addConsumeLocation(msg);
     workflowStart(msg);
     try {
       long start = System.currentTimeMillis();

--- a/interlok-core/src/main/java/com/adaptris/core/NullMessageConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NullMessageConsumer.java
@@ -32,28 +32,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Default NO-OP consumer implementation", tag = "consumer,base", recommended = {NullConnection.class})
 public class NullMessageConsumer extends AdaptrisMessageConsumerImp {
 	
-	public NullMessageConsumer() {
-		setMessageFactory(null);
-	}
-
-  /** @see com.adaptris.core.AdaptrisComponent#close() */
-  public void close() {
-    // do nothing
-  }
-
-  /** @see com.adaptris.core.AdaptrisComponent#init() */
-  public void init() throws CoreException {
-    // do nothing
-  }
-
-  /** @see com.adaptris.core.AdaptrisComponent#start() */
-  public void start() throws CoreException {
-    // do nothing
-  }
-
-  /** @see com.adaptris.core.AdaptrisComponent#stop() */
-  public void stop() {
-    // do nothing
+  public NullMessageConsumer() {
+    setMessageFactory(null);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -25,17 +25,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-
 import org.apache.commons.lang3.Range;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPool;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -329,6 +326,7 @@ public class PoolingWorkflow extends WorkflowImp {
 
   private void onMessage(AdaptrisMessage msg) {
     try {
+      addConsumeLocation(msg);
       currentThreadName = Thread.currentThread().getName();
       if (poolLock.permitAvailable()) {
         workflowStart(msg);

--- a/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
@@ -76,7 +76,7 @@ public class StandardWorkflow extends StandardWorkflowImpl {
   }
 
   protected void handleMessage(final AdaptrisMessage msg, boolean clone) {
-    AdaptrisMessage wip = msg;
+    AdaptrisMessage wip = addConsumeLocation(msg);
     workflowStart(msg);
     try {
       long start = System.currentTimeMillis();

--- a/interlok-core/src/main/java/com/adaptris/core/StandardWorkflowImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardWorkflowImpl.java
@@ -67,6 +67,7 @@ public abstract class StandardWorkflowImpl extends WorkflowImp {
 
   @Override
   protected void prepareWorkflow() throws CoreException {
+    // Consumers / services / producers already prepared.
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -31,6 +31,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.NotBlank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -822,5 +823,16 @@ public abstract class WorkflowImp implements Workflow {
       };
     }
     return ObjectUtils.defaultIfNull(getMessageLogger(), DEFAULT_MSG_LOGGER);
+  }
+
+  protected AdaptrisMessage addConsumeLocation(AdaptrisMessage msg) {
+    String key = getConsumer().consumeLocationKey();
+    if (!StringUtils.isBlank(key)) {
+      String consumeLocation = msg.getMetadataValue(key);
+      if (!StringUtils.isEmpty(consumeLocation)) {
+        msg.addMessageHeader(CoreConstants.MESSAGE_CONSUME_LOCATION, consumeLocation);
+      }
+    }
+    return msg;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
@@ -20,11 +20,9 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
-
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -33,6 +31,7 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConsumeDestination;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.util.Args;
@@ -89,7 +88,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Pickup messages from the filesystem", tag = "consumer,fs,filesystem",
     metadata =
     {
-        "originalname", "lastmodified", "fsFileSize", "fsConsumeDir", "fsParentDir"
+        CoreConstants.ORIGINAL_NAME_KEY, CoreConstants.FS_FILE_SIZE,
+        CoreConstants.FILE_LAST_MODIFIED_KEY, CoreConstants.FS_CONSUME_DIRECTORY,
+        CoreConstants.MESSAGE_CONSUME_LOCATION, CoreConstants.FS_CONSUME_PARENT_DIR
     }, recommended =
     {
         NullConnection.class

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
@@ -22,7 +22,6 @@ import static com.adaptris.core.CoreConstants.FS_CONSUME_PARENT_DIR;
 import static com.adaptris.core.CoreConstants.FS_FILE_SIZE;
 import static com.adaptris.core.CoreConstants.ORIGINAL_NAME_KEY;
 import static org.apache.commons.lang.StringUtils.isEmpty;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -30,13 +29,10 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import javax.management.MalformedObjectNameException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.BooleanUtils;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -366,6 +362,18 @@ public abstract class FsConsumerImpl extends AdaptrisPollingConsumer {
     return verifyDirectory().listFiles(FsHelper.createFilter(getDestination().getFilterExpression(), fileFilterImp())).length;
 
   }
+
+  /**
+   * Provides the metadata key '{@value CoreConstants.FS_CONSUME_DIRECTORY}' that contains the
+   * directory (if not null) where the file was read from.
+   * 
+   * @since 3.9.0
+   */
+  @Override
+  public String consumeLocationKey() {
+    return FS_CONSUME_DIRECTORY;
+  }
+
   private static class JmxFactory extends RuntimeInfoComponentFactory {
 
     @Override

--- a/interlok-core/src/main/java/com/adaptris/core/fs/MovingNonDeletingFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/MovingNonDeletingFsConsumer.java
@@ -4,15 +4,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-
 import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.ConsumeDestination;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.util.Args;
@@ -28,7 +27,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup messages from the filesystem and move them afterwards", tag = "consumer,fs,filesystem", metadata =
 {
-	"originalname", "lastmodified", "fsFileSize", "fsConsumeDir", "fsParentDir"
+        CoreConstants.ORIGINAL_NAME_KEY, CoreConstants.FS_FILE_SIZE,
+        CoreConstants.FILE_LAST_MODIFIED_KEY, CoreConstants.FS_CONSUME_DIRECTORY,
+        CoreConstants.MESSAGE_CONSUME_LOCATION, CoreConstants.FS_CONSUME_PARENT_DIR
 }, recommended =
 {
 	NullConnection.class

--- a/interlok-core/src/main/java/com/adaptris/core/fs/NonDeletingFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/NonDeletingFsConsumer.java
@@ -26,6 +26,7 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConsumeDestination;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullConnection;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -60,7 +61,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup messages from the filesystem without deleting them afterwards", tag = "consumer,fs,filesystem", metadata =
 {
-    "originalname", "lastmodified", "fsFileSize", "fsConsumeDir", "fsParentDir"
+        CoreConstants.ORIGINAL_NAME_KEY, CoreConstants.FS_FILE_SIZE,
+        CoreConstants.FILE_LAST_MODIFIED_KEY, CoreConstants.FS_CONSUME_DIRECTORY,
+        CoreConstants.MESSAGE_CONSUME_LOCATION, CoreConstants.FS_CONSUME_PARENT_DIR
 }, recommended =
 {
     NullConnection.class

--- a/interlok-core/src/main/java/com/adaptris/core/fs/TraversingFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/TraversingFsConsumer.java
@@ -21,12 +21,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConsumeDestination;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullConnection;
 import com.adaptris.fs.FsException;
@@ -44,7 +44,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup messages from the filesystem; traversing sub-directories", tag = "consumer,fs,filesystem", metadata =
 {
-    "originalname", "lastmodified", "fsFileSize", "fsConsumeDir", "fsParentDir"
+        CoreConstants.ORIGINAL_NAME_KEY, CoreConstants.FS_FILE_SIZE,
+        CoreConstants.FILE_LAST_MODIFIED_KEY, CoreConstants.FS_CONSUME_DIRECTORY,
+        CoreConstants.MESSAGE_CONSUME_LOCATION, CoreConstants.FS_CONSUME_PARENT_DIR
 },
     recommended = {NullConnection.class})
 @DisplayOrder(order = {"poller", "createDirs", "fileFilterImp", "fileSorter", "wipSuffix", "resetWipFiles"})

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
@@ -28,6 +28,7 @@ import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
@@ -66,7 +67,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup messages from an FTP or SFTP server", tag = "consumer,ftp,ftps,sftp", metadata =
 {
-    "originalname", "fsFileSize"
+        CoreConstants.ORIGINAL_NAME_KEY, CoreConstants.FS_FILE_SIZE,
+        CoreConstants.FS_CONSUME_DIRECTORY, CoreConstants.MESSAGE_CONSUME_LOCATION
 }, 
     recommended = {FileTransferConnection.class})
 @DisplayOrder(order = {"poller", "workDirectory", "fileFilterImp", "procDirectory", "wipSuffix", "quietInterval"})

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
@@ -19,12 +19,9 @@ package com.adaptris.core.ftp;
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
 import static org.apache.commons.lang.StringUtils.isEmpty;
-
 import java.io.File;
 import java.io.FileFilter;
-
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -109,6 +106,7 @@ public class FtpConsumer extends FtpConsumerImpl {
     }
   }
 
+  @Override
   protected String configureWorkDir(String path) {
     if (!isEmpty(getWorkDirectory())) {
       return path + getWorkDirectory();
@@ -116,6 +114,7 @@ public class FtpConsumer extends FtpConsumerImpl {
     return super.configureWorkDir(path);
   }
 
+  @Override
   protected boolean accept(String path) throws Exception {
     if (path.endsWith(wipSuffix())) {
       log.warn("[{}] matches [{}], assuming part processed and ignoring", path, wipSuffix());
@@ -145,7 +144,8 @@ public class FtpConsumer extends FtpConsumerImpl {
     try (EncoderWrapper wrapper = encWrapper) {
       ftpClient.get(wrapper, wipFile);
     }
-    AdaptrisMessage adpMsg = addStandardMetadata(encWrapper.build(), filename);
+    AdaptrisMessage adpMsg =
+        addStandardMetadata(encWrapper.build(), filename, FtpHelper.getDirectory(fullPath));
     retrieveAdaptrisMessageListener().onAdaptrisMessage(adpMsg);
 
     if (procDir != null) {

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumerImpl.java
@@ -17,12 +17,10 @@
 package com.adaptris.core.ftp;
 
 import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
-
 import java.io.FileFilter;
 import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageConsumer;
@@ -90,8 +88,9 @@ public abstract class FtpConsumerImpl extends AdaptrisPollingConsumer {
     return result;
   }
 
-  protected AdaptrisMessage addStandardMetadata(AdaptrisMessage msg, String filename) {
+  protected AdaptrisMessage addStandardMetadata(AdaptrisMessage msg, String filename, String dir) {
     msg.addMetadata(CoreConstants.ORIGINAL_NAME_KEY, filename);
+    msg.addMetadata(CoreConstants.FS_CONSUME_DIRECTORY, dir);
     msg.addMetadata(CoreConstants.FS_FILE_SIZE, "" + msg.getSize());
     return msg;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumerImpl.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core.ftp;
 
+import static com.adaptris.core.CoreConstants.FS_CONSUME_DIRECTORY;
 import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -225,4 +226,14 @@ public abstract class FtpConsumerImpl extends AdaptrisPollingConsumer {
     quietInterval = interval;
   }
 
+  /**
+   * Provides the metadata key '{@value CoreConstants.FS_CONSUME_DIRECTORY}' that contains the
+   * directory (if not null) where the file was read from.
+   * 
+   * @since 3.9.0
+   */
+  @Override
+  public String consumeLocationKey() {
+    return FS_CONSUME_DIRECTORY;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpHelper.java
@@ -15,7 +15,7 @@
 */
 package com.adaptris.core.ftp;
 
-public class FtpHelper {
+public abstract class FtpHelper {
   public static final String FORWARD_SLASH = "/";
   public static final String BACK_SLASH = "\\";
 
@@ -28,21 +28,36 @@ public class FtpHelper {
    */
   public static String getFilename(String s, boolean windowsWorkaround) {
     String result = s;
-    int slashPos = -1;
-    if (windowsWorkaround) {
-      slashPos = s.lastIndexOf(BACK_SLASH);
-    }
-    else {
-      slashPos = s.lastIndexOf(FORWARD_SLASH);
-    }
+    int slashPos = lastSlash(s, windowsWorkaround);
     if (slashPos >= 0 && s.length() > slashPos) {
       result = s.substring(slashPos + 1);
     }
     return result;
   }
 
+  public static String getDirectory(String s, boolean windows) {
+    String result = s;
+    int slashPos = lastSlash(s, windows);
+    if (slashPos >= 0) {
+      result = s.substring(0, slashPos);
+    }
+    return result;
+  }
+
+  private static int lastSlash(String s, boolean windows) {
+    if (windows) {
+      return s.lastIndexOf(BACK_SLASH);
+    } else {
+      return s.lastIndexOf(FORWARD_SLASH);
+    }
+  }
+
   public static String getFilename(String fullPath) {
     return getFilename(fullPath, false);
+  }
+
+  public static String getDirectory(String fullPath) {
+    return getDirectory(fullPath, false);
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/RelaxedFtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/RelaxedFtpConsumer.java
@@ -17,10 +17,8 @@
 package com.adaptris.core.ftp;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -93,7 +91,8 @@ public class RelaxedFtpConsumer extends FtpConsumerImpl {
     try (EncoderWrapper wrapper = encWrapper) {
       ftpClient.get(wrapper, fullPath);
     }
-    AdaptrisMessage adpMsg = addStandardMetadata(encWrapper.build(), filename);
+    AdaptrisMessage adpMsg =
+        addStandardMetadata(encWrapper.build(), filename, FtpHelper.getDirectory(fullPath));
     retrieveAdaptrisMessageListener().onAdaptrisMessage(adpMsg);
     try {
       ftpClient.delete(fullPath);

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/RelaxedFtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/RelaxedFtpConsumer.java
@@ -25,6 +25,7 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -58,7 +59,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup messages from an FTP/SFTP server without renaming the file first", metadata =
 {
-    "originalname", "fsFileSize"
+        CoreConstants.ORIGINAL_NAME_KEY, CoreConstants.FS_FILE_SIZE,
+        CoreConstants.FS_CONSUME_DIRECTORY, CoreConstants.MESSAGE_CONSUME_LOCATION
 }, 
     tag = "consumer,ftp,ftps,sftp", recommended = {FileTransferConnection.class})
 @DisplayOrder(order =

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpProducer.java
@@ -21,13 +21,11 @@ import java.io.PrintWriter;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.BooleanUtils;
-
 import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
@@ -66,6 +64,7 @@ public abstract class HttpProducer<A, B> extends RequestReplyProducerImp {
   @Valid
   @NotNull
   @AutoPopulated
+  @AffectsMetadata
   private ResponseHeaderHandler<B> responseHeaderHandler;
 
   @AdvancedConfig

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
@@ -22,7 +22,6 @@ import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URI;
 import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URL;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.join;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -40,17 +39,14 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
@@ -303,6 +299,17 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
         DEFAULT_EXPECT_INTERVAL);
   }
 
+  /**
+   * Provides the metadata key '{@value JettyConstants.JETTY_URI}' that contains the URI which
+   * triggered the consumer.
+   * 
+   * @since 3.9.0
+   */
+  @Override
+  public String consumeLocationKey() {
+    return JettyConstants.JETTY_URI;
+  }
+
   protected class BasicServlet extends HttpServlet {
 
     private static final long serialVersionUID = 2007082301L;
@@ -403,9 +410,9 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
         catch (TimeoutException e) {
           timeout.handleTimeout(response);
         }
-        if ((monitor.getEndTime() - monitor.getStartTime()) > warnAfter()) {
+        if (monitor.getEndTime() - monitor.getStartTime() > warnAfter()) {
           log.warn("Message ({}) took longer than expected; {}ms", loggingId,
-              ((monitor.getEndTime() - monitor.getStartTime())));
+              monitor.getEndTime() - monitor.getStartTime());
         }
       }
     }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyMessageConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyMessageConsumer.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.NotNull;
 import org.apache.commons.io.IOUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -86,11 +87,13 @@ public class JettyMessageConsumer extends BasicJettyConsumer {
   @Valid
   @NotNull
   @AdvancedConfig
+  @AffectsMetadata
   private ParameterHandler<HttpServletRequest> parameterHandler;
   @AutoPopulated
   @Valid
   @NotNull
   @AdvancedConfig
+  @AffectsMetadata
   private HeaderHandler<HttpServletRequest> headerHandler;
 
   public JettyMessageConsumer() {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyMessageConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyMessageConsumer.java
@@ -17,25 +17,22 @@
 package com.adaptris.core.http.jetty;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.io.IOUtils;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.http.server.HeaderHandler;
 import com.adaptris.core.http.server.ParameterHandler;
@@ -76,7 +73,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Listen for HTTP traffic on the specified URI", tag = "consumer,http,https", metadata =
 {
-    "jettyURI", "jettyURL", "jettyQueryString", "httpmethod"
+        JettyConstants.JETTY_QUERY_STRING, JettyConstants.JETTY_URI, JettyConstants.JETTY_URL,
+        CoreConstants.HTTP_METHOD, CoreConstants.MESSAGE_CONSUME_LOCATION
 }, recommended =
 {
     EmbeddedConnection.class, JettyConnection.class

--- a/interlok-core/src/main/java/com/adaptris/core/jms/BasicJavaxJmsMessageTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/BasicJavaxJmsMessageTranslator.java
@@ -18,7 +18,6 @@ package com.adaptris.core.jms;
 
 import javax.jms.JMSException;
 import javax.jms.Message;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -44,9 +43,6 @@ public class BasicJavaxJmsMessageTranslator extends MessageTypeTranslatorImp {
     super();
   }
   
-  public BasicJavaxJmsMessageTranslator(boolean moveJmsHeaders) {
-    super(moveJmsHeaders);
-  }
   
   /**
    * <p>

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumerImpl.java
@@ -307,6 +307,8 @@ public abstract class JmsConsumerImpl extends AdaptrisMessageConsumerImp impleme
   /**
    * Provides the metadata key {@value JmsConstants#JMS_DESTINATION} which will only be populated if
    * {@link MessageTypeTranslatorImp#getMoveJmsHeaders()} is true.
+   * 
+   * @since 3.9.0
    */
   @Override
   public String consumeLocationKey() {

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumerImpl.java
@@ -18,7 +18,6 @@ package com.adaptris.core.jms;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static com.adaptris.core.jms.NullCorrelationIdSource.defaultIfNull;
-
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
@@ -27,10 +26,8 @@ import javax.jms.Session;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-
 import org.apache.commons.lang.BooleanUtils;
 import org.slf4j.Logger;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.AdaptrisMessageConsumerImp;
@@ -305,6 +302,15 @@ public abstract class JmsConsumerImpl extends AdaptrisMessageConsumerImp impleme
   private static Session nullify(Session s) {
     JmsUtils.closeQuietly(s);
     return null;
+  }
+
+  /**
+   * Provides the metadata key {@value JmsConstants#JMS_DESTINATION} which will only be populated if
+   * {@link MessageTypeTranslatorImp#getMoveJmsHeaders()} is true.
+   */
+  @Override
+  public String consumeLocationKey() {
+    return JmsConstants.JMS_DESTINATION;
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsPollingConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsPollingConsumerImpl.java
@@ -152,8 +152,7 @@ public abstract class JmsPollingConsumerImpl extends AdaptrisPollingConsumer imp
     messageConsumer = createConsumer();
     messageTranslator.registerSession(session);
     messageTranslator.registerMessageFactory(defaultIfNull(getMessageFactory()));
-    LifecycleHelper.init(messageTranslator);
-    LifecycleHelper.start(messageTranslator);
+    LifecycleHelper.initAndStart(messageTranslator);
     if (additionalDebug()) {
       log.trace("connected to broker in {}ms", System.currentTimeMillis() - start);
     }
@@ -216,8 +215,7 @@ public abstract class JmsPollingConsumerImpl extends AdaptrisPollingConsumer imp
     }
     long start = System.currentTimeMillis();
     messageTranslator.registerSession(null);
-    LifecycleHelper.stop(messageTranslator);
-    LifecycleHelper.close(messageTranslator);
+    LifecycleHelper.stopAndClose(messageTranslator);
     JmsUtils.closeQuietly(messageConsumer);
     JmsUtils.closeQuietly(session);
     JmsUtils.closeQuietly(connection, true);
@@ -469,4 +467,14 @@ public abstract class JmsPollingConsumerImpl extends AdaptrisPollingConsumer imp
     return managedTransaction;
   }
 
+  /**
+   * Provides the metadata key {@value JmsConstants#JMS_DESTINATION} which will only be populated if
+   * {@link MessageTypeTranslatorImp#getMoveJmsHeaders()} is true.
+   * 
+   * @since 3.9.0
+   */
+  @Override
+  public String consumeLocationKey() {
+    return JmsConstants.JMS_DESTINATION;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/MessageTypeTranslatorImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/MessageTypeTranslatorImp.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core.jms;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import javax.jms.JMSException;
@@ -23,6 +25,7 @@ import javax.jms.Message;
 import javax.jms.Session;
 import javax.validation.Valid;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.adaptris.annotation.AdvancedConfig;
@@ -89,11 +92,6 @@ public abstract class MessageTypeTranslatorImp implements MessageTypeTranslator,
   public MessageTypeTranslatorImp() {
     registerMessageFactory(new DefaultMessageFactory());
     helper = new MetadataHandler(this);
-  }
-
-  public MessageTypeTranslatorImp(boolean moveJmsHeaders) {
-    this();
-    setMoveJmsHeaders(moveJmsHeaders);
   }
 
   /**
@@ -180,42 +178,6 @@ public abstract class MessageTypeTranslatorImp implements MessageTypeTranslator,
   }
 
   /**
-   *
-   * @see com.adaptris.core.AdaptrisComponent#init()
-   */
-  @Override
-  public void init() throws CoreException {
-
-  }
-
-  /**
-   *
-   * @see com.adaptris.core.AdaptrisComponent#start()
-   */
-  @Override
-  public void start() throws CoreException {
-
-  }
-
-  /**
-   *
-   * @see com.adaptris.core.AdaptrisComponent#stop()
-   */
-  @Override
-  public void stop() {
-
-  }
-
-  /**
-   *
-   * @see com.adaptris.core.AdaptrisComponent#close()
-   */
-  @Override
-  public void close() {
-
-  }
-
-  /**
    * Report all non-critical errors with a stacktrace.
    * <p>
    * When moving JMS Headers, it is possible depending on the vendor that some exceptions are thrown when attempting to get standard
@@ -254,13 +216,40 @@ public abstract class MessageTypeTranslatorImp implements MessageTypeTranslator,
 
   @Override
   public MetadataFilter metadataFilter() {
-    return getMetadataFilter() != null ? getMetadataFilter() : DEFAULT_FILTER;
+    return ObjectUtils.defaultIfNull(getMetadataFilter(), DEFAULT_FILTER);
   }
 
   @Override
   public List<MetadataConverter> metadataConverters(){
-    return getMetadataConverters() != null ? getMetadataConverters() : Collections.emptyList();
+    return ObjectUtils.defaultIfNull(getMetadataConverters(), Collections.emptyList());
   }
+
+  public <T extends MessageTypeTranslatorImp> T withMetadataConverters(
+      List<MetadataConverter> list) {
+    setMetadataConverters(list);
+    return (T) this;
+  }
+
+  public <T extends MessageTypeTranslatorImp> T withMetadataConverters(
+      MetadataConverter... list) {
+    return withMetadataConverters(new ArrayList<>(Arrays.asList(list)));
+  }
+
+  public <T extends MessageTypeTranslatorImp> T withReportAllErrors(Boolean b) {
+    setReportAllErrors(b);
+    return (T) this;
+  }
+
+  public <T extends MessageTypeTranslatorImp> T withMoveJmsHeaders(Boolean b) {
+    setMoveJmsHeaders(b);
+    return (T) this;
+  }
+
+  public <T extends MessageTypeTranslatorImp> T withMetadataFilter(MetadataFilter f) {
+    setMetadataFilter(f);
+    return (T) this;
+  }
+
 
   /**
    * Convenience method to translate a {@link Message} into a {@link com.adaptris.core.AdaptrisMessage}.

--- a/interlok-core/src/main/java/com/adaptris/core/jms/TextMessageTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/TextMessageTranslator.java
@@ -19,7 +19,6 @@ package com.adaptris.core.jms;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.TextMessage;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -44,10 +43,6 @@ public final class TextMessageTranslator extends MessageTypeTranslatorImp {
     super();
   }
 
-  public TextMessageTranslator(boolean moveJmsHeaders) {
-    super(moveJmsHeaders);
-  }
-
   /**
    * <p>
    * Translates an <code>AdaptrisMessage</code> into a <code>TextMessage</code>
@@ -58,6 +53,7 @@ public final class TextMessageTranslator extends MessageTypeTranslatorImp {
    * @return a new <code>TextMessage</code>
    * @throws JMSException
    */
+  @Override
   public Message translate(AdaptrisMessage msg) throws JMSException {
     return helper.moveMetadata(msg, session.createTextMessage(msg.getContent()));
   }
@@ -72,6 +68,7 @@ public final class TextMessageTranslator extends MessageTypeTranslatorImp {
    * @return an <code>AdaptrisMessage</code>
    * @throws JMSException
    */
+  @Override
   public AdaptrisMessage translate(Message msg) throws JMSException {
     AdaptrisMessage result = currentMessageFactory().newMessage(((TextMessage) msg).getText());
     return helper.moveMetadata(msg, result);

--- a/interlok-core/src/main/java/com/adaptris/core/jmx/JmxNotificationConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jmx/JmxNotificationConsumer.java
@@ -48,11 +48,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("jmx-notification-consumer")
 @AdapterComponent
 @ComponentProfile(summary = "Listen for notifications against the specified ObjectName", tag = "consumer,jmx",
+    metadata = {com.adaptris.core.jmx.JmxNotificationConsumer.JMX_NOTIF_SOURCE},
     recommended = {JmxConnection.class})
 @DisplayOrder(order = {"serializer"})
 public class JmxNotificationConsumer extends AdaptrisMessageConsumerImp implements NotificationListener {
 
-  private static final String JMX_NOTIF_SOURCE = "jmxNotificationSource";
+  public static final String JMX_NOTIF_SOURCE = "jmxNotificationSource";
 
   private static final TimeInterval DEFAULT_INTERVAL = new TimeInterval(60L, TimeUnit.SECONDS);
   @NotNull

--- a/interlok-core/src/main/java/com/adaptris/core/jmx/JmxNotificationConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jmx/JmxNotificationConsumer.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServerConnection;
 import javax.management.Notification;
@@ -27,9 +26,7 @@ import javax.management.NotificationListener;
 import javax.management.ObjectName;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.BooleanUtils;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -54,6 +51,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
     recommended = {JmxConnection.class})
 @DisplayOrder(order = {"serializer"})
 public class JmxNotificationConsumer extends AdaptrisMessageConsumerImp implements NotificationListener {
+
+  private static final String JMX_NOTIF_SOURCE = "jmxNotificationSource";
 
   private static final TimeInterval DEFAULT_INTERVAL = new TimeInterval(60L, TimeUnit.SECONDS);
   @NotNull
@@ -122,6 +121,7 @@ public class JmxNotificationConsumer extends AdaptrisMessageConsumerImp implemen
   private AdaptrisMessage createMessage(Notification n) throws CoreException, IOException {
     AdaptrisMessageFactory fac = AdaptrisMessageFactory.defaultIfNull(getMessageFactory());
     AdaptrisMessage msg = getSerializer().serialize(n, fac.newMessage());
+    msg.addMessageHeader(JMX_NOTIF_SOURCE, n.getSource().toString());
     return msg;
   }
 
@@ -226,6 +226,17 @@ public class JmxNotificationConsumer extends AdaptrisMessageConsumerImp implemen
 
   long retryInterval() {
     return TimeInterval.toMillisecondsDefaultIfNull(getRetryInterval(), DEFAULT_INTERVAL);
+  }
+
+  /**
+   * Provides the metadata key '{@value #JMX_NOTIF_SOURCE}' that contains the source of the
+   * notifcation.
+   * 
+   * @since 3.9.0
+   */
+  @Override
+  public String consumeLocationKey() {
+    return JMX_NOTIF_SOURCE;
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsConsumer.java
@@ -17,18 +17,16 @@
 package com.adaptris.core.lms;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-
 import java.io.File;
 import java.io.IOException;
-
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConsumeDestination;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.fs.FsConsumer;
@@ -68,7 +66,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup messages from the filesystem with large message support", tag = "consumer,fs,filesystem", metadata =
 {
-    "originalname", "lastmodified", "fsFileSize", "fsConsumeDir", "fsParentDir"
+        CoreConstants.ORIGINAL_NAME_KEY, CoreConstants.FS_FILE_SIZE,
+        CoreConstants.FILE_LAST_MODIFIED_KEY, CoreConstants.FS_CONSUME_DIRECTORY,
+        CoreConstants.MESSAGE_CONSUME_LOCATION, CoreConstants.FS_CONSUME_PARENT_DIR
 }, recommended =
 {
     NullConnection.class

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/EmbeddedFtpServer.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/EmbeddedFtpServer.java
@@ -17,7 +17,6 @@
 package com.adaptris.core.ftp;
 
 import static org.junit.Assert.assertTrue;
-
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,7 +24,6 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.ResourceBundle;
-
 import org.mockftpserver.core.command.Command;
 import org.mockftpserver.core.command.ReplyCodes;
 import org.mockftpserver.core.session.Session;
@@ -37,7 +35,6 @@ import org.mockftpserver.fake.filesystem.FileEntry;
 import org.mockftpserver.fake.filesystem.FileSystem;
 import org.mockftpserver.fake.filesystem.FileSystemEntry;
 import org.mockftpserver.fake.filesystem.UnixFakeFileSystem;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreConstants;
 
@@ -122,7 +119,8 @@ public class EmbeddedFtpServer {
   public void assertMessages(List<AdaptrisMessage> list, int count) {
     // assertEquals("All files consumed/produced", count, list.size());
     for (AdaptrisMessage m : list) {
-      assertTrue(m.containsKey(CoreConstants.ORIGINAL_NAME_KEY));
+      assertTrue(m.headersContainsKey(CoreConstants.ORIGINAL_NAME_KEY));
+      assertTrue(m.headersContainsKey(CoreConstants.FS_CONSUME_DIRECTORY));
       // assertEquals(PAYLOAD, m.getContent().trim());
     }
   }
@@ -132,6 +130,7 @@ public class EmbeddedFtpServer {
     public MdtmCommandHandler() {
     }
 
+    @Override
     protected void handle(Command command, Session session) {
       SimpleDateFormat tsFormat = new SimpleDateFormat("yyyyMMddHHmmss");
       verifyLoggedIn(session);
@@ -147,6 +146,7 @@ public class EmbeddedFtpServer {
     }
 
     // This is to override with the mdtm resource bundle w/o having to change the resource bundle
+    @Override
     public ResourceBundle getReplyTextBundle() {
       return wrap(super.getReplyTextBundle());
     }

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpHelperTest.java
@@ -1,0 +1,52 @@
+package com.adaptris.core.ftp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import org.junit.Test;
+
+public class FtpHelperTest extends FtpHelper {
+
+  private static final String FILENAME = "filename";
+  private static final String UNIX_DIR = "/home/interlok/path/to";
+  private static final String WINDOWS_DIR = "\\home\\interlok\\path\\to";
+  private static final String UNIX_PATH = UNIX_DIR + "/" + FILENAME;
+  private static final String WINDOWS_PATH = WINDOWS_DIR + "\\" + FILENAME;
+
+  @Test
+  public void testGetFilename() {
+    String filename = getFilename(UNIX_PATH);
+    assertEquals(FILENAME, filename);
+
+    filename = getFilename(UNIX_PATH, true);
+    assertNotEquals(FILENAME, filename);
+    assertEquals(UNIX_PATH, filename);
+
+    filename = getFilename(WINDOWS_PATH, true);
+    assertEquals(FILENAME, filename);
+
+    filename = getFilename(WINDOWS_PATH, false);
+    assertNotEquals(FILENAME, filename);
+    assertEquals(WINDOWS_PATH, filename);
+
+  }
+
+  @Test
+  public void testGetDirectory() {
+    String directory = getDirectory(UNIX_PATH);
+    assertEquals(UNIX_DIR, directory);
+
+    directory = getDirectory(UNIX_PATH, true);
+    assertNotEquals(UNIX_DIR, directory);
+    assertEquals(UNIX_PATH, directory);
+
+    directory = getDirectory(WINDOWS_PATH, true);
+    assertEquals(WINDOWS_DIR, directory);
+
+    directory = getDirectory(WINDOWS_PATH, false);
+    assertNotEquals(WINDOWS_DIR, directory);
+    assertEquals(WINDOWS_PATH, directory);
+
+  }
+
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jms/GenericMessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/GenericMessageTypeTranslatorCase.java
@@ -15,11 +15,8 @@
 */
 package com.adaptris.core.jms;
 
-import java.util.Arrays;
-
 import javax.jms.Message;
 import javax.jms.Session;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
@@ -34,11 +31,11 @@ public abstract class GenericMessageTypeTranslatorCase extends MessageTypeTransl
 
   public void testMetadataConverter() throws Exception {
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    MessageTypeTranslatorImp trans = createTranslator();
-    trans.setMetadataConverters(
-        Arrays.asList(new StringMetadataConverter(new RegexMetadataFilter().withIncludePatterns(STRING_METADATA)),
-            new IntegerMetadataConverter(new RegexMetadataFilter().withIncludePatterns(INTEGER_METADATA)),
-            new BooleanMetadataConverter(new RegexMetadataFilter().withIncludePatterns(BOOLEAN_METADATA))));
+    MessageTypeTranslatorImp trans = createTranslator().withMetadataConverters(
+        new StringMetadataConverter(new RegexMetadataFilter().withIncludePatterns(STRING_METADATA)),
+        new IntegerMetadataConverter(new RegexMetadataFilter().withIncludePatterns(INTEGER_METADATA)),
+        new BooleanMetadataConverter(
+            new RegexMetadataFilter().withIncludePatterns(BOOLEAN_METADATA)));
     try {
       broker.start();
       Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MessageTypeTranslatorCase.java
@@ -26,14 +26,11 @@ import static com.adaptris.core.jms.JmsConstants.JMS_REDELIVERED;
 import static com.adaptris.core.jms.JmsConstants.JMS_REPLY_TO;
 import static com.adaptris.core.jms.JmsConstants.JMS_TIMESTAMP;
 import static com.adaptris.core.jms.JmsConstants.JMS_TYPE;
-
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -89,10 +86,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
   }
 
   public void testRoundTrip() throws Exception {
-    MessageTypeTranslatorImp translator = createTranslator();
-    translator.setMoveJmsHeaders(true);
-    translator.setMetadataFilter(new NoOpMetadataFilter());
-    translator.setReportAllErrors(true);
+    MessageTypeTranslatorImp translator =
+        createTranslator().withMoveJmsHeaders(true).withMetadataFilter(new NoOpMetadataFilter())
+            .withReportAllErrors(true);
     StandaloneProducer p1 = createProducer(translator);
     StandaloneProducer p2 = roundTrip(p1);
     assertRoundtripEquality(p1, p2);
@@ -239,7 +235,7 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
 
   public void testMoveJmsHeadersAdaptrisMessageToJmsMessage() throws Exception {
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    MessageTypeTranslatorImp trans = createTranslator();
+    MessageTypeTranslatorImp trans = createTranslator().withMoveJmsHeaders(true);
     try {
       broker.start();
       Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
@@ -248,7 +244,6 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
       addMetadata(msg);
       addRedundantJmsHeaders(msg);
 
-      trans.setMoveJmsHeaders(true);
       start(trans, session);
 
       Message jmsMsg = trans.translate(msg);
@@ -291,8 +286,8 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
 
   public void testMoveMetadata_AdaptrisMessageToJmsMessage_RemoveAll() throws Exception {
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    MessageTypeTranslatorImp trans = createTranslator();
-    trans.setMetadataFilter(new RemoveAllMetadataFilter());
+    MessageTypeTranslatorImp trans =
+        createTranslator().withMetadataFilter(new RemoveAllMetadataFilter());
     try {
       broker.start();
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsTransactedWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsTransactedWorkflowTest.java
@@ -18,7 +18,6 @@ package com.adaptris.core.jms.activemq;
 
 import static com.adaptris.core.jms.JmsConfig.DEFAULT_PAYLOAD;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createSafeUniqueId;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,10 +25,8 @@ import java.util.Random;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.BaseCase;
@@ -574,7 +571,7 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     workflow.setProducer(new MockMessageProducer());
     JmsConsumerImpl jmsCons = isPtp ? new PtpConsumer(new ConfiguredConsumeDestination(target, null, threadName)) : new PasConsumer(
         new ConfiguredConsumeDestination(target, null, threadName));
-    jmsCons.setMessageTranslator(new TextMessageTranslator(true));
+    jmsCons.setMessageTranslator(new TextMessageTranslator().withMoveJmsHeaders(true));
     workflow.setConsumer(jmsCons);
     return workflow;
   }
@@ -591,7 +588,7 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     BasicActiveMqImplementation vendorImpl = new BasicActiveMqImplementation();
     JmsConnection jmsConn = mq.getJmsConnection(vendorImpl, true);
     jmsCons.setVendorImplementation(jmsConn.getVendorImplementation());
-    jmsCons.setMessageTranslator(new TextMessageTranslator(true));
+    jmsCons.setMessageTranslator(new TextMessageTranslator().withMoveJmsHeaders(true));
     jmsCons.setClientId(jmsConn.getClientId());
     workflow.setConsumer(jmsCons);
     return workflow;
@@ -606,6 +603,7 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
   }
 
   private class RandomlyFail extends ServiceImp {
+    @Override
     public void doService(AdaptrisMessage msg) throws ServiceException {
       int i = new Random().nextInt(20) + 1;
       if ((i & i - 1) == 0) {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqConsumerTest.java
@@ -20,7 +20,6 @@ import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.AdvancedActiveMqImplementationTest.createImpl;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.addBlobUrlRef;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
@@ -29,6 +28,7 @@ import com.adaptris.core.ChannelList;
 import com.adaptris.core.ClosedState;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.NullProcessingExceptionHandler;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
@@ -120,6 +120,9 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
           new PasProducer(new ConfiguredProduceDestination(getName())));
       execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
       assertMessages(jms, 1);
+      AdaptrisMessage consumed = jms.getMessages().get(0);
+      // Since it's not a workflow; this will be false.
+      assertFalse(consumed.headersContainsKey(CoreConstants.MESSAGE_CONSUME_LOCATION));
     }
     finally {
       activeMqBroker.destroy();


### PR DESCRIPTION
- Add default method to AdaptrisMessageConsumer (String consumeLocationKey())
- Workflows now use consumeLocationKey from the consumer to attempt to copy that metadata value to the key `_interlokMessageConsumedFrom` which should give you logging along the lines of

```
DEBUG [hello-world@nauseous-northcutt] [c.a.c.StandardWorkflow] start processing msg [DefaultAdaptrisMessageImp[uniqueId=41a869bb-8dec-4d77-9ffa-a7351d048904,metadata=[[httpmethod]=[GET], [jettyURL]=[http://localhost:8080/hello-world], [_interlokMessageConsumedFrom]=[/hello-world], [jettyURI]=[/hello-world]]]]
```
- Add tests for behaviour
-  FS (_fsConsumeDir_)/ Jetty (_jettyURI_)/ JMX / JMS / FTP now override consumeLocationKey()
- JMS won't work unless move-jms-headers = true in the message-type-translator (but this is acceptable I think)
- JMX gives you the "Notification#getSource().toString()"
- FTP re-uses fsConsumeDir as its key.

Other consumer implementations aren't affected...
Might need to modify XA workflows / consumers?