### PR TITLE
INTERLOK-2834 Add MultipartMessageBuilder

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/DefaultAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DefaultAdaptrisMessageImp.java
@@ -17,7 +17,6 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FilterOutputStream;
@@ -25,10 +24,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
-
 import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.util.IdGenerator;
 
 /**
@@ -111,20 +109,13 @@ public class DefaultAdaptrisMessageImp extends AdaptrisMessageImp {
   }
   
   /** @see AdaptrisMessage#setContent(String, String) */
+  @Override
   public void setContent(String payloadString, String charEnc) {
     if (payloadString != null) {
-      try {
-        if (!isEmpty(charEnc)) {
-          payload = payloadString.getBytes(charEnc);
-        }
-        else {
-          payload = payloadString.getBytes();
-        }
+        Charset charset =
+            Charset.forName(StringUtils.defaultIfBlank(charEnc, Charset.defaultCharset().name()));
+        payload = payloadString.getBytes(charset);
         setContentEncoding(charEnc);
-      }
-      catch (UnsupportedEncodingException e) {
-        throw new RuntimeException(e);
-      }
     }
     else {
       payload = new byte[0];

--- a/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayFromMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayFromMetadata.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.common;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Wraps a metadata value as a byte[]
+ * 
+ * @config byte-array-from-metadata
+ */
+@XStreamAlias("byte-array-from-metadata")
+@ComponentProfile(summary="Turn a metadata value into a byte array.", since="3.9.0")
+@DisplayOrder(order = {"key", "translator"})
+public class ByteArrayFromMetadata extends ByteArrayFromMetadataWrapper {
+
+  public ByteArrayFromMetadata() {
+    super();
+  }
+
+  @Override
+  public byte[] wrap(InterlokMessage m) throws Exception {
+    String value = m.getMessageHeaders().get(getKey());
+    return toByteArray(value);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayFromMetadataWrapper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayFromMetadataWrapper.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.common;
+
+import javax.validation.Valid;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.util.Args;
+import com.adaptris.interlok.types.MessageWrapper;
+import com.adaptris.util.text.ByteTranslator;
+import com.adaptris.util.text.SimpleByteTranslator;
+
+public abstract class ByteArrayFromMetadataWrapper implements MessageWrapper<byte[]> {
+
+  @NotBlank
+  private String key;
+  @AdvancedConfig
+  @Valid
+  @InputFieldDefault(value = "SimpleByteTranslator")
+  private ByteTranslator translator;
+
+  public ByteArrayFromMetadataWrapper() {
+
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  /**
+   * Specify the key to retrieve from.
+   * 
+   * @param key
+   */
+  public void setKey(String key) {
+    this.key = Args.notBlank(key, "key");
+  }
+
+
+  public ByteTranslator getTranslator() {
+    return translator;
+  }
+
+  /**
+   * Set the translator that will give us bytes.
+   * 
+   * @param t
+   */
+  public void setTranslator(ByteTranslator t) {
+    this.translator = t;
+  }
+
+  private ByteTranslator translator() {
+    return ObjectUtils.defaultIfNull(getTranslator(), new SimpleByteTranslator());
+  }
+
+  public <T extends ByteArrayFromMetadataWrapper> T withKey(String s) {
+    setKey(s);
+    return (T) this;
+  }
+
+  public <T extends ByteArrayFromMetadataWrapper> T withTranslator(ByteTranslator s) {
+    setTranslator(s);
+    return (T) this;
+  }
+
+  protected byte[] toByteArray(String s) throws Exception {
+    if (StringUtils.isBlank(s)) {
+      return new byte[0];
+    }
+    return translator().translate(s);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayFromObjectMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayFromObjectMetadata.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.common;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Wraps an object metadata value as a byte[]
+ * 
+ * <p>
+ * If the object metadata value is a {@link String} then it is converted using the configured
+ * translator; otherwise it is assumed to already be a byte array.
+ * </p>
+ * 
+ * @config byte-array-from-object-metadata
+ */
+@XStreamAlias("byte-array-from-object-metadata")
+@ComponentProfile(summary = "Turn a object metadata value into a byte array.", since = "3.9.0")
+@DisplayOrder(order = {"key", "translator"})
+public class ByteArrayFromObjectMetadata extends ByteArrayFromMetadataWrapper {
+
+  public ByteArrayFromObjectMetadata() {
+    super();
+  }
+
+  @Override
+  public byte[] wrap(InterlokMessage m) throws Exception {
+    Object o = m.getObjectHeaders().get(getKey());
+    if (o instanceof String) {
+      return toByteArray((String) o);
+    }
+    return (byte[]) o;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayFromPayload.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayFromPayload.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.common;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.activemq.util.ByteArrayOutputStream;
+import org.apache.commons.io.IOUtils;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.adaptris.interlok.types.MessageWrapper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+
+/**
+ * Returns the message payload as as byte array.
+ * 
+ * @config byte-array-from-payload
+ */
+@XStreamAlias("byte-array-from-payload")
+@ComponentProfile(summary = "Returns the message payload as as byte array.", since = "3.9.0")
+public class ByteArrayFromPayload implements MessageWrapper<byte[]> {
+
+  public ByteArrayFromPayload() {
+
+  }
+
+  @Override
+  public byte[] wrap(InterlokMessage m) throws Exception {
+    if (m instanceof AdaptrisMessage) {
+      return ((AdaptrisMessage) m).getPayload();
+    }
+    return toByteArray(m);
+  }
+
+  private byte[] toByteArray(InterlokMessage m) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (InputStream i = m.getInputStream(); OutputStream o = out) {
+      IOUtils.copy(i, o);
+    }
+    return out.toByteArray();
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/InlineMimePartBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/InlineMimePartBuilder.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.mime;
+
+import static com.adaptris.util.text.mime.MimeConstants.HEADER_CONTENT_TYPE;
+import javax.mail.internet.InternetHeaders;
+import javax.mail.internet.MimeBodyPart;
+import javax.validation.Valid;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.metadata.MetadataFilter;
+import com.adaptris.core.metadata.RemoveAllMetadataFilter;
+import com.adaptris.core.util.Args;
+import com.adaptris.interlok.types.MessageWrapper;
+import com.adaptris.util.GuidGenerator;
+import com.adaptris.util.text.mime.MimeUtils;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Builds a MIME Body part using byte arrays
+ * 
+ * @config inline-mime-body-part-builder
+ * @since 3.9.0
+ */
+@ComponentProfile(summary = "Builds a MIME Body part using a byte array", since = "3.9.0")
+@DisplayOrder(order = {"contentId", "contentType", "contentEncoding", "body", "partHeaderFilter"})
+@XStreamAlias("inline-mime-body-part-builder")
+public class InlineMimePartBuilder implements MimePartBuilder {
+
+  private static final GuidGenerator ID_GEN = new GuidGenerator();
+
+  @InputFieldDefault(value = "the payload")
+  @Valid
+  private MessageWrapper<byte[]> body;
+  @InputFieldDefault(value = "RemoveAllMetaddata")
+  @Valid
+  private MetadataFilter partHeaderFilter;
+  @InputFieldDefault(value = "none")
+  @InputFieldHint(expression = true)
+  @AdvancedConfig
+  private String contentEncoding;
+  @InputFieldDefault(value = "application/octet-stream")
+  @InputFieldHint(expression = true)
+  private String contentType;
+  @InputFieldDefault(value = "auto-generated GUID")
+  @InputFieldHint(expression = true)
+  private String contentId;
+
+  public InlineMimePartBuilder() {
+
+  }
+
+
+  @Override
+  public MimeBodyPart build(AdaptrisMessage msg) throws Exception {
+    InternetHeaders hdrs = new InternetHeaders();
+    byte[] encodedData = MimeUtils.encodeData(body().wrap(msg), contentEncoding(msg), hdrs);
+    hdrs.addHeader(HEADER_CONTENT_TYPE, contentType(msg));
+    // This allows the metadata filter to override the content-type.
+    MetadataCollection metadata = partHeaderFilter().filter(msg);
+    metadata.forEach((e) -> {
+      hdrs.addHeader(e.getKey(), e.getValue());
+    });
+    MimeBodyPart part = new MimeBodyPart(hdrs, encodedData);
+    // This means the content-id is always from the configured contentID expression.
+    part.setContentID(contentId(msg));
+    return part;
+  }
+
+
+  public MessageWrapper<byte[]> getBody() {
+    return body;
+  }
+
+  public void setBody(MessageWrapper<byte[]> body) {
+    this.body = Args.notNull(body, "body");
+  }
+
+  public MetadataFilter getPartHeaderFilter() {
+    return partHeaderFilter;
+  }
+
+  /**
+   * Set any additional headers that need to be set for this nested part.
+   * 
+   * @param filter the metadata filter.
+   */
+  public void setPartHeaderFilter(MetadataFilter filter) {
+    this.partHeaderFilter = filter;
+  }
+
+  public String getContentEncoding() {
+    return contentEncoding;
+  }
+
+  /**
+   * Set the Content-Transfer-Encoding for the part.
+   * 
+   * <p>
+   * Set the encoding of the mime part; if the mime part contains text you probably don't need to
+   * specify this; any RFC2045 value is supported such as
+   * {@code base64,quoted-printable,uuencode,x-uuencode,x-uue,binary,7bit,8bit} and is passed
+   * directly to {@code MimeUtility#encode(java.io.OutputStream, String, String)}.
+   * </p>
+   * 
+   * @param s the Content-Transfer-Encoding, which supports the {@code %message{}} syntax to resolve
+   *        metadata, default is 'null', no encoding.
+   */
+  public void setContentEncoding(String s) {
+    this.contentEncoding = s;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  /**
+   * Set the Content-Type for the part.
+   * 
+   * @param s the Content-Type, which supports the {@code %message{}} syntax to resolve metadata; if
+   *        not specified defaults to {@code application/octet-stream}
+   */
+  public void setContentType(String s) {
+    this.contentType = s;
+  }
+
+  public String getContentId() {
+    return contentId;
+  }
+
+  /**
+   * Set the Content-ID for the part,
+   * 
+   * @param s the Content-ID, which supports the {@code %message{}} syntax to resolve metadata;
+   *        defaults to a new GUID if no value is specified.
+   */
+  public void setContentId(String s) {
+    this.contentId = s;
+  }
+
+  public InlineMimePartBuilder withBody(MessageWrapper<byte[]> body) {
+    setBody(body);
+    return this;
+  }
+
+  public InlineMimePartBuilder withContentEncoding(String s) {
+    setContentEncoding(s);
+    return this;
+  }
+
+  public InlineMimePartBuilder withContentId(String s) {
+    setContentId(s);
+    return this;
+  }
+
+  public InlineMimePartBuilder withContentType(String s) {
+    setContentType(s);
+    return this;
+  }
+
+  public InlineMimePartBuilder withPartHeaderFilter(MetadataFilter filter) {
+    setPartHeaderFilter(filter);
+    return this;
+  }
+
+  private MetadataFilter partHeaderFilter() {
+    return ObjectUtils.defaultIfNull(getPartHeaderFilter(), new RemoveAllMetadataFilter());
+  }
+
+  private String contentEncoding(AdaptrisMessage m) {
+    return m.resolve(getContentEncoding());
+  }
+
+  private String contentType(AdaptrisMessage msg) {
+    return StringUtils.defaultIfBlank(msg.resolve(getContentType()), "application/octet-stream");
+  }
+
+  private String contentId(AdaptrisMessage msg) {
+    return StringUtils.defaultIfBlank(msg.resolve(getContentId()), ID_GEN.getUUID());
+  }
+
+  private MessageWrapper<byte[]> body() {
+    return ObjectUtils.defaultIfNull(getBody(), (m) -> {
+      // Since we know it's an adaptrisMessage, otherwise some dirtiness with ByteArrayOutputStreams
+      return ((AdaptrisMessage) m).getPayload();
+    });
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Adaptris Ltd.
+ * Copyright 2019 Adaptris Ltd.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,30 +12,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
+ */
 package com.adaptris.core.services.mime;
 
-import com.adaptris.core.ServiceCase;
+import javax.mail.internet.MimeBodyPart;
+import com.adaptris.core.AdaptrisMessage;
 
-public abstract class MimeServiceExample extends ServiceCase {
-
-  /**
-   * Key in unit-test.properties that defines where example goes unless overriden {@link #setBaseDir(String)}.
-   * 
-   */
-  public static final String BASE_DIR_KEY = "MimeServiceExamples.baseDir";
-
-  public MimeServiceExample() {
-    super();
-    if (PROPERTIES.getProperty(BASE_DIR_KEY) != null) {
-      setBaseDir(PROPERTIES.getProperty(BASE_DIR_KEY));
-    }
-  }
-
-  public MimeServiceExample(String name) {
-    this();
-    setName(name);
-  }
+@FunctionalInterface
+public interface MimePartBuilder {
+  /** Build the body part */
+  MimeBodyPart build(AdaptrisMessage msg) throws Exception;
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
@@ -146,8 +146,8 @@ public class MultipartMessageBuilder extends ServiceImp {
    * @param s the Content-ID, which supports the {@code %message{}} syntax to resolve metadata;
    *        defaults to the messages unique id if no value is specified.
    */
-  public void setContentId(String contentId) {
-    this.contentId = contentId;
+  public void setContentId(String s) {
+    this.contentId = s;
   }
 
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
@@ -58,6 +58,9 @@ public class MultipartMessageBuilder extends ServiceImp {
   @InputFieldDefault(value = "the messages unique-id")
   @InputFieldHint(expression = true)
   private String contentId;
+  @InputFieldDefault(value = "mixed")
+  @InputFieldHint(expression = true)
+  private String mimeContentSubType;
   @AdvancedConfig
   @Valid
   @InputFieldDefault(value = "RemoveAllMetadataFilter")
@@ -98,7 +101,7 @@ public class MultipartMessageBuilder extends ServiceImp {
 
   protected MultiPartOutput createOutputPart(AdaptrisMessage msg)
       throws Exception {
-    MultiPartOutput output = new MultiPartOutput(contentId(msg));
+    MultiPartOutput output = new MultiPartOutput(contentId(msg), mimeContentSubType(msg));
     MetadataCollection metadata = mimeHeaderFilter().filter(msg);
     metadata.forEach((e) -> {
       output.setHeader(e.getKey(), e.getValue());
@@ -138,13 +141,28 @@ public class MultipartMessageBuilder extends ServiceImp {
   }
 
   /**
-   * Set the Content-ID for the part,
+   * Set the Content-ID for the Multipart,
    * 
    * @param s the Content-ID, which supports the {@code %message{}} syntax to resolve metadata;
    *        defaults to the messages unique id if no value is specified.
    */
   public void setContentId(String contentId) {
     this.contentId = contentId;
+  }
+
+
+  public String getMimeContentSubType() {
+    return mimeContentSubType;
+  }
+
+  /**
+   * Set the sub type for the Multipart
+   * 
+   * @param s the content subtype, which supports the {@code %message{}} syntax to resolve metadata;
+   *        defaults to 'mixed' if not specified.
+   */
+  public void setMimeContentSubType(String sub) {
+    this.mimeContentSubType = sub;
   }
 
   public MultipartMessageBuilder withMimeHeaderFilter(MetadataFilter filter) {
@@ -166,6 +184,11 @@ public class MultipartMessageBuilder extends ServiceImp {
     return this;
   }
 
+  public MultipartMessageBuilder withMimeContentSubType(String s) {
+    setMimeContentSubType(s);
+    return this;
+  }
+
   private String contentId(AdaptrisMessage msg) {
     return StringUtils.defaultIfBlank(msg.resolve(getContentId()), msg.getUniqueId());
   }
@@ -174,5 +197,9 @@ public class MultipartMessageBuilder extends ServiceImp {
     return ObjectUtils.defaultIfNull(getMimeHeaderFilter(), new RemoveAllMetadataFilter());
   }
 
+  private String mimeContentSubType(AdaptrisMessage msg) {
+    String sub = msg.resolve(getMimeContentSubType());
+    return StringUtils.defaultIfBlank(sub, "mixed");
+  }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.mime;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.mail.internet.MimeBodyPart;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.metadata.MetadataFilter;
+import com.adaptris.core.metadata.RemoveAllMetadataFilter;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.util.text.mime.MultiPartOutput;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+/**
+ * Constructs a multipart MIME payload from various sources.
+ * 
+ * @config multipart-message-builder
+ * @since 3.9.0
+ */
+@XStreamAlias("multipart-message-builder")
+@ComponentProfile(summary = "Creates a MIME payload from various sources", since = "3.9.0", tag = "mime")
+public class MultipartMessageBuilder extends ServiceImp {
+
+  @XStreamImplicit
+  @NotNull
+  private List<MimePartBuilder> mimeParts;
+  @InputFieldDefault(value = "the messages unique-id")
+  @InputFieldHint(expression = true)
+  private String contentId;
+  @AdvancedConfig
+  @Valid
+  @InputFieldDefault(value = "RemoveAllMetadataFilter")
+  private MetadataFilter mimeHeaderFilter;
+
+  public MultipartMessageBuilder() {
+    setMimeParts(new ArrayList<MimePartBuilder>());
+  }
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      MultiPartOutput output = createOutputPart(msg);
+      for (MimePartBuilder builder : getMimeParts()) {
+        MimeBodyPart part = builder.build(msg);
+        output.addPart(part, part.getContentID());
+      }
+      try (OutputStream out = msg.getOutputStream()) {
+        output.writeTo(out);
+      }
+      msg.addMetadata(CoreConstants.MSG_MIME_ENCODED, Boolean.TRUE.toString());
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+  protected MultiPartOutput createOutputPart(AdaptrisMessage msg)
+      throws Exception {
+    MultiPartOutput output = new MultiPartOutput(contentId(msg));
+    MetadataCollection metadata = mimeHeaderFilter().filter(msg);
+    metadata.forEach((e) -> {
+      output.setHeader(e.getKey(), e.getValue());
+    });
+    return output;
+  }
+
+
+  public List<MimePartBuilder> getMimeParts() {
+    return mimeParts;
+  }
+
+  /**
+   * Specify what is going to build the mime message.
+   * 
+   * @param parts the parts that will form the mime message.
+   */
+  public void setMimeParts(List<MimePartBuilder> parts) {
+    this.mimeParts = Args.notNull(parts, "mime-parts");
+  }
+
+  public MetadataFilter getMimeHeaderFilter() {
+    return mimeHeaderFilter;
+  }
+
+  /**
+   * Set any additional headers that need to be set for this Mime Message
+   * 
+   * @param filter the metadata filter.
+   */
+  public void setMimeHeaderFilter(MetadataFilter filter) {
+    this.mimeHeaderFilter = filter;
+  }
+
+  public String getContentId() {
+    return contentId;
+  }
+
+  /**
+   * Set the Content-ID for the part,
+   * 
+   * @param s the Content-ID, which supports the {@code %message{}} syntax to resolve metadata;
+   *        defaults to the messages unique id if no value is specified.
+   */
+  public void setContentId(String contentId) {
+    this.contentId = contentId;
+  }
+
+  public MultipartMessageBuilder withMimeHeaderFilter(MetadataFilter filter) {
+    setMimeHeaderFilter(filter);
+    return this;
+  }
+
+  public MultipartMessageBuilder withMimeParts(List<MimePartBuilder> list) {
+    setMimeParts(list);
+    return this;
+  }
+
+  public MultipartMessageBuilder withMimeParts(MimePartBuilder... builders) {
+    return withMimeParts(new ArrayList<>(Arrays.asList(builders)));
+  }
+
+  public MultipartMessageBuilder withContentId(String s) {
+    setContentId(s);
+    return this;
+  }
+
+  private String contentId(AdaptrisMessage msg) {
+    return StringUtils.defaultIfBlank(msg.resolve(getContentId()), msg.getUniqueId());
+  }
+
+  private MetadataFilter mimeHeaderFilter() {
+    return ObjectUtils.defaultIfNull(getMimeHeaderFilter(), new RemoveAllMetadataFilter());
+  }
+
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
@@ -158,8 +158,8 @@ public class MultipartMessageBuilder extends ServiceImp {
   /**
    * Set the sub type for the Multipart
    * 
-   * @param s the content subtype, which supports the {@code %message{}} syntax to resolve metadata;
-   *        defaults to 'mixed' if not specified.
+   * @param sub the content subtype, which supports the {@code %message{}} syntax to resolve
+   *        metadata; defaults to 'mixed' if not specified.
    */
   public void setMimeContentSubType(String sub) {
     this.mimeContentSubType = sub;

--- a/interlok-core/src/main/java/com/adaptris/util/text/mime/MimeUtils.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/mime/MimeUtils.java
@@ -1,0 +1,26 @@
+package com.adaptris.util.text.mime;
+
+import static com.adaptris.util.text.mime.MimeConstants.HEADER_CONTENT_ENCODING;
+import static org.apache.commons.lang.StringUtils.isBlank;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetHeaders;
+import javax.mail.internet.MimeUtility;
+
+public class MimeUtils {
+
+
+  public static byte[] encodeData(byte[] data, String encoding, InternetHeaders hdrs)
+      throws MessagingException, IOException {
+    if (!isBlank(encoding)) {
+      hdrs.setHeader(HEADER_CONTENT_ENCODING, encoding);
+    }
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (OutputStream encodedOut = MimeUtility.encode(out, encoding)) {
+      encodedOut.write(data);
+    }
+    return out.toByteArray();
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayFromPayloadTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayFromPayloadTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2016 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.common;
+
+import static org.junit.Assert.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.security.MessageDigest;
+import java.util.Map;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.interlok.types.InterlokMessage;
+
+public class ByteArrayFromPayloadTest {
+
+  private static final byte[] BYTE_ARRAY = "Hello World".getBytes();
+
+  @Test
+  public void testWrapAdaptrisMessage() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(BYTE_ARRAY);
+    byte[] wrapped = new ByteArrayFromPayload().wrap(msg);
+    assertTrue(MessageDigest.isEqual(BYTE_ARRAY, wrapped));
+  }
+  
+  @Test
+  public void testWrapInterlokMessage() throws Exception {
+    InterlokMessage msg = new MyInterlokMessage();
+    byte[] wrapped = new ByteArrayFromPayload().wrap(msg);
+    assertTrue(MessageDigest.isEqual(BYTE_ARRAY, wrapped));
+  }
+
+  private class MyInterlokMessage implements InterlokMessage {
+
+    @Override
+    public String getUniqueId() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setUniqueId(String uniqueId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContent() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContent(String payload, String encoding) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String> getMessageHeaders() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMessageHeaders(Map<String, String> metadata) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addMessageHeader(String key, String value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeMessageHeader(String key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContentEncoding() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentEncoding(String payloadEncoding) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Reader getReader() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Writer getWriter() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Writer getWriter(String encoding) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+      return new ByteArrayInputStream(BYTE_ARRAY);
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addObjectHeader(Object key, Object object) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<Object, Object> getObjectHeaders() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean headersContainsKey(String key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String resolve(String s, boolean multiline) {
+      throw new UnsupportedOperationException();
+    }
+
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayMetadataTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+
+public class ByteArrayMetadataTest {
+
+  private static final String HELLO_WORLD = "Hello World";
+  private static final byte[] BYTE_ARRAY = "Hello World".getBytes(Charset.defaultCharset());
+  private static final String KEY = "key";
+
+  @Test
+  public void testWrapString() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata(KEY, HELLO_WORLD);
+    byte[] wrapped = new ByteArrayFromMetadata().withKey(KEY).wrap(msg);
+    assertTrue(MessageDigest.isEqual(BYTE_ARRAY, wrapped));
+  }
+
+  @Test
+  public void testWrapEmptyString() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata(KEY, "");
+    byte[] wrapped = new ByteArrayFromMetadata().withKey(KEY).wrap(msg);
+    assertEquals(0, wrapped.length);
+  }
+
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayObjectMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayObjectMetadataTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+
+public class ByteArrayObjectMetadataTest {
+
+  private static final byte[] BYTE_ARRAY = "Hello World".getBytes(Charset.defaultCharset());
+  private static final String KEY = "key";
+
+  @Test
+  public void testWrapNullObject() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.getObjectHeaders().put(KEY, null);
+    byte[] wrapped = new ByteArrayFromObjectMetadata().withKey(KEY).wrap(msg);
+    assertNull(wrapped);
+  }
+  
+  @Test(expected = ClassCastException.class)
+  public void testWrapNotByteArray() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.getObjectHeaders().put(KEY, new Object());
+    byte[] wrapped = new ByteArrayFromObjectMetadata().withKey(KEY).wrap(msg);
+  }
+
+  @Test
+  public void testWrapByteArray() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.getObjectHeaders().put(KEY, BYTE_ARRAY);
+    byte[] wrapped = new ByteArrayFromObjectMetadata().withKey(KEY).wrap(msg);
+    assertTrue(MessageDigest.isEqual(BYTE_ARRAY, wrapped));
+  }
+
+  @Test
+  public void testWrapString() throws Exception {
+    String s = StringUtils.toEncodedString(BYTE_ARRAY, Charset.defaultCharset());
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.getObjectHeaders().put(KEY, s);
+    byte[] wrapped = new ByteArrayFromObjectMetadata().withKey(KEY).wrap(msg);
+    assertTrue(MessageDigest.isEqual(BYTE_ARRAY, wrapped));
+  }
+
+  @Test
+  public void testWrapEmptyString() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.getObjectHeaders().put(KEY, "");
+    byte[] wrapped = new ByteArrayFromObjectMetadata().withKey(KEY).wrap(msg);
+    assertEquals(0, wrapped.length);
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/mime/FlattenMimePartTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/mime/FlattenMimePartTest.java
@@ -24,9 +24,6 @@ import com.adaptris.util.text.mime.BodyPartIterator;
 
 public class FlattenMimePartTest extends MimeServiceExample {
 
-  public FlattenMimePartTest(java.lang.String testName) {
-    super(testName);
-  }
 
   @Override
   protected void setUp() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/services/mime/MimePartBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/mime/MimePartBuilderTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.mime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import javax.mail.internet.MimeBodyPart;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+
+public class MimePartBuilderTest {
+
+  @Test
+  public void testBuild() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    InlineMimePartBuilder builder = new InlineMimePartBuilder();
+    MimeBodyPart part = builder.build(msg);
+    assertNotNull(part);
+    assertNotNull(part.getContentID());
+  }
+
+  @Test
+  public void testBuild_WithContentEncoding() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    InlineMimePartBuilder builder = new InlineMimePartBuilder().withContentEncoding("base64");
+    MimeBodyPart part = builder.build(msg);
+    assertNotNull(part);
+    assertNotNull(part.getContentID());
+    assertNotNull(part.getEncoding());
+  }
+
+  @Test
+  public void testBuild_WithContentId() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    InlineMimePartBuilder builder =
+        new InlineMimePartBuilder().withContentId("%message{%uniqueId}");
+    MimeBodyPart part = builder.build(msg);
+    assertNotNull(part);
+    assertEquals(msg.getUniqueId(), part.getContentID());
+  }
+
+  @Test
+  public void testBuild_WithPartHeader() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    msg.addMetadata("X-Interlok-Mime", "yes");
+    InlineMimePartBuilder builder =
+        new InlineMimePartBuilder().withContentId("%message{%uniqueId}")
+            .withPartHeaderFilter(new RegexMetadataFilter().withIncludePatterns("X-Interlok.*"));
+    MimeBodyPart part = builder.build(msg);
+    assertNotNull(part);
+    assertEquals(msg.getUniqueId(), part.getContentID());
+    assertEquals(1, part.getHeader("X-Interlok-Mime").length);
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/mime/MimePartChooserTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/mime/MimePartChooserTest.java
@@ -22,10 +22,8 @@ import static com.adaptris.core.services.mime.MimeJunitHelper.PAYLOAD_2;
 import static com.adaptris.core.services.mime.MimeJunitHelper.PAYLOAD_3;
 import static com.adaptris.core.services.mime.MimeJunitHelper.create;
 import static com.adaptris.util.text.mime.MimeConstants.HEADER_CONTENT_ENCODING;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreConstants;
@@ -52,9 +50,6 @@ public class MimePartChooserTest extends MimeServiceExample {
       new com.adaptris.util.text.mime.SelectByHeader("Content-Type", "text/xml")
   };
 
-  public MimePartChooserTest(java.lang.String testName) {
-    super(testName);
-  }
 
   @Override
   protected void setUp() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/services/mime/MultipartMessageBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/mime/MultipartMessageBuilderTest.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright 2019 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.adaptris.core.services.mime;
+
+import org.apache.commons.lang3.BooleanUtils;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.ServiceCase;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.common.ByteArrayFromMetadata;
+import com.adaptris.core.common.ByteArrayFromObjectMetadata;
+import com.adaptris.core.common.ByteArrayFromPayload;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
+import com.adaptris.util.GuidGenerator;
+
+public class MultipartMessageBuilderTest extends MimeServiceExample {
+
+  @Override
+  protected MultipartMessageBuilder retrieveObjectForSampleConfig() {
+    return new MultipartMessageBuilder().withMimeParts(
+        new InlineMimePartBuilder()
+            .withBody(new ByteArrayFromObjectMetadata().withKey("ObjectMetadataKey"))
+            .withContentType("application/octet-stream").withContentId("from-object-metadata"),
+        new InlineMimePartBuilder()
+            .withBody(new ByteArrayFromMetadata().withKey("StringMetadataKey"))
+            .withContentType("application/octet-stream").withContentId("from-string-metadata"),
+        new InlineMimePartBuilder().withBody(new ByteArrayFromPayload())
+            .withContentId("%message{%uniqueId}").withPartHeaderFilter(
+                new RegexMetadataFilter().withIncludePatterns("Content-Disposition")));
+  }
+
+  public void testService() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    assertFalse(msg.headersContainsKey(CoreConstants.MSG_MIME_ENCODED));
+    MultipartMessageBuilder service =
+        new MultipartMessageBuilder().withMimeParts(new InlineMimePartBuilder());
+    // default just uses the payload.
+    ServiceCase.execute(service, msg);
+    String payload = msg.getContent();
+    // The unique-id forms the content-id.
+    assertTrue(payload.contains(msg.getUniqueId()));
+    assertTrue(msg.headersContainsKey(CoreConstants.MSG_MIME_ENCODED));
+    assertTrue(
+        BooleanUtils.toBoolean(msg.getMetadataValue(CoreConstants.MSG_MIME_ENCODED)));
+  }
+
+  public void testService_WithContentId() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    msg.addMetadata("customContentId", new GuidGenerator().safeUUID());
+
+    MultipartMessageBuilder service =
+        new MultipartMessageBuilder().withMimeParts(new InlineMimePartBuilder())
+            .withContentId("%message{customContentId}");
+    ServiceCase.execute(service, msg);
+    String payload = msg.getContent();
+    assertTrue(payload.contains(msg.getMetadataValue("customContentId")));
+  }
+
+  public void testService_WithHeader() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    msg.addMetadata("X-Interlok-Mime", "yes");
+    MultipartMessageBuilder service =
+        new MultipartMessageBuilder().withMimeParts(new InlineMimePartBuilder())
+            .withMimeHeaderFilter(new RegexMetadataFilter().withIncludePatterns("X-Interlok.*"));
+    // default just uses the payload.
+    ServiceCase.execute(service, msg);
+    String payload = msg.getContent();
+    // The unique-id forms the content-id.
+    assertTrue(payload.contains(msg.getUniqueId()));
+    assertTrue(payload.contains("X-Interlok-Mime"));
+  }
+
+  public void testService_Exception() throws Exception {
+    AdaptrisMessage msg = new DefectiveMessageFactory(WhenToBreak.OUTPUT).newMessage("Hello World");
+    MultipartMessageBuilder service =
+        new MultipartMessageBuilder().withMimeParts(new InlineMimePartBuilder());
+    try {
+      ServiceCase.execute(service, msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/mime/MultipartMessageBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/mime/MultipartMessageBuilderTest.java
@@ -72,6 +72,16 @@ public class MultipartMessageBuilderTest extends MimeServiceExample {
     assertTrue(payload.contains(msg.getMetadataValue("customContentId")));
   }
 
+  public void testService_WithSubType() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    MultipartMessageBuilder service = new MultipartMessageBuilder()
+        .withMimeParts(new InlineMimePartBuilder()).withMimeContentSubType("form-data");
+    ServiceCase.execute(service, msg);
+    String payload = msg.getContent();
+    System.err.println(payload);
+    assertTrue(payload.contains("multipart/form-data"));
+  }
+
   public void testService_WithHeader() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
     msg.addMetadata("X-Interlok-Mime", "yes");


### PR DESCRIPTION
Added supporting ByteArray message wrapper implementations.
Add MultipartMessageBuilder which supports
- Arbitrary headers at the top level via mime-header-filter
- Custom expression based Content-ID

Nested parts are created using inline-mime-part-builder (working off byte-arrays) these support
- Expression based Content-ID + Content-Type + Content-Transfer-Encoding
- Arbitrary headers built from metadata for each part.
