### PR TITLE
INTERLOK-2902 Add file on the login-service-factory

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/core/management/webserver/JettyServerManager.java
+++ b/interlok-common/src/main/java/com/adaptris/core/management/webserver/JettyServerManager.java
@@ -60,6 +60,16 @@ public class JettyServerManager implements ServerManager {
   private static final String DEFAULT_DESCRIPTOR_XML = "com/adaptris/core/management/webserver/jetty-webdefault-failsafe.xml";
   private static final String OVERRIDE_DESCRIPTOR_XML = "jetty-webdefault.xml";
 
+  /**
+   * System property that controls whether or not starting the {@code WebAppContext} should throw an exception or not.
+   * <p>
+   * The default is false for backwards compatibility; but can be toggled to true; it will be defaulted to true in a future release.
+   * </p>
+   */
+  public static final String SYS_PROP_THROW_UNAVAILABLE_EXCEPTION = "interlok.jetty.throw.unavailable.on.startup";
+
+  private static final boolean THROW_UNAVAILABLE_ON_START = Boolean.getBoolean(SYS_PROP_THROW_UNAVAILABLE_EXCEPTION);
+
   public static final String CONTEXT_PATH = "contextPath";
   /**
    * @deprecated since 3.9.1 has no meaning and is ignored.
@@ -140,6 +150,7 @@ public class JettyServerManager implements ServerManager {
     // Have to stop the WAR before we can reconfigure the security handler, not true if we just want
     // to add a new servlet; but it's probaby good practice to.
     rootWar.stop();
+    rootWar.setThrowUnavailableOnStartupException(THROW_UNAVAILABLE_ON_START);
     String pathSpec = (String) additionalProperties.get(CONTEXT_PATH);
     log.trace("Adding servlet to existing ROOT WebAppContext against {}", pathSpec);
     rootWar.addServlet(servlet, pathSpec);

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/HashLoginServiceFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/HashLoginServiceFactory.java
@@ -64,7 +64,7 @@ public class HashLoginServiceFactory extends LoginServiceFactoryImpl {
 
   @Override
   public LoginService retrieveLoginService() throws Exception {
-    HashLoginService loginService = new HashLoginService(getUserRealm(), getFilename());
+    HashLoginService loginService = new HashLoginService(getUserRealm(), validateFilename());
     loginService.setHotReload(true);
     return new LoginServiceProxy().withLoginService(loginService);
   }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JdbcLoginServiceFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JdbcLoginServiceFactory.java
@@ -25,7 +25,7 @@ public class JdbcLoginServiceFactory extends LoginServiceFactoryImpl {
 
   @Override
   public LoginService retrieveLoginService() throws Exception {
-    JDBCLoginService loginService = new JDBCLoginService(getUserRealm(), getFilename());
+    JDBCLoginService loginService = new JDBCLoginService(getUserRealm(), validateFilename());
     return new LoginServiceProxy().withLoginService(loginService);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/LoginServiceFactoryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/LoginServiceFactoryImpl.java
@@ -1,10 +1,13 @@
 package com.adaptris.core.http.jetty;
 
+import java.io.File;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.Args;
+import com.adaptris.fs.FsWorker;
 
 /**
  * Abstract configuration for bundled {@code org.eclipse.jetty.security.LoginService} implementations.
@@ -45,6 +48,10 @@ public abstract class LoginServiceFactoryImpl implements JettyLoginServiceFactor
     return filename;
   }
 
+  public String validateFilename() throws Exception {
+    return FsWorker.checkReadable(new File(getFilename())).getCanonicalPath();
+  }
+
   /**
    * Set the filename containing the configuration for the concrete class.
    * <p>
@@ -63,4 +70,5 @@ public abstract class LoginServiceFactoryImpl implements JettyLoginServiceFactor
     setFilename(s);
     return (T) this;
   }
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/LoginServiceFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/LoginServiceFactoryTest.java
@@ -25,14 +25,19 @@ import org.eclipse.jetty.security.JDBCLoginService;
 import org.eclipse.jetty.security.LoginService;
 import org.junit.Test;
 
+import com.adaptris.core.BaseCase;
+
 public class LoginServiceFactoryTest {
+
 
   @Test
   public void testCreateHashLoginService() throws Exception {
+    // So we don't fall foul of INTERLOK-2902
+    String realm = BaseCase.PROPERTIES.getProperty(HttpConsumerTest.JETTY_USER_REALM);
     HashLoginServiceFactory factory =
-        new HashLoginServiceFactory().withUserRealm("InterlokJetty").withFilename("/path/to/properties");
+        new HashLoginServiceFactory().withUserRealm("InterlokJetty").withFilename(realm);
     assertEquals("InterlokJetty", factory.getUserRealm());
-    assertEquals("/path/to/properties", factory.getFilename());
+    assertNotNull(factory.getFilename());
     LoginService loginService = factory.retrieveLoginService();
     assertNotNull(loginService);
     assertTrue(loginService instanceof LoginServiceProxy);
@@ -43,10 +48,13 @@ public class LoginServiceFactoryTest {
 
   @Test
   public void testCreateJdbcLoginService() throws Exception {
+    // while the realm.properties doesn't actually contain the right info, it will
+    // exist so we don't fall foul of INTERLOK-2902
+    String realm = BaseCase.PROPERTIES.getProperty(HttpConsumerTest.JETTY_USER_REALM);
     JdbcLoginServiceFactory factory =
-        new JdbcLoginServiceFactory().withUserRealm("InterlokJetty").withFilename("/path/to/properties");
+        new JdbcLoginServiceFactory().withUserRealm("InterlokJetty").withFilename(realm);
     assertEquals("InterlokJetty", factory.getUserRealm());
-    assertEquals("/path/to/properties", factory.getFilename());
+    assertNotNull(factory.getFilename());
     LoginService loginService = factory.retrieveLoginService();
     assertNotNull(loginService);
     assertTrue(loginService instanceof LoginServiceProxy);


### PR DESCRIPTION
- Add file verification using FsWorker.checkReadable() when create the actual login services.
- Add a system property that controls whether or not we call setThrowUnavailableOnStartupException on the webapp context