### PR TITLE
INTERLOK-2846 Add on-max behaviour.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/DoWhile.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/DoWhile.java
@@ -54,8 +54,7 @@ public class DoWhile extends While {
       do {
         getThen().getService().doService(msg);
         loopCount++;
-        if (exceedsMax(loopCount)) {
-          log.debug("Reached maximum loops({}), breaking.", maxLoops());
+        if (!continueLooping(loopCount, msg)) {
           break;
         }
         log.trace("Testing condition for 'DO-WHILE', with condition class {}",

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/MaxLoopBehaviour.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/MaxLoopBehaviour.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.conditional;
+
+import com.adaptris.core.AdaptrisMessage;
+
+/**
+ * Functional interface that defines behaviour when max-loops is encountered in {@link While} or {@link DoWhile}.
+ * 
+ */
+@FunctionalInterface
+public interface MaxLoopBehaviour {
+
+  void onMax(AdaptrisMessage msg) throws Exception;
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/OnMaxNoOp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/OnMaxNoOp.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.conditional;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * {@link MaxLoopBehaviour} implementation that does nothing.
+ * 
+ * <p>
+ * This means that the message is not touched as it exits the do-while or while loop, no exception is thrown. This effectively
+ * preserves the previous behaviour.
+ * </p>
+ * 
+ * @config max-loops-no-behaviour
+ *
+ */
+@XStreamAlias("max-loops-no-behaviour")
+@ComponentProfile(summary = "MaxLoopBehaviour implementation that has no behaviour.", since = "3.9.1")
+public class OnMaxNoOp implements MaxLoopBehaviour {
+
+  @Override
+  public void onMax(AdaptrisMessage msg) throws Exception {
+    return;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/OnMaxStopProcessing.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/OnMaxStopProcessing.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.conditional;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * {@link MaxLoopBehaviour} implementation that marks a message with metadata that stop processing.
+ * 
+ * <p>
+ * What happens will be dependent on the parent workflow and parent service collection implementation. But this implementation will
+ * mark the message with the metadata keys {@link com.adaptris.core.CoreConstants#STOP_PROCESSING_KEY} and
+ * {@link com.adaptris.core.CoreConstants#KEY_WORKFLOW_SKIP_PRODUCER}.
+ * </p>
+ * </p>
+ * 
+ * @config max-loops-stop-processing
+ *
+ */
+@XStreamAlias("max-loops-stop-processing")
+@ComponentProfile(summary = "MaxLoopBehaviour implementation that marks a message with 'stop-processing' flags", since = "3.9.1")
+public class OnMaxStopProcessing implements MaxLoopBehaviour {
+
+  @Override
+  public void onMax(AdaptrisMessage msg) throws Exception {
+    msg.addMetadata(CoreConstants.STOP_PROCESSING_KEY, CoreConstants.STOP_PROCESSING_VALUE);
+    msg.addMetadata(CoreConstants.KEY_WORKFLOW_SKIP_PRODUCER, CoreConstants.STOP_PROCESSING_VALUE);
+  }
+
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/OnMaxThrowException.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/OnMaxThrowException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.conditional;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * {@link MaxLoopBehaviour} implementation that throws a {@link ServiceException}.
+ * 
+ * <p>
+ * When the maximum number of loops is hit; an exception is thrown.
+ * </p>
+ * 
+ * @config max-loops-throw-exception
+ *
+ */
+@XStreamAlias("max-loops-throw-exception")
+@ComponentProfile(summary = "MaxLoopBehaviour implementation that throws a ServiceException.", since = "3.9.1")
+public class OnMaxThrowException implements MaxLoopBehaviour {
+
+  @Override
+  public void onMax(AdaptrisMessage msg) throws Exception {
+    throw new ServiceException("Exceeded Max Loops");
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/DoWhileTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/DoWhileTest.java
@@ -20,11 +20,13 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
@@ -57,9 +59,7 @@ public class DoWhileTest extends ConditionalServiceExample {
     thenService = new ThenService();
     thenService.setService(mockService);
     
-    doWhile = new DoWhile();
-    doWhile.setThen(thenService);
-    doWhile.setCondition(mockCondition);
+    doWhile = new DoWhile().withThen(thenService).withCondition(mockCondition);
     
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
     
@@ -98,11 +98,29 @@ public class DoWhileTest extends ConditionalServiceExample {
     when(mockCondition.evaluate(message))
         .thenReturn(true);
     
-    doWhile.setMaxLoops(5);
+    doWhile.withMaxLoops(5);
+    doWhile.withOnMaxLoops((e) -> {
+      return;
+    });
     doWhile.doService(message);
     
     verify(mockService, times(5)).doService(message);
   }
+
+  @Test
+  public void testMaxLoops_ThenFail() throws Exception {
+    when(mockCondition.evaluate(message)).thenReturn(true);
+
+    doWhile.withMaxLoops(5);
+    doWhile.withOnMaxLoops(new OnMaxThrowException());
+    try {
+      doWhile.doService(message);
+    } catch (ServiceException expected) {
+
+    }
+    verify(mockService, times(5)).doService(message);
+  }
+
   
   @Test
   public void testShouldRunServiceUnconfiguredFive() throws Exception {
@@ -113,7 +131,7 @@ public class DoWhileTest extends ConditionalServiceExample {
         .thenReturn(true)
         .thenReturn(true)
         .thenReturn(false);
-    doWhile.setMaxLoops(0); // loop forever
+    doWhile.withMaxLoops(0); // loop forever
     doWhile.doService(message);
     verify(mockService, times(5)).doService(message);
   }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/MaxLoopBehaviourTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/MaxLoopBehaviourTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adaptris.core.services.conditional;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.ServiceException;
+
+public class MaxLoopBehaviourTest {
+
+  @Test
+  public void testOnMaxNoOp() throws Exception {
+    OnMaxNoOp behaviour = new OnMaxNoOp();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    behaviour.onMax(msg);
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testOnMaxThrowException() throws Exception {
+    OnMaxThrowException behaviour = new OnMaxThrowException();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    behaviour.onMax(msg);
+  }
+
+  @Test
+  public void testOnMaxStopProcessing() throws Exception {
+    OnMaxStopProcessing behaviour = new OnMaxStopProcessing();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    behaviour.onMax(msg);
+    assertEquals(CoreConstants.STOP_PROCESSING_VALUE, msg.getMetadataValue(CoreConstants.STOP_PROCESSING_KEY));
+    assertEquals(CoreConstants.STOP_PROCESSING_VALUE, msg.getMetadataValue(CoreConstants.KEY_WORKFLOW_SKIP_PRODUCER));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/WhileTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/WhileTest.java
@@ -20,8 +20,11 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
@@ -53,9 +56,7 @@ public class WhileTest extends ConditionalServiceExample {
     thenService = new ThenService();
     thenService.setService(mockService);
     
-    logicalExpression = new While();
-    logicalExpression.setThen(thenService);
-    logicalExpression.setCondition(mockCondition);
+    logicalExpression = new While().withThen(thenService).withCondition(mockCondition);
     
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
     
@@ -97,6 +98,20 @@ public class WhileTest extends ConditionalServiceExample {
     verify(mockService, times(5)).doService(message);
   }
   
+
+  @Test
+  public void testMaxLoops_ThenFail() throws Exception {
+    when(mockCondition.evaluate(message)).thenReturn(true);
+
+    logicalExpression.withMaxLoops(5).withOnMaxLoops(new OnMaxThrowException());
+    try {
+      logicalExpression.doService(message);
+    } catch (ServiceException expected) {
+
+    }
+    verify(mockService, times(5)).doService(message);
+  }
+
   public void testShouldRunServiceUnconfiguredFive() throws Exception {
     when(mockCondition.evaluate(message))
         .thenReturn(true)


### PR DESCRIPTION
- Implementations are "no-op", "throw-exception", "add-stop-processing" flags.
- behaviour is marked as advanced config.

More builder methods that use unchecked things :)