### PR TITLE
INTERLOK-2848 Check character set is valid

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessage.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessage.java
@@ -68,7 +68,9 @@ public interface AdaptrisMessage extends InterlokMessage {
    *             string; since 2.9.3
    */
   @Deprecated
-  void setStringPayload(String payload);
+  default void setStringPayload(String payload) {
+    setContent(payload, null);
+  }
 
   /**
    * <p>
@@ -82,7 +84,9 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 Use {@link #setContent(String, String)}
    */
   @Deprecated
-  void setStringPayload(String payload, String charEncoding);
+  default void setStringPayload(String payload, String charEncoding) {
+    setContent(payload, null);
+  }
 
   /**
    * <p>
@@ -97,7 +101,9 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {{@link #getContent()} instead.
    */
   @Deprecated
-  String getStringPayload();
+  default String getStringPayload() {
+    return getContent();
+  }
 
 
   /**
@@ -111,7 +117,9 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {{@link #setContentEncoding(String)} instead.
    */
   @Deprecated
-  void setCharEncoding(String charEncoding);
+  default void setCharEncoding(String charEncoding) {
+    setContentEncoding(charEncoding);
+  }
 
   /**
    * <p>
@@ -124,7 +132,9 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {{@link #getContentEncoding()} instead.
    */
   @Deprecated
-  String getCharEncoding();
+  default String getCharEncoding() {
+    return getContentEncoding();
+  }
 
   /**
    * <p>
@@ -164,7 +174,9 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {@link #headersContainsKey(String)} instead.
    */
   @Deprecated
-  boolean containsKey(String key);
+  default boolean containsKey(String key) {
+    return headersContainsKey(key);
+  }
 
   /**
    * <p>
@@ -287,7 +299,9 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {@link #addObjectHeader(Object, Object)} instead.
    */
   @Deprecated
-  void addObjectMetadata(String key, Object object);
+  default void addObjectMetadata(String key, Object object) {
+    addObjectHeader(key, object);
+  }
 
   /**
    * <p>
@@ -298,7 +312,9 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {@link #getObjectHeaders()} instead.
    */
   @Deprecated
-  Map getObjectMetadata();
+  default Map getObjectMetadata() {
+    return getObjectHeaders();
+  }
 
   /**
    * <p>

--- a/interlok-core/src/main/java/com/adaptris/core/DefaultAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DefaultAdaptrisMessageImp.java
@@ -17,16 +17,18 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+
 import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.util.IdGenerator;
 
 /**
@@ -96,18 +98,6 @@ public class DefaultAdaptrisMessageImp extends AdaptrisMessageImp {
     return payload != null ? payload.length : 0;
   }
 
-  /** @see AdaptrisMessage#setStringPayload(String) */
-  @Override
-  public void setStringPayload(String s) {
-    setStringPayload(s, null);
-  }
-
-  /** @see AdaptrisMessage#setStringPayload(String, String) */
-  @Override
-  public void setStringPayload(String payloadString, String charEnc) {
-    this.setContent(payloadString, charEnc);
-  }
-  
   /** @see AdaptrisMessage#setContent(String, String) */
   @Override
   public void setContent(String payloadString, String charEnc) {
@@ -123,14 +113,6 @@ public class DefaultAdaptrisMessageImp extends AdaptrisMessageImp {
     }
   }
   
-  
-
-  /** @see AdaptrisMessage#getStringPayload() */
-  @Override
-  public String getStringPayload() {
-    return this.getContent();
-  }
-  
   /** @see AdaptrisMessage#getContent() */
   @Override
   public String getContent() {
@@ -139,12 +121,7 @@ public class DefaultAdaptrisMessageImp extends AdaptrisMessageImp {
         return new String(payload);
       }
       else {
-        try { // want this to be runtime Exc.
-          return new String(payload, getContentEncoding());
-        }
-        catch (UnsupportedEncodingException e) {
-          throw new RuntimeException(e);
-        }
+        return new String(payload, Charset.forName(getContentEncoding()));
       }
     }
     return null;

--- a/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMessageImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMessageImpl.java
@@ -98,20 +98,6 @@ class FileBackedMessageImpl extends AdaptrisMessageImp implements FileBackedMess
   public long getSize() {
     return inputFile == null ? 0 : inputFile.length();
   }
-
-  /** @see AdaptrisMessage#setStringPayload(String) */
-  @Override
-  public void setStringPayload(String s) {
-    setStringPayload(s, null);
-  }
-
-  /** @see AdaptrisMessage#setStringPayload(String, String) 
-   * @deprecated Since 3.0.6 use setContent(String, String). 
-   **/
-  @Deprecated
-  public void setStringPayload(String payloadString, String charEnc) {
-    this.setContent(payloadString, charEnc);
-  }
   
   @Override
   public void setContent(String content, String charEncoding) {
@@ -122,15 +108,6 @@ class FileBackedMessageImpl extends AdaptrisMessageImp implements FileBackedMess
         setContentEncoding(charEncoding);
       }
     });
