### PR TITLE
ADR-0005 - Deprecate and remove Destination

### DIFF
--- a/docs/adr/0005-remove-produce-destination.md
+++ b/docs/adr/0005-remove-produce-destination.md
@@ -73,7 +73,7 @@ Finally there is a special `JmsReplyToDestination` that is in use; this uses obj
 * Neutral, because there will be crossover period where both styles need to be valid; and how do we message this change to the existing users without a massive kerfuffle.
 * Good, it ultimately simplifies the configuration
 * Good, because it allows producers to define their own configuration, in fact having a non-string based destination.
-* __*Bad, because it's a massive change*__
+* __*Neutral/Bad, because it's changes the produce/request contract in AdaptrisMessageProducer*__
 
 ### Additional ProduceDestination implementations
 

--- a/docs/adr/0005-remove-produce-destination.md
+++ b/docs/adr/0005-remove-produce-destination.md
@@ -70,7 +70,7 @@ Finally there is a special `JmsReplyToDestination` that is in use; this uses obj
 #### Consequences 
 
 * Bad, because synchronisation between the UI and core releases...
-* Neutral, because there will be crossover period where both styles need to be valid; and it's a messaging thing for the existing users.
+* Neutral, because there will be crossover period where both styles need to be valid; and how do we message this change to the existing users without a massive kerfuffle.
 * Good, it ultimately simplifies the configuration
 * Good, because it allows producers to define their own configuration, in fact having a non-string based destination.
 * __*Bad, because it's a massive change*__

--- a/docs/adr/0005-remove-produce-destination.md
+++ b/docs/adr/0005-remove-produce-destination.md
@@ -4,7 +4,7 @@ title: 0005-remove-produce-destination
 ---
 # Deprecate and ultimately remove Destination
 
-* Status: PROPOSED
+* Status: Accepted
 * Deciders: Lewin Chan, Aaron McGrath, Paul Higginson, Sebastien Belin, Matt Warman
 * Date: 2019-07-30
 

--- a/docs/adr/0005-remove-produce-destination.md
+++ b/docs/adr/0005-remove-produce-destination.md
@@ -2,7 +2,7 @@
 layout: page
 title: 0005-remove-produce-destination
 ---
-# Deprecate and ultimately remove ProduceDestination
+# Deprecate and ultimately remove Destination
 
 * Status: PROPOSED
 * Deciders: Lewin Chan, Aaron McGrath, Paul Higginson, Sebastien Belin, Matt Warman
@@ -12,11 +12,13 @@ title: 0005-remove-produce-destination
 
 If we consider something like `jms-topic-producer` then we have to configure a produce destination what contains the topic. Traditionally, if we wanted a metadata driven destination, then it would have to be done via a `metadata-destination` but now with the `%message{metadata-key}` expression language; we would just use configured-produce-destination everywhere. However; this isn't necessarily obvious to the user. Additionally, we cannot have a destination that isn't a String.
 
-There are some producers that have 2 mandatory pieces of information that would be considered the _destination_. For instance the AWS Kinesis producer requires both a _stream-name_ and a _partition-key_. This kind of requirement doesn't lend itself very well to a `produce-destination`; we can't make the destination return a delimited string since both of those values are essentially arbitrary. So we either completely ignore produce-destination, or we use the destination for the stream name, and then something else entirely for the partition key. 
+There are some producers that have 2 mandatory pieces of information that would be considered the _destination_. For instance the AWS Kinesis producer requires both a _stream-name_ and a _partition-key_. This kind of requirement doesn't lend itself very well to a `produce-destination`; we can't make the destination return a delimited string since both of those values are essentially arbitrary. So we either completely ignore produce-destination, or we use the destination for the stream name, and then something else entirely for the partition key.
 
 There are already some producers that ignore the destination entirely: SAP Idoc producer, Jetty Response Producer are the two that immediately spring to mind. So if isn't mandatory, then why have it?
 
-## Decision Drivers 
+EDIT: 2020-06-16 The proposal is to also remove `ConsumeDestination` as well as `ProduceDestination`
+
+## Decision Drivers
 
 * Less confusion for new users.
 * Clean up configuration to take advantage of new features.
@@ -30,35 +32,29 @@ There are already some producers that ignore the destination entirely: SAP Idoc 
 
 ## Decision Outcome
 
-...
-
+Deprecate and Remove
 
 ### Status Quo
 
 We're in the army now.
 
