### PR TITLE
INTERLOK-2965 - Make sure we have a null value translator as default

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheEntryEvaluator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/CacheEntryEvaluator.java
@@ -25,6 +25,7 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -182,7 +183,7 @@ public class CacheEntryEvaluator {
    * @return the configured key translator via {@link #setValueTranslator(CacheValueTranslator)} or a default translator if null.
    */
   public CacheValueTranslator valueTranslator() {
-    return ObjectUtils.defaultIfNull(getValueTranslator(), (msg) -> null);
+    return ObjectUtils.defaultIfNull(getValueTranslator(), new NullCacheValueTranslator());
   }
 
   public String getFriendlyName() {
@@ -200,5 +201,17 @@ public class CacheEntryEvaluator {
 
   public String friendlyName() {
     return ObjectUtils.defaultIfNull(getFriendlyName(), this.getClass().getSimpleName());
+  }
+  
+  public static class NullCacheValueTranslator implements CacheValueTranslator {
+    @Override
+    public Object getValueFromMessage(AdaptrisMessage msg) throws CoreException {
+      return null;
+    }
+
+    @Override
+    public void addValueToMessage(AdaptrisMessage msg, Object value) throws CoreException {
+
+    }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/CacheEntryEvaluatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/CacheEntryEvaluatorTest.java
@@ -3,13 +3,14 @@ package com.adaptris.core.services.cache;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-
+import java.util.Collections;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.BaseCase;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.cache.CacheEntryEvaluator.NullCacheValueTranslator;
 import com.adaptris.core.services.cache.translators.MetadataCacheValueTranslator;
 import com.adaptris.core.services.cache.translators.StaticCacheValueTranslator;
 
@@ -231,6 +232,12 @@ public class CacheEntryEvaluatorTest extends BaseCase {
     eval.setErrorOnEmptyValue(false);
     AdaptrisMessage msg = createMessage(new ArrayList<MetadataElement>());
     assertEquals(null, eval.getValue(msg));
+  }
+
+  public void testNullCacheValueTranslator() throws Exception {
+    NullCacheValueTranslator cvt = new CacheEntryEvaluator.NullCacheValueTranslator();
+    assertNull(cvt.getValueFromMessage(createMessage(Collections.EMPTY_SET)));
+    cvt.addValueToMessage(createMessage(Collections.EMPTY_SET), null);
   }
 
   protected AdaptrisMessage createMessage(Collection<MetadataElement> metadata) {


### PR DESCRIPTION
If we have configured a remove-from-cache; then we might be in a situation where we call valueTranslator.addValueToMessage(). In this case, because of the functional interface + default method change we will throw an exception, but the user may explicitly have configured no value-translator since they don't want to retrieve the value...

i.e. if we configure this : 
```
                <remove-from-cache>
                  <unique-id>remove-request-from-cache</unique-id>
                  <connection class="shared-connection">
                    <lookup-name>request-cache</lookup-name>
                  </connection>
                  <cache-entry-evaluator>
                    <key-translator class="static-cache-value-translator">
                      <value>%message{%uniqueId}</value>
                    </key-translator>
                  </cache-entry-evaluator>
                </remove-from-cache>
```

Then we get an exception; but we really shouldn't.
