### PR TITLE
INTERLOK-2872 Deprecated JndiBindable#getLookupName

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.util.LifecycleHelper;
 
 /**
@@ -41,6 +42,8 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
   @AdvancedConfig
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   private String lookupName;
   @AdvancedConfig
   @Valid
@@ -293,42 +296,59 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
     uniqueId = s;
   }
 
+  @Override
   public void changeState(ComponentState s) {
     state = s;
   }
 
   /** @see com.adaptris.core.StateManagedComponent#requestInit() */
+  @Override
   public void requestInit() throws CoreException {
     state.requestInit(this);
   }
 
   /** @see com.adaptris.core.StateManagedComponent#requestStart() */
+  @Override
   public void requestStart() throws CoreException {
     state.requestStart(this);
   }
 
   /** @see com.adaptris.core.StateManagedComponent#requestStop() */
+  @Override
   public void requestStop() {
     state.requestStop(this);
   }
 
   /** @see com.adaptris.core.StateManagedComponent#requestClose() */
+  @Override
   public void requestClose() {
     state.requestClose(this);
   }
 
+  @Override
   public ComponentState retrieveComponentState() {
     return state;
   }
 
+  @Override
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   public String getLookupName() {
     return lookupName;
   }
 
+  /**
+   * 
+   * @deprecated since 3.9.1 with no replacement; and will be removed to avoid JNDI ambiguity
+   * 
+   */
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   public void setLookupName(String jndiName) {
     this.lookupName = jndiName;
   }
 
