### PR TITLE
INTERLOK-2901 Ensure XmlHelper+XmlTransform configure the builder properly

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/XpathProduceDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/XpathProduceDestination.java
@@ -18,17 +18,16 @@ package com.adaptris.core;
 
 import static com.adaptris.core.util.XmlHelper.createXmlUtils;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
-
-import org.hibernate.validator.constraints.NotBlank;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.KeyValuePairSet;
 import com.adaptris.util.XmlUtils;
@@ -45,18 +44,14 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * </p>
  * 
  * @config xpath-produce-destination
- * @author lchan
- * @author $Author: lchan $
  */
 @XStreamAlias("xpath-produce-destination")
 @DisplayOrder(order = {"xpath", "defaultDestination", "namespaceContext", "xmlDocumentFactoryConfig"})
 public class XpathProduceDestination implements MessageDrivenDestination {
 
   @NotNull
-  @NotBlank
   private String xpath;
   @NotNull
-  @NotBlank
   private String defaultDestination;
 
   @AdvancedConfig
@@ -93,13 +88,16 @@ public class XpathProduceDestination implements MessageDrivenDestination {
    */
   @Override
   public boolean equals(Object obj) {
-    boolean rc = false;
+    if (obj == null) return false;
+    if (obj == this) return true;
     if (obj instanceof XpathProduceDestination) {
-      XpathProduceDestination x = (XpathProduceDestination) obj;
-      rc = getXpath().equals(x.getXpath())
-          && getDefaultDestination().equals(x.getDefaultDestination());
+      XpathProduceDestination item = (XpathProduceDestination) obj;
+      return new EqualsBuilder().append(item.getXpath(), this.getXpath())
+          .append(item.getDefaultDestination(), this.getDefaultDestination())
+          .append(item.getXmlDocumentFactoryConfig(), this.getXmlDocumentFactoryConfig())
+          .append(item.getNamespaceContext(), this.getNamespaceContext()).isEquals();
     }
-    return rc;
+    return false;
   }
 
   /**
@@ -108,15 +106,15 @@ public class XpathProduceDestination implements MessageDrivenDestination {
    */
   @Override
   public int hashCode() {
-    int hc = 0;
-    hc += xpath.hashCode();
-    hc += defaultDestination.hashCode();
-    return hc;
+    return new HashCodeBuilder().append(getXpath()).append(getDefaultDestination()).append(getXmlDocumentFactoryConfig())
+        .append(getNamespaceContext())
+        .toHashCode();
   }
 
   /**
    * @see ProduceDestination#getDestination(com.adaptris.core.AdaptrisMessage)
    */
+  @Override
   public String getDestination(AdaptrisMessage msg) {
     String result = defaultDestination;
     try {
@@ -128,7 +126,7 @@ public class XpathProduceDestination implements MessageDrivenDestination {
       XmlUtils xml = createXmlUtils(msg, ctx, builder);
       String s = xml.getSingleTextItem(xpath);
       if (isBlank(s)) {
-        logR.warn(xpath + " returned no results");
+        logR.warn("[{}] returned no results", xpath);
       }
       else {
         result = s;
@@ -137,7 +135,7 @@ public class XpathProduceDestination implements MessageDrivenDestination {
     catch (Exception e) {
       logR.warn("Exception caught attempting to parse message, using default destination");
     }
-    logR.trace("Returning [" + result + "]");
+    logR.trace("Returning [{}]", result);
     return result;
   }
 
@@ -158,10 +156,7 @@ public class XpathProduceDestination implements MessageDrivenDestination {
    * @param s the xpath
    */
   public void setXpath(String s) {
-    if (s == null) {
-      throw new IllegalArgumentException("Xpath may not be null");
-    }
-    xpath = s;
+    xpath = Args.notNull(s, "xpath");
   }
 
   /**
@@ -178,10 +173,7 @@ public class XpathProduceDestination implements MessageDrivenDestination {
    * @param s the defaultDestination to set
    */
   public void setDefaultDestination(String s) {
-    if (s == null) {
-      throw new IllegalArgumentException("DefaultDestination may not be null");
-    }
-    this.defaultDestination = s;
+    this.defaultDestination = Args.notNull(s, "defaultDestination");
   }
 
   /**
@@ -215,7 +207,7 @@ public class XpathProduceDestination implements MessageDrivenDestination {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcXPathParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcXPathParameter.java
@@ -17,13 +17,10 @@
 package com.adaptris.core.jdbc;
 import static com.adaptris.util.text.xml.XPath.newXPathInstance;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
-
 import org.hibernate.validator.constraints.NotBlank;
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
@@ -138,6 +135,6 @@ public class JdbcXPathParameter extends NullableParameter {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/XmlDocumentAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/XmlDocumentAggregator.java
@@ -17,12 +17,9 @@
 package com.adaptris.core.services.aggregator;
 
 import java.util.Collection;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
@@ -128,6 +125,6 @@ public class XmlDocumentAggregator extends MessageAggregatorImpl {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionAsXml.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ExceptionAsXml.java
@@ -16,13 +16,11 @@
 package com.adaptris.core.services.exception;
 
 import javax.validation.Valid;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
@@ -101,7 +99,6 @@ public class ExceptionAsXml implements ExceptionSerializer {
       Document newDoc =
           exceptionGenerator().create(exception, msg.getMetadataValue(Workflow.WORKFLOW_ID_KEY),
               (String) msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION_CAUSE));
-      documentFactoryBuilder().build().newDocumentBuilder().newDocument();
       Document result = documentMerge().merge(XmlHelper.createDocument(msg, documentFactoryBuilder(), ignoreXmlParseExceptions()),
           newDoc);
       String encoding = XmlHelper.getXmlEncoding(msg, getXmlEncoding());
@@ -191,7 +188,7 @@ public class ExceptionAsXml implements ExceptionSerializer {
   }
   
   private DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcDataQueryService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcDataQueryService.java
@@ -270,7 +270,7 @@ public class JdbcDataQueryService extends JdbcServiceWithParameters implements D
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 
   public JdbcStatementCreator getStatementCreator() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcIteratingDataCaptureServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/JdbcIteratingDataCaptureServiceImpl.java
@@ -19,18 +19,15 @@ package com.adaptris.core.services.jdbc;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-
 import javax.validation.Valid;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
@@ -220,7 +217,7 @@ public abstract class JdbcIteratingDataCaptureServiceImpl extends JdbcDataCaptur
   }
 
   private DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/SplittingXmlPayloadTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/SplittingXmlPayloadTranslator.java
@@ -236,7 +236,7 @@ public class SplittingXmlPayloadTranslator extends XmlPayloadTranslatorImpl {
   private DocumentBuilderFactoryBuilder documentFactoryBuilder(AdaptrisMessage msg) {
     DocumentBuilderFactoryBuilder factoryBuilder =
         (DocumentBuilderFactoryBuilder) msg.getObjectHeaders().get(JdbcDataQueryService.KEY_DOCBUILDER_FAC);
-    return DocumentBuilderFactoryBuilder.newInstance(factoryBuilder);
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(factoryBuilder);
   }
   
   public Integer getMaxRowsPerMessage() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/XmlPayloadTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/XmlPayloadTranslator.java
@@ -18,16 +18,13 @@ package com.adaptris.core.services.jdbc;
 
 import java.sql.SQLException;
 import java.util.List;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
@@ -159,7 +156,7 @@ public class XmlPayloadTranslator extends XmlPayloadTranslatorImpl {
   private DocumentBuilderFactoryBuilder documentFactoryBuilder(AdaptrisMessage msg) {
     DocumentBuilderFactoryBuilder factoryBuilder =
         (DocumentBuilderFactoryBuilder) msg.getObjectHeaders().get(JdbcDataQueryService.KEY_DOCBUILDER_FAC);
-    return DocumentBuilderFactoryBuilder.newInstance(factoryBuilder);
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(factoryBuilder);
   }
 
   private boolean isPreserveOriginalMessage() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/XpathMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/XpathMetadataService.java
@@ -20,13 +20,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
-
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -166,6 +163,6 @@ public class XpathMetadataService extends MetadataServiceImpl {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/XpathObjectMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/XpathObjectMetadataService.java
@@ -18,13 +18,10 @@ package com.adaptris.core.services.metadata;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
-
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -102,6 +99,7 @@ public class XpathObjectMetadataService extends ServiceImp {
 
   }
 
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     NamespaceContext namespaceCtx = SimpleNamespaceContext.create(getNamespaceContext(), msg);
     try {
@@ -172,6 +170,6 @@ public class XpathObjectMetadataService extends ServiceImp {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/path/XPathService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/path/XPathService.java
@@ -21,7 +21,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
@@ -33,13 +32,11 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -219,6 +216,7 @@ public class XPathService extends ServiceImp {
   }
 
   // @Override
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     NamespaceContext namespaceContext = SimpleNamespaceContext.create(getNamespaceContext(), msg);
     try {
@@ -304,7 +302,7 @@ public class XPathService extends ServiceImp {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder(NamespaceContext namespaceCtx) {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig(), namespaceCtx);
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig(), namespaceCtx);
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/XmlSyntaxIdentifierImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/XmlSyntaxIdentifierImpl.java
@@ -18,9 +18,7 @@ package com.adaptris.core.services.routing;
 
 import javax.validation.Valid;
 import javax.xml.namespace.NamespaceContext;
-
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
@@ -74,6 +72,6 @@ public abstract class XmlSyntaxIdentifierImpl extends SyntaxIdentifierImpl {
   }
 
   private DocumentBuilderFactoryBuilder documentFactoryBuilder(NamespaceContext nc) {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig(), nc);
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig(), nc);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathDocumentCopier.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathDocumentCopier.java
@@ -17,18 +17,14 @@
 package com.adaptris.core.services.splitter;
 
 import static com.adaptris.core.util.XmlHelper.createDocument;
-
 import java.io.IOException;
-
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
-
 import org.hibernate.validator.constraints.NotBlank;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
@@ -169,6 +165,6 @@ public class XpathDocumentCopier extends MessageCopier {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathMessageSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathMessageSplitter.java
@@ -17,22 +17,18 @@
 package com.adaptris.core.services.splitter;
 
 import static com.adaptris.core.util.XmlHelper.createDocument;
-
 import java.io.IOException;
-
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
-
 import org.hibernate.validator.constraints.NotBlank;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
@@ -192,7 +188,7 @@ public class XpathMessageSplitter extends MessageSplitterImp {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 
   private class XmlSplitGenerator extends SplitMessageIterator {
@@ -222,6 +218,7 @@ public class XpathMessageSplitter extends MessageSplitterImp {
       nodeListIndex = 0;
     }
 
+    @Override
     protected AdaptrisMessage constructAdaptrisMessage() throws Exception {
       if (nodeListIndex < nodeList.getLength()) {
         Node e = nodeList.item(nodeListIndex);

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlBasicValidator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlBasicValidator.java
@@ -17,7 +17,6 @@
 package com.adaptris.core.transform;
 
 import javax.validation.Valid;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -68,6 +67,6 @@ public class XmlBasicValidator extends MessageValidatorImpl {
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlRuleValidator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlRuleValidator.java
@@ -15,20 +15,16 @@
 package com.adaptris.core.transform;
 
 import static com.adaptris.core.util.XmlHelper.createDocument;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
@@ -174,6 +170,6 @@ public class XmlRuleValidator extends MessageValidatorImpl {
   }
 
   private DocumentBuilderFactoryBuilder documentFactoryBuilder(NamespaceContext nc) {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig(), nc);
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig(), nc);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/DocumentBuilderFactoryBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/DocumentBuilderFactoryBuilder.java
@@ -1,20 +1,19 @@
 package com.adaptris.core.util;
 
 import java.util.Map;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.xml.sax.EntityResolver;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -166,10 +165,18 @@ public class DocumentBuilderFactoryBuilder {
    * Convenient method for null protection.
    * 
    * @param b an existing DocumentBuilderFactoryBuilder instance (or null)
-   * @return a new instance or the passed parameter.
+   * @return a new instance or the passed parameter.]
+   * @deprecated since 3.9.1 this is poorly named, use
+   *             {@link #newInstanceIfNull(DocumentBuilderFactoryBuilder)} instead.
    */
+  @Deprecated
+  @Removal(version = "3.11.0")
   public static final DocumentBuilderFactoryBuilder newInstance(DocumentBuilderFactoryBuilder b) {
-    return b == null ? newInstance() : b;
+    return newInstanceIfNull(b);
+  }
+
+  public static final DocumentBuilderFactoryBuilder newInstanceIfNull(DocumentBuilderFactoryBuilder b) {
+    return ObjectUtils.defaultIfNull(b, newInstance());
   }
 
   /**
@@ -178,21 +185,39 @@ public class DocumentBuilderFactoryBuilder {
    * @param b an existing DocumentBuilderFactoryBuilder instance (or null)
    * @return a new instance or the passed parameter.
    * @see #newRestrictedInstance()
+   * @deprecated since 3.9.1 this is poorly named, use
+   *             {@link #newRestrictedInstanceIfNull(DocumentBuilderFactoryBuilder)} instead.
    */
+  @Deprecated
+  @Removal(version = "3.11.0")
   public static final DocumentBuilderFactoryBuilder newRestrictedInstance(DocumentBuilderFactoryBuilder b) {
-    return b == null ? newRestrictedInstance() : b;
+    return newRestrictedInstanceIfNull(b);
+  }
+
+  public static final DocumentBuilderFactoryBuilder newRestrictedInstanceIfNull(DocumentBuilderFactoryBuilder b) {
+    return ObjectUtils.defaultIfNull(b, newRestrictedInstance());
   }
 
   /**
    * Convenient method for null protection.
    * 
+   * @deprecated since 3.9.1 this is poorly named, use
+   *             {@link #newInstanceIfNull(DocumentBuilderFactoryBuilder, NamespaceContext)} instead.
    */
+  @Deprecated
+  @Removal(version = "3.11.0")
   public static final DocumentBuilderFactoryBuilder newInstance(DocumentBuilderFactoryBuilder b, NamespaceContext ctx) {
+    return newInstanceIfNull(b, ctx);
+  }
+
+
+  public static final DocumentBuilderFactoryBuilder newInstanceIfNull(DocumentBuilderFactoryBuilder b, NamespaceContext ctx) {
     if (b != null) {
       return b;
     }
     return ctx == null ? newInstance() : newInstance().withNamespaceAware(true);
   }
+
 
   /**
    * Configure a document builder factory
@@ -233,6 +258,15 @@ public class DocumentBuilderFactoryBuilder {
     return configure(configure(f).newDocumentBuilder());
   }
 
+  /**
+   * Create a {@link DocumentBuilderFactory}.
+   * 
+   * <p>
+   * If all you're doing is creating a {@link DocumentBuilder} straight after calling this method,
+   * don't forget to call {@link #configure(DocumentBuilder)} to make sure you configure the
+   * underlying {@link DocumentBuilder} with any configured {@link #getEntityResolver()}.
+   * </p>
+   */
   public DocumentBuilderFactory build() throws ParserConfigurationException {
     return configure(DocumentBuilderFactory.newInstance());
   }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/MappedResolver.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/MappedResolver.java
@@ -24,6 +24,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.core.util.Args;
 import com.adaptris.util.KeyValuePairSet;
 import com.adaptris.util.URLString;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -47,6 +48,7 @@ public class MappedResolver extends Resolver {
     setMappings(new KeyValuePairSet());
   }
 
+  @Override
   protected InputStream retrieveAndCache(URLString url) throws Exception {
     String key = url.toString();
     String candidate = getMappings().getValueIgnoringKeyCase(key);
@@ -54,7 +56,7 @@ public class MappedResolver extends Resolver {
       debugLog("[{}] mapped to [{}]", key, candidate);
       return super.retrieveAndCache(new URLString(candidate));
     }
-    debugLog("No mapping for [{}]; as-is", key);
+    debugLog("No mapping for [{}]; using as-is", key);
     return super.retrieveAndCache(url);
   }
 
@@ -72,7 +74,7 @@ public class MappedResolver extends Resolver {
    * @param kvps
    */
   public void setMappings(KeyValuePairSet kvps) {
-    this.mappings = kvps;
+    this.mappings = Args.notNull(kvps, "mappings");
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/Resolver.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/Resolver.java
@@ -72,13 +72,14 @@ public class Resolver implements EntityResolver, URIResolver {
     String key = url.toString();
     InputStream result = null;
     if (!hm.containsKey(key)) {
+      debugLog("Nothing in cache for [{}]", key);
       ByteArrayOutputStream output = new ByteArrayOutputStream();
       StreamUtil.copyAndClose(URLHelper.connect(url), output);
       hm.put(key, output);
       result = new ByteArrayInputStream(output.toByteArray());
     }
     else {
-      debugLog("Resolve from cache {}", key);
+      debugLog("Resolved from cache [{}]", key);
       result = new ByteArrayInputStream(hm.get(key).toByteArray());
     }
     return result;
@@ -123,8 +124,7 @@ public class Resolver implements EntityResolver, URIResolver {
         String url = base.substring(0, end + 1);
         myUrl = new URL(url + href);
       }
-      StreamSource ret = new StreamSource(retrieveAndCache(new URLString(myUrl)), myUrl.toExternalForm());
-      result = ret;
+      result = new StreamSource(retrieveAndCache(new URLString(myUrl)), myUrl.toExternalForm());
     }
     catch (Exception e) {
       debugLog("Couldn't handle [{}][{}], fallback to default parser behaviour", href, base);

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformer.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformer.java
@@ -16,8 +16,7 @@
 
 package com.adaptris.util.text.xml;
 
-import static com.adaptris.core.util.DocumentBuilderFactoryBuilder.newInstance;
-
+import static com.adaptris.core.util.DocumentBuilderFactoryBuilder.newInstanceIfNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,7 +24,6 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.Iterator;
 import java.util.Map;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
@@ -33,12 +31,10 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 
 /**
@@ -149,12 +145,17 @@ public class XmlTransformer {
     transform(transformer, xmlIn, xmlOut, xsl, null);
   }
 
+  private DocumentBuilder docBuilder() throws ParserConfigurationException {
+    DocumentBuilderFactoryBuilder myBuilder = newInstanceIfNull(builder);
+    return myBuilder.newDocumentBuilder(myBuilder.build());
+  }
+
   private Source createSource(InputStream in) throws ParserConfigurationException, SAXException, IOException {
-    return createSource(newInstance(builder).build().newDocumentBuilder(), new InputSource(in));
+    return createSource(docBuilder(), new InputSource(in));
   }
 
   private Source createSource(Reader in) throws ParserConfigurationException, SAXException, IOException {
-    return createSource(newInstance(builder).build().newDocumentBuilder(), new InputSource(in));
+    return createSource(docBuilder(), new InputSource(in));
   }
 
   private Source createSource(DocumentBuilder docBuilder, InputSource source) throws SAXException, IOException {

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
@@ -21,11 +21,9 @@ import javax.xml.transform.ErrorListener;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -68,7 +66,7 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XpathMergeImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XpathMergeImpl.java
@@ -16,10 +16,7 @@
 
 package com.adaptris.util.text.xml;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.KeyValuePairSet;
@@ -62,8 +59,8 @@ public abstract class XpathMergeImpl extends MergeImpl {
   }
 
   protected XmlUtils create(Document doc) throws Exception {
-    XmlUtils xml = new XmlUtils(SimpleNamespaceContext.create(getNamespaceContext()),
-        documentFactoryBuilder().configure(DocumentBuilderFactory.newInstance()));
+    DocumentBuilderFactoryBuilder builder = documentFactoryBuilder();
+    XmlUtils xml = new XmlUtils(builder.getEntityResolver(), SimpleNamespaceContext.create(getNamespaceContext()), builder.build());
     xml.setSource(doc);
     return xml;
   }
@@ -78,6 +75,6 @@ public abstract class XpathMergeImpl extends MergeImpl {
   }
 
   private DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return DocumentBuilderFactoryBuilder.newInstance(getXmlDocumentFactoryConfig());
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/XpathProduceDestinationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/XpathProduceDestinationTest.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
@@ -39,8 +40,7 @@ public class XpathProduceDestinationTest extends ExampleProduceDestinationCase {
   public void testSetNamespaceContext() {
     XpathProduceDestination obj = new XpathProduceDestination();
     assertNull(obj.getNamespaceContext());
-    KeyValuePairSet kvps = new KeyValuePairSet();
-    kvps.add(new KeyValuePair("hello", "world"));
+    KeyValuePairSet kvps = createContextEntries();
     obj.setNamespaceContext(kvps);
     assertEquals(kvps, obj.getNamespaceContext());
     obj.setNamespaceContext(null);
@@ -112,12 +112,14 @@ public class XpathProduceDestinationTest extends ExampleProduceDestinationCase {
 
   public void testValidXpathDestination() {
     XpathProduceDestination dest1 = new XpathProduceDestination(DEST_XPATH, DEFAULT_DEST);
+    dest1.setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder.newInstance());
     String s = dest1.getDestination(AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_DOC));
     assertEquals("Value from Xpath", "value", s);
   }
 
   public void testValidXpathFunctionDestination() {
     XpathProduceDestination dest1 = new XpathProduceDestination(DEST_XPATH_WITH_FUNCTION, DEFAULT_DEST);
+    dest1.setNamespaceContext(createContextEntries());
     String s = dest1.getDestination(AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_DOC));
     assertEquals("Value from Xpath", "root", s);
   }
@@ -157,6 +159,17 @@ public class XpathProduceDestinationTest extends ExampleProduceDestinationCase {
         + "<!--\n\nThis ProduceDestination implementation derives its destination from an XML document"
         + "\nConfigure an XPath to retrieve some data from the document, and this will be used" + "\nas the destination."
         + "\nIf the XPath cannot be evaluated then the default destination will be used" + "\n\n-->\n";
+  }
+
+  private KeyValuePairSet createContextEntries() {
+    KeyValuePairSet contextEntries = new KeyValuePairSet();
+    contextEntries.add(new KeyValuePair("svrl", "http://purl.oclc.org/dsdl/svrl"));
+    contextEntries.add(new KeyValuePair("xsd", "http://www.w3.org/2001/XMLSchema"));
+    contextEntries.add(new KeyValuePair("xs", "http://www.w3.org/2001/XMLSchema"));
+    contextEntries.add(new KeyValuePair("sch", "http://www.ascc.net/xml/schematron"));
+    contextEntries.add(new KeyValuePair("iso", "http://purl.oclc.org/dsdl/schematron"));
+    contextEntries.add(new KeyValuePair("dp", "http://www.dpawson.co.uk/ns#"));
+    return contextEntries;
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/XpathProduceDestinationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/XpathProduceDestinationTest.java
@@ -51,6 +51,7 @@ public class XpathProduceDestinationTest extends ExampleProduceDestinationCase {
     assertEquals(new XpathProduceDestination(), new XpathProduceDestination());
     XpathProduceDestination d1 = new XpathProduceDestination(DEST_XPATH);
     XpathProduceDestination d2 = new XpathProduceDestination(DEST_XPATH);
+    assertFalse(d1.equals(null));
     assertNotSame(new XpathProduceDestination(), d1);
     assertEquals(d1, d2);
     assertEquals(d2, d1);

--- a/interlok-core/src/test/java/com/adaptris/core/util/DocumentBuilderFactoryBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/DocumentBuilderFactoryBuilderTest.java
@@ -19,18 +19,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
-
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 import com.adaptris.util.text.xml.Resolver;
@@ -56,6 +52,7 @@ public class DocumentBuilderFactoryBuilderTest {
   public void tearDown() throws Exception {}
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testNewInstance() {
     DocumentBuilderFactoryBuilder b = DocumentBuilderFactoryBuilder.newInstance();
     assertNotNull(b.getFeatures());
@@ -67,6 +64,7 @@ public class DocumentBuilderFactoryBuilderTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testNewRestrictedInstance() {
     DocumentBuilderFactoryBuilder b = DocumentBuilderFactoryBuilder.newRestrictedInstance();
     assertNotNull(b.getFeatures());

--- a/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
@@ -20,14 +20,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
-
 import javax.xml.namespace.NamespaceContext;
-
 import org.junit.Test;
 import org.w3c.dom.Document;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;


### PR DESCRIPTION
- Make sure that creation of XmlUtils uses the entity from the builder; This has the side effect of having no caching Resolver; however this is acceptable since most of the time the XmlUtils class is gc'd so
the caching is somewhat pointless.
- Improve logging in the Resolvers
- Deprecated newInstance() methods in DocumentBuilderFactoryBuilder since they are really poorly named!