-#### Consequences 
+#### Consequences
 
 * Good, because there's no work to do, apart from new producers that don't fit the existing produce-destination paradigm.
 * Bad, because we aren't simplifying the object model and configuration.
 
-### Deprecate ProduceDestination
+### Deprecate Destination
 
-If we deprecate ProduceDestination, then that means marking it is deprecated in `AdaptrisProducerImp`; this means that the UI will no longer display the destination when you create a new producer in the UI; that means we need to introduce a new annotation that the UI can use that tells it whether to display the deprecated ProduceDestination. There will be consequences to this, the deprecation warning notices in the settings editor for instance, would have to be disabled for ProduceDestination if there's no annotation.
+If we deprecate Destination then we need to
 
-#### Annotation for the UI.
-
-```java
-@OverridesProduceDestination
-public class JmsTopicProducer {
-  
-  private String topicName
-}
-```
-
-If the OverridesProduceDestination exists, then the UI can safely hide the produce destination in the settings editor. If there is no such annotation, then it has to display the destination still. 
-
-That means we can have a phased approach to fully removing the produce destination.
+* Deprecate destination as a member in all producers and consumers (AdaptrisMessageWorker as well?)
+* Ensure that all producers and consumers provide an alternative method for specifying the destination
+    * For FsConsumer we might have a "directory-name" that is a String -> `%message{directory}`
+    * Ditto FsProducer
+    * It might be different for other producer/consumer types
+* Deprecate the produce/request methods in the main producer interface.
+    * Default it to "null", and make sure it's not NotNull
+    * this means that the UI will no longer display the destination when you create a new producer in the UI; but if you have it configured, it will be present with the deprecated warnings.
 
 #### JmsReplyToDestination
 
@@ -67,11 +63,10 @@ Finally there is a special `JmsReplyToDestination` that is in use; this uses obj
 * Change the JMS Producer implementations so that if the object metadata exists (use-jms-reply-to-if-available=true), then it uses the JmsReplyTo value.
 * Deprecate JmsReplyToDestination
 
-#### Consequences 
+#### Consequences
 
-* Bad, because synchronisation between the UI and core releases...
 * Neutral, because there will be crossover period where both styles need to be valid; and how do we message this change to the existing users without a massive kerfuffle.
-* Good, it ultimately simplifies the configuration
+* Good, it ultimately simplifies the configuration, leaving us "less work" with ConfigBean translations.
 * Good, because it allows producers to define their own configuration, in fact having a non-string based destination.
 * __*Neutral/Bad, because it's changes the produce/request contract in AdaptrisMessageProducer*__
 
@@ -79,9 +74,8 @@ Finally there is a special `JmsReplyToDestination` that is in use; this uses obj
 
 For the Kinesis produce we could introduce a new `KinesisProduceDestination` that contains an additional getPartitionKey() method (or we make it generic, and add a getQualifier() method).
 
-#### Consequences 
+#### Consequences
 
 * Good, because we aren't modifying the object model
 * Bad, because we have to cast ProduceDestination
 * Bad, because we still have to support the situation where the user has only configured a ConfiguredProduceDestination or similar.
-

--- a/docs/adr/0005-remove-produce-destination.md
+++ b/docs/adr/0005-remove-produce-destination.md
@@ -1,76 +1,87 @@
 ---
 layout: page
-title: template
+title: 0005-remove-produce-destination
 ---
-# [short title of solved problem and solution]
+# Deprecate and ultimately remove ProduceDestination
 
-* Status: [accepted , superseeded by [ADR-0005](template.md) , deprecated , ...] <!-- optional -->
-* Deciders: [list everyone involved in the decision] <!-- optional -->
-* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
-
-Technical Story: [description , ticket/issue URL] <!-- optional -->
+* Status: PROPOSED
+* Deciders: Lewin Chan, Aaron McGrath, Paul Higginson, Sebastien Belin, Matt Warman
+* Date: 2019-07-30
 
 ## Context and Problem Statement
 
