### PR TITLE
INTERLOK-2759 Change method signature to return an int.

### DIFF
--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/JdbcMapInsertCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/JdbcMapInsertCase.java
@@ -127,8 +127,8 @@ public abstract class JdbcMapInsertCase {
     }
   }
 
-  protected static <T> T configureForTests(T t) {
-    JdbcMapInsert service = (JdbcMapInsert) t;
+  protected static <T extends JdbcMapInsert> T configureForTests(T t) {
+    JdbcMapInsert service = t;
     JdbcConnection connection = new JdbcConnection();
     connection.setConnectUrl(JDBC_URL);
     connection.setDriverImp(JDBC_DRIVER);

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/JdbcMapUpsertTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/JdbcMapUpsertTest.java
@@ -16,6 +16,7 @@
 package com.adaptris.core.services.jdbc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.InputStream;
@@ -97,11 +98,13 @@ public class JdbcMapUpsertTest extends JdbcMapInsertCase {
   @Test
   public void testService_Insert() throws Exception {
     createDatabase();
-    UpsertProperties service = configureForTests(createService());
+    UpsertProperties service = configureForTests(createService()).withRowsAffectedMetadataKey("rowsInserted");
     service.setIdField(ID_ELEMENT_VALUE);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CONTENT);
     ServiceCase.execute(service, msg);
     doAssert(1);
+    assertTrue(msg.headersContainsKey("rowsInserted"));
+    assertEquals("1", msg.getMetadataValue("rowsInserted"));
   }
 
   @Test
@@ -133,10 +136,12 @@ public class JdbcMapUpsertTest extends JdbcMapInsertCase {
   public void testService_Update() throws Exception {
     createDatabase();
     populateDatabase();
-    UpsertProperties service = configureForTests(createService());
+    UpsertProperties service = configureForTests(createService()).withRowsAffectedMetadataKey("rowsUpdated");
     service.setIdField(ID_ELEMENT_VALUE);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CONTENT);
     ServiceCase.execute(service, msg);
+    assertTrue(msg.headersContainsKey("rowsUpdated"));
+    assertEquals("1", msg.getMetadataValue("rowsUpdated"));
     doAssert(1);
     checkDob(ALICE, DOB);
   }
@@ -220,7 +225,6 @@ public class JdbcMapUpsertTest extends JdbcMapInsertCase {
     }
   }
 
-  @SuppressWarnings("deprecation")
   protected class UpsertProperties extends JdbcMapUpsert {
 
     @Override
@@ -228,11 +232,11 @@ public class JdbcMapUpsertTest extends JdbcMapInsertCase {
       Connection conn = null;
       try {
         conn = getConnection(msg);
-        handleUpsert(table(msg), conn, mapify(msg));
-        commit(conn, msg);
+        addUpdatedMetadata(handleUpsert(table(msg), conn, mapify(msg)), msg);
+        JdbcUtil.commit(conn, msg);
       }
       catch (Exception e) {
-        rollback(conn, msg);
+        JdbcUtil.rollback(conn, msg);
         throw ExceptionHelper.wrapServiceException(e);
       }
       finally {


### PR DESCRIPTION
- Change method signature to return int
- add helper method to add the metadata if configured.
- this change doesn't have any impact in intelrok-core; but it will have downstream impact on interlok-csv / interlok-json etc.