### PR TITLE
INTERLOK-2840 Add www-form-url-encded to/from metadata.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/RequestParameterConverterService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/RequestParameterConverterService.java
@@ -17,51 +17,56 @@
 package com.adaptris.core.http;
 
 import java.util.Map;
-
 import javax.mail.internet.ContentType;
-
 import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.services.metadata.FormDataToMetadata;
+import com.adaptris.core.services.metadata.MetadataToPayloadService;
 import com.adaptris.util.URLHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
- * Implementation of <code>Service</code> which parses the incoming HTTP Request parameters and converts all request parameters into
- * Metadata.
+ * Implementation of <code>Service</code> which parses the incoming HTTP Request parameters and
+ * converts all request parameters into Metadata.
  * </p>
  * <p>
- * If the client is sending data to the adapter, it is possible that the client will send data as though it were a standard Html
- * Form post. In situations like that, then the payload is a number of URLEncoded key value pairs. This service can be used to
- * convert all the Request parameters into metadata.
+ * If the client is sending data to the adapter, it is possible that the client will send data as
+ * though it were a standard Html Form post. In situations like that, then the payload is a number
+ * of URLEncoded key value pairs. This service can be used to convert all the Request parameters
+ * into metadata.
  * </p>
  * <p>
- * If the <code>parameterForPayload</code> field is configured and present in the request parameters, then this will become the
- * message payload, otherwise the payload remains unchanged.
+ * If the <code>parameterForPayload</code> field is configured and present in the request
+ * parameters, then this will become the message payload, otherwise the payload remains unchanged.
  * </p>
  * <p>
- * In all cases, the metadata value associated with <code>contentTypeKey</code> will be matched against the configured
- * <code>contentTypeValue</code> If the values match, then the payload is converted, otherwise no action is performed on the
- * payload. If there is a charset parameter supplied with the content type metadata, then this charset will be used to decode the
- * parameters, and used as the CharEncoding on the AdaptriMessage
+ * In all cases, the metadata value associated with <code>contentTypeKey</code> will be matched
+ * against the configured <code>contentTypeValue</code> If the values match, then the payload is
+ * converted, otherwise no action is performed on the payload. If there is a charset parameter
+ * supplied with the content type metadata, then this charset will be used to decode the parameters,
+ * and used as the CharEncoding on the AdaptriMessage
  * </p>
  * 
  * @config http-request-parameter-converter-service
  * 
- * @author lchan
+ * @deprecated since 3.9.0 use {@link FormDataToMetadata} with a {@link MetadataToPayloadService} as
+ *             required.
  */
 @XStreamAlias("http-request-parameter-converter-service")
 @AdapterComponent
 @ComponentProfile(summary = "Turn HTTP Request parameters (from a HTTP POST) into metadata", tag = "service,metadata,http,https")
 @DisplayOrder(order = {"parameterForPayload", "contentTypeKey", "contentTypeValue"})
