### PR TITLE
INTERLOK-2663 Add rare as an attribute to AdvancedConfig

### DIFF
--- a/interlok-core-apt/src/main/java/com/adaptris/annotation/AdvancedConfig.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/annotation/AdvancedConfig.java
@@ -24,10 +24,16 @@ import java.lang.annotation.Target;
 /**
  * An interface for making a "hint" for the UI where to display this field.
  * 
- * @author lchan
  * @since 3.0.5
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface AdvancedConfig {
+  /**
+   * Whether or not this field should be considered 'rare' and hidden most of the time.
+   * 
+   * @return true if enabled, defaults to false.
+   * @since 3.9.2
+   */
+  boolean rare() default false;
 }

--- a/interlok-core/src/main/java/com/adaptris/core/Adapter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/Adapter.java
@@ -75,14 +75,14 @@ public final class Adapter implements StateManagedComponentContainer, ComponentL
   @NotNull
   @AutoPopulated
   @NotBlank
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private String startUpEventImp;
   @NotNull
   @AutoPopulated
   @NotBlank
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private String heartbeatEventImp;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @Valid
   private LogHandler logHandler;
   @NotNull

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
@@ -19,13 +19,10 @@ package com.adaptris.core;
 import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
-
 import javax.validation.Valid;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.Removal;
@@ -41,7 +38,7 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @Deprecated
   @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   private String lookupName;

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageWorkerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageWorkerImp.java
@@ -18,16 +18,12 @@ package com.adaptris.core;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-
 import javax.validation.Valid;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.ManagedThreadFactory;
@@ -46,7 +42,7 @@ public abstract class AdaptrisMessageWorkerImp implements AdaptrisMessageWorker 
   @AdvancedConfig
   @Valid
   private AdaptrisMessageEncoder encoder;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "false")
   private Boolean isTrackingEndpoint;
 

--- a/interlok-core/src/main/java/com/adaptris/core/QuartzCronPoller.java
+++ b/interlok-core/src/main/java/com/adaptris/core/QuartzCronPoller.java
@@ -216,7 +216,7 @@ public class QuartzCronPoller extends PollerImp {
   private String quartzId;
   @AdvancedConfig
   private String schedulerGroup;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "true")
   private Boolean useCustomThreadPool;
 

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
@@ -18,21 +18,17 @@ package com.adaptris.core;
 
 import static com.adaptris.core.util.LoggingHelper.friendlyName;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-
 import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -53,7 +49,7 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
   private static final OutOfStateHandler DEFAULT_STATE_HANDLER = new RaiseExceptionOutOfStateHandler();
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @Deprecated
   @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   private String lookupName;
@@ -64,7 +60,7 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean continueOnFail;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "false")
   private Boolean isTrackingEndpoint;
   @AdvancedConfig
@@ -412,7 +408,7 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
       log.debug("Service restarts on error, restarting [{}]", serviceName);
       restartService(service);
     } 
-    if ((service != null) && (service.continueOnFailure())) {
+    if (service != null && service.continueOnFailure()) {
       log.debug("continue-on-fail is true, ignoring Exception [{}] from [{}]", e.getMessage(), serviceName);
     }
     else {

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
@@ -17,11 +17,9 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.Removal;
@@ -43,7 +41,7 @@ public abstract class ServiceImp implements Service {
   private transient ComponentState serviceState;
   private transient boolean prepared = false;
   
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @Deprecated
   @Removal(version = "3.11.0", message = "Will be removed to avoid JNDI ambiguity")
   private String lookupName;
@@ -52,7 +50,7 @@ public abstract class ServiceImp implements Service {
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean continueOnFail;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "false")
   private Boolean isTrackingEndpoint;
 

--- a/interlok-core/src/main/java/com/adaptris/core/SharedServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedServiceImpl.java
@@ -1,12 +1,10 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.hibernate.validator.constraints.NotBlank;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -24,7 +22,7 @@ public abstract class SharedServiceImpl extends SharedComponent implements Servi
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean continueOnFail;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "false")
   private Boolean isTrackingEndpoint;
 

--- a/interlok-core/src/main/java/com/adaptris/core/StandaloneConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandaloneConsumer.java
@@ -44,7 +44,7 @@ public class StandaloneConsumer implements AdaptrisMessageConsumer, StateManaged
 
   private AdaptrisConnection connection;
   private AdaptrisMessageConsumer consumer;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "false")
   private Boolean isTrackingEndpoint;
   private transient ComponentState consumerState;

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -105,7 +105,7 @@ public abstract class WorkflowImp implements Workflow {
   @AutoPopulated
   private List<WorkflowInterceptor> interceptors;
   @Valid
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private TimeInterval channelUnavailableWaitInterval;
   @AdvancedConfig
   @InputFieldDefault(value = "message-logger-default")

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
@@ -100,9 +100,9 @@ public class FsConsumer extends FsConsumerImpl {
 
   @NotBlank
   @AutoPopulated
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private String wipSuffix;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "false")
   private Boolean resetWipFiles;
 

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsImmediateEventPoller.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsImmediateEventPoller.java
@@ -27,9 +27,7 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.PollerImp;
 import com.adaptris.util.TimeInterval;
@@ -61,10 +59,8 @@ public class FsImmediateEventPoller extends PollerImp {
 
   private static final long DEFAULT_CREATION_COMPLETE_CHECK_MS = 500;
   
-  @NotNull
-  @AutoPopulated
   @Valid
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private TimeInterval creationCompleteCheck;
 
   private transient boolean stopped = false;

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
@@ -78,9 +78,9 @@ public class FtpConsumer extends FtpConsumerImpl {
   @NotNull
   @AutoPopulated
   private String workDirectory = "/work";
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private String procDirectory;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private String wipSuffix;
 
   public FtpConsumer() {

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpProducer.java
@@ -97,11 +97,11 @@ public class FtpProducer extends RequestReplyProducerImp {
 
   private String destDirectory;
   private String buildDirectory;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private String replyDirectory = null;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private String replyProcDirectory = null;
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "true")
   private Boolean replyUsesEncoder;
   @Valid

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyAsyncWorkflowInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyAsyncWorkflowInterceptor.java
@@ -16,15 +16,11 @@
 package com.adaptris.core.http.jetty;
 
 import static com.adaptris.core.http.jetty.JettyConstants.JETTY_WRAPPER;
-
 import java.util.concurrent.TimeUnit;
-
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -36,7 +32,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
 import net.jodah.expiringmap.ExpiringMap;
 
 /**
@@ -113,7 +108,7 @@ public class JettyAsyncWorkflowInterceptor extends JettyWorkflowInterceptorImpl 
 
   @InputFieldHint(style = "BLANKABLE")
   @InputFieldDefault(value = "")
-  @AdvancedConfig
+  @AdvancedConfig(rare = true)
   private String cacheKey;
 
   @Override


### PR DESCRIPTION
- Mark channel-wait-unavailable as rare in workflowImp
- Mark is-tracking-endpoint as rare in services.
- Mark startupEventImp / heartbeatEventImp as rare in Adapter
- Mark wipSuffix as rare in Fs / FtpConsumer
- Mark cacheKey as rare in JettyAsyncInterceptor
- Mark useCustomThreadPool as rare in QuartzCronPoller
This should cover at least one of each of the main types of object that have dedicated settings