### PR TITLE
INTERLOK-2833 Add arbitrary headers to nested mime-parts

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/metadata/FixedValuesMetadataFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/metadata/FixedValuesMetadataFilter.java
@@ -1,0 +1,62 @@
+package com.adaptris.core.metadata;
+
+import java.util.Arrays;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.MetadataElement;
+import com.adaptris.core.util.Args;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * {@link MetadataFilter} that just uses the configured {@link KeyValuePairSet} as the metadata.
+ * <p>
+ * This class will have the effect of replacing all metadata with a fixed set of metadata.
+ * </p>
+ * 
+ * @config fixed-values-metadata-filter
+ * @since 3.9.0
+ */
+@XStreamAlias("fixed-values-metadata-filter")
+@ComponentProfile(summary = "Replaces all metadata with a fixed set of metadata", since = "3.9.0")
+public class FixedValuesMetadataFilter extends MetadataFilterImpl {
+  
+  @Valid
+  @NotNull
+  @AutoPopulated
+  private KeyValuePairSet metadata;
+  
+  public FixedValuesMetadataFilter() {
+    setMetadata(new KeyValuePairSet());
+  }
+
+  @Override
+  public MetadataCollection filter(MetadataCollection original) {
+    MetadataCollection result = new MetadataCollection();
+    getMetadata().forEach((e) -> {
+      result.add(new MetadataElement(e.getKey(), e.getValue()));
+    });
+    return result;
+  }
+
+  public KeyValuePairSet getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(KeyValuePairSet metadata) {
+    this.metadata = Args.notNull(metadata, "metadata");
+  }
+
+  public FixedValuesMetadataFilter withMetadata(KeyValuePairSet kvps) {
+    setMetadata(kvps);
+    return this;
+  }
+  
+  public FixedValuesMetadataFilter withMetadata(KeyValuePair...keyValuePairs) {
+    return withMetadata(new KeyValuePairSet(Arrays.asList(keyValuePairs)));
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/IgnoreOriginalMimeAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/IgnoreOriginalMimeAggregator.java
@@ -17,12 +17,12 @@
 package com.adaptris.core.services.aggregator;
 
 import java.io.IOException;
-
 import javax.mail.MessagingException;
-
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreConstants;
+import com.adaptris.core.MetadataCollection;
 import com.adaptris.util.text.mime.MultiPartOutput;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -48,11 +48,20 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("ignore-original-mime-aggregator")
-@DisplayOrder(order = {"encoding", "overwriteMetadata", "partContentIdMetadataKey"})
+@DisplayOrder(order = {"encoding", "mimeContentSubType", "mimeHeaderFilter", "overwriteMetadata",
+    "partContentId", "partContentType", "partHeaderFilter"})
+@ComponentProfile(
+    summary = "Aggregator implementation that creates a new mime part for each message that needs to be joined up")
 public class IgnoreOriginalMimeAggregator extends MimeAggregator {
 
   @Override
   protected MultiPartOutput createInitialPart(AdaptrisMessage original) throws MessagingException, IOException {
-    return new MultiPartOutput(original.getUniqueId());
+    MultiPartOutput output =
+        new MultiPartOutput(original.getUniqueId(), mimeContentSubType(original));
+    MetadataCollection metadata = mimeHeaderFilter().filter(original);
+    metadata.forEach((e) -> {
+      output.setHeader(e.getKey(), e.getValue());
+    });
+    return output;
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/metadata/FixedValuesMetadataFilterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/metadata/FixedValuesMetadataFilterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.metadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import java.util.Map;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.util.KeyValuePair;
+
+public class FixedValuesMetadataFilterTest {
+
+
+  @Test
+  public void testFilterMessage() throws Exception {
+    FixedValuesMetadataFilter filter =
+        new FixedValuesMetadataFilter().withMetadata(new KeyValuePair("hello", "world"));
+    MetadataCollection c = filter.filter(createMessage());
+    assertEquals(1, c.size());
+    Map<String, String> map = MetadataCollection.asMap(c);
+    assertFalse(map.containsKey("someRandomKey"));
+  }
+
+  @Test
+  public void testFilterSet() throws Exception {
+    FixedValuesMetadataFilter filter =
+        new FixedValuesMetadataFilter().withMetadata(new KeyValuePair("hello", "world"));
+    MetadataCollection c = filter.filter(createMessage().getMetadata());
+    assertEquals(1, c.size());
+    Map<String, String> map = MetadataCollection.asMap(c);
+    assertFalse(map.containsKey("someRandomKey"));
+  }
+
+  @Test
+  public void testFilterCollection() throws Exception {
+    FixedValuesMetadataFilter filter =
+        new FixedValuesMetadataFilter().withMetadata(new KeyValuePair("hello", "world"));
+    MetadataCollection c = filter.filter(new MetadataCollection(createMessage().getMetadata()));
+    assertEquals(1, c.size());
+    Map<String, String> map = MetadataCollection.asMap(c);
+    assertFalse(map.containsKey("someRandomKey"));
+  }
+
+  private AdaptrisMessage createMessage() {
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    message.addMetadata("someRandomKey", "Some random value");
+    message.addMetadata("JackAndJill", "Ran up some hill");
+    message.addMetadata("JillAndJack", "Broke their backs");
+    return message;
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MimeAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MimeAggregatorTest.java
@@ -18,7 +18,6 @@ package com.adaptris.core.services.aggregator;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
@@ -53,8 +52,7 @@ public class MimeAggregatorTest extends MimeAggregatorCase {
     service.setService(new NullService());
     service.setTimeout(new TimeInterval(10L, TimeUnit.SECONDS));
     service.setSplitter(new LineCountSplitter());
-    MimeAggregator aggr = createAggregatorForTests();
-    aggr.setEncoding("base64");
+    MimeAggregator aggr = createAggregatorForTests().withEncoding("base64");
     service.setAggregator(aggr);
     execute(service, msg);
     BodyPartIterator input = MimeHelper.createBodyPartIterator(msg);


### PR DESCRIPTION
- Introduce new part-content-id and part-content-type expressions
- Deprecate metadata-key variants
- Add part-header-filter which adds headers for each nested part
- Add mime-header-filter which adds headers to the top level.
- Tests; 100% on MimeAggregator
- Fix bug with MultipartOutput; which was probably introduced when we added support for large message mime-encoding...
- Add a FixedValueMetadataFilter which means we can hard-code metadata elements (much like add-metadata-service) where a metadata-filter is used. Since we don't always have access to the 'message' we can't make this filter resolve metadata via the expression language.

```
Message-ID: 8d00402b-59bf-4fd1-b98a-581c80b54ef0
Mime-Version: 1.0
Content-Type: multipart/form-data; 
	boundary="----=_Part_20_1306660310.1560366164987"
Content-Length: 515
```
is now possible via `<mime-content-sub-type>`