+@Deprecated
+@Removal(version = "3.11.0", message = "Use FormDataToMetadata instead")
 public class RequestParameterConverterService extends ServiceImp {
   public static final String DEFAULT_CONTENT_TYPE_KEY = HttpConstants.CONTENT_TYPE;
   public static final String DEFAULT_CONTENT_TYPE_VALUE = HttpConstants.WWW_FORM_URLENCODE;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/CreateQueryStringFromMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/CreateQueryStringFromMetadata.java
@@ -16,11 +16,7 @@
 
 package com.adaptris.core.services.metadata;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.validation.Valid;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.hibernate.validator.constraints.NotBlank;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
@@ -28,16 +24,13 @@ import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.MetadataCollection;
-import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
-import com.adaptris.core.metadata.MetadataFilter;
-import com.adaptris.core.metadata.RemoveAllMetadataFilter;
+import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -50,72 +43,54 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("create-query-string-from-metadata")
 @AdapterComponent
 @ComponentProfile(summary = "Create the query portion of a URL from metadata", tag = "service,metadata,http,https")
-@DisplayOrder(order = {"metadata-filter", "metadataKeys", "resultKey", "querySeparator"})
-public class CreateQueryStringFromMetadata extends ServiceImp {
-
-  private static final String AMPERSAND = "&";
+@DisplayOrder(order = {"metadata-filter", "resultKey", "separator", "includeQueryPrefix"})
+public class CreateQueryStringFromMetadata extends UrlEncodedMetadataValues {
 
   @NotBlank
   @AffectsMetadata
   private String resultKey;
   @AdvancedConfig
-  @InputFieldHint(style = "BLANKABLE")
-  private String querySeparator;
-  @AdvancedConfig
   @InputFieldDefault(value = "true")
   private Boolean includeQueryPrefix;
-  @Valid
-  @InputFieldDefault(value = "RemoveAllMetadataFilter")
-  private MetadataFilter metadataFilter;
+  @Deprecated
+  @Removal(version = "3.11.0", message = "use separator instead")
+  private String querySeparator;
+  private transient boolean warningLogged = false;
 
   public CreateQueryStringFromMetadata() {
   }
 
   @Override
+  public void prepare() throws CoreException {
+    Args.notBlank(resultKey, "resultKey");
+  }
+
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
-    StringBuilder queryString = new StringBuilder(includeQueryPrefix() ? "?" : "");
-
-    MetadataCollection filtered = metadataFilter().filter(msg);
-    for (MetadataElement e : filtered) {
+    try {
+      StringBuilder queryString = new StringBuilder(includeQueryPrefix() ? "?" : "");
+      queryString.append(buildEncodedString(msg));
       if (queryString.length() > 1) {
-        // This is not the first parameter so add a separator
-        queryString.append(querySeparator());
+        // We have added some parameters
+        msg.addMetadata(getResultKey(), queryString.toString());
+      } else {
+        // No params - return an empty string
+        msg.addMetadata(getResultKey(), "");
       }
-      try {
-        queryString.append(e.getKey()).append("=").append(URLEncoder.encode(e.getValue(), "UTF-8"));
-      } catch (UnsupportedEncodingException ex) {
-        // This will not occur, but we will deal with it nonetheless.
-        throw ExceptionHelper.wrapServiceException(ex);
-      }
-    }
-    if (queryString.length() > 1) {
-      // We have added some parameters
-      msg.addMetadata(getResultKey(), queryString.toString());
-    }
-    else {
-      // No params - return an empty string
-      msg.addMetadata(getResultKey(), "");
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
     }
   }
-
 
   @Override
-  protected void initService() throws CoreException {}
-
-  @Override
-  protected void closeService() {
-  }
-
-  public MetadataFilter getMetadataFilter() {
-    return metadataFilter;
-  }
-
-  public void setMetadataFilter(MetadataFilter metadataFilter) {
-    this.metadataFilter = metadataFilter;
-  }
-
-  private MetadataFilter metadataFilter() {
-    return ObjectUtils.defaultIfNull(getMetadataFilter(), new RemoveAllMetadataFilter());
+  protected String separator() {
+    if (getQuerySeparator() != null) {
+      LoggingHelper.logWarning(warningLogged, () -> {
+        warningLogged = true;
+      }, "query-separator deprecated; use a separator instead");
+      return getQuerySeparator();
+    }
+    return super.separator();
   }
 
   public String getResultKey() {
@@ -126,41 +101,6 @@ public class CreateQueryStringFromMetadata extends ServiceImp {
     this.resultKey = resultKey;
   }
 
-  /**
-   * @return the querySeparator
-   */
-  public String getQuerySeparator() {
-    return querySeparator;
-  }
-
-  /**
-   * Set the separator to be used in between each parameter in the query String..
-   * 
-   * <p>
-   * Although '&amp;' is the conventional standard (or even a semi-colon ';'), there isn't a formal standard for separating query
-   * parameters; RFC3986 simply states:
-   * </p>
-   * 
-   * <pre>
-   * {@code
-   *    URI           = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
-   *    query         = *( pchar / "/" / "?" )
-   * }
-   * </pre>
-   * 
-   * @param s the querySeparator to set, defaults to null which indicates '&amp;'.
-   */
-  public void setQuerySeparator(String s) {
-    querySeparator = s;
-  }
-
-  String querySeparator() {
-    return getQuerySeparator() == null ? AMPERSAND : getQuerySeparator();
-  }
-
-  @Override
-  public void prepare() throws CoreException {
-  }
 
   public Boolean getIncludeQueryPrefix() {
     return includeQueryPrefix;
@@ -175,7 +115,19 @@ public class CreateQueryStringFromMetadata extends ServiceImp {
     this.includeQueryPrefix = b;
   }
 
-  boolean includeQueryPrefix() {
+  private boolean includeQueryPrefix() {
     return BooleanUtils.toBooleanDefaultIfNull(getIncludeQueryPrefix(), true);
+  }
+
+  @Deprecated
+  @Removal(version = "3.11.0", message = "use separator instead")
+  public String getQuerySeparator() {
+    return querySeparator;
+  }
+
+  @Deprecated
+  @Removal(version = "3.11.0", message = "use separator instead")
+  public void setQuerySeparator(String s) {
+    this.querySeparator = s;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/FormDataFromMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/FormDataFromMetadata.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import java.nio.charset.StandardCharsets;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Service that creates something suitable to send as {@code application/x-www-url-form-encoded}
+ * from metadata.
+ * 
+ * @config www-url-form-encoded-payload-from-metadata
+ * 
+ */
+@XStreamAlias("www-url-form-encoded-payload-from-metadata")
+@AdapterComponent
+@ComponentProfile(summary = "Create a application/x-www-url-form-encoded payload from metadata",
+    tag = "service,metadata,http,https", since = "3.9.0")
+@DisplayOrder(order = {"metadata-filter", "separator"})
+public class FormDataFromMetadata extends UrlEncodedMetadataValues {
+
+  public FormDataFromMetadata() {
+  }
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      msg.setContent(buildEncodedString(msg), StandardCharsets.UTF_8.name());
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/FormDataToMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/FormDataToMetadata.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import javax.mail.internet.ContentType;
+import org.apache.commons.lang.StringUtils;
+import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.http.HttpConstants;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.util.URLHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Takes a application/x-www-url-form-encoded payload and extracts it as metadata.
+ * <p>
+ * If the client is sending data to the adapter, it is possible that the client will send data as
+ * though it were a standard Html Form post. In situations like that, then the payload is a number
+ * of URLEncoded key value pairs. This service can be used to convert all the Request parameters
+ * into metadata.
+ * </p>
+ *
+ * <p>
+ * {@code contentTypeKey} will be checked to see if the content-type is in fact
+ * {@code application/x-www-url-form-encoded}; if it is, then the payload is parsed as into
+ * metadata, note that the payload is always unchanged.
+ * </p>
+ * 
+ * @config www-url-form-encoded-payload-to-metadata
+ * 
+ */
+@XStreamAlias("www-url-form-encoded-payload-to-metadata")
+@AdapterComponent
+@ComponentProfile(summary = "Turn a application/www-url-form-encoded payload into metadata.",
+    tag = "service,metadata,http,https", since = "3.9.0")
+@DisplayOrder(order = {"contentTypeKey", "metadataPrefix"})
+public class FormDataToMetadata extends ServiceImp {
+  public static final String DEFAULT_CONTENT_TYPE_KEY = HttpConstants.CONTENT_TYPE;
+  public static final String DEFAULT_CONTENT_TYPE_VALUE = HttpConstants.WWW_FORM_URLENCODE;
+
+  @NotBlank
+  @AutoPopulated
+  @InputFieldDefault(value = DEFAULT_CONTENT_TYPE_KEY)
+  private String contentTypeKey;
+
+  @InputFieldDefault(value = "")
+  @AdvancedConfig
+  private String metadataPrefix;
+
+  public FormDataToMetadata() {
+  }
+
+  @Override
+  public void prepare() throws CoreException {}
+
+  @Override
+  protected void initService() throws CoreException {}
+
+  @Override
+  protected void closeService() {}
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      if (!msg.headersContainsKey(contentTypeKey())) {
+        log.trace("{} not found in metadata, ignoring", contentTypeKey());
+        return;
+      }
+      String ct = msg.getMetadataValue(contentTypeKey());
+      ContentType contentType = new ContentType(ct);
+      if (!DEFAULT_CONTENT_TYPE_VALUE.equalsIgnoreCase(contentType.getBaseType())) {
+        log.trace("{} does not match {}", ct, DEFAULT_CONTENT_TYPE_VALUE);
+        return;
+      }
+      Map<String, String> params =
+          URLHelper.queryStringToMap(msg.getContent(), StandardCharsets.UTF_8.name());
+      for (Map.Entry<String, String> e : params.entrySet()) {
+        msg.addMetadata(metadataPrefix() + e.getKey(), e.getValue());
+      }
+    }
+    catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+
+  public String getContentTypeKey() {
+    return contentTypeKey;
+  }
+
+  /**
+   * Set the metadata key for finding out the content-type.
+   *
+   * @param s the metadata key.
+   */
+  public void setContentTypeKey(String s) {
+    contentTypeKey = s;
+  }
+
+
+  public String getMetadataPrefix() {
+    return metadataPrefix;
+  }
+
+  public void setMetadataPrefix(String metadataPrefix) {
+    this.metadataPrefix = metadataPrefix;
+  }
+
+  public FormDataToMetadata withMetadataPrefix(String s) {
+    setMetadataPrefix(s);
+    return this;
+  }
+
+  public FormDataToMetadata withContentTypeKey(String s) {
+    setContentTypeKey(s);
+    return this;
+  }
+
+  private String metadataPrefix() {
+    return StringUtils.defaultIfBlank(getMetadataPrefix(), "");
+  }
+
+  private String contentTypeKey() {
+    return StringUtils.defaultIfBlank(getContentTypeKey(), DEFAULT_CONTENT_TYPE_KEY);
+  }
+
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/UrlEncodedMetadataValues.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/UrlEncodedMetadataValues.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import javax.validation.Valid;
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.MetadataElement;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.metadata.MetadataFilter;
+import com.adaptris.core.metadata.RemoveAllMetadataFilter;
+
+public abstract class UrlEncodedMetadataValues extends ServiceImp {
+
+  protected static final String AMPERSAND = "&";
+
+  @AdvancedConfig
+  @InputFieldHint(style = "BLANKABLE")
+  private String separator;
+  @Valid
+  @InputFieldDefault(value = "RemoveAllMetadataFilter")
+  private MetadataFilter metadataFilter;
+
+  public UrlEncodedMetadataValues() {
+  }
+
+  @Override
+  public void prepare() throws CoreException {}
+
+  @Override
+  protected void initService() throws CoreException {}
+
+  @Override
+  protected void closeService() {}
+
+  public MetadataFilter getMetadataFilter() {
+    return metadataFilter;
+  }
+
+  public void setMetadataFilter(MetadataFilter metadataFilter) {
+    this.metadataFilter = metadataFilter;
+  }
+
+  private MetadataFilter metadataFilter() {
+    return ObjectUtils.defaultIfNull(getMetadataFilter(), new RemoveAllMetadataFilter());
+  }
+
+
+  /**
+   * @return the querySeparator
+   */
+  public String getSeparator() {
+    return separator;
+  }
+
+  /**
+   * Set the separator to be used in between each parameter in the String..
+   * 
+   * <p>
+   * Although '&amp;' is the conventional standard (or even a semi-colon ';'), there isn't a formal
+   * standard for separating query parameters; RFC3986 simply states:
+   * </p>
+   * 
+   * <pre>
+   * {@code
+   *    URI           = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+   *    query         = *( pchar / "/" / "?" )
+   * }
+   * </pre>
+   * 
+   * @param s the separator to set, defaults to null which indicates '&amp;'.
+   */
+  public void setSeparator(String s) {
+    separator = s;
+  }
+
+  protected String separator() {
+    return ObjectUtils.defaultIfNull(getSeparator(), AMPERSAND);
+  }
+
+  protected String buildEncodedString(AdaptrisMessage msg) throws Exception {
+    MetadataCollection filtered = metadataFilter().filter(msg);
+    StringBuilder result = new StringBuilder();
+    for (MetadataElement e : filtered) {
+      if (result.length() > 1) {
+        // This is not the first parameter so add a separator
+        result.append(separator());
+      }
+      result.append(e.getKey()).append("=")
+            .append(URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8.name()));
+    }
+    return result.toString();
+  }
+
+  public <T extends UrlEncodedMetadataValues> T withMetadataFilter(MetadataFilter filter) {
+    setMetadataFilter(filter);
+    return (T) this;
+  }
+
+  public <T extends UrlEncodedMetadataValues> T withQuerySeparator(String s) {
+    setSeparator(s);
+    return (T) this;
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/RequestParameterConverterServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/RequestParameterConverterServiceTest.java
@@ -20,12 +20,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Iterator;
 import java.util.Properties;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.http.Http;
 
+@SuppressWarnings("deprecation")
 public class RequestParameterConverterServiceTest extends HttpServiceExample {
 
   private static final String TEST_VALUE = "the quick brown fox jumps over the lazy dog";

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/CreateQueryStringFromMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/CreateQueryStringFromMetadataTest.java
@@ -36,15 +36,18 @@ public class CreateQueryStringFromMetadataTest extends MetadataServiceExample {
 
   public void testQuerySeparator() throws Exception {
     CreateQueryStringFromMetadata service = new CreateQueryStringFromMetadata();
-    assertNull(service.getQuerySeparator());
-    assertEquals("&", service.querySeparator());
-    service.setQuerySeparator(",");
-    assertEquals(",", service.querySeparator());
-    assertEquals(",", service.getQuerySeparator());
+    assertNull(service.getSeparator());
+    assertEquals("&", service.separator());
+    service.setSeparator(",");
+    assertEquals(",", service.separator());
+    assertEquals(",", service.getSeparator());
 
-    service.setQuerySeparator(null);
-    assertEquals("&", service.querySeparator());
+    service.setSeparator(null);
     service.setQuerySeparator(",");
+
+    assertEquals(",", service.separator());
+    service.setQuerySeparator(null);
+    assertEquals("&", service.separator());
   }
 
   public void testService_SimpleQueryString() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/FormDataFromMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/FormDataFromMetadataTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
+
+public class FormDataFromMetadataTest extends MetadataServiceExample {
+
+
+  private FormDataFromMetadata createService() {
+    FormDataFromMetadata svc = new FormDataFromMetadata();
+    svc.setMetadataFilter(new RegexMetadataFilter().withIncludePatterns("param1", "param2", "param3"));
+    return svc;
+  }
+
+
+  public void testService_SimpleQueryString() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata("param1", "one");
+    msg.addMetadata("param2", "two");
+    msg.addMetadata("param3", "three");
+    execute(createService(), msg);
+    assertTrue(msg.getContent().contains("param2=two"));
+    assertTrue(msg.getContent().contains("param1=one"));
+    assertTrue(msg.getContent().contains("param3=three"));
+  }
+
+
+  public void testService_NoOutput() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    execute(createService(), msg);
+    assertEquals("", msg.getContent());
+  }
+
+  public void testService_ComplexQueryString() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata("param1", "this is a field");
+    msg.addMetadata("param3", "was it clear (already)?");
+    execute(createService(), msg);
+    assertTrue(msg.getContent().contains("param1=this+is+a+field"));
+    assertTrue(msg.getContent().contains("param3=was+it+clear+%28already%29%3F"));
+  }
+
+  public void testService_Failure() throws Exception {
+    AdaptrisMessage msg = new DefectiveMessageFactory(WhenToBreak.METADATA_GET).newMessage();
+    msg.addMetadata("param1", "this is a field");
+    msg.addMetadata("param3", "was it clear (already)?");
+    FormDataToMetadata service = new FormDataToMetadata();
+    try {
+      execute(createService(), msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
+  @Override
+  protected FormDataFromMetadata retrieveObjectForSampleConfig() {
+    return createService();
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/FormDataToMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/FormDataToMetadataTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.adaptris.core.services.metadata;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Properties;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
+import com.adaptris.http.Http;
+
+public class FormDataToMetadataTest extends MetadataServiceExample {
+
+  private static final String TEST_VALUE = "the quick brown fox jumps over the lazy dog";
+  private static final String XML_VALUE =
+      "<?xml version=\"1.0\" " + "encoding=\"UTF-8\"?>" + System.lineSeparator() + "<root>"
+          + "<unencrypted>Unencrypted xpath</unencrypted>" + "</root>";
+
+  private static final String COMPLEX_PARAM = "complexParam";
+
+  @Override
+  protected FormDataToMetadata retrieveObjectForSampleConfig() {
+    return new FormDataToMetadata().withContentTypeKey("Content-Type");
+  }
+
+  public void testService_NoContentType() throws Exception {
+    String payload = formatAsFormData(createProperties());
+    FormDataToMetadata service = new FormDataToMetadata();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
+    execute(service, msg);
+    assertEquals(payload, msg.getContent());
+    assertEquals(0, msg.getMetadata().size());
+  }
+
+  public void testService_ContentTypeNotFormData() throws Exception {
+    String payload = formatAsFormData(createProperties());
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
+    msg.addMetadata(Http.CONTENT_TYPE, "application/xml");
+    FormDataToMetadata service = new FormDataToMetadata();
+    execute(service, msg);
+    assertEquals(payload, msg.getContent());
+    // mleMarker
+    assertEquals(1, msg.getMetadata().size());
+  }
+
+  public void testService() throws Exception {
+    String payload = formatAsFormData(createProperties(true));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(payload);
+    msg.addMetadata(Http.CONTENT_TYPE, "application/x-www-form-urlencoded");
+    FormDataToMetadata service = new FormDataToMetadata();
+    execute(service, msg);
+    // 11 items added; + mlemarker
+    assertEquals(12, msg.getMetadata().size());
+    assertEquals(XML_VALUE, msg.getMetadataValue(COMPLEX_PARAM));
+  }
+
+  public void testService_Failure() throws Exception {
+    String payload = formatAsFormData(createProperties());
+    AdaptrisMessage msg = new DefectiveMessageFactory(WhenToBreak.METADATA_GET).newMessage(payload);
+    msg.addMetadata(Http.CONTENT_TYPE, "application/x-www-form-urlencoded");
+    FormDataToMetadata service = new FormDataToMetadata();
+    try {
+      execute(service, msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
+
+  private Properties createProperties() {
+    return createProperties(false);
+  }
+
+  private Properties createProperties(boolean useXml) {
+    Properties p = new Properties();
+    for (int i = 0; i < 10; i++) {
+      p.setProperty("Key" + i, "Value" + i);
+    }
+    if (useXml) {
+      p.setProperty(COMPLEX_PARAM, XML_VALUE);
+    } else {
+      p.setProperty(COMPLEX_PARAM, TEST_VALUE);
+    }
+    return p;
+  }
+
+  private static String formatAsFormData(Properties p) throws UnsupportedEncodingException {
+    StringBuffer sb = new StringBuffer();
+    for (Iterator i = p.keySet().iterator(); i.hasNext();) {
+      String key = i.next().toString();
+      String value = p.getProperty(key);
+      sb.append(key).append("=").append(URLEncoder.encode(value, StandardCharsets.UTF_8.name()));
+      sb.append("&");
+    }
+    sb.deleteCharAt(sb.length() - 1);
+    return sb.toString();
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/DefectiveAdaptrisMessage.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/DefectiveAdaptrisMessage.java
@@ -20,9 +20,12 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
+import java.util.Map;
+import java.util.Set;
+import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.DefaultAdaptrisMessageImp;
+import com.adaptris.core.MetadataElement;
 import com.adaptris.util.IdGenerator;
 
 /**
@@ -53,6 +56,72 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
     }
     return super.getOutputStream();
   }
+
+  @Override
+  public boolean containsKey(String key) {
+    return headersContainsKey(key);
+  }
+
+  /** @see AdaptrisMessage#headersContainsKey(String) */
+  @Override
+  public boolean headersContainsKey(String key) {
+    if (((DefectiveMessageFactory) getFactory()).brokenMetadataGet()) {
+      throw new RuntimeException();
+    }
+    return super.headersContainsKey(key);
+  }
+
+  /** @see AdaptrisMessage#addMetadata(MetadataElement) */
+  @Override
+  public synchronized void addMetadata(MetadataElement e) {
+    if (((DefectiveMessageFactory) getFactory()).brokenMetadataSet()) {
+      throw new RuntimeException();
+    }
+    super.addMetadata(e);
+  }
+
+  /** @see AdaptrisMessage#removeMetadata(MetadataElement) */
+  @Override
+  public void removeMetadata(MetadataElement element) {
+    if (((DefectiveMessageFactory) getFactory()).brokenMetadataSet()) {
+      throw new RuntimeException();
+    }
+    super.removeMetadata(element);
+  }
+
+  /** @see AdaptrisMessage#removeMessageHeader(String) */
+  @Override
+  public void removeMessageHeader(String key) {
+    if (((DefectiveMessageFactory) getFactory()).brokenMetadataSet()) {
+      throw new RuntimeException();
+    }
+    super.removeMessageHeader(key);
+  }
+
+  @Override
+  public synchronized void clearMetadata() {
+    if (((DefectiveMessageFactory) getFactory()).brokenMetadataSet()) {
+      throw new RuntimeException();
+    }
+    super.clearMetadata();
+  }
+
+  @Override
+  public Map<String, String> getMessageHeaders() {
+    if (((DefectiveMessageFactory) getFactory()).brokenMetadataGet()) {
+      throw new RuntimeException();
+    }
+    return super.getMessageHeaders();
+  }
+
+  @Override
+  public Set<MetadataElement> getMetadata() { // lgtm [java/unsynchronized-getter]
+    if (((DefectiveMessageFactory) getFactory()).brokenMetadataGet()) {
+      throw new RuntimeException();
+    }
+    return super.getMetadata();
+  }
+
 
   private class ErroringOutputStream extends OutputStream {
 


### PR DESCRIPTION
- Deprecate RequestParameterConverter service for a FormDataToMetadata
- Add a FormDataFromMetadata
- Parameters on the URI will be handled by a ParameterHandler...
- Add a hierarchy to encode a filtered set of metadata.
- Add additional break when using metadata to DefectiveMessageFactory