### PR TITLE
INTERLOK-2865 Extend StandardDriver not StaxDriver

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdapterXStreamMarshallerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdapterXStreamMarshallerFactory.java
@@ -54,14 +54,25 @@ public class AdapterXStreamMarshallerFactory extends AdapterMarshallerFactory {
 
   private transient static Logger log = LoggerFactory.getLogger(AdapterXStreamMarshallerFactory.class);
 
+  /**
+   * Whether not extended debugging is emitted; defaults to false unless explicitly set via either the system property
+   * {@code interlok.xstream.debug} or {@code adp.xtream.debug}.
+   * 
+   */
   public static final transient boolean XSTREAM_DBG = Boolean.getBoolean("adp.xstream.debug")
       || Boolean.getBoolean("interlok.xstream.debug");
+  /**
+   * Whether or not we force XStream to use the JVMs internal Stax implementation; this defaults to 'true' unless explicitly
+   * set via the system property {@code interlok.xstream.jdk.stax}.
+   * 
+   */
+  public static final transient boolean XSTREAM_JDK_STAX_ONLY = Boolean.getBoolean("interlok.xstream.jdk.stax");
 
   private enum XStreamTypes {
     XML {
       @Override
       XStream createXStreamInstance() {
-        return new MyExtremeMarshaller(new PureJavaReflectionProvider(), new PrettyStaxDriver(cdataFields));
+        return new MyExtremeMarshaller(new PureJavaReflectionProvider(), new PrettyStaxDriver(cdataFields, XSTREAM_JDK_STAX_ONLY));
       }
 
       @Override

--- a/interlok-core/src/test/java/com/adaptris/core/marshaller/xstream/PrettyStaxDriverTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/marshaller/xstream/PrettyStaxDriverTest.java
@@ -46,7 +46,7 @@ public class PrettyStaxDriverTest {
 
   @Test
   public void testCreateReader() {
-    PrettyStaxDriver driver = new PrettyStaxDriver(cdata, true);
+    PrettyStaxDriver driver = new PrettyStaxDriver();
     assertNotNull(driver.createReader(new ByteArrayInputStream("<xml/>".getBytes(StandardCharsets.UTF_8))));
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/marshaller/xstream/PrettyStaxDriverTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/marshaller/xstream/PrettyStaxDriverTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.marshaller.xstream;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.HashSet;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.adaptris.annotation.AnnotationConstants;
+import com.adaptris.core.services.metadata.PayloadFromMetadataService;
+import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
+
+public class PrettyStaxDriverTest {
+
+  private static HashSet<String> cdata = new HashSet<>();
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    cdata = loadCDATA();
+  }
+
+  @Test
+  public void testCreateReader() {
+    PrettyStaxDriver driver = new PrettyStaxDriver(cdata, true);
+    assertNotNull(driver.createReader(new ByteArrayInputStream("<xml/>".getBytes(StandardCharsets.UTF_8))));
+  }
+
+  @Test
+  public void testCreateWriter() {
+    PrettyStaxDriver driver = new PrettyStaxDriver(cdata, true);
+    assertNotNull(driver.createWriter(new ByteArrayOutputStream()));
+  }
+
+  @Test
+  public void testXmlInputFactory() {
+    assertNotNull(new PrettyStaxDriver(cdata, true).createInputFactory());
+    assertNotNull(new PrettyStaxDriver(cdata, false).createInputFactory());
+  }
+
+  @Test
+  public void testXmlOutputFactory() {
+    assertNotNull(new PrettyStaxDriver(cdata, true).createOutputFactory());
+    assertNotNull(new PrettyStaxDriver(cdata, false).createOutputFactory());
+  }
+
+  @Test
+  public void testPrettyPrintWriter() throws Exception {
+    PrettyStaxDriver driver = new PrettyStaxDriver(cdata, true);
+    // service
+    //      <payload-from-metadata-service>
+    //        <unique-id>naughty-hodgkin</unique-id>
+    //        <template><![CDATA[Hello World]]></template>
+    //      </payload-from-metadata-service>
+    StringWriter writer = new StringWriter();
+    try (Writer w = writer) {
+      PrettyPrintWriter printWriter = (PrettyPrintWriter) driver.createWriter(w);
+      printWriter.startNode("payload-from-metadata-service", PayloadFromMetadataService.class);
+      printWriter.startNode("unique-id", String.class);
+      printWriter.setValue("naughty-hodgkin");
+      printWriter.endNode(); // unique-id
+      printWriter.startNode("template", String.class);
+      printWriter.setValue("Hello World");
+      printWriter.endNode(); // template
+      printWriter.endNode(); // payload-from-metadata-service
+    }
+    System.err.println(writer.toString());
+    assertTrue(writer.toString().contains("CDATA"));
+  }
+
+
+  private static HashSet<String> loadCDATA() throws Exception {
+    HashSet<String> result = new HashSet<>();
+    Enumeration<URL> mappings = PrettyStaxDriverTest.class.getClassLoader().getResources(AnnotationConstants.CDATA_PROPERTIES_FILE);
+    while (mappings.hasMoreElements()) {
+      try (InputStream in = mappings.nextElement().openStream()) {
+        result.addAll(XStreamUtils.readResource(in));
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
- Make PrettyStaxDriver extend StandardStaxDriver so that we use the JVM internal Stax implementation.
- Make it controllable via the system property "interlok.xstream.jdk.stax" which defaults to true.
- Add tests (apart from the no-args constructor) to make sure we get the desired behaviours.