-  }
-
-  /** @see AdaptrisMessage#getStringPayload() 
-   * @deprecated Since 3.0.6 use getContent(). 
-   **/
-  @Deprecated
-  @Override
-  public String getStringPayload() {
-    return this.getContent();
   }
   
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/ChangeCharEncodingService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/ChangeCharEncodingService.java
@@ -29,7 +29,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Changes the character encoding associated with a message.
  * <p>
  * this service does nothing with the data, but simply changes the character encoding associated with the message using
- * {@link com.adaptris.core.AdaptrisMessage#setCharEncoding(String)}. If this service is used, and there is no configured character encoding then the
+ * {@link com.adaptris.core.AdaptrisMessage#setContentEncoding(String)}. If this service is used, and there is no configured
+ * character encoding then the
  * character encoding associated with the message is set to null (which forces the platform default encoding).
  * </p>
  * 

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageCase.java
@@ -303,6 +303,13 @@ public abstract class AdaptrisMessageCase {
     assertEquals(Charset.forName("iso-8859-1").name(), msg1.getCharEncoding());
     msg1.setCharEncoding("iso-8859-2");
     assertEquals(Charset.forName("iso-8859-2").name(), msg1.getContentEncoding());
+    try {
+      msg1.setContentEncoding("well, this, should be invalid");
+      fail();
+    } catch (Exception expected) {
+
+    }
+
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageCase.java
@@ -34,6 +34,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -297,9 +298,11 @@ public abstract class AdaptrisMessageCase {
   public void testSetCharEncoding() throws Exception {
     AdaptrisMessage msg1 = createMessage();
 
-    msg1.setContentEncoding("ISO-8859-1");
+    msg1.setContentEncoding(StandardCharsets.ISO_8859_1.name());
 
-    assertTrue(msg1.getContentEncoding().equals("ISO-8859-1"));
+    assertEquals(Charset.forName("iso-8859-1").name(), msg1.getCharEncoding());
+    msg1.setCharEncoding("iso-8859-2");
+    assertEquals(Charset.forName("iso-8859-2").name(), msg1.getContentEncoding());
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/ChangeCharEncodingServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/ChangeCharEncodingServiceTest.java
@@ -16,6 +16,9 @@
 
 package com.adaptris.core.services;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.GeneralServiceExample;
@@ -28,7 +31,7 @@ public class ChangeCharEncodingServiceTest extends GeneralServiceExample {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    return new ChangeCharEncodingService("iso-8859-1");
+    return new ChangeCharEncodingService(StandardCharsets.ISO_8859_1.name());
   }
 
   public void testSetCharEncoding() {
@@ -47,7 +50,7 @@ public class ChangeCharEncodingServiceTest extends GeneralServiceExample {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello");
     assertNull(msg.getContentEncoding());
     execute(srv, msg);
-    assertEquals("iso-8859-1", msg.getContentEncoding());
+    assertEquals(Charset.forName("iso-8859-1"), Charset.forName(msg.getContentEncoding()));
   }
 
 }


### PR DESCRIPTION
- Execute Charset.forName() if charEnc != null which will throw a RuntimeException.
- Side effect is that the name is always the formal name (i.e.utf-8 => UTF-8).
- Made all the deprecated methods in AdaptrisMessage default to avoid code duplication.
- Fixed ChangeCharEncodingTest to use the formal name (since a string compare iso-8859-1 != ISO-8859-1)...