+  @Override
   public AdaptrisConnection cloneForTesting() throws CoreException {
     AdaptrisMarshaller m = DefaultMarshaller.getDefaultMarshaller();
     return (AdaptrisConnection) m.unmarshal(m.marshal(this));

--- a/interlok-core/src/main/java/com/adaptris/core/JndiBindable.java
+++ b/interlok-core/src/main/java/com/adaptris/core/JndiBindable.java
@@ -16,12 +16,15 @@
 
 package com.adaptris.core;
 
+import com.adaptris.annotation.Removal;
+
 /**
  * Interface for objects that can be bound to the internal JNDI context.
  * 
  * @author amcgrath
  * 
  */
+@Deprecated
 public interface JndiBindable {
 
   /**
@@ -33,7 +36,10 @@ public interface JndiBindable {
    * </p>
    * 
    * @return the lookup name.
+   * @deprecated since 3.9.1 with no replacement; the behaviour is ambiguous in some circumstances.
    */
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Deprecated since 3.9.1 with no replacement, since the behaviour is ambiguous")
   String getLookupName();
   
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
@@ -53,6 +54,8 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
   @AdvancedConfig
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   private String lookupName;
   
   private String uniqueId;
@@ -573,10 +576,19 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
   }
 
   @Override
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   public String getLookupName() {
     return lookupName;
   }
 
+  /**
+   * 
+   * @deprecated since 3.9.1 with no replacement; and will be removed to avoid JNDI ambiguity
+   * 
+   */
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   public void setLookupName(String lookupName) {
     this.lookupName = lookupName;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
@@ -17,11 +17,14 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.util.Args;
 import com.adaptris.util.GuidGenerator;
 
@@ -41,6 +44,8 @@ public abstract class ServiceImp implements Service {
   private transient boolean prepared = false;
   
   @AdvancedConfig
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   private String lookupName;
   private String uniqueId;
   private transient boolean isBranching; // defaults to false
@@ -220,6 +225,8 @@ public abstract class ServiceImp implements Service {
   }
 
   @Override
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   public String getLookupName() {
     return lookupName;
   }
@@ -231,7 +238,10 @@ public abstract class ServiceImp implements Service {
    * </p>
    * 
    * @param lookupName the lookup name.
+   * @deprecated since 3.9.1 with no replacement; and will be removed to avoid JNDI ambiguity
    */
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   public void setLookupName(String lookupName) {
     this.lookupName = lookupName;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/SharedConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedConnection.java
@@ -84,6 +84,7 @@ public class SharedConnection extends SharedComponent implements AdaptrisConnect
     // No-Op as requestXXX invokes the underlying connection
   }
 
+  @Override
   public void changeState(ComponentState newState) {
     // No-Op as requestXXX invokes the underlying connection
   }
@@ -171,10 +172,16 @@ public class SharedConnection extends SharedComponent implements AdaptrisConnect
     return (T) getProxiedConnection();
   }
 
+  @Override
   public String getLookupName() {
     return lookupName;
   }
 
+  /**
+   * Set the unique-id of the connection that we will lookup.
+   * 
+   * @param jndiName the name
+   */
   public void setLookupName(String jndiName) {
     this.lookupName = jndiName;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/util/JndiHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/JndiHelper.java
@@ -35,6 +35,7 @@ import com.adaptris.core.JndiBindable;
 import com.adaptris.core.JndiContextFactory;
 import com.adaptris.core.jdbc.DatabaseConnection;
 
+@SuppressWarnings("deprecation")
 public class JndiHelper {
 
   private static transient Logger log = LoggerFactory.getLogger(JndiHelper.class);

--- a/interlok-core/src/test/java/com/adaptris/core/JndiContextFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/JndiContextFactoryTest.java
@@ -35,6 +35,7 @@ import com.adaptris.naming.adapter.NamingContext;
 
 import junit.framework.TestCase;
 
+@SuppressWarnings("deprecation")
 public class JndiContextFactoryTest extends TestCase {
 
   private Properties env = new Properties();

--- a/interlok-core/src/test/java/com/adaptris/core/ServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ServiceCase.java
@@ -18,6 +18,7 @@ package com.adaptris.core;
 
 import java.util.List;
 
+import com.adaptris.core.stubs.ObjectUtils;
 import com.adaptris.core.util.LifecycleHelper;
 
 /**
@@ -219,6 +220,28 @@ public abstract class ServiceCase extends ExampleConfigCase {
       for (Object o : retrieveObjectsForSampleConfig()) {
         assertUniqueId((Service) o);
       }
+    }
+  }
+
+
+  public void testLookupName() throws Exception {
+    Object input = retrieveObjectForCastorRoundTrip();
+    if (input != null) {
+      assertLookupName((Service) input);
+    } else {
+      retrieveObjectsForSampleConfig().forEach(e -> assertLookupName((Service) e));
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  // If it has get/set Lookupname lets test it.
+  private void assertLookupName(Service s) {
+    try {
+      ObjectUtils.invokeSetter(s, s.getClass(), "setLookupName", "getLookupName", "myLookupName");
+      assertEquals("myLookupName", s.getLookupName());
+    } catch (Exception e) {
+      // method probably doesn't exist; so it's not ServiceImp?
+
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/SharedComponentListTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/SharedComponentListTest.java
@@ -73,6 +73,8 @@ public class SharedComponentListTest extends ExampleConfigCase {
 
   private enum ConnectionBuilder {
     FtpConnectionBuilder {
+      @Override
+      @SuppressWarnings("deprecation")
       AdaptrisConnection build() {
         FtpConnection c = new FtpConnection("goofy_edison");
         c.setLookupName("adapter:comp/env/optional-lookup-name");
@@ -81,6 +83,7 @@ public class SharedComponentListTest extends ExampleConfigCase {
       }
     },
     PooledJdbcConnectionBuilder {
+      @Override
       AdaptrisConnection build() {
         JdbcPooledConnection connection = new JdbcPooledConnection();
         connection.setUniqueId("vigilant_hypatia");
@@ -89,6 +92,7 @@ public class SharedComponentListTest extends ExampleConfigCase {
       }
     },
     AdvancedPooledJdbcConnectionBuilder {
+      @Override
       AdaptrisConnection build() {
         AdvancedJdbcPooledConnection connection = new AdvancedJdbcPooledConnection();
         connection.setUniqueId("amused_goldberg");
@@ -163,8 +167,7 @@ public class SharedComponentListTest extends ExampleConfigCase {
       for (ConnectionBuilder b : ConnectionBuilder.values()) {
         adapter.getSharedComponents().addConnection(b.build());
       }
-      TransactionManager transactionManager = new DummyTransactionManager("nifty_mcclintock",
-          "adapter:comp/env/myTransactionManager");
+      TransactionManager transactionManager = new DummyTransactionManager("myTransactionManager");
       adapter.getSharedComponents().setTransactionManager(transactionManager);
       Channel c = new Channel();
       c.setProduceConnection(new SharedConnection("goofy_edison"));
@@ -587,6 +590,7 @@ public class SharedComponentListTest extends ExampleConfigCase {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public void testSharedConnection_Lookup_FallbackToPlainName() throws Exception {
     Adapter adapter = new Adapter();
     adapter.setUniqueId(getName());

--- a/interlok-core/src/test/java/com/adaptris/core/transaction/DummyTransactionManager.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transaction/DummyTransactionManager.java
@@ -22,6 +22,11 @@ public class DummyTransactionManager implements TransactionManager {
   public DummyTransactionManager() {
   }
   
+
+  public DummyTransactionManager(String uniqueId) {
+    setUniqueId(uniqueId);
+  }
+
   public DummyTransactionManager(String uniqueId, String lookupName) {
     this.setLookupName(lookupName);
     this.setUniqueId(uniqueId);

--- a/interlok-core/src/test/java/com/adaptris/core/util/JndiHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/JndiHelperTest.java
@@ -36,6 +36,7 @@ import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
+@SuppressWarnings("deprecation")
 public class JndiHelperTest extends BaseCase {
   private Properties env = new Properties();
   public JndiHelperTest(String s) {


### PR DESCRIPTION
- ServiceImp#lookupName annotated with removal+deprecation
- ServiceCollectionImp#lookupName annotated with removal+deprecation
- AdaptrisConnectionImp#lookupName annotated with removal+deprecation

Since SharedService / SharedConnection implement Service & Connection directly there isn't any jiggery pokery around parent classes.