### PR TITLE
INTERLOK-2721 Added JdbcLoginServiceFactory

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/HashLoginServiceFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/HashLoginServiceFactory.java
@@ -1,15 +1,10 @@
 package com.adaptris.core.http.jetty;
 
-import javax.validation.constraints.NotNull;
-
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.LoginService;
-import org.hibernate.validator.constraints.NotBlank;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.adaptris.annotation.AutoPopulated;
-import com.adaptris.core.util.Args;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -49,23 +44,16 @@ CRYPT:my8hdCDBVkNU.
  * }
  * </pre>
  *
- * @author lchan
- *
+ * @config jetty-hash-login-service
  */
 @XStreamAlias("jetty-hash-login-service")
-public class HashLoginServiceFactory implements JettyLoginServiceFactory {
-  private transient Logger log = LoggerFactory.getLogger(this.getClass());
-
-  @NotNull
-  @NotBlank
-  @AutoPopulated
-  private String userRealm;
-  @NotNull
-  @NotBlank
-  private String filename;
+@DisplayOrder(order = {"userRealm", "filename"})
+@ComponentProfile(summary = "allows use of org.eclipse.jetty.security.HashLoginService to authenticate users",
+    tag = "jetty,authentication")
+public class HashLoginServiceFactory extends LoginServiceFactoryImpl {
 
   public HashLoginServiceFactory() {
-    setUserRealm("InterlokJetty");
+    super();
   }
 
   public HashLoginServiceFactory(String realm, String filename) {
@@ -75,30 +63,9 @@ public class HashLoginServiceFactory implements JettyLoginServiceFactory {
   }
 
   @Override
-  public LoginService retrieveLoginService() {
+  public LoginService retrieveLoginService() throws Exception {
     HashLoginService loginService = new HashLoginService(getUserRealm(), getFilename());
     loginService.setHotReload(true);
     return new LoginServiceProxy().withLoginService(loginService);
-  }
-
-  public String getUserRealm() {
-    return userRealm;
-  }
-
-  public void setUserRealm(String userRealm) {
-    this.userRealm = Args.notNull(userRealm, "userRealm");
-  }
-
-  public String getFilename() {
-    return filename;
-  }
-
-  /**
-   * Set the filename containing the username/password/roles.
-   * 
-   * @param filename the filename.
-   */
-  public void setFilename(String filename) {
-    this.filename = Args.notNull(filename, "filename");
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JdbcLoginServiceFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JdbcLoginServiceFactory.java
@@ -1,0 +1,32 @@
+package com.adaptris.core.http.jetty;
+
+import org.eclipse.jetty.security.JDBCLoginService;
+import org.eclipse.jetty.security.LoginService;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Allows you to configure a {@code org.eclipse.jetty.security.JDBCLoginService} as the login service to use with Jetty.
+ * <p>
+ * This simply exposes the Jetty JdbcLoginService as Interlok configuration. The documentation from
+ * <a href="https://wiki.eclipse.org/Jetty/Tutorial/Realms">the eclipse jetty site</a> should always
+ * be considered canonical.
+ * </p>
+ *
+ * @config jetty-jdbc-login-service
+ */
+@XStreamAlias("jetty-jdbc-login-service")
+@DisplayOrder(order = {"userRealm", "filename"})
+@ComponentProfile(summary = "allows use of org.eclipse.jetty.security.JDBCLoginService to authenticate users",
+    tag = "jetty,authentication", since = "3.9.1")
+public class JdbcLoginServiceFactory extends LoginServiceFactoryImpl {
+
+  @Override
+  public LoginService retrieveLoginService() throws Exception {
+    JDBCLoginService loginService = new JDBCLoginService(getUserRealm(), getFilename());
+    return new LoginServiceProxy().withLoginService(loginService);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyLoginServiceFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyLoginServiceFactory.java
@@ -8,6 +8,6 @@ import org.eclipse.jetty.security.LoginService;
  */
 public interface JettyLoginServiceFactory {
 
-  public LoginService retrieveLoginService();
+  public LoginService retrieveLoginService() throws Exception;
   
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/LoginServiceFactoryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/LoginServiceFactoryImpl.java
@@ -1,0 +1,66 @@
+package com.adaptris.core.http.jetty;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.util.Args;
+
+/**
+ * Abstract configuration for bundled {@code org.eclipse.jetty.security.LoginService} implementations.
+ *
+ */
+public abstract class LoginServiceFactoryImpl implements JettyLoginServiceFactory {
+
+  @NotBlank(message = "user realm may not be blank")
+  @AutoPopulated
+  @InputFieldDefault(value = "InterlokJetty")
+  private String userRealm;
+  @NotBlank(message = "login service configuration file may not be blank")
+  private String filename;
+
+  public LoginServiceFactoryImpl() {
+    setUserRealm("InterlokJetty");
+  }
+
+  public String getUserRealm() {
+    return userRealm;
+  }
+
+  /**
+   * Set the realm for the login service.
+   * 
+   * @param userRealm the realm.
+   */
+  public void setUserRealm(String userRealm) {
+    this.userRealm = Args.notNull(userRealm, "userRealm");
+  }
+
+  public <T extends LoginServiceFactoryImpl> T withUserRealm(String s) {
+    setUserRealm(s);
+    return (T) this;
+  }
+
+  public String getFilename() {
+    return filename;
+  }
+
+  /**
+   * Set the filename containing the configuration for the concrete class.
+   * <p>
+   * Depending on the concrete implementation, the file may well have different contents; for a {@link HashLoginServiceFactory} the
+   * file will contain username/password/roles; for a {@link JdbcLoginServiceFactory} it will contain properties that tell the
+   * underlying service how to connect to the database.
+   * </p>
+   * 
+   * @param filename the filename containing configuration.
+   */
+  public void setFilename(String filename) {
+    this.filename = Args.notNull(filename, "filename");
+  }
+
+  public <T extends LoginServiceFactoryImpl> T withFilename(String s) {
+    setFilename(s);
+    return (T) this;
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/HttpConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/HttpConsumerTest.java
@@ -1069,7 +1069,8 @@ public class HttpConsumerTest extends HttpConsumerExample {
 
   SecurityHandlerWrapper createSecurityHandlerExample() {
     ConfigurableSecurityHandler csh = new ConfigurableSecurityHandler();
-    HashLoginServiceFactory hsl = new HashLoginServiceFactory("InterlokJetty", "/path/to/realm.properties");
+    HashLoginServiceFactory hsl =
+        new HashLoginServiceFactory().withUserRealm("InterlokJetty").withFilename("/path/to/realm.properties");
     csh.setLoginService(hsl);
 
     SecurityConstraint securityConstraint = new SecurityConstraint();

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/LoginServiceFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/LoginServiceFactoryTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.http.jetty;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.JDBCLoginService;
+import org.eclipse.jetty.security.LoginService;
+import org.junit.Test;
+
+public class LoginServiceFactoryTest {
+
+  @Test
+  public void testCreateHashLoginService() throws Exception {
+    HashLoginServiceFactory factory =
+        new HashLoginServiceFactory().withUserRealm("InterlokJetty").withFilename("/path/to/properties");
+    assertEquals("InterlokJetty", factory.getUserRealm());
+    assertEquals("/path/to/properties", factory.getFilename());
+    LoginService loginService = factory.retrieveLoginService();
+    assertNotNull(loginService);
+    assertTrue(loginService instanceof LoginServiceProxy);
+    LoginServiceProxy proxy = (LoginServiceProxy) loginService;
+    assertEquals(1, proxy.getBeans().size());
+    assertEquals(HashLoginService.class, proxy.getBeans().iterator().next().getClass());
+  }
+
+  @Test
+  public void testCreateJdbcLoginService() throws Exception {
+    JdbcLoginServiceFactory factory =
+        new JdbcLoginServiceFactory().withUserRealm("InterlokJetty").withFilename("/path/to/properties");
+    assertEquals("InterlokJetty", factory.getUserRealm());
+    assertEquals("/path/to/properties", factory.getFilename());
+    LoginService loginService = factory.retrieveLoginService();
+    assertNotNull(loginService);
+    assertTrue(loginService instanceof LoginServiceProxy);
+    LoginServiceProxy proxy = (LoginServiceProxy) loginService;
+    assertEquals(1, proxy.getBeans().size());
+    assertEquals(JDBCLoginService.class, proxy.getBeans().iterator().next().getClass());
+  }
+
+}


### PR DESCRIPTION
- Since both JDBCLoginService and HashLoginService have the same configuration; make an abstract class with generics.
- Add a JDBCLoginService variant; reusing LoginServiceProxy from INTERLOK-2799
- Add unit tests checking behaviour only.