### PR TITLE
INTERLOK-2852 Add a condition to MessageAggregator

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/fs/AggregatingFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/AggregatingFsConsumer.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.fs;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileFilter;
@@ -26,7 +27,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
 import javax.validation.Valid;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
@@ -95,7 +98,7 @@ public class AggregatingFsConsumer extends AggregatingConsumerImpl<AggregatingFs
     try {
       result = isEmpty(dest.getFilterExpression()) ? readSingleFile(dest, msg.getFactory()) : readMultipleFiles(dest,
           msg.getFactory());
-      getMessageAggregator().joinMessage(msg, result);
+      getMessageAggregator().joinMessage(msg, result, condition());
     }
     catch (Exception e) {
       rethrowServiceException(e);
@@ -284,6 +287,5 @@ public class AggregatingFsConsumer extends AggregatingConsumerImpl<AggregatingFs
   Boolean isDeleteAggregatedFiles(){
     return getDeleteAggregatedFiles() == null ? true : getDeleteAggregatedFiles();
   }
-
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/AggregatingFtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/AggregatingFtpConsumer.java
@@ -18,11 +18,15 @@ package com.adaptris.core.ftp;
 
 import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
@@ -92,7 +96,7 @@ public class AggregatingFtpConsumer extends AggregatingConsumerImpl<AggregatingF
         getDestination().generate(msg));
     try {
       result = isEmpty(cfg.dest.getFilterExpression()) ? single(cfg, msg.getFactory()) : multiple(cfg, msg.getFactory());
-      getMessageAggregator().joinMessage(msg, result);
+      getMessageAggregator().joinMessage(msg, result, condition());
       if (deleteAggregatedFiles()) {
         deleteFilesQuietly(result, cfg);
       }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/AggregatingQueueConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/AggregatingQueueConsumer.java
@@ -18,10 +18,12 @@ package com.adaptris.core.jms;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
+
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
@@ -91,7 +93,7 @@ public class AggregatingQueueConsumer extends AggregatingConsumerImpl<Aggregatin
         result.add(getMessageTranslator().translate(next));
         next = nextMessage(consumer);
       }
-      getMessageAggregator().joinMessage(msg, result);
+      getMessageAggregator().joinMessage(msg, result, condition());
     }
     catch (CoreException | JMSException e) {
       rethrowServiceException(e);

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/MessageAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/MessageAggregator.java
@@ -50,8 +50,8 @@ public interface MessageAggregator {
    * down to the implementation.
    * </p>
    * 
-   * @param msg the msg to insert all the messages into
-   * @param msgs the list of messages to join.
+   * @param original the msg to insert all the messages into
+   * @param messages the list of messages to join.
    * @param filter a condition to filter messages for inclusion or not.
    * @throws CoreException wrapping any other exception
    * @since 3.9.1

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingSplitJoinService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingSplitJoinService.java
@@ -20,8 +20,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.pool2.impl.GenericObjectPool;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -56,7 +58,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Split a message and then execute the associated services on the split items, aggregating the split messages afterwards", tag = "service,splitjoin", since = "3.7.1")
 @DisplayOrder(order =
 {
-    "splitter", "service", "aggregator", "maxThreads", "timeout", "warmStart"
+    "splitter", "service", "aggregator", "condition", "maxThreads", "timeout", "warmStart"
 })
 public class PoolingSplitJoinService extends SplitJoinService {
 

--- a/interlok-core/src/test/java/com/adaptris/core/fs/AggregatingFsConsumeServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/AggregatingFsConsumeServiceTest.java
@@ -42,10 +42,12 @@ public class AggregatingFsConsumeServiceTest extends AggregatingServiceExample {
     super(name);
   }
 
+  @Override
   public void setUp() throws Exception {
     super.setUp();
   }
 
+  @Override
   public void tearDown() throws Exception {
     super.tearDown();
   }
@@ -55,7 +57,7 @@ public class AggregatingFsConsumeServiceTest extends AggregatingServiceExample {
     File tempFile = TempFileUtils.createTrackedFile(o);
     String url = "file://localhost/" + tempFile.getCanonicalPath().replaceAll("\\\\", "/");
     ConsumeDestinationGenerator cdg = createConsumeDestination(url, null);
-    AggregatingFsConsumer afc = createConsumer(cdg, new ReplaceWithFirstMessage());
+    AggregatingFsConsumer afc = createConsumer(cdg, new ReplaceWithFirstMessage()).withCondition((msg) -> true);
     AggregatingFsConsumeService service = createAggregatingService(afc);
     File wipFile = new File(tempFile.getParent(), tempFile.getName() + afc.wipSuffix());
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/NullMessageAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/NullMessageAggregatorTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.Service;
 import com.adaptris.core.services.splitter.XpathDocumentCopier;
 
@@ -28,6 +29,15 @@ public class NullMessageAggregatorTest extends AggregatingServiceExample {
 
   public NullMessageAggregatorTest(String name) {
     super(name);
+  }
+
+  public void testEvaluateFilter() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Goodbye");
+
+    assertTrue(MessageAggregator.evaluateFilter(msg, (m) -> true));
+    assertFalse(MessageAggregator.evaluateFilter(msg, (m) -> {
+      throw new CoreException();
+    }));
   }
 
   public void testJoinMessage() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitJoinServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitJoinServiceTest.java
@@ -26,15 +26,18 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
@@ -122,7 +125,7 @@ public class SplitJoinServiceTest {
   public void testService_WithException() throws Exception {
     // This is a 100 line message, so we expect to get 11 parts.
     AdaptrisMessage msg = SplitterCase.createLineCountMessageInput();
-    SplitJoinService service = createServiceForTests();
+    SplitJoinService service = createServiceForTests().withCondition((m) -> true);
     // The service doesn't actually matter right now.
     service.setService(asCollection(new ThrowExceptionService(new ConfiguredException(testName.getMethodName()))));
     service.setTimeout(new TimeInterval(10L, TimeUnit.SECONDS));
@@ -231,7 +234,7 @@ public class SplitJoinServiceTest {
   public void testService_WithXmlJoiner() throws Exception {
     // This is a XML doc with 3 iterable elements...
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(SplitterCase.XML_MESSAGE);
-    SplitJoinService service = createServiceForTests();
+    SplitJoinService service = createServiceForTests().withCondition((m) -> true);
     // The service doesn't actually matter right now.
     service.setService(asCollection(new NullService()));
     service.setTimeout(new TimeInterval(10L, TimeUnit.SECONDS));


### PR DESCRIPTION
- Add a default method to MessageAggregator
- Add a Conditon to AggregatorConsumerImpl / SplitJoin.
- JsonArrayAggregator still needs to override the default method, since it has the additional "include-failed-evaluations" capability.