### PR TITLE
INTERLOK-2965 simplified cache services

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
@@ -1,0 +1,37 @@
+package com.adaptris.core.services.cache;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Simplified version of {@link AddToCacheService} that doesn't use {@link CacheEntryEvaluators}.
+ * 
+ * <p>
+ * Most of the time, you only want to add a single item to the cache rather than a list of items;
+ * this simplified service allows you to do just that. It does not have a list of entries that are
+ * evaluated, you simply specify a key and a {@link CacheValueTranslator} which is used to extract
+ * the value for storing in the cache; no checking is done of the resulting serializable-ness (or
+ * not) of the value, it is simply inserted into the cache.
+ * </p>
+ * 
+ * @config add-single-value-to-cache
+ */
+@XStreamAlias("add-single-value-to-cache")
+@ComponentProfile(summary = "Add a single key/value to the configured cache cache", since = "3.9.2", tag = "service,cache",
+    recommended = {CacheConnection.class})
+public class AddValueToCache extends SingleKeyValueCacheImpl {
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      Cache cache = retrieveCache();
+      cache.put(msg.resolve(getKey()), getValueTranslator().getValueFromMessage(msg));
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
@@ -8,7 +8,7 @@ import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Simplified version of {@link AddToCacheService} that doesn't use {@link CacheEntryEvaluators}.
+ * Version of {@link AddToCacheService} that doesn't use {@link CacheEntryEvaluators}.
  * 
  * <p>
  * Most of the time, you only want to add a single item to the cache rather than a list of items;

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheEntryEvaluator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheEntryEvaluator.java
@@ -16,17 +16,15 @@
 package com.adaptris.core.services.cache;
 
 import javax.validation.Valid;
-
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -157,7 +155,7 @@ public class CacheEntryEvaluator {
    * @return the configured key translator via {@link #setKeyTranslator(CacheKeyTranslator)} or a default translator if null.
    */
   public CacheKeyTranslator keyTranslator() {
-    return getKeyTranslator() != null ? getKeyTranslator() : new NullCacheTranslator();
+    return ObjectUtils.defaultIfNull(getKeyTranslator(), (msg) -> null);
   }
 
   /**
@@ -184,7 +182,7 @@ public class CacheEntryEvaluator {
    * @return the configured key translator via {@link #setValueTranslator(CacheValueTranslator)} or a default translator if null.
    */
   public CacheValueTranslator valueTranslator() {
-    return getValueTranslator() != null ? getValueTranslator() : new NullCacheTranslator();
+    return ObjectUtils.defaultIfNull(getValueTranslator(), (msg) -> null);
   }
 
   public String getFriendlyName() {
@@ -201,23 +199,6 @@ public class CacheEntryEvaluator {
   }
 
   public String friendlyName() {
-    return getFriendlyName() == null ? this.getClass().getSimpleName() : getFriendlyName();
-  }
-
-  private class NullCacheTranslator implements CacheValueTranslator, CacheKeyTranslator {
-
-    @Override
-    public Object getValueFromMessage(AdaptrisMessage msg) throws CoreException {
-      return null;
-    }
-
-    @Override
-    public void addValueToMessage(AdaptrisMessage msg, Object value) throws CoreException {
-    }
-
-    @Override
-    public String getKeyFromMessage(AdaptrisMessage msg) throws CoreException {
-      return null;
-    }
+    return ObjectUtils.defaultIfNull(getFriendlyName(), this.getClass().getSimpleName());
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheKeyTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheKeyTranslator.java
@@ -22,6 +22,7 @@ import com.adaptris.core.CoreException;
  * Get the key from the message.
  *
  */
+@FunctionalInterface
 public interface CacheKeyTranslator {
 
   String getKeyFromMessage(AdaptrisMessage msg) throws CoreException;

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheServiceBase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheServiceBase.java
@@ -20,28 +20,17 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AutoPopulated;
-import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.ConnectedService;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
-import com.adaptris.core.cache.Cache;
-import com.adaptris.core.cache.CacheProvider;
 import com.adaptris.core.util.Args;
-import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Base class that provides common functions used by all cache services
  * 
  */
-public abstract class CacheServiceBase extends ServiceImp implements ConnectedService {
-
-  @Valid
-  @NotNull
-  private AdaptrisConnection connection;
+public abstract class CacheServiceBase extends CacheServiceImpl {
 
   @Valid
   @XStreamImplicit
@@ -51,45 +40,6 @@ public abstract class CacheServiceBase extends ServiceImp implements ConnectedSe
 
   public CacheServiceBase() {
     setCacheEntryEvaluators(new ArrayList<CacheEntryEvaluator>());
-  }
-
-
-  @Override
-  public void prepare() throws CoreException {
-    try {
-      Args.notNull(getConnection(), "connection");
-      LifecycleHelper.prepare(getConnection());
-    }
-    catch (IllegalArgumentException e) {
-      throw ExceptionHelper.wrapCoreException(e);
-    }
-  }
-
-  @Override
-  public void closeService() {
-    LifecycleHelper.close(getConnection());
-  }
-
-  @Override
-  public void initService() throws CoreException {
-    LifecycleHelper.init(getConnection());
-
-  }
-
-  @Override
-  public void start() throws CoreException {
-    super.start();
-    LifecycleHelper.start(getConnection());
-  }
-
-  @Override
-  public void stop() {
-    super.stop();
-    LifecycleHelper.stop(getConnection());
-  }
-
-  protected Cache retrieveCache() {
-    return getConnection().retrieveConnection(CacheProvider.class).retrieveCache();
   }
 
   public List<CacheEntryEvaluator> getCacheEntryEvaluators() {
@@ -106,16 +56,6 @@ public abstract class CacheServiceBase extends ServiceImp implements ConnectedSe
 
   public void addCacheEntryEvaluator(CacheEntryEvaluator generator) {
     cacheEntryEvaluators.add(generator);
-  }
-
-  @Override
-  public AdaptrisConnection getConnection() {
-    return connection;
-  }
-
-  @Override
-  public void setConnection(AdaptrisConnection cacheConnection) {
-    this.connection = Args.notNull(cacheConnection, "connection");
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheServiceBase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheServiceBase.java
@@ -17,13 +17,10 @@ package com.adaptris.core.services.cache;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.AdaptrisConnection;
-import com.adaptris.core.AdaptrisConnectionImp;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConnectedService;
 import com.adaptris.core.CoreException;
@@ -43,10 +40,8 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 public abstract class CacheServiceBase extends ServiceImp implements ConnectedService {
 
   @Valid
+  @NotNull
   private AdaptrisConnection connection;
-
-  // All this for backwards compatibility. dammit.
-  private transient AdaptrisConnection cacheConnection;
 
   @Valid
   @XStreamImplicit
@@ -62,8 +57,8 @@ public abstract class CacheServiceBase extends ServiceImp implements ConnectedSe
   @Override
   public void prepare() throws CoreException {
     try {
-      cacheConnection = Args.notNull(connection, "connection");
-      LifecycleHelper.prepare(cacheConnection);
+      Args.notNull(getConnection(), "connection");
+      LifecycleHelper.prepare(getConnection());
     }
     catch (IllegalArgumentException e) {
       throw ExceptionHelper.wrapCoreException(e);
@@ -72,29 +67,29 @@ public abstract class CacheServiceBase extends ServiceImp implements ConnectedSe
 
   @Override
   public void closeService() {
-    LifecycleHelper.close(cacheConnection);
+    LifecycleHelper.close(getConnection());
   }
 
   @Override
   public void initService() throws CoreException {
-    LifecycleHelper.init(cacheConnection);
+    LifecycleHelper.init(getConnection());
 
   }
 
   @Override
   public void start() throws CoreException {
     super.start();
-    LifecycleHelper.start(cacheConnection);
+    LifecycleHelper.start(getConnection());
   }
 
   @Override
   public void stop() {
     super.stop();
-    LifecycleHelper.stop(cacheConnection);
+    LifecycleHelper.stop(getConnection());
   }
 
   protected Cache retrieveCache() {
-    return cacheConnection.retrieveConnection(CacheProvider.class).retrieveCache();
+    return getConnection().retrieveConnection(CacheProvider.class).retrieveCache();
   }
 
   public List<CacheEntryEvaluator> getCacheEntryEvaluators() {
@@ -120,7 +115,7 @@ public abstract class CacheServiceBase extends ServiceImp implements ConnectedSe
 
   @Override
   public void setConnection(AdaptrisConnection cacheConnection) {
-    this.connection = cacheConnection;
+    this.connection = Args.notNull(cacheConnection, "connection");
   }
 
   /**
@@ -139,44 +134,6 @@ public abstract class CacheServiceBase extends ServiceImp implements ConnectedSe
       }
     }
     cvt.addValueToMessage(msg, value);
-  }
-
-  private class CacheWrapper extends AdaptrisConnectionImp implements CacheProvider {
-    private Cache myCache;
-    public CacheWrapper(Cache c) {
-      myCache = c;
-    }
-
-    @Override
-    protected void prepareConnection() throws CoreException {
-      LifecycleHelper.prepare(myCache);
-    }
-
-    @Override
-    protected void initConnection() throws CoreException {
-      LifecycleHelper.init(myCache);
-    }
-
-    @Override
-    protected void startConnection() throws CoreException {
-      LifecycleHelper.start(myCache);
-    }
-
-    @Override
-    protected void stopConnection() {
-      LifecycleHelper.stop(myCache);
-    }
-
-    @Override
-    protected void closeConnection() {
-      LifecycleHelper.close(myCache);
-    }
-
-    @Override
-    public Cache retrieveCache() {
-      return myCache;
-    }
-
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheServiceImpl.java
@@ -1,0 +1,80 @@
+package com.adaptris.core.services.cache;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.ConnectedService;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.SharedConnection;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.cache.CacheProvider;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
+
+public abstract class CacheServiceImpl extends ServiceImp implements ConnectedService {
+  @Valid
+  @NotNull
+  private AdaptrisConnection connection;
+
+
+  @Override
+  public void prepare() throws CoreException {
+    try {
+      Args.notNull(getConnection(), "connection");
+      LifecycleHelper.prepare(getConnection());
+    } catch (IllegalArgumentException e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
+  }
+
+  @Override
+  public void closeService() {
+    LifecycleHelper.close(getConnection());
+  }
+
+  @Override
+  public void initService() throws CoreException {
+    LifecycleHelper.init(getConnection());
+
+  }
+
+  @Override
+  public void start() throws CoreException {
+    super.start();
+    LifecycleHelper.start(getConnection());
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+    LifecycleHelper.stop(getConnection());
+  }
+
+  protected Cache retrieveCache() {
+    return getConnection().retrieveConnection(CacheProvider.class).retrieveCache();
+  }
+
+  @Override
+  public AdaptrisConnection getConnection() {
+    return connection;
+  }
+
+  /**
+   * Set the connection associated with this cache service.
+   * 
+   * @see CacheConnection
+   * @see SharedConnection
+   */
+  @Override
+  public void setConnection(AdaptrisConnection cacheConnection) {
+    this.connection = Args.notNull(cacheConnection, "connection");
+  }
+
+  public <T extends CacheServiceImpl> T withConnection(AdaptrisConnection c) {
+    setConnection(c);
+    return (T) this;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheValueTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheValueTranslator.java
@@ -23,6 +23,7 @@ import com.adaptris.core.CoreException;
  * value into one.
  *
  */
+@FunctionalInterface
 public interface CacheValueTranslator<S> {
 
   /**
@@ -33,8 +34,12 @@ public interface CacheValueTranslator<S> {
 
   /**
    * Injects the supplied Object value into the message,
-   *
+   * 
+   * @implNote The default implementation throws an UnsupportedOperationException and should be
+   *           overridden.
    */
-  void addValueToMessage(AdaptrisMessage msg, S value) throws CoreException;
+  default void addValueToMessage(AdaptrisMessage msg, S value) throws CoreException {
+    throw new UnsupportedOperationException("Add value is not supported for this type of translator");
+  }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/GetValueFromCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/GetValueFromCache.java
@@ -1,0 +1,72 @@
+package com.adaptris.core.services.cache;
+
+import org.apache.commons.lang3.BooleanUtils;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Simplified version of {@link RetrieveFromCacheService} that doesn't use
+ * {@link CacheEntryEvaluators}.
+ * 
+ * <p>
+ * Most of the time, you only want to retrieve a single item to the cache rather than a list of
+ * items; this simplified service allows you to do just that. It does not have a list of entries
+ * that are evaluated, you simply specify a key and a {@link CacheValueTranslator} which is used to
+ * insert the value from the cache.
+ * </p>
+ * 
+ * @config get-single-value-from-cache
+ */
+@XStreamAlias("get-single-value-from-cache")
+@ComponentProfile(summary = "Retrieve a value from the configured cache", since = "3.9.2", tag = "service,cache",
+    recommended = {CacheConnection.class})
+public class GetValueFromCache extends SingleKeyValueCacheImpl {
+
+  @InputFieldDefault(value = "true")
+  private Boolean exceptionIfNotFound;
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      Cache cache = retrieveCache();
+      String key = msg.resolve(getKey());
+      Object value = cache.get(key);
+      if (value != null || !exceptionIfNotFound()) {
+        getValueTranslator().addValueToMessage(msg, value);
+      } else {
+        throw new ServiceException(String.format("%s not found in cache", key));
+      }
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+
+  public Boolean getExceptionIfNotFound() {
+    return exceptionIfNotFound;
+  }
+
+  /**
+   * Whether or not to throw an exception if the key is not in the cache.
+   *
+   * @param b default is true
+   */
+  public void setExceptionIfNotFound(Boolean b) {
+    exceptionIfNotFound = b;
+  }
+
+  public GetValueFromCache withExceptionIfNotFound(Boolean b) {
+    setExceptionIfNotFound(b);
+    return this;
+  }
+
+  private boolean exceptionIfNotFound() {
+    return BooleanUtils.toBooleanDefaultIfNull(getExceptionIfNotFound(), true);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/GetValueFromCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/GetValueFromCache.java
@@ -10,14 +10,13 @@ import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Simplified version of {@link RetrieveFromCacheService} that doesn't use
- * {@link CacheEntryEvaluators}.
+ * Version of {@link RetrieveFromCacheService} that doesn't use {@link CacheEntryEvaluators}.
  * 
  * <p>
  * Most of the time, you only want to retrieve a single item to the cache rather than a list of
  * items; this simplified service allows you to do just that. It does not have a list of entries
  * that are evaluated, you simply specify a key and a {@link CacheValueTranslator} which is used to
- * insert the value from the cache.
+ * insert the value from the cache into the current message.
  * </p>
  * 
  * @config get-single-value-from-cache

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/RemoveKeyFromCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/RemoveKeyFromCache.java
@@ -8,10 +8,11 @@ import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Simplified version of {@link RemoveFromCacheService} that doesn't retrieve the value.
+ * Simplified version of {@link RemoveFromCacheService} that doesn't retrieve the value for
+ * insertion into the message.
  * 
  * 
- * @config remove-keyfrom-cache
+ * @config remove-key-from-cache
  */
 @XStreamAlias("remove-key-from-cache")
 @ComponentProfile(summary = "Remove a key from the configured cache", since = "3.9.2", tag = "service,cache",

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/RemoveKeyFromCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/RemoveKeyFromCache.java
@@ -1,0 +1,30 @@
+package com.adaptris.core.services.cache;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Simplified version of {@link RemoveFromCacheService} that doesn't retrieve the value.
+ * 
+ * 
+ * @config remove-keyfrom-cache
+ */
+@XStreamAlias("remove-key-from-cache")
+@ComponentProfile(summary = "Remove a key from the configured cache", since = "3.9.2", tag = "service,cache",
+    recommended = {CacheConnection.class})
+public class RemoveKeyFromCache extends SingleKeyCacheService {
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      Cache cache = retrieveCache();
+      cache.remove(msg.resolve(getKey()));
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/SingleKeyCacheService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/SingleKeyCacheService.java
@@ -1,0 +1,36 @@
+package com.adaptris.core.services.cache;
+
+import javax.validation.constraints.NotBlank;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.Args;
+
+public abstract class SingleKeyCacheService extends CacheServiceImpl {
+  @InputFieldHint(expression = true)
+  @NotBlank
+  private String key;
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notBlank(getKey(), "key");
+    super.prepare();
+  }
+
+  public <T extends SingleKeyCacheService> T withKey(String s) {
+    setKey(s);
+    return (T) this;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  /**
+   * Set the cache key.
+   * 
+   * @param key the key.
+   */
+  public void setKey(String key) {
+    this.key = Args.notBlank(key, "key");
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/SingleKeyCacheService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/SingleKeyCacheService.java
@@ -28,7 +28,7 @@ public abstract class SingleKeyCacheService extends CacheServiceImpl {
   /**
    * Set the cache key.
    * 
-   * @param key the key.
+   * @param key the key, which supports the {@code %message{}} syntax to resolve metadata.
    */
   public void setKey(String key) {
     this.key = Args.notBlank(key, "key");

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/SingleKeyValueCacheImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/SingleKeyValueCacheImpl.java
@@ -1,0 +1,44 @@
+package com.adaptris.core.services.cache;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.Args;
+
+
+public abstract class SingleKeyValueCacheImpl extends SingleKeyCacheService {
+
+  @Valid
+  @NotNull
+  private CacheValueTranslator valueTranslator;
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notNull(getValueTranslator(), "valueTranslator");
+    super.prepare();
+  }
+
+  /**
+   * What to do with the cache-value.
+   * 
+   * @param translator default is null, which depending on the concrete classes has different
+   *        meanings.
+   */
+  public void setValueTranslator(CacheValueTranslator translator) {
+    valueTranslator = Args.notNull(translator, "valueTranslator");
+  }
+
+  /**
+   * Get the configured value translator.
+   *
+   * @return the configured value translator.
+   */
+  public CacheValueTranslator getValueTranslator() {
+    return valueTranslator;
+  }
+
+  public <T extends SingleKeyValueCacheImpl> T withValueTranslator(CacheValueTranslator t) {
+    setValueTranslator(t);
+    return (T) this;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/SingleKeyValueCacheImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/SingleKeyValueCacheImpl.java
@@ -21,8 +21,7 @@ public abstract class SingleKeyValueCacheImpl extends SingleKeyCacheService {
   /**
    * What to do with the cache-value.
    * 
-   * @param translator default is null, which depending on the concrete classes has different
-   *        meanings.
+   * @param translator the translator, which depending on the concrete classes has different meanings.
    */
   public void setValueTranslator(CacheValueTranslator translator) {
     valueTranslator = Args.notNull(translator, "valueTranslator");

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/BytePayloadCacheValueTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/BytePayloadCacheValueTranslator.java
@@ -15,19 +15,11 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("byte-payload-cache-value-translator")
 public class BytePayloadCacheValueTranslator implements CacheValueTranslator<byte[]> {
 
-  /**
-   * @return byte[] containing the payload of the message
-   */
   @Override
   public byte[] getValueFromMessage(AdaptrisMessage msg) throws CoreException {
     return msg.getPayload();
   }
 
-  /**
-   * @param msg the {@link AdaptrisMessage}
-   * @param value byte[] to be set as the payload of the message
-   * @throws IllegalArgumentException if value is not of type byte[]
-   */
   @Override
   public void addValueToMessage(AdaptrisMessage msg, byte[] value) throws CoreException {
     msg.setPayload(value);

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/StaticCacheValueTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/StaticCacheValueTranslator.java
@@ -35,7 +35,7 @@ public class StaticCacheValueTranslator implements CacheValueTranslator<String>,
    */
   @Override
   public String getValueFromMessage(AdaptrisMessage msg) throws CoreException {
-    return msg.resolve(value);
+    return msg.resolve(getValue());
   }
 
   /**
@@ -49,6 +49,11 @@ public class StaticCacheValueTranslator implements CacheValueTranslator<String>,
 
   public String getValue() {
     return value;
+  }
+
+  public StaticCacheValueTranslator withValue(String s) {
+    setValue(s);
+    return this;
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/StaticCacheValueTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/StaticCacheValueTranslator.java
@@ -39,14 +39,6 @@ public class StaticCacheValueTranslator implements CacheValueTranslator<String>,
   }
 
   /**
-   * @throws UnsupportedOperationException this method is not implemented for this translator
-   */
-  @Override
-  public void addValueToMessage(AdaptrisMessage msg, String value) throws CoreException {
-    throw new UnsupportedOperationException("StaticCacheValueTranslator can't add things to a message.");
-  }
-
-  /**
    * Sets the static value.
    *
    * @param s the value, which supports the {@code %message{}} syntax to resolve metadata.

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/StringPayloadCacheTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/StringPayloadCacheTranslator.java
@@ -1,7 +1,6 @@
 package com.adaptris.core.services.cache.translators;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.services.cache.CacheKeyTranslator;
@@ -29,19 +28,11 @@ public class StringPayloadCacheTranslator implements CacheValueTranslator<String
     setCharEncoding(s);
   }
 
-  /**
-   * @return byte[] containing the payload of the message
-   */
   @Override
   public String getValueFromMessage(AdaptrisMessage msg) throws CoreException {
     return msg.getContent();
   }
 
-  /**
-   * @param msg the {@link AdaptrisMessage}
-   * @param value byte[] to be set as the payload of the message
-   * @throws IllegalArgumentException if value is not of type byte[]
-   */
   @Override
   public void addValueToMessage(AdaptrisMessage msg, String value) throws CoreException {
     if (isEmpty(getCharEncoding())) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/XpathCacheValueTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/XpathCacheValueTranslator.java
@@ -69,15 +69,6 @@ public class XpathCacheValueTranslator implements CacheValueTranslator<String>, 
   }
 
   /**
-   * @throws UnsupportedOperationException this method is not implemented for this translator
-   */
-  @Override
-  public void addValueToMessage(AdaptrisMessage msg, String value) throws CoreException {
-    throw new UnsupportedOperationException(
-        "We do not support direct injection into payload via XPath, store as metadata and post process using XSLT instead");
-  }
-
-  /**
    * Sets the XPath to use to query the message
    *
    * @param s

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/XpathCacheValueTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/translators/XpathCacheValueTranslator.java
@@ -36,6 +36,7 @@ public class XpathCacheValueTranslator implements CacheValueTranslator<String>, 
   @InputFieldHint(expression = true)
   private String xpath;
   @Valid
+  @AdvancedConfig
   private KeyValuePairSet namespaceContext = null;
   @AdvancedConfig
   @Valid
@@ -55,7 +56,7 @@ public class XpathCacheValueTranslator implements CacheValueTranslator<String>, 
   @Override
   public String getValueFromMessage(AdaptrisMessage msg) throws CoreException {
     NamespaceContext ctx = SimpleNamespaceContext.create(getNamespaceContext(), msg);
-    DocumentBuilderFactoryBuilder builder = documentFactoryBuilder();
+    DocumentBuilderFactoryBuilder builder = documentFactoryBuilder(ctx);
     String result = null;
     try {
       XPath xp = XPath.newXPathInstance(builder, ctx);
@@ -102,8 +103,8 @@ public class XpathCacheValueTranslator implements CacheValueTranslator<String>, 
     this.xmlDocumentFactoryConfig = xml;
   }
 
-  DocumentBuilderFactoryBuilder documentFactoryBuilder() {
-    return getXmlDocumentFactoryConfig() != null ? getXmlDocumentFactoryConfig() : DocumentBuilderFactoryBuilder.newInstance();
+  private DocumentBuilderFactoryBuilder documentFactoryBuilder(NamespaceContext ctx) {
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig(), ctx);
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/AddValueToCacheTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/AddValueToCacheTest.java
@@ -1,0 +1,55 @@
+package com.adaptris.core.services.cache;
+
+import java.util.EnumSet;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.services.cache.translators.StringPayloadCacheTranslator;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;;
+
+public class AddValueToCacheTest extends SingleKeyCacheCase {
+
+  public void testDoService() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+
+    Cache cache = createCacheInstanceForTests();
+    AddValueToCache service = new AddValueToCache().withValueTranslator(new StringPayloadCacheTranslator())
+        .withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      service.doService(msg);
+      Object value = cache.get(msg.getUniqueId());
+      assertEquals("Hello World", value);
+    } finally {
+      stop(service);
+    }
+  }
+
+
+  public void testDoService_WithError() throws Exception {
+    
+    AdaptrisMessage msg = new DefectiveMessageFactory(EnumSet.of(WhenToBreak.METADATA_GET)).newMessage("Hello World");
+    msg.addMetadata("metadataKey", "value");
+    Cache cache = createCacheInstanceForTests();
+    AddValueToCache service = new AddValueToCache().withValueTranslator(new StringPayloadCacheTranslator())
+        .withKey("%message{metadataKey}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      service.doService(msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    } finally {
+      stop(service);
+    }
+  }
+
+  @Override
+  protected AddValueToCache retrieveObjectForSampleConfig() {
+    return new AddValueToCache().withValueTranslator(new StringPayloadCacheTranslator()).withKey("%message{%uniqueId}")
+        .withConnection(new CacheConnection().withCacheInstance(createCacheInstanceForTests()));
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/CacheServiceExample.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/CacheServiceExample.java
@@ -2,7 +2,6 @@ package com.adaptris.core.services.cache;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import com.adaptris.core.BranchingServiceCollection;
 import com.adaptris.core.Service;
 import com.adaptris.core.ServiceCase;
@@ -10,7 +9,7 @@ import com.adaptris.core.cache.Cache;
 
 public abstract class CacheServiceExample extends ServiceCase {
 
-  private static final String BASE_DIR_KEY = "CacheServiceExamples.baseDir";
+  protected static final String BASE_DIR_KEY = "CacheServiceExamples.baseDir";
   protected static final String HYPHEN = "-";
 
   public CacheServiceExample() {

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/CheckAndRetrieveCacheTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/CheckAndRetrieveCacheTest.java
@@ -2,7 +2,6 @@ package com.adaptris.core.services.cache;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.BranchingServiceCollection;
 import com.adaptris.core.MetadataElement;
@@ -23,7 +22,7 @@ public class CheckAndRetrieveCacheTest extends CacheServiceBaseCase {
     assertTrue(service.isBranching());
   }
 
-  public void testDoService_InCache() throws Exception {
+  public void testDoService_Error() throws Exception {
     AdaptrisMessage msg = createMessage("Hello World", Arrays.asList(new MetadataElement[]
     {
         new MetadataElement(LOOKUP_VALUE, LOOKUP_VALUE)
@@ -42,6 +41,26 @@ public class CheckAndRetrieveCacheTest extends CacheServiceBaseCase {
       assertEquals(LOOKED_UP_VALUE, msg.getMetadataValue(LOOKUP_METADATA_KEY));
     }
     finally {
+      stop(service);
+    }
+  }
+
+  public void testDoService_InCache() throws Exception {
+    AdaptrisMessage msg =
+        createMessage("Hello World", Arrays.asList(new MetadataElement[] {new MetadataElement(LOOKUP_VALUE, LOOKUP_VALUE)}));
+
+    ExpiringMapCache cache = createCacheInstanceForTests();
+    CheckAndRetrieve service = createServiceForTests();
+    try {
+      service.setConnection(new CacheConnection(cache));
+      service.setKeysFoundServiceId(FOUND);
+      service.setKeysNotFoundServiceId(NOT_FOUND);
+      start(service);
+      cache.put(LOOKUP_VALUE, LOOKED_UP_VALUE);
+      service.doService(msg);
+      assertEquals(FOUND, msg.getNextServiceId());
+      assertEquals(LOOKED_UP_VALUE, msg.getMetadataValue(LOOKUP_METADATA_KEY));
+    } finally {
       stop(service);
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/CheckCacheServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/CheckCacheServiceTest.java
@@ -3,10 +3,11 @@ package com.adaptris.core.services.cache;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.BranchingServiceCollection;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.cache.ExpiringMapCache;
 import com.adaptris.core.services.cache.translators.MetadataCacheValueTranslator;
 import com.adaptris.util.TimeInterval;
@@ -21,6 +22,32 @@ public class CheckCacheServiceTest extends CacheServiceBaseCase {
 
     CheckCacheService service = createServiceForTests();
     assertTrue(service.isBranching());
+  }
+
+
+  public void testDoService_Error() throws Exception {
+    AdaptrisMessage msg =
+        createMessage("Hello World", Arrays.asList(new MetadataElement[] {new MetadataElement(LOOKUP_VALUE, LOOKUP_VALUE)}));
+    ExpiringMapCache cache =
+        new KeysSizeUnsupportedCache().withMaxEntries(10).withExpiration(new TimeInterval(10L, TimeUnit.SECONDS));
+    CheckCacheService service = new CheckCacheService() {
+      @Override
+      protected boolean eval(AdaptrisMessage msg, FoundInCache callback) throws CoreException {
+        throw new CoreException();
+      }
+    };
+    try {
+      service.withConnection(new CacheConnection().withCacheInstance(cache));
+      service.setKeysFoundServiceId(FOUND);
+      service.setKeysNotFoundServiceId(NOT_FOUND);
+      start(service);
+      cache.put(LOOKUP_VALUE, LOOKED_UP_VALUE);
+      service.doService(msg);
+      fail();
+    } catch (ServiceException expected) {
+    } finally {
+      stop(service);
+    }
   }
 
   public void testDoService_InCache() throws Exception {
@@ -112,10 +139,12 @@ public class CheckCacheServiceTest extends CacheServiceBaseCase {
 
   protected static class KeysSizeUnsupportedCache extends ExpiringMapCache {
 
+    @Override
     public List<String> getKeys() {
       throw new UnsupportedOperationException("getKeys");
     }
 
+    @Override
     public int size() {
       throw new UnsupportedOperationException("size");
     }

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/GetValueFromCacheTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/GetValueFromCacheTest.java
@@ -1,0 +1,74 @@
+package com.adaptris.core.services.cache;
+
+import static org.junit.Assert.assertNotEquals;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.services.cache.translators.StringPayloadCacheTranslator;;
+
+public class GetValueFromCacheTest extends SingleKeyCacheCase {
+
+  public void testDoService() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+
+    Cache cache = createCacheInstanceForTests();
+    GetValueFromCache service = new GetValueFromCache().withValueTranslator(new StringPayloadCacheTranslator())
+        .withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      cache.put(msg.getUniqueId(), "Goodbye Cruel World");
+
+      service.doService(msg);
+      assertNotEquals("Hello World", msg.getContent());
+      assertEquals("Goodbye Cruel World", msg.getContent());
+    } finally {
+      stop(service);
+    }
+  }
+
+  public void testDoService_NotFoundWithError() throws Exception {
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    Cache cache = createCacheInstanceForTests();
+    GetValueFromCache service =
+        new GetValueFromCache().withExceptionIfNotFound(false).withValueTranslator(new StringPayloadCacheTranslator())
+            .withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      service.doService(msg);
+      assertNotEquals("Hello World", msg.getContent());
+    } catch (ServiceException expected) {
+
+    } finally {
+      stop(service);
+    }
+  }
+
+
+
+  public void testDoService_WithError() throws Exception {
+    
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    Cache cache = createCacheInstanceForTests();
+    GetValueFromCache service =
+        new GetValueFromCache().withExceptionIfNotFound(true).withValueTranslator(new StringPayloadCacheTranslator())
+        .withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      service.doService(msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    } finally {
+      stop(service);
+    }
+  }
+
+  @Override
+  protected GetValueFromCache retrieveObjectForSampleConfig() {
+    return new GetValueFromCache().withValueTranslator(new StringPayloadCacheTranslator()).withKey("%message{%uniqueId}")
+        .withConnection(new CacheConnection().withCacheInstance(createCacheInstanceForTests()));
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/RemoveKeyFromCacheTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/RemoveKeyFromCacheTest.java
@@ -1,0 +1,55 @@
+package com.adaptris.core.services.cache;
+
+import java.util.EnumSet;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;;
+
+public class RemoveKeyFromCacheTest extends SingleKeyCacheCase {
+
+  public void testDoService() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+
+    Cache cache = createCacheInstanceForTests();
+    RemoveKeyFromCache service =
+        new RemoveKeyFromCache().withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      cache.put(msg.getUniqueId(), msg.getContent());
+      assertNotNull(cache.get(msg.getUniqueId()));
+      service.doService(msg);
+      assertNull(cache.get(msg.getUniqueId()));
+    } finally {
+      stop(service);
+    }
+  }
+
+
+  public void testDoService_WithError() throws Exception {
+    
+    AdaptrisMessage msg = new DefectiveMessageFactory(EnumSet.of(WhenToBreak.METADATA_GET)).newMessage("Hello World");
+    msg.addMetadata("metadataKey", "value");
+    Cache cache = createCacheInstanceForTests();
+    RemoveKeyFromCache service =
+        new RemoveKeyFromCache().withKey("%message{metadataKey}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      service.doService(msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    } finally {
+      stop(service);
+    }
+  }
+
+  @Override
+  protected RemoveKeyFromCache retrieveObjectForSampleConfig() {
+    return new RemoveKeyFromCache().withKey("%message{%uniqueId}")
+        .withConnection(new CacheConnection().withCacheInstance(createCacheInstanceForTests()));
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/SingleKeyCacheCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/SingleKeyCacheCase.java
@@ -1,0 +1,21 @@
+package com.adaptris.core.services.cache;
+
+import java.util.concurrent.TimeUnit;
+import com.adaptris.core.ServiceCase;
+import com.adaptris.core.cache.ExpiringMapCache;
+import com.adaptris.util.TimeInterval;
+
+public abstract class SingleKeyCacheCase extends ServiceCase {
+
+
+  public SingleKeyCacheCase() {
+    if (PROPERTIES.getProperty(CacheServiceExample.BASE_DIR_KEY) != null) {
+      setBaseDir(PROPERTIES.getProperty(CacheServiceExample.BASE_DIR_KEY));
+    }
+  }
+
+  protected ExpiringMapCache createCacheInstanceForTests() {
+    return new ExpiringMapCache().withMaxEntries(10).withExpiration(new TimeInterval(10L, TimeUnit.SECONDS));
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/BytePayloadCacheValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/BytePayloadCacheValueTranslatorTest.java
@@ -1,16 +1,16 @@
 package com.adaptris.core.services.cache.translators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.security.MessageDigest;
-
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.services.cache.CacheValueTranslator;
 
 public class BytePayloadCacheValueTranslatorTest extends CacheValueTranslatorBaseCase {
 
-  public BytePayloadCacheValueTranslatorTest(String s) {
-    super(s);
-  }
-
+  @Test
   public void testGetValueFromMessage() throws Exception {
     BytePayloadCacheValueTranslator translator = new BytePayloadCacheValueTranslator();
     AdaptrisMessage message = createMessage();
@@ -18,6 +18,7 @@ public class BytePayloadCacheValueTranslatorTest extends CacheValueTranslatorBas
     assertEquals(PAYLOAD.getBytes().length, translator.getValueFromMessage(message).length);
   }
 
+  @Test
   public void testAddValueToMessage() throws Exception {
     BytePayloadCacheValueTranslator translator = new BytePayloadCacheValueTranslator();
     AdaptrisMessage message = createMessage();
@@ -25,6 +26,7 @@ public class BytePayloadCacheValueTranslatorTest extends CacheValueTranslatorBas
     assertTrue(MessageDigest.isEqual("Hello World".getBytes(), message.getPayload()));
   }
 
+  @Test
   public void testAddInvalidValueToMessage() throws Exception {
     AdaptrisMessage message = createMessage();
     CacheValueTranslator translator = new BytePayloadCacheValueTranslator();

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/CacheValueTranslatorBaseCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/CacheValueTranslatorBaseCase.java
@@ -4,10 +4,9 @@ import javax.jms.JMSException;
 import javax.jms.Queue;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.jms.JmsConstants;
 
-public class CacheValueTranslatorBaseCase extends BaseCase {
+public class CacheValueTranslatorBaseCase {
 
   static final String VALUE_TWO = "two";
   static final String VALUE_ONE = "one";
@@ -15,10 +14,6 @@ public class CacheValueTranslatorBaseCase extends BaseCase {
   static final String KEY_TWO = "keyTwo";
   static final String KEY_ONE = "keyOne";
   static final String PAYLOAD = "<root xmlns=\"uri:test\"> <element id=\"one\">abc</element> <element id=\"two\">def</element>   <element id=\"three\" marker=\"true\">ghi</element> </root>";
-
-  public CacheValueTranslatorBaseCase(String s) {
-    super(s);
-  }
 
   protected AdaptrisMessage createMessage() {
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD);

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/JmsReplyToCacheValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/JmsReplyToCacheValueTranslatorTest.java
@@ -1,25 +1,33 @@
 package com.adaptris.core.services.cache.translators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import javax.jms.JMSException;
 import javax.jms.Queue;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.JmsConstants;
 import com.adaptris.core.services.cache.CacheValueTranslator;
 
-@SuppressWarnings("deprecation")
 public class JmsReplyToCacheValueTranslatorTest extends CacheValueTranslatorBaseCase {
 
-
-  public JmsReplyToCacheValueTranslatorTest(String s) {
-    super(s);
-  }
-
+  @Test
   public void testGetValueFromMessage() throws Exception {
     AdaptrisMessage msg = createMessage();
     JmsReplyToCacheValueTranslator translator = new JmsReplyToCacheValueTranslator();
     assertEquals("myQueue", ((Queue) translator.getValueFromMessage(msg)).getQueueName());
   }
 
+  @Test
+  public void testGetNoReplyTo() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD);
+    JmsReplyToCacheValueTranslator translator = new JmsReplyToCacheValueTranslator();
+    assertNull(translator.getValueFromMessage(msg));
+  }
+
+  @Test
   public void testAddValueToMessage() throws Exception {
     AdaptrisMessage message = createMessage();
     JmsReplyToCacheValueTranslator translator = new JmsReplyToCacheValueTranslator();
@@ -29,9 +37,10 @@ public class JmsReplyToCacheValueTranslatorTest extends CacheValueTranslatorBase
         return "HelloWorld";
       }
     });
-    assertEquals("HelloWorld", ((Queue)message.getObjectMetadata().get(JmsConstants.OBJ_JMS_REPLY_TO_KEY)).getQueueName());
+    assertEquals("HelloWorld", ((Queue) message.getObjectHeaders().get(JmsConstants.OBJ_JMS_REPLY_TO_KEY)).getQueueName());
   }
 
+  @Test
   public void testAddInvalidValueToMessage() throws Exception {
     AdaptrisMessage message = createMessage();
     CacheValueTranslator translator = new JmsReplyToCacheValueTranslator();

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/MetadataCacheValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/MetadataCacheValueTranslatorTest.java
@@ -1,19 +1,19 @@
 package com.adaptris.core.services.cache.translators;
 
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 
 public class MetadataCacheValueTranslatorTest extends CacheValueTranslatorBaseCase {
 
-  public MetadataCacheValueTranslatorTest(String s) {
-    super(s);
-  }
-
+  @Test
   public void testGetValueFromMessage() throws Exception {
     MetadataCacheValueTranslator translator = new MetadataCacheValueTranslator(KEY_TWO);
     AdaptrisMessage message = createMessage();
     assertEquals(VALUE_TWO, translator.getValueFromMessage(message));
   }
 
+  @Test
   public void testAddValueToMessage() throws Exception {
     MetadataCacheValueTranslator translator = new MetadataCacheValueTranslator(KEY_TWO);
     AdaptrisMessage message = createMessage();

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/ObjectMetadataCacheValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/ObjectMetadataCacheValueTranslatorTest.java
@@ -1,18 +1,16 @@
 package com.adaptris.core.services.cache.translators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import javax.jms.JMSException;
 import javax.jms.Queue;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.jms.JmsConstants;
 
-@SuppressWarnings("deprecation")
 public class ObjectMetadataCacheValueTranslatorTest extends CacheValueTranslatorBaseCase {
 
-
-  public ObjectMetadataCacheValueTranslatorTest(String s) {
-    super(s);
-  }
-
+  @Test
   public void testGetValueFromMessage() throws Exception {
     AdaptrisMessage msg = createMessage();
     // We can just reuse the OBJ_JMS_REPLY_TO_KEY metadata
@@ -21,6 +19,17 @@ public class ObjectMetadataCacheValueTranslatorTest extends CacheValueTranslator
     assertEquals("myQueue", ((Queue) translator.getValueFromMessage(msg)).getQueueName());
   }
 
+
+  @Test
+  public void testGetValueFromMessage_NonExistent() throws Exception {
+    AdaptrisMessage msg = createMessage();
+    // We can just reuse the OBJ_JMS_REPLY_TO_KEY metadata
+    ObjectMetadataCacheValueTranslator translator = new ObjectMetadataCacheValueTranslator();
+    translator.setMetadataKey("MyNonExistentKey");
+    assertNull(translator.getValueFromMessage(msg));
+  }
+
+  @Test
   public void testAddValueToMessage() throws Exception {
     AdaptrisMessage message = createMessage();
     ObjectMetadataCacheValueTranslator translator = new ObjectMetadataCacheValueTranslator();
@@ -31,6 +40,6 @@ public class ObjectMetadataCacheValueTranslatorTest extends CacheValueTranslator
         return "HelloWorld";
       }
     });
-    assertEquals("HelloWorld", ((Queue)message.getObjectMetadata().get(JmsConstants.OBJ_JMS_REPLY_TO_KEY)).getQueueName());
+    assertEquals("HelloWorld", ((Queue) message.getObjectHeaders().get(JmsConstants.OBJ_JMS_REPLY_TO_KEY)).getQueueName());
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/StaticCacheValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/StaticCacheValueTranslatorTest.java
@@ -1,0 +1,38 @@
+package com.adaptris.core.services.cache.translators;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+
+@SuppressWarnings("deprecation")
+public class StaticCacheValueTranslatorTest extends CacheValueTranslatorBaseCase {
+
+  @Test
+  public void testGetKeyFromMessage() throws Exception {
+    StaticCacheValueTranslator translator = new StaticCacheValueTranslator().withValue("Hello");
+    AdaptrisMessage message = createMessage();
+    assertEquals("Hello", translator.getKeyFromMessage(message));
+  }
+
+
+  @Test
+  public void testGetValueFromMessage() throws Exception {
+    StaticCacheValueTranslator translator = new StaticCacheValueTranslator().withValue("Hello");
+    AdaptrisMessage message = createMessage();
+    assertEquals("Hello", translator.getValueFromMessage(message));
+  }
+
+  @Test
+  public void testAddValueToMessage() throws Exception {
+    StaticCacheValueTranslator translator = new StaticCacheValueTranslator().withValue("Hello");
+    AdaptrisMessage message = createMessage();
+    try {
+      translator.addValueToMessage(message, "some value");
+      fail();
+    }
+    catch (UnsupportedOperationException expected) {
+
+    }
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/StringPayloadCacheValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/StringPayloadCacheValueTranslatorTest.java
@@ -1,33 +1,40 @@
 package com.adaptris.core.services.cache.translators;
 
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
 
-@SuppressWarnings("deprecation")
 public class StringPayloadCacheValueTranslatorTest extends CacheValueTranslatorBaseCase {
 
-  public StringPayloadCacheValueTranslatorTest(String s) {
-    super(s);
+  @Test
+  public void testGetKeyFromMessage() throws Exception {
+    StringPayloadCacheTranslator translator = new StringPayloadCacheTranslator();
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage("hello world");
+    assertEquals("hello world", translator.getKeyFromMessage(message));
   }
 
+  @Test
   public void testGetValueFromMessage() throws Exception {
     StringPayloadCacheTranslator translator = new StringPayloadCacheTranslator();
-    AdaptrisMessage message = createMessage();
-
-    assertEquals(PAYLOAD.length(), translator.getValueFromMessage(message).length());
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage("hello world");
+    assertEquals("hello world", translator.getValueFromMessage(message));
   }
 
+  @Test
   public void testAddValueToMessage() throws Exception {
     StringPayloadCacheTranslator translator = new StringPayloadCacheTranslator();
     AdaptrisMessage message = createMessage();
     translator.addValueToMessage(message, "Hello World");
-    assertEquals("Hello World", message.getStringPayload());
+    assertEquals("Hello World", message.getContent());
   }
 
+  @Test
   public void testAddValueToMessage_WithEncoding() throws Exception {
     StringPayloadCacheTranslator translator = new StringPayloadCacheTranslator("UTF-8");
     AdaptrisMessage message = createMessage();
     translator.addValueToMessage(message, "Hello World");
-    assertEquals("Hello World", message.getStringPayload());
-    assertEquals("UTF-8", message.getCharEncoding());
+    assertEquals("Hello World", message.getContent());
+    assertEquals("UTF-8", message.getContentEncoding());
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/XpathCacheValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/translators/XpathCacheValueTranslatorTest.java
@@ -1,25 +1,32 @@
 package com.adaptris.core.services.cache.translators;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
-@SuppressWarnings("deprecation")
 public class XpathCacheValueTranslatorTest extends CacheValueTranslatorBaseCase {
 
 
-  public XpathCacheValueTranslatorTest(String s) {
-    super(s);
+  @Test
+  public void testGetKeyFromMessage() throws Exception {
+    XpathCacheValueTranslator translator = createTranslator();
+    AdaptrisMessage message = createMessage();
+    assertEquals("abc", translator.getKeyFromMessage(message));
   }
 
+  @Test
   public void testGetValueFromMessage() throws Exception {
     XpathCacheValueTranslator translator = createTranslator();
     AdaptrisMessage message = createMessage();
     assertEquals("abc", translator.getValueFromMessage(message));
   }
 
+  @Test
   public void testGetValueFromMessage_DocumentBuilderFactory() throws Exception {
     XpathCacheValueTranslator translator = createTranslator();
     translator.setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder.newInstance());
@@ -27,10 +34,11 @@ public class XpathCacheValueTranslatorTest extends CacheValueTranslatorBaseCase 
     assertEquals("abc", translator.getValueFromMessage(message));
   }
 
+  @Test
   public void testGetValueFromMessage_NotXml() throws Exception {
     XpathCacheValueTranslator translator = createTranslator();
     AdaptrisMessage message = createMessage();
-    message.setStringPayload("This is not XML");
+    message.setContent("This is not XML", null);
     try {
       translator.getValueFromMessage(message);
       fail();
@@ -40,14 +48,7 @@ public class XpathCacheValueTranslatorTest extends CacheValueTranslatorBaseCase 
     }
   }
 
-  // No longer a valid test, change to use SAXON means that this will never resolve
-  // public void testGetValueFromMessage_NoNamespace() throws Exception {
-  // XpathCacheValueTranslator translator = new XpathCacheValueTranslator();
-  // translator.setXpath("/root/element[@id='one']");
-  // AdaptrisMessage message = createMessage();
-  // assertEquals("abc", translator.getValueFromMessage(message));
-  // }
-
+  @Test
   public void testAddValue() throws Exception {
     XpathCacheValueTranslator translator = createTranslator();
     AdaptrisMessage message = createMessage();

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/DefectiveAdaptrisMessage.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/DefectiveAdaptrisMessage.java
@@ -43,7 +43,7 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
 
   @Override
   public InputStream getInputStream() throws IOException {
-    if (((DefectiveMessageFactory) getFactory()).brokenInput()) {
+    if (getFactory().brokenInput()) {
       return new ErroringInputStream(super.getInputStream());
     }
     return super.getInputStream();
@@ -51,7 +51,7 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
 
   @Override
   public OutputStream getOutputStream() throws IOException {
-    if (((DefectiveMessageFactory) getFactory()).brokenOutput()) {
+    if (getFactory().brokenOutput()) {
       return new ErroringOutputStream();
     }
     return super.getOutputStream();
@@ -65,7 +65,7 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
   /** @see AdaptrisMessage#headersContainsKey(String) */
   @Override
   public boolean headersContainsKey(String key) {
-    if (((DefectiveMessageFactory) getFactory()).brokenMetadataGet()) {
+    if (getFactory().brokenMetadataGet()) {
       throw new RuntimeException();
     }
     return super.headersContainsKey(key);
@@ -74,7 +74,7 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
   /** @see AdaptrisMessage#addMetadata(MetadataElement) */
   @Override
   public synchronized void addMetadata(MetadataElement e) {
-    if (((DefectiveMessageFactory) getFactory()).brokenMetadataSet()) {
+    if (getFactory().brokenMetadataSet()) {
       throw new RuntimeException();
     }
     super.addMetadata(e);
@@ -83,7 +83,7 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
   /** @see AdaptrisMessage#removeMetadata(MetadataElement) */
   @Override
   public void removeMetadata(MetadataElement element) {
-    if (((DefectiveMessageFactory) getFactory()).brokenMetadataSet()) {
+    if (getFactory().brokenMetadataSet()) {
       throw new RuntimeException();
     }
     super.removeMetadata(element);
@@ -92,7 +92,7 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
   /** @see AdaptrisMessage#removeMessageHeader(String) */
   @Override
   public void removeMessageHeader(String key) {
-    if (((DefectiveMessageFactory) getFactory()).brokenMetadataSet()) {
+    if (getFactory().brokenMetadataSet()) {
       throw new RuntimeException();
     }
     super.removeMessageHeader(key);
@@ -100,7 +100,7 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
 
   @Override
   public synchronized void clearMetadata() {
-    if (((DefectiveMessageFactory) getFactory()).brokenMetadataSet()) {
+    if (getFactory().brokenMetadataSet()) {
       throw new RuntimeException();
     }
     super.clearMetadata();
@@ -108,7 +108,7 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
 
   @Override
   public Map<String, String> getMessageHeaders() {
-    if (((DefectiveMessageFactory) getFactory()).brokenMetadataGet()) {
+    if (getFactory().brokenMetadataGet()) {
       throw new RuntimeException();
     }
     return super.getMessageHeaders();
@@ -116,10 +116,31 @@ public class DefectiveAdaptrisMessage extends DefaultAdaptrisMessageImp {
 
   @Override
   public Set<MetadataElement> getMetadata() { // lgtm [java/unsynchronized-getter]
-    if (((DefectiveMessageFactory) getFactory()).brokenMetadataGet()) {
+    if (getFactory().brokenMetadataGet()) {
       throw new RuntimeException();
     }
     return super.getMetadata();
+  }
+
+  @Override
+  public String getMetadataValue(String key) { // is case-sensitive
+    if (getFactory().brokenMetadataGet()) {
+      throw new RuntimeException();
+    }
+    return super.getMetadataValue(key);
+  }
+
+  @Override
+  public String getMetadataValueIgnoreKeyCase(String key) {
+    if (getFactory().brokenMetadataGet()) {
+      throw new RuntimeException();
+    }
+    return super.getMetadataValueIgnoreKeyCase(key);
+  }
+
+  @Override
+  public DefectiveMessageFactory getFactory() {
+    return (DefectiveMessageFactory) super.getFactory();
   }
 
 


### PR DESCRIPTION
Hierarchy change to existing services for re-use.

- AddValueToCache which adds a single value to the cache
- RemoveKeyFromCache which removes a single key from the cache without retrieving it.
- GetValueFromCache allows you to retrieve a single value from the cache (with exception-if-not-found support).
- There is no "check-cache" since this can be done with the exists-in-cache condition (since we want to discourage branching-service-collection).
- 100% coverage on translators; 
- remove the cache wrapper from CacheServiceBase which was used to wrap the deprecated cache (up until 3.9.0)
- Added some additional methods for DefectiveMessage.

Looks like : 

```xml
<add-single-value-to-cache>
   <connection class="cache-connection"/>
   <key>%message{%uniqueId}</key>
   <value-translator class="string-payload-cache-translator"/>
</add-single-value-to-cache>
<get-single-value-from-cache>
   <connection class="cache-connection"/>
   <key>%message{%uniqueId}</key>
   <value-translator class="string-payload-cache-translator"/>
</get-single-value-from-cache>
<remove-key-from-cache>
   <connection class="cache-connection"/>
   <key>%message{%uniqueId}</key>
</remove-key-from-cache>
```