-[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+If we consider something like `jms-topic-producer` then we have to configure a produce destination what contains the topic. Traditionally, if we wanted a metadata driven destination, then it would have to be done via a `metadata-destination` but now with the `%message{metadata-key}` expression language; we would just use configured-produce-destination everywhere. However; this isn't necessarily obvious to the user. Additionally, we cannot have a destination that isn't a String.
 
-## Decision Drivers <!-- optional -->
+There are some producers that have 2 mandatory pieces of information that would be considered the _destination_. For instance the AWS Kinesis producer requires both a _stream-name_ and a _partition-key_. This kind of requirement doesn't lend itself very well to a `produce-destination`; we can't make the destination return a delimited string since both of those values are essentially arbitrary. So we either completely ignore produce-destination, or we use the destination for the stream name, and then something else entirely for the partition key. 
 
-* [driver 1, e.g., a force, facing concern, ...]
-* [driver 2, e.g., a force, facing concern, ...]
-* ... <!-- numbers of drivers can vary -->
+There are already some producers that ignore the destination entirely: SAP Idoc producer, Jetty Response Producer are the two that immediately spring to mind. So if isn't mandatory, then why have it?
+
+## Decision Drivers 
+
+* Less confusion for new users.
+* Clean up configuration to take advantage of new features.
+* Make things more predictable.
 
 ## Considered Options
 
-* [option 1]
-* [option 2]
-* [option 3]
-* ... <!-- numbers of options can vary -->
+* The status quo is always an option.
+* Deprecate ProduceDestination
+* Introduce alternative implementations to ProduceDestination.
 
 ## Decision Outcome
 
-Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver , which resolves force force , ... , comes out best (see below)].
+...
 
-### Positive Consequences <!-- optional -->
 
-* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, ...]
-* ...
+### Status Quo
 
-### Negative consequences <!-- optional -->
+We're in the army now.
 
-* [e.g., compromising quality attribute, follow-up decisions required, ...]
-* ...
+#### Consequences 
 
-## Pros and Cons of the Options <!-- optional -->
+* Good, because there's no work to do, apart from new producers that don't fit the existing produce-destination paradigm.
+* Bad, because we aren't simplifying the object model and configuration.
 
-### [option 1]
+### Deprecate ProduceDestination
 
-[example , description , pointer to more information , ...] <!-- optional -->
+If we deprecate ProduceDestination, then that means marking it is deprecated in `AdaptrisProducerImp`; this means that the UI will no longer display the destination when you create a new producer in the UI; that means we need to introduce a new annotation that the UI can use that tells it whether to display the deprecated ProduceDestination. There will be consequences to this, the deprecation warning notices in the settings editor for instance, would have to be disabled for ProduceDestination if there's no annotation.
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+#### Annotation for the UI.
 
-### [option 2]
+```java
+@OverridesProduceDestination
+public class JmsTopicProducer {
+  
+  private String topicName
+}
+```
 
-[example , description , pointer to more information , ...] <!-- optional -->
+If the OverridesProduceDestination exists, then the UI can safely hide the produce destination in the settings editor. If there is no such annotation, then it has to display the destination still. 
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+That means we can have a phased approach to fully removing the produce destination.
 
-### [option 3]
+#### JmsReplyToDestination
 
-[example , description , pointer to more information , ...] <!-- optional -->
+Finally there is a special `JmsReplyToDestination` that is in use; this uses object metadata to derive the `javax.jms.Destination` (and is handled specially by the JMS Producer Impls).
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* Change the JMS Producer implementations so that if the object metadata exists (use-jms-reply-to-if-available=true), then it uses the JmsReplyTo value.
+* Deprecate JmsReplyToDestination
 
-## Links <!-- optional -->
+#### Consequences 
 
-* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
-* ... <!-- numbers of links can vary -->
+* Bad, because synchronisation between the UI and core releases...
+* Neutral, because there will be crossover period where both styles need to be valid; and it's a messaging thing for the existing users.
+* Good, it ultimately simplifies the configuration
+* Good, because it allows producers to define their own configuration, in fact having a non-string based destination.
+* __*Bad, because it's a massive change*__
+
+### Additional ProduceDestination implementations
+
+For the Kinesis produce we could introduce a new `KinesisProduceDestination` that contains an additional getPartitionKey() method (or we make it generic, and add a getQualifier() method).
+
+#### Consequences 
+
+* Good, because we aren't modifying the object model
+* Bad, because we have to cast ProduceDestination
+* Bad, because we still have to support the situation where the user has only configured a ConfiguredProduceDestination or similar.
+


### PR DESCRIPTION
It's a big change, so we need to think about the consequences.
https://github.com/adaptris/interlok/blob/adr/ADR-0005/docs/adr/0005-remove-produce-destination.md

(or after merge : https://github.com/adaptris/interlok/blob/develop/docs/adr/0005-remove-produce-destination.md)