### PR TITLE
IINTERLOK-2629 jms tests made optional

### DIFF
--- a/interlok-core/src/test/java/com/adaptris/core/BaseCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/BaseCase.java
@@ -157,7 +157,8 @@ public abstract class BaseCase extends TestCase {
     }
   }
 
-  protected static void assertRoundtripEquality(Object input, Object output, List<Class> classesToIgnore) throws Exception {
+  public static void assertRoundtripEquality(Object input, Object output,
+      List<Class> classesToIgnore) throws Exception {
     if (input == null && output == null) {
       return;
     }
@@ -205,7 +206,7 @@ public abstract class BaseCase extends TestCase {
     }
   }
 
-  protected static void assertRoundtripEquality(Object input, Object output) throws Exception {
+  public static void assertRoundtripEquality(Object input, Object output) throws Exception {
     assertRoundtripEquality(input, output, new ArrayList<Class>());
   }
 
@@ -260,14 +261,15 @@ public abstract class BaseCase extends TestCase {
     return ObjectUtils.invokeGetter(obj, methodName);
   }
 
-  protected static EventHandler createandStartDummyEventHandler() throws CoreException {
+  public static EventHandler createandStartDummyEventHandler() throws CoreException {
     DefaultEventHandler eh = new DefaultEventHandler();
     LifecycleHelper.init(eh);
     LifecycleHelper.start(eh);
     return eh;
   }
 
-  protected static ProcessingExceptionHandler createandStartDummyMessageErrorHandler() throws CoreException {
+  public static ProcessingExceptionHandler createandStartDummyMessageErrorHandler()
+      throws CoreException {
     StandardProcessingExceptionHandler eh = new StandardProcessingExceptionHandler();
     LifecycleHelper.init(eh);
     LifecycleHelper.start(eh);

--- a/interlok-core/src/test/java/com/adaptris/core/BaseCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/BaseCase.java
@@ -49,8 +49,8 @@ import junit.framework.TestCase;
  * </p>
  */
 public abstract class BaseCase extends TestCase {
-  protected static final long MAX_WAIT = 65000;
-  protected static final int DEFAULT_WAIT_INTERVAL = 100;
+  public static final long MAX_WAIT = 65000;
+  public static final int DEFAULT_WAIT_INTERVAL = 100;
 
   public static final Properties PROPERTIES;
   public static final String PROPERTIES_RESOURCE = "unit-tests.properties";

--- a/interlok-core/src/test/java/com/adaptris/core/jms/ActiveJmsConnectionErrorHandlerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/ActiveJmsConnectionErrorHandlerCase.java
@@ -16,17 +16,25 @@
 
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import java.util.concurrent.TimeUnit;
-
-import com.adaptris.core.BaseCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.util.TimeInterval;
 
-public abstract class ActiveJmsConnectionErrorHandlerCase extends BaseCase {
+public abstract class ActiveJmsConnectionErrorHandlerCase {
 
-  public ActiveJmsConnectionErrorHandlerCase(String name) {
-    super(name);
-  }
+  @Rule
+  public TestName testName = new TestName();
+  protected Logger log = LoggerFactory.getLogger(this.getClass());
 
+  @Test
   public void testRetryInterval() {
     ActiveJmsConnectionErrorHandler handler = new ActiveJmsConnectionErrorHandler();
     assertNull(handler.getCheckInterval());
@@ -48,6 +56,7 @@ public abstract class ActiveJmsConnectionErrorHandlerCase extends BaseCase {
     assertEquals(5000, handler.retryInterval());
   }
 
+  @Test
   public void testAdditionalLogging() {
     ActiveJmsConnectionErrorHandler ajceh = new ActiveJmsConnectionErrorHandler();
     assertNull(ajceh.getAdditionalLogging());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/AggregatingJmsConsumeServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/AggregatingJmsConsumeServiceTest.java
@@ -17,7 +17,6 @@
 package com.adaptris.core.jms;
 
 import java.util.concurrent.TimeUnit;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.DefaultMessageFactory;
@@ -46,19 +45,27 @@ public class AggregatingJmsConsumeServiceTest extends AggregatingServiceExample 
     super(name);
   }
 
+  @Override
   public void setUp() throws Exception {
     super.setUp();
   }
 
+  @Override
   public void tearDown() throws Exception {
     super.tearDown();
   }
 
+  @Override
   protected boolean doStateTests() {
     return false;
   }
   
   public void testNoOpMethods() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AggregatingJmsConsumeService service = createService(broker);
     try {
@@ -79,6 +86,11 @@ public class AggregatingJmsConsumeServiceTest extends AggregatingServiceExample 
   }
 
   public void testService() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AggregatingJmsConsumeService service = createService(broker);
     try {
@@ -98,6 +110,11 @@ public class AggregatingJmsConsumeServiceTest extends AggregatingServiceExample 
   }
 
   public void testServiceWithTimeout() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AggregatingJmsConsumeService service = createService(broker);
     try {
@@ -120,6 +137,11 @@ public class AggregatingJmsConsumeServiceTest extends AggregatingServiceExample 
   }
 
   public void testService_MultipleMessages() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AggregatingQueueConsumer consumer = new AggregatingQueueConsumer();
     consumer.setMessageAggregator(new IgnoreOriginalMimeAggregator());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/AutoConvertMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/AutoConvertMessageTranslatorTest.java
@@ -19,9 +19,12 @@ package com.adaptris.core.jms;
 import static com.adaptris.core.jms.ObjectMessageTranslatorTest.assertException;
 import static com.adaptris.core.jms.ObjectMessageTranslatorTest.readException;
 import static com.adaptris.core.jms.ObjectMessageTranslatorTest.write;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayOutputStream;
-
 import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
@@ -30,7 +33,8 @@ import javax.jms.MessageEOFException;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.MetadataElement;
@@ -51,11 +55,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
       INTEGER_VALUE, BOOLEAN_VALUE, STRING_VALUE
   };
 
-  public AutoConvertMessageTranslatorTest(String name) {
-    super(name);
-  }
 
+  @Test
   public void testConvertFromConsumeTypeBytes() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -83,8 +86,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
 
   }
-  
+
+  @Test
   public void testConvertFromConsumeTypeText() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -113,7 +118,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   }
   
+  @Test
   public void testConvertFromConsumeTypeTextRemoveKeyAfter() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -145,8 +153,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
 
   }
-  
+
+  @Test
   public void testConvertFromConsumeTypeTextDefaultRemoveKeyAfter() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -178,7 +188,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   }
   
+  @Test
   public void testConvertFromConsumeTypeMap() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -206,7 +219,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   }
   
+  @Test
   public void testConvertFromConsumeTypeObject() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -236,7 +252,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   }
   
+  @Test
   public void testConvertFromConsumeTypeBytesNoMetadataKey() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -266,7 +285,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   }
   
+  @Test
   public void testConvertFromConsumeTypeBytesIllegalMetadataKey() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -295,7 +317,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   }
   
+  @Test
   public void testBytesMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -320,7 +345,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   }
 
+  @Test
   public void testAdaptrisMessageToBytesMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType(AutoConvertMessageTranslator.SupportedMessageType.Bytes.name());
@@ -343,7 +371,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
   }
 
+  @Test
   public void testAdaptrisMessageToTextMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType(AutoConvertMessageTranslator.SupportedMessageType.Text.name());
@@ -364,7 +395,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
   }
 
+  @Test
   public void testMapMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -387,7 +421,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
   }
 
+  @Test
   public void testAdaptrisMessageToMapMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType(AutoConvertMessageTranslator.SupportedMessageType.Map.name());
@@ -410,7 +447,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
   }
 
+  @Test
   public void testObjectMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -435,7 +475,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
   }
 
+  @Test
   public void testAdaptrisMessageToObjectMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType(AutoConvertMessageTranslator.SupportedMessageType.Object.name());
@@ -458,7 +501,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
   }
   
+  @Test
   public void testMessageToAdaptrisMessageWithFallback() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -479,7 +525,10 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
   }
   
+  @Test
   public void testAdaptrisMessageToMessageWithFallback() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/AutoConvertMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/AutoConvertMessageTranslatorTest.java
@@ -33,7 +33,6 @@ import javax.jms.MessageEOFException;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -58,7 +57,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testConvertFromConsumeTypeBytes() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -89,7 +88,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testConvertFromConsumeTypeText() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -120,7 +119,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
   
   @Test
   public void testConvertFromConsumeTypeTextRemoveKeyAfter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -156,7 +155,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testConvertFromConsumeTypeTextDefaultRemoveKeyAfter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -190,7 +189,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
   
   @Test
   public void testConvertFromConsumeTypeMap() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -221,7 +220,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
   
   @Test
   public void testConvertFromConsumeTypeObject() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -254,7 +253,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
   
   @Test
   public void testConvertFromConsumeTypeBytesNoMetadataKey() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -287,7 +286,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
   
   @Test
   public void testConvertFromConsumeTypeBytesIllegalMetadataKey() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -319,7 +318,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
   
   @Test
   public void testBytesMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -347,7 +346,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testAdaptrisMessageToBytesMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -373,7 +372,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testAdaptrisMessageToTextMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -397,7 +396,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testMapMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -423,7 +422,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testAdaptrisMessageToMapMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -449,7 +448,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testObjectMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -477,7 +476,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
 
   @Test
   public void testAdaptrisMessageToObjectMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
@@ -503,7 +502,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
   
   @Test
   public void testMessageToAdaptrisMessageWithFallback() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 
@@ -527,7 +526,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
   
   @Test
   public void testAdaptrisMessageToMessageWithFallback() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BasicJavaxJmsMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BasicJavaxJmsMessageTranslatorTest.java
@@ -16,6 +16,9 @@
 
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import javax.jms.BytesMessage;
 import javax.jms.MapMessage;
 import javax.jms.Message;
@@ -23,18 +26,17 @@ import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import javax.jms.StreamMessage;
 import javax.jms.TextMessage;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
-  
-  public BasicJavaxJmsMessageTranslatorTest(String name) {
-    super(name);
-  }
 
+  @Test
   public void testMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {
@@ -53,7 +55,9 @@ public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTransl
     }
   }
 
+  @Test
   public void testAdaptrisMessageToMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {
@@ -79,7 +83,9 @@ public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTransl
     }
   }
   
+  @Test
   public void testAdaptrisMessageWithPayloadToMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BasicJavaxJmsMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BasicJavaxJmsMessageTranslatorTest.java
@@ -26,7 +26,6 @@ import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import javax.jms.StreamMessage;
 import javax.jms.TextMessage;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -36,7 +35,7 @@ public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTransl
 
   @Test
   public void testMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {
@@ -57,7 +56,7 @@ public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTransl
 
   @Test
   public void testAdaptrisMessageToMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {
@@ -85,7 +84,7 @@ public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTransl
   
   @Test
   public void testAdaptrisMessageWithPayloadToMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BasicJmsProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BasicJmsProducerCase.java
@@ -18,10 +18,8 @@ package com.adaptris.core.jms;
 
 import static com.adaptris.core.jms.JmsConfig.DEFAULT_PAYLOAD;
 import static com.adaptris.core.jms.JmsUtils.closeQuietly;
-
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import javax.jms.Destination;
 import javax.jms.Message;
 import javax.jms.MessageListener;
@@ -31,14 +29,12 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
 import javax.jms.TopicSubscriber;
-
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQQueueSender;
 import org.apache.activemq.ActiveMQSession;
 import org.apache.activemq.ActiveMQTopicPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
@@ -68,6 +64,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
 
   // INTERLOK-2121
   public void testProducerSession_Invalided() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     DefinedJmsProducer producer = createProducer(new ConfiguredProduceDestination(getName()));
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
@@ -86,6 +87,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testProduce_CaptureOutgoingMessageDetails() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     DefinedJmsProducer producer = createProducer(new ConfiguredProduceDestination(getName()));
     producer.setCaptureOutgoingMessageDetails(true);
@@ -107,6 +113,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testProduceAndConsume_IntegerAcknowledgementMode_IntegerDeliveryMode() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode(String.valueOf(AcknowledgeMode.Mode.AUTO_ACKNOWLEDGE.acknowledgeMode()));
@@ -143,6 +154,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testDefaultSessionFactory() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -169,6 +185,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testPerMessageSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -195,6 +216,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testTimedInactivitySession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -228,6 +254,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testTimedInactivitySession_SessionStillValid() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -258,6 +289,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testMessageCountSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -290,6 +326,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testMessageCountSession_SessionStillValid() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -320,6 +361,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testMessageSizeSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -353,6 +399,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testMessageSizeSession_SessionStillValid() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -382,6 +433,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testMetadataSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -423,6 +479,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testMultipleProducersWithSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -451,6 +512,11 @@ public abstract class BasicJmsProducerCase extends JmsProducerCase {
   }
 
   public void testMultipleRequestorWithSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     ServiceList serviceList = new ServiceList(new Service[]
     {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BooleanMetadataConverterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BooleanMetadataConverterTest.java
@@ -1,8 +1,10 @@
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
 import javax.jms.Message;
-
+import org.junit.Test;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 
@@ -13,10 +15,6 @@ public class BooleanMetadataConverterTest extends ConvertingMetadataConverterCas
 
   private static final boolean VALUE = true;
   private static final String STRING_VALUE = String.valueOf(VALUE);
-
-  public BooleanMetadataConverterTest(String name) {
-    super(name);
-  }
 
   @Override
   MetadataConverter createConverter() {
@@ -33,6 +31,7 @@ public class BooleanMetadataConverterTest extends ConvertingMetadataConverterCas
     assertEquals(VALUE, jmsMsg.getBooleanProperty(HEADER));
   }
 
+  @Test
   public void testConstruct() throws Exception {
     BooleanMetadataConverter mc = new BooleanMetadataConverter();
     assertTrue(mc.getMetadataFilter() instanceof NoOpMetadataFilter);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BytesMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BytesMessageTranslatorTest.java
@@ -16,21 +16,23 @@
 
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyByte;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
-
 import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageEOFException;
 import javax.jms.Session;
-
+import org.junit.Assume;
+import org.junit.Test;
 import org.mockito.Mockito;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.MetadataElement;
@@ -53,16 +55,13 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
       BYTES_ALT[i] = (byte) j;
     }
   }
-  
-  public BytesMessageTranslatorTest(String name) {
-    super(name);
-  }
-
 
   // We aren't actually producing the message, so we have to
   // switch to read-only mode.
   @Override
+  @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -88,7 +87,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   // We aren't actually producing the message, so we have to
   // switch to read-only mode.
   @Override
+  @Test
   public void testMoveJmsHeadersJmsMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -124,7 +125,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   }
 
   @Override
+  @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage_RemoveAllFilter() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     trans.setMetadataFilter(new RemoveAllMetadataFilter());
@@ -149,7 +152,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   }
 
   @Override
+  @Test
   public void testMoveMetadata_JmsMessageToAdaptrisMessage_WithFilter() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
@@ -177,7 +182,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   }
 
+  @Test
   public void testBytesMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -198,7 +205,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
   }
 
+  @Test
   public void testBytesMessageToAdaptrisMessage_Alt() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -219,8 +228,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   }
 
 
-
+  @Test
   public void testBytesMessageToAdaptrisMessage_StreamFailure() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -243,12 +253,15 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
   }
 
+  @Test
   public void testBytesMessageToAdaptrisMessage_StreamFailure_CheckedJMSException() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     BytesMessage jmsMsg = Mockito.mock(BytesMessage.class);
     Session session = Mockito.mock(Session.class);
-    doThrow(new JMSException(getName())).when(jmsMsg).readByte();
+    doThrow(new JMSException(testName.getMethodName())).when(jmsMsg).readByte();
     when(session.createBytesMessage()).thenReturn(jmsMsg);
     BytesMessageTranslator trans = new BytesMessageTranslator() {
+      @Override
       long streamThreshold() {
         return TEXT.length() - 1;
       }
@@ -266,8 +279,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
   }
 
-
+  @Test
   public void testAdaptrisMessageToBytesMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -288,9 +302,12 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
   }
 
+  @Test
   public void testAdaptrisMessageToBytesMessage_StreamFailure() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     BytesMessageTranslator trans = new BytesMessageTranslator() {
+      @Override
       long streamThreshold() {
         return TEXT.length() - 1;
       }
@@ -312,12 +329,15 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
   }
 
+  @Test
   public void testAdaptrisMessageToBytesMessage_StreamFailure_CheckedJMSException() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     BytesMessage jmsMsg = Mockito.mock(BytesMessage.class);
     Session session = Mockito.mock(Session.class);
-    doThrow(new JMSException(getName())).when(jmsMsg).writeByte(anyByte());
+    doThrow(new JMSException(testName.getMethodName())).when(jmsMsg).writeByte(anyByte());
     when(session.createBytesMessage()).thenReturn(jmsMsg);
     BytesMessageTranslator trans = new BytesMessageTranslator() {
+      @Override
       long streamThreshold() {
         return TEXT.length() - 1;
       }
@@ -341,6 +361,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     BytesMessageTranslator trans = new BytesMessageTranslator() {
 
+      @Override
       long streamThreshold() {
         return TEXT.length() -1;
       }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BytesMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BytesMessageTranslatorTest.java
@@ -357,7 +357,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
 
 
+  @Test
   public void testAdaptrisMessageToBytesMessage_ExceedsThreshold() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     BytesMessageTranslator trans = new BytesMessageTranslator() {
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BytesMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BytesMessageTranslatorTest.java
@@ -30,7 +30,6 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageEOFException;
 import javax.jms.Session;
-import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
@@ -61,7 +60,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   @Override
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -89,7 +88,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   @Override
   @Test
   public void testMoveJmsHeadersJmsMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -127,7 +126,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   @Override
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage_RemoveAllFilter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     trans.setMetadataFilter(new RemoveAllMetadataFilter());
@@ -154,7 +153,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   @Override
   @Test
   public void testMoveMetadata_JmsMessageToAdaptrisMessage_WithFilter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
@@ -184,7 +183,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testBytesMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -207,7 +206,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testBytesMessageToAdaptrisMessage_Alt() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -230,7 +229,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testBytesMessageToAdaptrisMessage_StreamFailure() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -255,7 +254,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testBytesMessageToAdaptrisMessage_StreamFailure_CheckedJMSException() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     BytesMessage jmsMsg = Mockito.mock(BytesMessage.class);
     Session session = Mockito.mock(Session.class);
     doThrow(new JMSException(testName.getMethodName())).when(jmsMsg).readByte();
@@ -281,7 +280,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testAdaptrisMessageToBytesMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -304,7 +303,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testAdaptrisMessageToBytesMessage_StreamFailure() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     BytesMessageTranslator trans = new BytesMessageTranslator() {
       @Override
@@ -331,7 +330,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testAdaptrisMessageToBytesMessage_StreamFailure_CheckedJMSException() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     BytesMessage jmsMsg = Mockito.mock(BytesMessage.class);
     Session session = Mockito.mock(Session.class);
     doThrow(new JMSException(testName.getMethodName())).when(jmsMsg).writeByte(anyByte());
@@ -359,7 +358,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testAdaptrisMessageToBytesMessage_ExceedsThreshold() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     BytesMessageTranslator trans = new BytesMessageTranslator() {
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/ConvertingMetadataConverterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/ConvertingMetadataConverterCase.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.fail;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
@@ -30,7 +29,7 @@ public abstract class ConvertingMetadataConverterCase extends MetadataConverterC
 
   @Test
   public void testConvertFailure() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     try {
@@ -49,7 +48,7 @@ public abstract class ConvertingMetadataConverterCase extends MetadataConverterC
 
   @Test
   public void testConvertFailure_Strict() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     mc.setStrictConversion(true);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/ConvertingMetadataConverterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/ConvertingMetadataConverterCase.java
@@ -15,39 +15,41 @@
 */
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public abstract class ConvertingMetadataConverterCase extends MetadataConverterCase {
 
-  public ConvertingMetadataConverterCase(String name) {
-    super(name);
-  }
-
-
+  @Test
   public void testConvertFailure() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     try {
       broker.start();
       Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       MetadataCollection metadataCollection = new MetadataCollection();
-      metadataCollection.add(new MetadataElement(HEADER, getName()));
+      metadataCollection.add(new MetadataElement(HEADER, testName.getMethodName()));
       Message jmsMsg = session.createMessage();
       mc.moveMetadata(metadataCollection, jmsMsg);
-      assertEquals(getName(), jmsMsg.getStringProperty(HEADER));
+      assertEquals(testName.getMethodName(), jmsMsg.getStringProperty(HEADER));
     }
     finally {
       broker.destroy();
     }
   }
 
+  @Test
   public void testConvertFailure_Strict() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     mc.setStrictConversion(true);
@@ -55,7 +57,7 @@ public abstract class ConvertingMetadataConverterCase extends MetadataConverterC
       broker.start();
       Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       MetadataCollection metadataCollection = new MetadataCollection();
-      metadataCollection.add(new MetadataElement(HEADER, getName()));
+      metadataCollection.add(new MetadataElement(HEADER, testName.getMethodName()));
       Message jmsMsg = session.createMessage();
       mc.moveMetadata(metadataCollection, jmsMsg);
       fail();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/FailoverJmsConsumerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/FailoverJmsConsumerCase.java
@@ -18,7 +18,6 @@ package com.adaptris.core.jms;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.Channel;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
@@ -35,6 +34,11 @@ public abstract class FailoverJmsConsumerCase extends JmsConsumerCase {
 
 
   public void testBug1012() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/FailoverJmsProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/FailoverJmsProducerCase.java
@@ -21,9 +21,7 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.Channel;
 import com.adaptris.core.CoreException;
@@ -43,6 +41,11 @@ public abstract class FailoverJmsProducerCase extends JmsProducerCase {
   }
 
   public void testBug1012() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     try {
@@ -77,6 +80,11 @@ public abstract class FailoverJmsProducerCase extends JmsProducerCase {
   }
 
   public void testNeverConnects() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     connection.addConnection(new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:123456")));
@@ -99,6 +107,11 @@ public abstract class FailoverJmsProducerCase extends JmsProducerCase {
   }
 
   public void testEventuallyConnects() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     final EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     connection.addConnection(new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:123456")));
@@ -131,6 +144,11 @@ public abstract class FailoverJmsProducerCase extends JmsProducerCase {
   }
 
   public void testConnectionEquals() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     connection.addConnection(broker.getJmsConnection(new BasicActiveMqImplementation(), true));
@@ -149,6 +167,11 @@ public abstract class FailoverJmsProducerCase extends JmsProducerCase {
   }
 
   public void testDelegatedMethods() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     connection.addConnection(broker.getJmsConnection(new BasicActiveMqImplementation(), true));

--- a/interlok-core/src/test/java/com/adaptris/core/jms/GenericMessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/GenericMessageTypeTranslatorCase.java
@@ -17,7 +17,6 @@ package com.adaptris.core.jms;
 
 import javax.jms.Message;
 import javax.jms.Session;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -29,7 +28,7 @@ public abstract class GenericMessageTypeTranslatorCase extends MessageTypeTransl
 
   @Test
   public void testMetadataConverter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator().withMetadataConverters(
         new StringMetadataConverter(new RegexMetadataFilter().withIncludePatterns(STRING_METADATA)),

--- a/interlok-core/src/test/java/com/adaptris/core/jms/GenericMessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/GenericMessageTypeTranslatorCase.java
@@ -17,6 +17,8 @@ package com.adaptris.core.jms;
 
 import javax.jms.Message;
 import javax.jms.Session;
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
@@ -24,12 +26,10 @@ import com.adaptris.core.metadata.RegexMetadataFilter;
 
 public abstract class GenericMessageTypeTranslatorCase extends MessageTypeTranslatorCase {
 
-  public GenericMessageTypeTranslatorCase(String name) {
-    super(name);
-  }
 
-
+  @Test
   public void testMetadataConverter() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator().withMetadataConverters(
         new StringMetadataConverter(new RegexMetadataFilter().withIncludePatterns(STRING_METADATA)),

--- a/interlok-core/src/test/java/com/adaptris/core/jms/IntegerMetadataConverterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/IntegerMetadataConverterTest.java
@@ -1,8 +1,10 @@
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
 import javax.jms.Message;
-
+import org.junit.Test;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 
@@ -14,10 +16,6 @@ public class IntegerMetadataConverterTest extends ConvertingMetadataConverterCas
 
   private static final int VALUE = 10;
   private static final String STRING_VALUE = String.valueOf(VALUE);
-
-  public IntegerMetadataConverterTest(String name) {
-    super(name);
-  }
 
   @Override
   MetadataConverter createConverter() {
@@ -34,6 +32,7 @@ public class IntegerMetadataConverterTest extends ConvertingMetadataConverterCas
     assertEquals(VALUE, jmsMsg.getIntProperty(HEADER));
   }
 
+  @Test
   public void testConstruct() throws Exception {
     IntegerMetadataConverter mc = new IntegerMetadataConverter();
     assertTrue(mc.getMetadataFilter() instanceof NoOpMetadataFilter);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
@@ -5,16 +5,13 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import javax.jms.CompletionListener;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageProducer;
-
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.CoreException;
@@ -43,6 +40,7 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   @Mock private StandardProcessingExceptionHandler mockExceptionHandler;
   
   
+  @Override
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     
@@ -151,6 +149,11 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   }
   
   public void testEmbeddedSuccessHandler() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedArtemis broker = new EmbeddedArtemis();
     JmsAsyncProducer producer = new JmsAsyncProducer();
     producer.setAsyncMessageErrorHandler(mockExceptionHandler);
@@ -178,6 +181,11 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   }
   
   public void testEmbeddedJmsException() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedArtemis broker = new EmbeddedArtemis();
     JmsAsyncProducer producer = new JmsAsyncProducer();
     producer.setAsyncMessageErrorHandler(mockExceptionHandler);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConfig.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConfig.java
@@ -18,6 +18,7 @@ package com.adaptris.core.jms;
 
 import java.util.Arrays;
 import java.util.List;
+import com.adaptris.core.BaseCase;
 
 public abstract class JmsConfig {
 
@@ -35,4 +36,7 @@ public abstract class JmsConfig {
   protected static final List<MessageTypeTranslator> MESSAGE_TRANSLATOR_LIST = Arrays
       .asList(MESSAGE_TRANSLATORS);
 
+  public static boolean jmsTestsEnabled() {
+    return Boolean.parseBoolean(BaseCase.PROPERTIES.getProperty("jms.tests.enabled", "true"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConnectionTest.java
@@ -18,7 +18,6 @@ package com.adaptris.core.jms;
 
 import static org.junit.Assert.assertNotSame;
 import javax.jms.Session;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -31,7 +30,7 @@ public class JmsConnectionTest {
 
   @Test
   public void testSession() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConnectionTest.java
@@ -17,13 +17,11 @@
 package com.adaptris.core.jms;
 
 import static org.junit.Assert.assertNotSame;
-
 import javax.jms.Session;
-
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 import com.adaptris.core.util.LifecycleHelper;
 
@@ -33,6 +31,7 @@ public class JmsConnectionTest {
 
   @Test
   public void testSession() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
@@ -23,16 +23,12 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.jms.MessageConsumer;
-
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneConsumer;
@@ -48,6 +44,7 @@ public class JmsConsumerTest extends JmsConsumerCase {
   @Mock private BasicActiveMqImplementation mockVendor;
   @Mock MessageConsumer mockMessageConsumer;
 
+  @Override
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
   }
@@ -58,6 +55,11 @@ public class JmsConsumerTest extends JmsConsumerCase {
 
 
   public void testDeferConsumerCreationToVendor() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     
     when(mockVendor.createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class)))
@@ -98,6 +100,11 @@ public class JmsConsumerTest extends JmsConsumerCase {
   }
   
   public void testDefaultFalseDeferConsumerCreationToVendor() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     
     when(mockVendor.createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class)))
@@ -140,6 +147,11 @@ public class JmsConsumerTest extends JmsConsumerCase {
   }
   
   public void testDurableTopicConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
@@ -165,6 +177,11 @@ public class JmsConsumerTest extends JmsConsumerCase {
   }
   
   public void testSharedDurableTopicConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedArtemis activeMqBroker = new EmbeddedArtemis();
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=MySubId&sharedConsumerId=" + getName();
 
@@ -190,6 +207,11 @@ public class JmsConsumerTest extends JmsConsumerCase {
   }
   
   public void testSharedTopicConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedArtemis activeMqBroker = new EmbeddedArtemis();
     String rfc6167 = "jms:topic:" + getName() + "?sharedConsumerId=" + getName();
 
@@ -215,6 +237,11 @@ public class JmsConsumerTest extends JmsConsumerCase {
   }
 
   public void testTopicConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:topic:" + getName();
 
@@ -240,6 +267,11 @@ public class JmsConsumerTest extends JmsConsumerCase {
   }
 
   public void testQueueConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:queue:" + getName();
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
@@ -23,23 +23,19 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.jms.Topic;
-
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQSession;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ConfiguredConsumeDestination;
@@ -64,6 +60,7 @@ public class JmsProducerTest extends JmsProducerCase {
   @Mock private Session mockSession;
   @Mock private Message mockMessage;
 
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     MockitoAnnotations.initMocks(this);
@@ -297,6 +294,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testProduce_JmsReplyToDestination() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -324,7 +326,11 @@ public class JmsProducerTest extends JmsProducerCase {
 
   public void testProduce_CaptureOutgoingMessageDetails() throws Exception {
     String rfc6167 = "jms:queue:" + getName();
-
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsProducer producer = createProducer(new ConfiguredProduceDestination(rfc6167));
     producer.setCaptureOutgoingMessageDetails(true);
@@ -345,6 +351,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testProduceAndConsume_DeliveryMode() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "?deliveryMode=PERSISTENT";
 
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
@@ -365,6 +376,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testProduceAndConsume_Priority() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "?priority=5";
 
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
@@ -386,6 +402,11 @@ public class JmsProducerTest extends JmsProducerCase {
 
 
   public void testProduceAndConsume_TimeToLive() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "?timeToLive=60000";
 
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
@@ -423,6 +444,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testDefaultSessionFactory() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -450,6 +476,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testPerMessageSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -478,6 +509,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testTimedInactivitySession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -513,6 +549,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testTimedInactivitySession_SessionStillValid() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -546,6 +587,11 @@ public class JmsProducerTest extends JmsProducerCase {
 
   public void testMessageCountSession() throws Exception {
     String rfc6167 = "jms:queue:" + getName() + "";
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -579,6 +625,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testMessageCountSession_SessionStillValid() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -611,6 +662,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testMessageSizeSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -647,6 +703,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testMessageSizeSession_SessionStillValid() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -678,6 +739,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testMetadataSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -721,6 +787,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testMultipleProducersWithSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConsumerImpl consumer = createConsumer(new ConfiguredConsumeDestination(getName()));
@@ -751,6 +822,11 @@ public class JmsProducerTest extends JmsProducerCase {
   }
 
   public void testMultipleRequestorWithSession() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     String rfc6167 = "jms:queue:" + getName() + "";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     ServiceList serviceList =

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsTransactedWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsTransactedWorkflowTest.java
@@ -20,10 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import com.adaptris.core.Channel;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
@@ -67,6 +65,11 @@ public class JmsTransactedWorkflowTest extends ExampleWorkflowCase {
   }
 
   public void testInit_UnsupportedConsumer() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     Channel channel = createStartableChannel(broker);
     JmsTransactedWorkflow workflow = (JmsTransactedWorkflow) channel.getWorkflowList().get(0);
@@ -95,6 +98,11 @@ public class JmsTransactedWorkflowTest extends ExampleWorkflowCase {
   }
 
   public void testInit_UnsupportedProduceExceptionHandler() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     Channel channel = createStartableChannel(broker);
     JmsTransactedWorkflow workflow = (JmsTransactedWorkflow) channel.getWorkflowList().get(0);
@@ -114,6 +122,11 @@ public class JmsTransactedWorkflowTest extends ExampleWorkflowCase {
   }
 
   public void testInit() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     Channel channel = createStartableChannel(broker);
     try {
@@ -127,6 +140,11 @@ public class JmsTransactedWorkflowTest extends ExampleWorkflowCase {
   }
 
   public void testStart() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     Channel channel = createStartableChannel(broker);
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsUtilsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsUtilsTest.java
@@ -19,7 +19,6 @@ package com.adaptris.core.jms;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-
 import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.MessageConsumer;
@@ -27,15 +26,15 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
-
+import org.junit.Assume;
 import org.junit.Test;
-
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public class JmsUtilsTest {
 
   @Test
   public void testCloseSession() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -56,6 +55,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testCloseConnection() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -83,6 +83,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testStopConnection() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -105,6 +106,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testDeleteTemporaryTopic() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -128,6 +130,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testDeleteTemporaryQueue() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -150,6 +153,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testDeleteTemporaryDestination() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -175,6 +179,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testCloseProducer() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -197,6 +202,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testCloseConsumer() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsUtilsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsUtilsTest.java
@@ -26,7 +26,6 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
@@ -34,7 +33,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testCloseSession() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -55,7 +54,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testCloseConnection() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -83,7 +82,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testStopConnection() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -106,7 +105,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testDeleteTemporaryTopic() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -130,7 +129,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testDeleteTemporaryQueue() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -153,7 +152,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testDeleteTemporaryDestination() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -179,7 +178,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testCloseProducer() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();
@@ -202,7 +201,7 @@ public class JmsUtilsTest {
 
   @Test
   public void testCloseConsumer() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     try {
       broker.start();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/LongMetadataConverterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/LongMetadataConverterTest.java
@@ -1,8 +1,10 @@
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
 import javax.jms.Message;
-
+import org.junit.Test;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 
@@ -13,10 +15,6 @@ public class LongMetadataConverterTest extends ConvertingMetadataConverterCase {
 
   private static final long VALUE = 10L;
   private static final String STRING_VALUE = String.valueOf(VALUE);
-
-  public LongMetadataConverterTest(String name) {
-    super(name);
-  }
 
   @Override
   MetadataConverter createConverter() {
@@ -33,6 +31,7 @@ public class LongMetadataConverterTest extends ConvertingMetadataConverterCase {
     assertEquals(VALUE, jmsMsg.getLongProperty(HEADER));
   }
 
+  @Test
   public void testConstruct() throws Exception {
     LongMetadataConverter mc = new LongMetadataConverter();
     assertTrue(mc.getMetadataFilter() instanceof NoOpMetadataFilter);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MapMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MapMessageTranslatorTest.java
@@ -16,10 +16,12 @@
 
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertTrue;
 import javax.jms.MapMessage;
 import javax.jms.Message;
 import javax.jms.Session;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
@@ -28,11 +30,6 @@ import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
  */
 public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
   private static final String BODY_KEY1 = "bodykey1";
-
-  public MapMessageTranslatorTest(String name) {
-    super(name);
-  }
-
 
   /**
    * @see com.adaptris.core.jms.MessageTypeTranslatorCase#createMessage(javax.jms.Session)
@@ -52,7 +49,9 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
     return t;
   }
 
+  @Test
   public void testMapMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {
@@ -73,7 +72,9 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
     }
   }
 
+  @Test
   public void testAdaptrisMessageToMapMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {
@@ -97,7 +98,9 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
     }
   }
 
+  @Test
   public void testAdaptrisMessageToMapMessageWithMetadataAsPayload() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MapMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MapMessageTranslatorTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertTrue;
 import javax.jms.MapMessage;
 import javax.jms.Message;
 import javax.jms.Session;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -51,7 +50,7 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
   @Test
   public void testMapMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {
@@ -74,7 +73,7 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
   @Test
   public void testAdaptrisMessageToMapMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {
@@ -100,7 +99,7 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
   @Test
   public void testAdaptrisMessageToMapMessageWithMetadataAsPayload() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MessageIdCorrelationIdSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MessageIdCorrelationIdSourceTest.java
@@ -17,16 +17,14 @@ package com.adaptris.core.jms;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
-
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
@@ -46,6 +44,7 @@ public class MessageIdCorrelationIdSourceTest {
 
   @Test
   public void testCorrelationIdAdaptrisMessage_ToMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -66,6 +65,7 @@ public class MessageIdCorrelationIdSourceTest {
 
   @Test
   public void testCorrelationIdMessage_AdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -90,6 +90,7 @@ public class MessageIdCorrelationIdSourceTest {
 
   @Test
   public void testCorrelationIdMessage_AdaptrisMessage_NoCorrelationId() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MessageIdCorrelationIdSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MessageIdCorrelationIdSourceTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertNotSame;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +43,7 @@ public class MessageIdCorrelationIdSourceTest {
 
   @Test
   public void testCorrelationIdAdaptrisMessage_ToMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -65,7 +64,7 @@ public class MessageIdCorrelationIdSourceTest {
 
   @Test
   public void testCorrelationIdMessage_AdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -90,7 +89,7 @@ public class MessageIdCorrelationIdSourceTest {
 
   @Test
   public void testCorrelationIdMessage_AdaptrisMessage_NoCorrelationId() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MessageTypeTranslatorCase.java
@@ -26,11 +26,21 @@ import static com.adaptris.core.jms.JmsConstants.JMS_REDELIVERED;
 import static com.adaptris.core.jms.JmsConstants.JMS_REPLY_TO;
 import static com.adaptris.core.jms.JmsConstants.JMS_TIMESTAMP;
 import static com.adaptris.core.jms.JmsConstants.JMS_TYPE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -49,7 +59,7 @@ import com.adaptris.core.util.LifecycleHelper;
 /**
  */
 @SuppressWarnings("deprecation")
-public abstract class MessageTypeTranslatorCase extends BaseCase {
+public abstract class MessageTypeTranslatorCase {
 
 
   public static final String INTEGER_VALUE = "-1";
@@ -62,36 +72,28 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
   public static final String TEXT2 = "jumps over the lazy dog";
 
   protected transient Log log = LogFactory.getLog(this.getClass());
-
-  public MessageTypeTranslatorCase(String name) {
-    super(name);
-  }
-
-  @Override
-  protected void setUp() throws Exception {
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-  }
+  @Rule
+  public TestName testName = new TestName();
 
   protected abstract MessageTypeTranslatorImp createTranslator() throws Exception;
 
   protected abstract Message createMessage(Session session) throws Exception;
 
   private StandaloneProducer createProducer(MessageTypeTranslator mt) throws Exception {
-    PasProducer producer = new PasProducer(new ConfiguredProduceDestination(getName()));
+    PasProducer producer =
+        new PasProducer(new ConfiguredProduceDestination(testName.getMethodName()));
     producer.setMessageTranslator(mt);
     return new StandaloneProducer(new JmsConnection(), producer);
   }
 
+  @Test
   public void testRoundTrip() throws Exception {
     MessageTypeTranslatorImp translator =
         createTranslator().withMoveJmsHeaders(true).withMetadataFilter(new NoOpMetadataFilter())
             .withReportAllErrors(true);
     StandaloneProducer p1 = createProducer(translator);
     StandaloneProducer p2 = roundTrip(p1);
-    assertRoundtripEquality(p1, p2);
+    BaseCase.assertRoundtripEquality(p1, p2);
   }
 
   protected StandaloneProducer roundTrip(StandaloneProducer src) throws Exception {
@@ -100,6 +102,7 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
     return (StandaloneProducer) m.unmarshal(xml);
   }
 
+  @Test
   public void testSetMetadataFilter() throws Exception {
     MessageTypeTranslatorImp translator = createTranslator();
     assertNull(translator.getMetadataFilter());
@@ -115,6 +118,7 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
     assertEquals(NoOpMetadataFilter.class, translator.metadataFilter().getClass());
   }
 
+  @Test
   public void testSetMoveJmsHeaders() throws Exception {
     MessageTypeTranslatorImp translator = createTranslator();
     assertNull(translator.getMoveJmsHeaders());
@@ -127,6 +131,7 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
     assertFalse(translator.moveJmsHeaders());
   }
 
+  @Test
   public void testSetReportAllErrors() throws Exception {
     MessageTypeTranslatorImp translator = createTranslator();
     assertNull(translator.getReportAllErrors());
@@ -139,7 +144,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
     assertFalse(translator.reportAllErrors());
   }
 
+  @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -158,7 +165,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
 
   }
 
+  @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage_RemoveAllFilter() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     trans.setMetadataFilter(new RemoveAllMetadataFilter());
@@ -179,7 +188,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
     }
   }
 
+  @Test
   public void testMoveMetadata_JmsMessageToAdaptrisMessage_WithFilter() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
@@ -203,7 +214,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
 
   }
 
+  @Test
   public void testMoveJmsHeadersJmsMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -233,7 +246,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
 
   }
 
+  @Test
   public void testMoveJmsHeadersAdaptrisMessageToJmsMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator().withMoveJmsHeaders(true);
     try {
@@ -263,7 +278,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
 
   }
 
+  @Test
   public void testMoveMetadataAdaptrisMessageToJmsMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -284,7 +301,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
     }
   }
 
+  @Test
   public void testMoveMetadata_AdaptrisMessageToJmsMessage_RemoveAll() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans =
         createTranslator().withMetadataFilter(new RemoveAllMetadataFilter());
@@ -308,8 +327,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
     }
   }
 
+  @Test
   public void testMoveMetadata_AdaptrisMessageToJmsMessage_WithFilter() throws Exception {
-
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
@@ -333,7 +353,9 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
     }
   }
 
+  @Test
   public void testBug895() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -357,8 +379,6 @@ public abstract class MessageTypeTranslatorCase extends BaseCase {
 
     }
   }
-
-
 
   public static void assertMetadata(AdaptrisMessage msg) {
     assertMetadata(msg, new MetadataElement(STRING_METADATA, STRING_VALUE));

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MessageTypeTranslatorCase.java
@@ -37,7 +37,6 @@ import javax.jms.Message;
 import javax.jms.Session;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -146,7 +145,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -167,7 +166,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage_RemoveAllFilter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     trans.setMetadataFilter(new RemoveAllMetadataFilter());
@@ -190,7 +189,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveMetadata_JmsMessageToAdaptrisMessage_WithFilter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
@@ -216,7 +215,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveJmsHeadersJmsMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -248,7 +247,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveJmsHeadersAdaptrisMessageToJmsMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator().withMoveJmsHeaders(true);
     try {
@@ -280,7 +279,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveMetadataAdaptrisMessageToJmsMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
@@ -303,7 +302,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveMetadata_AdaptrisMessageToJmsMessage_RemoveAll() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans =
         createTranslator().withMetadataFilter(new RemoveAllMetadataFilter());
@@ -329,7 +328,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveMetadata_AdaptrisMessageToJmsMessage_WithFilter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
@@ -355,7 +354,7 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testBug895() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MetadataConverterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MetadataConverterCase.java
@@ -64,7 +64,9 @@ public abstract class MetadataConverterCase {
     }
   }
 
+  @Test
   public void testSetPropertyWithReserved() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MetadataConverterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MetadataConverterCase.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -47,7 +46,7 @@ public abstract class MetadataConverterCase {
 
   @Test
   public void testSetProperty() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     try {
@@ -66,7 +65,7 @@ public abstract class MetadataConverterCase {
 
   @Test
   public void testSetPropertyWithReserved() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MetadataConverterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MetadataConverterCase.java
@@ -1,10 +1,16 @@
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
-
-import com.adaptris.core.BaseCase;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
@@ -14,14 +20,14 @@ import com.adaptris.core.metadata.RegexMetadataFilter;
 /**
  * @author mwarman
  */
-public abstract class MetadataConverterCase extends BaseCase {
+public abstract class MetadataConverterCase {
+
+  @Rule
+  public TestName testName = new TestName();
 
   static final String HEADER = "header";
 
-  MetadataConverterCase(String name) {
-    super(name);
-  }
-
+  @Test
   public void testMetadataFilter() throws Exception {
     MetadataConverter mc = createConverter();
     assertTrue(mc.getMetadataFilter() instanceof NoOpMetadataFilter);
@@ -29,6 +35,7 @@ public abstract class MetadataConverterCase extends BaseCase {
     assertTrue(mc.getMetadataFilter() instanceof RegexMetadataFilter);
   }
 
+  @Test
   public void testStrict() throws Exception {
     MetadataConverter mc = createConverter();
     assertFalse(mc.strict());
@@ -38,7 +45,9 @@ public abstract class MetadataConverterCase extends BaseCase {
     assertEquals(Boolean.FALSE, mc.getStrictConversion());
   }
 
+  @Test
   public void testSetProperty() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MetadataCorrelationIdSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MetadataCorrelationIdSourceTest.java
@@ -28,7 +28,6 @@ import javax.jms.TextMessage;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -45,7 +44,7 @@ public class MetadataCorrelationIdSourceTest {
 
   @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
@@ -69,7 +68,7 @@ public class MetadataCorrelationIdSourceTest {
 
   @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId_NoMetadataKey() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -92,7 +91,7 @@ public class MetadataCorrelationIdSourceTest {
 
   @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId_EmptyValue() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -115,7 +114,7 @@ public class MetadataCorrelationIdSourceTest {
 
   @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -138,7 +137,7 @@ public class MetadataCorrelationIdSourceTest {
 
   @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata_NoMetadataKey() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -161,7 +160,7 @@ public class MetadataCorrelationIdSourceTest {
 
   @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata_NoValue() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MetadataCorrelationIdSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MetadataCorrelationIdSourceTest.java
@@ -16,20 +16,26 @@
 
 package com.adaptris.core.jms;
 
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 @SuppressWarnings("deprecation")
-public class MetadataCorrelationIdSourceTest extends BaseCase {
+public class MetadataCorrelationIdSourceTest {
 
   private static final String CORRELATIONID_KEY = "correlationid_key";
   private static final String TEXT = "The quick brown fox";
@@ -37,16 +43,9 @@ public class MetadataCorrelationIdSourceTest extends BaseCase {
 
   protected transient Log log = LogFactory.getLog(this.getClass());
 
-  /**
-   * <p>
-   * Creates a new instance.
-   * </p>
-   */
-  public MetadataCorrelationIdSourceTest(String arg0) throws Exception {
-    super(arg0);
-  }
-
+  @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
@@ -68,7 +67,9 @@ public class MetadataCorrelationIdSourceTest extends BaseCase {
     }
   }
 
+  @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId_NoMetadataKey() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -89,7 +90,9 @@ public class MetadataCorrelationIdSourceTest extends BaseCase {
     }
   }
 
+  @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId_EmptyValue() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -110,7 +113,9 @@ public class MetadataCorrelationIdSourceTest extends BaseCase {
     }
   }
 
+  @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -131,7 +136,9 @@ public class MetadataCorrelationIdSourceTest extends BaseCase {
     }
   }
 
+  @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata_NoMetadataKey() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -152,7 +159,9 @@ public class MetadataCorrelationIdSourceTest extends BaseCase {
     }
   }
 
+  @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata_NoValue() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     JmsConnection conn = broker.getJmsConnection();
     try {
@@ -172,6 +181,7 @@ public class MetadataCorrelationIdSourceTest extends BaseCase {
     }
   }
 
+  @Test
   public void testSetMetadataKey() {
     MetadataCorrelationIdSource mcs = new MetadataCorrelationIdSource();
     assertEquals(null, mcs.getMetadataKey());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/ObjectMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/ObjectMessageTranslatorTest.java
@@ -16,27 +16,27 @@
 
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-
 import javax.jms.Message;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public class ObjectMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
-  public ObjectMessageTranslatorTest(String name) {
-    super(name);
-  }
-
+  @Test
   public void testObjectMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = new ObjectMessageTranslator();
     try {
@@ -60,7 +60,9 @@ public class ObjectMessageTranslatorTest extends GenericMessageTypeTranslatorCas
     }
   }
 
+  @Test
   public void testAdaptrisMessageToObjectMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = new ObjectMessageTranslator();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/ObjectMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/ObjectMessageTranslatorTest.java
@@ -26,7 +26,6 @@ import java.io.OutputStream;
 import javax.jms.Message;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -36,7 +35,7 @@ public class ObjectMessageTranslatorTest extends GenericMessageTypeTranslatorCas
 
   @Test
   public void testObjectMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = new ObjectMessageTranslator();
     try {
@@ -62,7 +61,7 @@ public class ObjectMessageTranslatorTest extends GenericMessageTypeTranslatorCas
 
   @Test
   public void testAdaptrisMessageToObjectMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = new ObjectMessageTranslator();
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/StringMetadataConverterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/StringMetadataConverterTest.java
@@ -1,8 +1,10 @@
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
 import javax.jms.Message;
-
+import org.junit.Test;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 
@@ -12,10 +14,6 @@ import com.adaptris.core.metadata.RegexMetadataFilter;
 public class StringMetadataConverterTest extends MetadataConverterCase {
 
   private static final String VALUE = "value";
-
-  public StringMetadataConverterTest(String name) {
-    super(name);
-  }
 
   @Override
   MetadataConverter createConverter() {
@@ -32,6 +30,7 @@ public class StringMetadataConverterTest extends MetadataConverterCase {
     assertEquals(VALUE, jmsMsg.getStringProperty(HEADER));
   }
 
+  @Test
   public void testConstruct() throws Exception {
     StringMetadataConverter mc = new StringMetadataConverter();
     assertTrue(mc.getMetadataFilter() instanceof NoOpMetadataFilter);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/TextMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/TextMessageTranslatorTest.java
@@ -16,10 +16,14 @@
 
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
@@ -27,11 +31,10 @@ import com.adaptris.core.metadata.RegexMetadataFilter;
 
 public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
-  public TextMessageTranslatorTest(String name) {
-    super(name);
-  }
 
+  @Test
   public void testTextMessageToAdaptrisMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TextMessageTranslator trans = new TextMessageTranslator();
     try {
@@ -50,7 +53,9 @@ public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase 
     }
   }
 
+  @Test
   public void testAdaptrisMessageToTextMessage() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TextMessageTranslator trans = new TextMessageTranslator();
     try {
@@ -70,36 +75,38 @@ public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase 
       broker.destroy();
     }
   }
-  
-  public void testAdaptrisMessageToTextMessageWithMetadataFilter() throws Exception {
-	    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-	    TextMessageTranslator trans = new TextMessageTranslator();
-	    
-	    RegexMetadataFilter filter = new RegexMetadataFilter();
-	    filter.addExcludePattern(INTEGER_METADATA);
-	    trans.setMetadataFilter(filter);
-	    try {
-	      broker.start();
-	      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
-	      start(trans, session);
 
-	      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
-	      addMetadata(msg);
-	      Message jmsMsg = trans.translate(msg);
-	      assertTrue("jmsMsg instanceof TextMessage", jmsMsg instanceof TextMessage);
-	      assertEquals(TEXT, ((TextMessage) jmsMsg).getText());
-	      
-	      assertEquals(STRING_VALUE, jmsMsg.getStringProperty(STRING_METADATA));
-	      assertEquals(BOOLEAN_VALUE, jmsMsg.getStringProperty(BOOLEAN_METADATA));
-	      assertEquals(Boolean.valueOf(BOOLEAN_VALUE).booleanValue(), jmsMsg.getBooleanProperty(BOOLEAN_METADATA)); // default
-	      // We should not of copied the integer value according to the filter.
-	      assertNull(jmsMsg.getStringProperty(INTEGER_METADATA));
-	    }
-	    finally {
-	      stop(trans);
-	      broker.destroy();
-	    }
-	  }
+  @Test
+  public void testAdaptrisMessageToTextMessageWithMetadataFilter() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    EmbeddedActiveMq broker = new EmbeddedActiveMq();
+    TextMessageTranslator trans = new TextMessageTranslator();
+
+    RegexMetadataFilter filter = new RegexMetadataFilter();
+    filter.addExcludePattern(INTEGER_METADATA);
+    trans.setMetadataFilter(filter);
+    try {
+      broker.start();
+      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      start(trans, session);
+
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
+      addMetadata(msg);
+      Message jmsMsg = trans.translate(msg);
+      assertTrue("jmsMsg instanceof TextMessage", jmsMsg instanceof TextMessage);
+      assertEquals(TEXT, ((TextMessage) jmsMsg).getText());
+
+      assertEquals(STRING_VALUE, jmsMsg.getStringProperty(STRING_METADATA));
+      assertEquals(BOOLEAN_VALUE, jmsMsg.getStringProperty(BOOLEAN_METADATA));
+      assertEquals(Boolean.valueOf(BOOLEAN_VALUE).booleanValue(),
+          jmsMsg.getBooleanProperty(BOOLEAN_METADATA)); // default
+      // We should not of copied the integer value according to the filter.
+      assertNull(jmsMsg.getStringProperty(INTEGER_METADATA));
+    } finally {
+      stop(trans);
+      broker.destroy();
+    }
+  }
 
   /**
    * @see com.adaptris.core.jms.MessageTypeTranslatorCase#createMessage(javax.jms.Session)

--- a/interlok-core/src/test/java/com/adaptris/core/jms/TextMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/TextMessageTranslatorTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -34,7 +33,7 @@ public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase 
 
   @Test
   public void testTextMessageToAdaptrisMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TextMessageTranslator trans = new TextMessageTranslator();
     try {
@@ -55,7 +54,7 @@ public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase 
 
   @Test
   public void testAdaptrisMessageToTextMessage() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TextMessageTranslator trans = new TextMessageTranslator();
     try {
@@ -78,7 +77,7 @@ public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase 
 
   @Test
   public void testAdaptrisMessageToTextMessageWithMetadataFilter() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TextMessageTranslator trans = new TextMessageTranslator();
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveJmsConnectionErrorHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveJmsConnectionErrorHandlerTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import java.security.SecureRandom;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -38,7 +37,6 @@ import com.adaptris.core.StartedState;
 import com.adaptris.core.Workflow;
 import com.adaptris.core.jms.ActiveJmsConnectionErrorHandler;
 import com.adaptris.core.jms.ActiveJmsConnectionErrorHandlerCase;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
@@ -53,7 +51,6 @@ public class ActiveJmsConnectionErrorHandlerTest extends ActiveJmsConnectionErro
 
   @Test
   public void testConnectionErrorHandler() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
@@ -80,7 +77,6 @@ public class ActiveJmsConnectionErrorHandlerTest extends ActiveJmsConnectionErro
 
   @Test
   public void testConnectionErrorHandlerWithJndi() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     String oldName = Thread.currentThread().getName();
     Thread.currentThread().setName(testName.getMethodName());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
@@ -114,7 +110,6 @@ public class ActiveJmsConnectionErrorHandlerTest extends ActiveJmsConnectionErro
 
   @Test
   public void testConnectionErrorHandlerWhileConnectionIsClosed() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
@@ -141,7 +136,6 @@ public class ActiveJmsConnectionErrorHandlerTest extends ActiveJmsConnectionErro
 
   @Test
   public void testBug1926() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
@@ -167,7 +161,6 @@ public class ActiveJmsConnectionErrorHandlerTest extends ActiveJmsConnectionErro
 
   @Test
   public void testActiveRestartSharedConnection() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     Adapter adapter = new Adapter();
     adapter.setUniqueId(testName.getMethodName());
@@ -216,7 +209,6 @@ public class ActiveJmsConnectionErrorHandlerTest extends ActiveJmsConnectionErro
 
   @Test
   public void testActiveRestartSharedConnection_ChannelNotStarted() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     Adapter adapter = new Adapter();
     adapter.setUniqueId(testName.getMethodName());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsPollingConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsPollingConsumerTest.java
@@ -23,7 +23,6 @@ import static com.adaptris.core.jms.JmsProducerCase.createMessage;
 import static com.adaptris.core.jms.activemq.ActiveMqPasPollingConsumerTest.shutdownQuietly;
 import static com.adaptris.core.jms.activemq.ActiveMqPasPollingConsumerTest.startAndStop;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -33,7 +32,6 @@ import com.adaptris.core.FixedIntervalPoller;
 import com.adaptris.core.Poller;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsPollingConsumer;
 import com.adaptris.core.jms.JmsProducer;
@@ -51,7 +49,6 @@ public class ActiveMqJmsPollingConsumerTest {
 
   @Test
   public void testTopic_NoSubscriptionId() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     String rfc6167 = "jms:topic:" + testName.getMethodName();
     final EmbeddedActiveMq broker = new EmbeddedActiveMq();
     final StandaloneConsumer consumer =
@@ -68,7 +65,6 @@ public class ActiveMqJmsPollingConsumerTest {
 
   @Test
   public void testQueue_ProduceConsume() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 5;
     String rfc6167 = "jms:queue:" + testName.getMethodName();
     final EmbeddedActiveMq broker = new EmbeddedActiveMq();
@@ -95,7 +91,6 @@ public class ActiveMqJmsPollingConsumerTest {
 
   @Test
   public void testTopic_ProduceConsume() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 5;
     String rfc6167 =
         "jms:topic:" + testName.getMethodName() + "?subscriptionId=" + testName.getMethodName();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsPollingConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsPollingConsumerTest.java
@@ -16,20 +16,24 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.waitForMessages;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.JmsProducerCase.createMessage;
 import static com.adaptris.core.jms.activemq.ActiveMqPasPollingConsumerTest.shutdownQuietly;
 import static com.adaptris.core.jms.activemq.ActiveMqPasPollingConsumerTest.startAndStop;
-
 import java.util.concurrent.TimeUnit;
-
-import com.adaptris.core.BaseCase;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.FixedIntervalPoller;
 import com.adaptris.core.Poller;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsPollingConsumer;
 import com.adaptris.core.jms.JmsProducer;
@@ -38,24 +42,20 @@ import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.core.util.ManagedThreadFactory;
 import com.adaptris.util.TimeInterval;
 
-public class ActiveMqJmsPollingConsumerTest extends BaseCase {
+public class ActiveMqJmsPollingConsumerTest {
+
+  @Rule
+  public TestName testName = new TestName();
 
   private static final ManagedThreadFactory MY_THREAD_FACTORY = new ManagedThreadFactory();
 
-  public ActiveMqJmsPollingConsumerTest(String arg0) {
-    super(arg0);
-  }
-
-  @Override
-  protected void setUp() throws Exception {}
-
-  @Override
-  protected void tearDown() throws Exception {}
-
+  @Test
   public void testTopic_NoSubscriptionId() throws Exception {
-    String rfc6167 = "jms:topic:" + getName();
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    String rfc6167 = "jms:topic:" + testName.getMethodName();
     final EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    final StandaloneConsumer consumer = createStandaloneConsumer(broker, getName(), rfc6167);
+    final StandaloneConsumer consumer =
+        createStandaloneConsumer(broker, testName.getMethodName(), rfc6167);
     try {
       broker.start();
       consumer.registerAdaptrisMessageListener(new MockMessageListener());
@@ -66,13 +66,16 @@ public class ActiveMqJmsPollingConsumerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testQueue_ProduceConsume() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 5;
-    String rfc6167 = "jms:queue:" + getName();
+    String rfc6167 = "jms:queue:" + testName.getMethodName();
     final EmbeddedActiveMq broker = new EmbeddedActiveMq();
     final StandaloneProducer sender =
         new StandaloneProducer(broker.getJmsConnection(), new JmsProducer(new ConfiguredProduceDestination(rfc6167)));
-    final StandaloneConsumer receiver = createStandaloneConsumer(broker, getName(), rfc6167);
+    final StandaloneConsumer receiver =
+        createStandaloneConsumer(broker, testName.getMethodName(), rfc6167);
     try {
       broker.start();
       MockMessageListener jms = new MockMessageListener();
@@ -90,14 +93,17 @@ public class ActiveMqJmsPollingConsumerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testTopic_ProduceConsume() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 5;
-    String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
+    String rfc6167 =
+        "jms:topic:" + testName.getMethodName() + "?subscriptionId=" + testName.getMethodName();
     final EmbeddedActiveMq broker = new EmbeddedActiveMq();
     final StandaloneProducer sender =
         new StandaloneProducer(broker.getJmsConnection(), new JmsProducer(new ConfiguredProduceDestination(rfc6167)));
     Sometime poller = new Sometime();
-    JmsPollingConsumer consumer = createConsumer(broker, getName(), rfc6167, poller);
+    JmsPollingConsumer consumer = createConsumer(broker, testName.getMethodName(), rfc6167, poller);
     final StandaloneConsumer receiver = new StandaloneConsumer(consumer);
     try {
       broker.start();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsTransactedWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsTransactedWorkflowTest.java
@@ -31,7 +31,6 @@ import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -50,7 +49,6 @@ import com.adaptris.core.ServiceList;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardProcessingExceptionHandler;
 import com.adaptris.core.Workflow;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConsumerImpl;
 import com.adaptris.core.jms.JmsPollingConsumerImpl;
@@ -80,7 +78,6 @@ public class ActiveMqJmsTransactedWorkflowTest {
   @Test
   public void testHandleChannelUnavailableWithException_Bug2343() throws Exception {
     int msgCount = 10;
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
     final Channel channel = createStartableChannel(activeMqBroker, true, "testHandleChannelUnavailableWithException_Bug2343",
@@ -113,7 +110,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testHandleChannelUnavailable_Bug2343() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -148,7 +145,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
   @Test
   public void testServiceException() throws Exception {
     int msgCount = 10;
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
 
@@ -172,7 +169,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testProduceException() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -206,7 +203,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testRuntimeException() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -242,7 +239,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
   // the transaction is successful.
   @Test
   public void testServiceExceptionNonStrictWithErrorHandler() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -278,7 +275,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
   // the queue.
   @Test
   public void testServiceExceptionStrictWithErrorHandler() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -308,7 +305,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testMessagesRolledBackUsingQueue() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -333,7 +330,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testMessagesRolledBackUsingTopic() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -360,7 +357,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testMessagesCommittedUsingQueue() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -385,7 +382,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testWorkflow_SkipProducer() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
@@ -418,7 +415,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testMessagesCommittedUsingTopic() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -441,7 +438,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testWorkflowWithInterceptor() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -467,7 +464,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testMessagesOrderedUsingQueue() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -502,7 +499,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testMessagesOrderedUsingTopic() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -535,7 +532,7 @@ public class ActiveMqJmsTransactedWorkflowTest {
 
   @Test
   public void testMessagesOrderedUsingQueuePollingConsumer() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsTransactedWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqJmsTransactedWorkflowTest.java
@@ -16,8 +16,12 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
+import static com.adaptris.core.BaseCase.waitForMessages;
 import static com.adaptris.core.jms.JmsConfig.DEFAULT_PAYLOAD;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createSafeUniqueId;
+import static junit.framework.TestCase.assertEquals;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -27,9 +31,10 @@ import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.Channel;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
@@ -45,6 +50,7 @@ import com.adaptris.core.ServiceList;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardProcessingExceptionHandler;
 import com.adaptris.core.Workflow;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConsumerImpl;
 import com.adaptris.core.jms.JmsPollingConsumerImpl;
@@ -66,24 +72,15 @@ import com.adaptris.util.TimeInterval;
 /**
  * Tests for JmsTransactedWorkflow that don't rely on Sonic.
  */
-public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
+public class ActiveMqJmsTransactedWorkflowTest {
 
   private static Log logR = LogFactory.getLog(ActiveMqJmsTransactedWorkflowTest.class);
 
-  public ActiveMqJmsTransactedWorkflowTest(String arg0) {
-    super(arg0);
-  }
 
-  @Override
-  protected void setUp() throws Exception {
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-  }
-
+  @Test
   public void testHandleChannelUnavailableWithException_Bug2343() throws Exception {
     int msgCount = 10;
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
     final Channel channel = createStartableChannel(activeMqBroker, true, "testHandleChannelUnavailableWithException_Bug2343",
@@ -114,7 +111,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testHandleChannelUnavailable_Bug2343() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -146,8 +145,10 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testServiceException() throws Exception {
     int msgCount = 10;
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
 
@@ -169,8 +170,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
-
+  @Test
   public void testProduceException() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -202,7 +204,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testRuntimeException() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -236,7 +240,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
 
   // In Non-Strict Mode, if you have configured an error handler, then
   // the transaction is successful.
+  @Test
   public void testServiceExceptionNonStrictWithErrorHandler() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -270,7 +276,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
   // In Strict Mode, Then even if you have configured an error handler, then
   // the transaction is unsucessful if we have an exception, leading to msgs on
   // the queue.
+  @Test
   public void testServiceExceptionStrictWithErrorHandler() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -298,7 +306,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testMessagesRolledBackUsingQueue() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -321,7 +331,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testMessagesRolledBackUsingTopic() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -346,7 +358,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testMessagesCommittedUsingQueue() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -369,7 +383,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testWorkflow_SkipProducer() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
@@ -400,7 +416,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testMessagesCommittedUsingTopic() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -421,7 +439,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testWorkflowWithInterceptor() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -445,7 +465,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testMessagesOrderedUsingQueue() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -478,7 +500,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testMessagesOrderedUsingTopic() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());
@@ -509,7 +533,9 @@ public class ActiveMqJmsTransactedWorkflowTest extends BaseCase {
     activeMqBroker.destroy();
   }
 
+  @Test
   public void testMessagesOrderedUsingQueuePollingConsumer() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 10;
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String destination = createSafeUniqueId(new Object());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPasPollingConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPasPollingConsumerTest.java
@@ -16,15 +16,20 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
+import static com.adaptris.core.BaseCase.waitForMessages;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.JmsProducerCase.createMessage;
-
+import static junit.framework.TestCase.fail;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.AdaptrisPollingConsumer;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.CoreException;
@@ -32,6 +37,7 @@ import com.adaptris.core.RandomIntervalPoller;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardWorkflow;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.PasPollingConsumer;
 import com.adaptris.core.jms.PasProducer;
@@ -41,24 +47,15 @@ import com.adaptris.core.util.ManagedThreadFactory;
 import com.adaptris.util.SafeGuidGenerator;
 import com.adaptris.util.TimeInterval;
 
-public class ActiveMqPasPollingConsumerTest extends BaseCase {
+public class ActiveMqPasPollingConsumerTest {
 
   private static final String MY_SUBSCRIPTION_ID = new SafeGuidGenerator().safeUUID();
   private static final ManagedThreadFactory MY_THREAD_FACTORY = new ManagedThreadFactory();
 
+  @Rule
+  public TestName testName = new TestName();
 
-  public ActiveMqPasPollingConsumerTest(String arg0) {
-    super(arg0);
-  }
-
-  @Override
-  protected void setUp() throws Exception {
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-  }
-
+  @Test
   public void testInitNoClientIdOrSubscriptionId() throws Exception {
     PasPollingConsumer consumer = create();
     try {
@@ -70,6 +67,7 @@ public class ActiveMqPasPollingConsumerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testInitClientOnly() throws Exception {
     PasPollingConsumer consumer = create();
     consumer.setClientId("xxxx");
@@ -83,6 +81,7 @@ public class ActiveMqPasPollingConsumerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testInitSubscriptionOnly() throws Exception {
     PasPollingConsumer consumer = create();
     consumer.setSubscriptionId("xxxx");
@@ -96,6 +95,7 @@ public class ActiveMqPasPollingConsumerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testInitClientAndSubscriptionSet() throws Exception {
     PasPollingConsumer consumer = create();
     consumer.setClientId("xxxx");
@@ -109,12 +109,15 @@ public class ActiveMqPasPollingConsumerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testProduceConsume() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 5;
     final EmbeddedActiveMq activeBroker = new EmbeddedActiveMq();
     final StandaloneProducer sender = new StandaloneProducer(activeBroker.getJmsConnection(), new PasProducer(
-        new ConfiguredProduceDestination(getName())));
-    final StandaloneConsumer receiver = createStandalone(activeBroker, "testProduceConsume", getName());
+            new ConfiguredProduceDestination(testName.getMethodName())));
+    final StandaloneConsumer receiver =
+        createStandalone(activeBroker, "testProduceConsume", testName.getMethodName());
     activeBroker.start();
     try {
       MockMessageListener jms = new MockMessageListener();
@@ -197,6 +200,7 @@ public class ActiveMqPasPollingConsumerTest extends BaseCase {
   static void shutdownQuietly(final StandaloneProducer sender, final StandaloneConsumer receiver,
       final EmbeddedActiveMq activeMqBroker) {
     MY_THREAD_FACTORY.newThread(new Runnable() {
+      @Override
       public void run() {
         LifecycleHelper.waitQuietly(1000);
         stop(sender);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPasPollingConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPasPollingConsumerTest.java
@@ -25,7 +25,6 @@ import static junit.framework.TestCase.fail;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -37,7 +36,6 @@ import com.adaptris.core.RandomIntervalPoller;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardWorkflow;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.PasPollingConsumer;
 import com.adaptris.core.jms.PasProducer;
@@ -111,7 +109,7 @@ public class ActiveMqPasPollingConsumerTest {
 
   @Test
   public void testProduceConsume() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 5;
     final EmbeddedActiveMq activeBroker = new EmbeddedActiveMq();
     final StandaloneProducer sender = new StandaloneProducer(activeBroker.getJmsConnection(), new PasProducer(

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPtpPollingConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPtpPollingConsumerTest.java
@@ -16,18 +16,22 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.waitForMessages;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.JmsProducerCase.createMessage;
 import static com.adaptris.core.jms.activemq.ActiveMqPasPollingConsumerTest.shutdownQuietly;
-
 import java.util.concurrent.TimeUnit;
-
-import com.adaptris.core.BaseCase;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.FixedIntervalPoller;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.PtpPollingConsumer;
 import com.adaptris.core.jms.PtpProducer;
@@ -35,27 +39,21 @@ import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.core.util.ManagedThreadFactory;
 import com.adaptris.util.TimeInterval;
 
-public class ActiveMqPtpPollingConsumerTest extends BaseCase {
+public class ActiveMqPtpPollingConsumerTest {
   private static final ManagedThreadFactory MY_THREAD_FACTORY = new ManagedThreadFactory();
 
-  public ActiveMqPtpPollingConsumerTest(String arg0) {
-    super(arg0);
-  }
+  @Rule
+  public TestName testName = new TestName();
 
-  @Override
-  protected void setUp() throws Exception {
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-  }
-
+  @Test
   public void testProduceConsume() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     int msgCount = 5;
     final EmbeddedActiveMq broker = new EmbeddedActiveMq();
     final StandaloneProducer sender = new StandaloneProducer(broker.getJmsConnection(), new PtpProducer(
-        new ConfiguredProduceDestination(getName())));
-    final StandaloneConsumer receiver = createConsumer(broker, "testProduceConsume", getName());
+            new ConfiguredProduceDestination(testName.getMethodName())));
+    final StandaloneConsumer receiver =
+        createConsumer(broker, "testProduceConsume", testName.getMethodName());
     try {
       broker.start();
       MockMessageListener jms = new MockMessageListener();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPtpPollingConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPtpPollingConsumerTest.java
@@ -22,7 +22,6 @@ import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.JmsProducerCase.createMessage;
 import static com.adaptris.core.jms.activemq.ActiveMqPasPollingConsumerTest.shutdownQuietly;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -31,7 +30,6 @@ import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.FixedIntervalPoller;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.PtpPollingConsumer;
 import com.adaptris.core.jms.PtpProducer;
@@ -47,7 +45,7 @@ public class ActiveMqPtpPollingConsumerTest {
 
   @Test
   public void testProduceConsume() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     int msgCount = 5;
     final EmbeddedActiveMq broker = new EmbeddedActiveMq();
     final StandaloneProducer sender = new StandaloneProducer(broker.getJmsConnection(), new PtpProducer(

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/AdvancedActiveMqImplementationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/AdvancedActiveMqImplementationTest.java
@@ -16,11 +16,12 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.ActiveMQPrefetchPolicy;
 import org.apache.activemq.RedeliveryPolicy;
 import org.apache.activemq.blob.BlobTransferPolicy;
-
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
@@ -28,13 +29,6 @@ public class AdvancedActiveMqImplementationTest extends BasicActiveMqImplementat
 
   private static final String TRUE = Boolean.TRUE.toString();
   private static final String FALSE = Boolean.FALSE.toString();
-
-  /**
-   * @param name
-   */
-  public AdvancedActiveMqImplementationTest(String name) {
-    super(name);
-  }
 
   @Override
   protected void doAssertions(ActiveMQConnectionFactory f) throws Exception {
@@ -48,9 +42,12 @@ public class AdvancedActiveMqImplementationTest extends BasicActiveMqImplementat
 
   private void doAssertions(BlobTransferPolicy p) throws Exception {
     assertNotNull("BlobTransferPolicy", p);
-    assertEquals("BlobUploadStrategy", ExampleNoOpBlobUploadStrategy.class, p.getUploadStrategy().getClass());
-    assertEquals("setBrokerUploadUrl", "http://localhost:80/activemq", p.getBrokerUploadUrl());
-    assertEquals("setDefaultUploadUrl", "ftp://myname:mypassword@localhost:21/activemq", p.getDefaultUploadUrl());
+    assertEquals("BlobUploadStrategy", ExampleNoOpBlobUploadStrategy.class,
+        p.getUploadStrategy().getClass());
+    assertEquals("setBrokerUploadUrl", "http://localhost:80/activemq",
+        p.getBrokerUploadUrl());
+    assertEquals("setDefaultUploadUrl", "ftp://myname:mypassword@localhost:21/activemq",
+        p.getDefaultUploadUrl());
     assertEquals("setUploadUrl", "https://localhost:443/activemq", p.getUploadUrl());
     assertEquals("setBufferSize", 256 * 1024, p.getBufferSize());
   }
@@ -67,7 +64,8 @@ public class AdvancedActiveMqImplementationTest extends BasicActiveMqImplementat
 
   private void doAssertions(RedeliveryPolicy p) throws Exception {
     assertNotNull("RedeliveryPolicy", p);
-    assertEquals("setBackOffMultiplier", Double.valueOf("10"), p.getBackOffMultiplier());
+    assertEquals("setBackOffMultiplier", Double.valueOf("10"),
+        Double.valueOf(p.getBackOffMultiplier()));
     assertEquals("setCollisionAvoidancePercent", 50, p.getCollisionAvoidancePercent());
     assertEquals("setInitialRedeliveryDelay", 10000, p.getInitialRedeliveryDelay());
     assertEquals("setUseCollisionAvoidance", true, p.isUseCollisionAvoidance());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/AdvancedActiveMqProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/AdvancedActiveMqProducerTest.java
@@ -17,14 +17,13 @@
 package com.adaptris.core.jms.activemq;
 
 import static com.adaptris.core.jms.activemq.AdvancedActiveMqImplementationTest.createImpl;
-
 import org.apache.activemq.ActiveMQPrefetchPolicy;
 import org.apache.activemq.RedeliveryPolicy;
-
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.PtpConsumer;
 import com.adaptris.core.jms.PtpProducer;
@@ -49,6 +48,11 @@ public class AdvancedActiveMqProducerTest extends BasicActiveMqProducerTest {
   }
 
   public void testQueueProduceAndConsumeWithRedeliveryPolicy() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/AdvancedActiveMqProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/AdvancedActiveMqProducerTest.java
@@ -76,6 +76,11 @@ public class AdvancedActiveMqProducerTest extends BasicActiveMqProducerTest {
   }
 
   public void testQueueProduceAndConsumeWithPrefetch() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqConsumerTest.java
@@ -38,6 +38,7 @@ import com.adaptris.core.Workflow;
 import com.adaptris.core.jms.AutoConvertMessageTranslator;
 import com.adaptris.core.jms.BytesMessageTranslator;
 import com.adaptris.core.jms.DefinedJmsProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConsumerCase;
 import com.adaptris.core.jms.PasConsumer;
@@ -105,6 +106,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testTopicProduceAndConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -131,6 +137,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testTopicProduceAndConsumeWithImplicitFallbackMessageTranslation() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -152,6 +163,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testTopicProduceAndConsumeWithExplicitFallbackMessageTranslation() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -188,6 +204,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testQueue_ProduceWhenConsumerStopped() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     PtpConsumer consumer = new PtpConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -220,6 +241,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testTopic_ProduceWhenConsumerStopped() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     PasConsumer consumer = new PasConsumer(new ConfiguredConsumeDestination(getName()));
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -252,6 +278,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testQueueProduceAndConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -274,6 +305,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testQueueProduceAndConsumeWithImplicitFallbackMessageTranslation() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -295,6 +331,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testQueueProduceAndConsumeWithExplicitFallbackMessageTranslation() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -319,6 +360,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   public void testBlobProduceConsume() throws Exception {
     if (!ExternalResourcesHelper.isExternalServerAvailable()) {
       log.debug("Blob Server not available; skipping test");
+      return;
+    }
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
       return;
     }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
@@ -348,6 +394,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
       log.debug("Blob Server not available; skipping test");
       return;
     }
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -371,6 +422,11 @@ public class BasicActiveMqConsumerTest extends JmsConsumerCase {
   }
 
   public void testStartWithDurableSubscribers_WithNonBlockingChannelStrategy() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqImplementationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqImplementationTest.java
@@ -25,14 +25,12 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsDestination;
 import com.adaptris.core.jms.PtpProducer;
@@ -64,7 +62,7 @@ public class BasicActiveMqImplementationTest {
 
   @Test
   public void testRfc6167_Basic() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneProducer producer = null;
 
@@ -93,7 +91,7 @@ public class BasicActiveMqImplementationTest {
 
   @Test
   public void testRfc6167_WithParams() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneProducer producer = null;
 
@@ -132,7 +130,7 @@ public class BasicActiveMqImplementationTest {
 
   @Test
   public void testRfc6167_Invalid() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneProducer producer = null;
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqImplementationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqImplementationTest.java
@@ -16,29 +16,33 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import javax.jms.JMSException;
-
 import org.apache.activemq.ActiveMQConnectionFactory;
-
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsDestination;
 import com.adaptris.core.jms.PtpProducer;
 import com.adaptris.core.jms.VendorImplementation;
 
-public class BasicActiveMqImplementationTest extends BaseCase {
+public class BasicActiveMqImplementationTest {
 
   protected static final String PRIMARY = "tcp://localhost:61616";
-
-  /**
-   * @param name
-   */
-  public BasicActiveMqImplementationTest(String name) {
-    super(name);
-  }
+  @Rule
+  public TestName testName = new TestName();
 
   public void testConnectionFactory() throws Exception {
     VendorImplementation mq = create();
@@ -57,14 +61,16 @@ public class BasicActiveMqImplementationTest extends BaseCase {
   }
 
 
+  @Test
   public void testRfc6167_Basic() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneProducer producer = null;
 
     try {
       broker.start();
       BasicActiveMqImplementation vendorImp = create();
-      PtpProducer ptp = new PtpProducer(new ConfiguredProduceDestination(getName()));
+      PtpProducer ptp = new PtpProducer(new ConfiguredProduceDestination(testName.getMethodName()));
       producer = new StandaloneProducer(broker.getJmsConnection(vendorImp), ptp);
       start(producer);
       // Send a message so that the session is correct.
@@ -84,14 +90,16 @@ public class BasicActiveMqImplementationTest extends BaseCase {
     }
   }
 
+  @Test
   public void testRfc6167_WithParams() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneProducer producer = null;
 
     try {
       broker.start();
       BasicActiveMqImplementation vendorImp = create();
-      PtpProducer ptp = new PtpProducer(new ConfiguredProduceDestination(getName()));
+      PtpProducer ptp = new PtpProducer(new ConfiguredProduceDestination(testName.getMethodName()));
       producer = new StandaloneProducer(broker.getJmsConnection(vendorImp), ptp);
       start(producer);
       // Send a message so that the session is correct.
@@ -121,15 +129,16 @@ public class BasicActiveMqImplementationTest extends BaseCase {
   }
 
 
-
+  @Test
   public void testRfc6167_Invalid() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneProducer producer = null;
 
     try {
       broker.start();
       BasicActiveMqImplementation vendorImp = create();
-      PtpProducer ptp = new PtpProducer(new ConfiguredProduceDestination(getName()));
+      PtpProducer ptp = new PtpProducer(new ConfiguredProduceDestination(testName.getMethodName()));
       producer = new StandaloneProducer(broker.getJmsConnection(vendorImp), ptp);
       start(producer);
       // Send a message so that the session is correct.

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqImplementationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqImplementationTest.java
@@ -44,6 +44,7 @@ public class BasicActiveMqImplementationTest {
   @Rule
   public TestName testName = new TestName();
 
+  @Test
   public void testConnectionFactory() throws Exception {
     VendorImplementation mq = create();
     JmsConnection c = new JmsConnection();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqProducerTest.java
@@ -21,7 +21,6 @@ import static com.adaptris.core.jms.JmsConfig.HIGHEST_PRIORITY;
 import static com.adaptris.core.jms.JmsConfig.LOWEST_PRIORITY;
 import static com.adaptris.core.jms.activemq.AdvancedActiveMqImplementationTest.createImpl;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.addBlobUrlRef;
-
 import javax.jms.DeliveryMode;
 import javax.jms.Destination;
 import javax.jms.Message;
@@ -32,12 +31,10 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
 import javax.jms.TopicSubscriber;
-
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQQueueSender;
 import org.apache.activemq.ActiveMQSession;
 import org.apache.activemq.ActiveMQTopicPublisher;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
@@ -47,6 +44,7 @@ import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandaloneRequestor;
 import com.adaptris.core.jms.BytesMessageTranslator;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConstants;
 import com.adaptris.core.jms.JmsProducerCase;
@@ -123,6 +121,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicRequestReply() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
@@ -144,6 +147,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicRequestReplyWithMessageWrongType() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(broker, getName(), false);
     try {
@@ -165,6 +173,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueRequestReply() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     QueueLoopback echo = new QueueLoopback(activeMqBroker, getName());
     try {
@@ -186,6 +199,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueRequestReplyWithMessageWrongType() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     QueueLoopback echo = new QueueLoopback(activeMqBroker, getName(), false);
     try {
@@ -209,6 +227,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicProduce_WithStaticReplyTo() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
@@ -231,6 +254,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueProduce_WithStaticReplyTo() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     QueueLoopback echo = new QueueLoopback(activeMqBroker, getName());
     try {
@@ -253,6 +281,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicProduceWithPerMessagePropertiesDisabled() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
@@ -278,6 +311,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicProduceWithPerMessageProperties() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
@@ -303,6 +341,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicProduceAndConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -324,6 +367,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicProduceAndConsume_CustomMessageFactory() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -347,6 +395,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicProduceAndConsume_WithEncoder() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -369,6 +422,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicProduceAndConsume_DurableSubscriber() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -404,6 +462,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicProduceAndConsumeWrongType() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -426,6 +489,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueProduceAndConsume() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -448,6 +516,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueProduceAndConsume_CustomMessageFactory() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -472,6 +545,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueProduceAndConsume_WithEncoder() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -496,6 +574,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueProduceAndConsumeWrongType() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -518,6 +601,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueProduceAndConsumeWithSecurity() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
     try {
       broker.start();
@@ -545,6 +633,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueProduceAndConsumeWithSecurity_EncryptedPassword() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
     try {
       broker.start();
@@ -606,6 +699,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   // }
 
   public void testBlobConsumeWithNonBlob() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -633,7 +731,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
       log.debug("Blob Server not available; skipping test");
       return;
     }
-
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -661,6 +763,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
       log.debug("Blob Server not available; skipping test");
       return;
     }
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -685,6 +792,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testTopicRequestReply_Bug2277() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
@@ -707,6 +819,11 @@ public class BasicActiveMqProducerTest extends JmsProducerCase {
   }
 
   public void testQueueRequestReply_Bug2277() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     QueueLoopback echo = new QueueLoopback(activeMqBroker, getName());
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BlobMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BlobMessageTranslatorTest.java
@@ -20,23 +20,20 @@ import static com.adaptris.core.jms.MessageTypeTranslatorCase.addMetadata;
 import static com.adaptris.core.jms.MessageTypeTranslatorCase.addProperties;
 import static com.adaptris.core.jms.MessageTypeTranslatorCase.assertJmsProperties;
 import static com.adaptris.core.jms.MessageTypeTranslatorCase.assertMetadata;
-
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.jms.Message;
 import javax.jms.Session;
-
 import org.apache.activemq.ActiveMQSession;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConstants;
 import com.adaptris.core.jms.JmsProducer;
@@ -70,6 +67,11 @@ public class BlobMessageTranslatorTest extends JmsProducerExample {
   }
 
   public void testMoveMetadataJmsMessageToAdaptrisMessage() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     MessageTypeTranslatorImp trans = new BlobMessageTranslator();
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConnection conn = null;
@@ -96,6 +98,11 @@ public class BlobMessageTranslatorTest extends JmsProducerExample {
   }
 
   public void testMoveJmsHeadersJmsMessageToAdaptrisMessage() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     MessageTypeTranslatorImp trans = new BlobMessageTranslator();
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConnection conn = null;
@@ -134,6 +141,11 @@ public class BlobMessageTranslatorTest extends JmsProducerExample {
   }
 
   public void testMoveMetadataAdaptrisMessageToJmsMessage() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     MessageTypeTranslatorImp trans = new BlobMessageTranslator();
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConnection conn = null;
@@ -162,6 +174,11 @@ public class BlobMessageTranslatorTest extends JmsProducerExample {
   }
 
   public void testBug895() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     MessageTypeTranslatorImp trans = new BlobMessageTranslator();
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConnection conn = null;

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/DestinationCacheJndiPasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/DestinationCacheJndiPasProducerTest.java
@@ -21,13 +21,11 @@ import static com.adaptris.core.BaseCase.stop;
 import static com.adaptris.core.BaseCase.waitForMessages;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
 import com.adaptris.core.jms.jndi.CachedDestinationJndiImplementation;
@@ -43,7 +41,7 @@ public class DestinationCacheJndiPasProducerTest extends JndiPasProducerCase {
 
   @Test
   public void testProduceAndConsumeWithCache() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/DestinationCacheJndiPasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/DestinationCacheJndiPasProducerTest.java
@@ -16,13 +16,18 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
+import static com.adaptris.core.BaseCase.waitForMessages;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
 import com.adaptris.core.jms.jndi.CachedDestinationJndiImplementation;
@@ -31,26 +36,19 @@ import com.adaptris.core.stubs.MockMessageListener;
 
 public class DestinationCacheJndiPasProducerTest extends JndiPasProducerCase {
 
-  public DestinationCacheJndiPasProducerTest(String name) {
-    super(name);
-  }
-
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-  }
-
   @Override
   protected CachedDestinationJndiImplementation createVendorImplementation() {
     return new CachedDestinationJndiImplementation();
   }
 
+  @Test
   public void testProduceAndConsumeWithCache() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
 
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(broker.getJndiPasConnection(recvVendorImp, false, queueName,
         topicName), new PasConsumer(new ConfiguredConsumeDestination(topicName)));

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/DestinationCacheJndiPtpProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/DestinationCacheJndiPtpProducerTest.java
@@ -24,13 +24,11 @@ import static org.junit.Assert.assertTrue;
 import java.util.Map;
 import javax.jms.Queue;
 import javax.jms.Topic;
-import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.MetadataDestination;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PtpProducer;
 import com.adaptris.core.jms.jndi.CachedDestinationJndiImplementation;
 import com.adaptris.core.stubs.MockMessageListener;
@@ -45,7 +43,7 @@ public class DestinationCacheJndiPtpProducerTest extends JndiPtpProducerCase {
 
   @Test
   public void testProduceWithCache() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     DestinationCachingJndiVendorImpl sendVendorImp = new DestinationCachingJndiVendorImpl();
     sendVendorImp.setUseJndiForQueues(true);
@@ -70,7 +68,7 @@ public class DestinationCacheJndiPtpProducerTest extends JndiPtpProducerCase {
 
   @Test
   public void testProduceWithCacheExceeded() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     DestinationCachingJndiVendorImpl jv = new DestinationCachingJndiVendorImpl(2);
     MockMessageListener jms = new MockMessageListener();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/DestinationCacheJndiPtpProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/DestinationCacheJndiPtpProducerTest.java
@@ -15,18 +15,22 @@
 */
 
 package com.adaptris.core.jms.activemq;
-
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import java.util.Map;
-
 import javax.jms.Queue;
 import javax.jms.Topic;
-
+import org.junit.Assume;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.MetadataDestination;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PtpProducer;
 import com.adaptris.core.jms.jndi.CachedDestinationJndiImplementation;
 import com.adaptris.core.stubs.MockMessageListener;
@@ -34,26 +38,19 @@ import com.adaptris.util.KeyValuePair;
 
 public class DestinationCacheJndiPtpProducerTest extends JndiPtpProducerCase {
 
-  public DestinationCacheJndiPtpProducerTest(String name) {
-    super(name);
-  }
-
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-  }
-
   @Override
   protected CachedDestinationJndiImplementation createVendorImplementation() {
     return new CachedDestinationJndiImplementation();
   }
 
+  @Test
   public void testProduceWithCache() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     DestinationCachingJndiVendorImpl sendVendorImp = new DestinationCachingJndiVendorImpl();
     sendVendorImp.setUseJndiForQueues(true);
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
 
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJndiPtpConnection(sendVendorImp, false,
         queueName, topicName), new PtpProducer(new ConfiguredProduceDestination(queueName)));
@@ -71,15 +68,17 @@ public class DestinationCacheJndiPtpProducerTest extends JndiPtpProducerCase {
     }
   }
 
+  @Test
   public void testProduceWithCacheExceeded() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     DestinationCachingJndiVendorImpl jv = new DestinationCachingJndiVendorImpl(2);
     MockMessageListener jms = new MockMessageListener();
     MetadataDestination dest = new MetadataDestination();
     dest.addKey("testProduceWithCacheExceeded");
 
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
 
     StandaloneProducer sp1 = new StandaloneProducer(broker.getJndiPtpConnection(jv, false, queueName, topicName), new PtpProducer(
         dest));

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/EmbeddedActiveMq.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/EmbeddedActiveMq.java
@@ -21,15 +21,12 @@ import static com.adaptris.core.PortManager.release;
 import static com.adaptris.core.jms.JmsConfig.DEFAULT_PAYLOAD;
 import static com.adaptris.core.jms.JmsConfig.DEFAULT_TTL;
 import static com.adaptris.core.jms.JmsConfig.HIGHEST_PRIORITY;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-
 import javax.jms.DeliveryMode;
 import javax.jms.JMSException;
 import javax.naming.Context;
-
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.Broker;
@@ -39,10 +36,11 @@ import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.jndi.ActiveMQInitialContextFactory;
 import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.commons.io.FileUtils;
-
+import org.junit.Assume;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.FailoverJmsConnection;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConstants;
 import com.adaptris.core.jms.jndi.StandardJndiImplementation;
@@ -71,6 +69,7 @@ public class EmbeddedActiveMq {
   }
 
   public EmbeddedActiveMq() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     brokerName = createSafeUniqueId(this);
     port = nextUnusedPort(61616);
   }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/EmbeddedArtemis.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/EmbeddedArtemis.java
@@ -18,19 +18,17 @@ package com.adaptris.core.jms.activemq;
 
 import static com.adaptris.core.PortManager.nextUnusedPort;
 import static com.adaptris.core.PortManager.release;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
-
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.commons.io.FileUtils;
-
+import org.junit.Assume;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.jndi.StandardJndiImplementation;
 import com.adaptris.core.util.JmxHelper;
@@ -61,7 +59,8 @@ public class EmbeddedArtemis {
  }
 
  public EmbeddedArtemis() throws Exception {
-   port = nextUnusedPort(61616);
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    port = nextUnusedPort(61616);
  }
 
  public String getName() {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPasProducerTest.java
@@ -16,32 +16,37 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.execute;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-
-import com.adaptris.core.BaseCase;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
 import com.adaptris.core.stubs.MockMessageListener;
 
-public class FailoverPasProducerTest extends BaseCase {
+public class FailoverPasProducerTest {
 
-  public FailoverPasProducerTest(String name) {
-    super(name);
-  }
+  @Rule
+  public TestName testName = new TestName();
 
+  @Test
   public void testProduceAndConsume() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(broker.getFailoverJmsConnection(false), new PasConsumer(
-        new ConfiguredConsumeDestination(getName())));
+            new ConfiguredConsumeDestination(testName.getMethodName())));
     MockMessageListener jms = new MockMessageListener();
     standaloneConsumer.registerAdaptrisMessageListener(jms);
     StandaloneProducer standaloneProducer = new StandaloneProducer(broker.getFailoverJmsConnection(false), new PasProducer(
-        new ConfiguredProduceDestination(getName())));
+            new ConfiguredProduceDestination(testName.getMethodName())));
     try {
       broker.start();
       execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPasProducerTest.java
@@ -19,7 +19,6 @@ package com.adaptris.core.jms.activemq;
 import static com.adaptris.core.BaseCase.execute;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -27,7 +26,6 @@ import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
 import com.adaptris.core.stubs.MockMessageListener;
@@ -39,7 +37,7 @@ public class FailoverPasProducerTest {
 
   @Test
   public void testProduceAndConsume() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(broker.getFailoverJmsConnection(false), new PasConsumer(
             new ConfiguredConsumeDestination(testName.getMethodName())));

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPtpProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPtpProducerTest.java
@@ -19,7 +19,6 @@ package com.adaptris.core.jms.activemq;
 import static com.adaptris.core.BaseCase.execute;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -27,7 +26,6 @@ import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PtpConsumer;
 import com.adaptris.core.jms.PtpProducer;
 import com.adaptris.core.stubs.MockMessageListener;
@@ -38,7 +36,7 @@ public class FailoverPtpProducerTest {
 
   @Test
   public void testProduceAndConsume() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(broker.getFailoverJmsConnection(true), new PtpConsumer(
             new ConfiguredConsumeDestination(testName.getMethodName())));

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPtpProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPtpProducerTest.java
@@ -16,32 +16,36 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.execute;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-
-import com.adaptris.core.BaseCase;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PtpConsumer;
 import com.adaptris.core.jms.PtpProducer;
 import com.adaptris.core.stubs.MockMessageListener;
 
-public class FailoverPtpProducerTest extends BaseCase {
+public class FailoverPtpProducerTest {
+  @Rule
+  public TestName testName = new TestName();
 
-  public FailoverPtpProducerTest(String name) {
-    super(name);
-  }
-
+  @Test
   public void testProduceAndConsume() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(broker.getFailoverJmsConnection(true), new PtpConsumer(
-        new ConfiguredConsumeDestination(getName())));
+            new ConfiguredConsumeDestination(testName.getMethodName())));
     MockMessageListener jms = new MockMessageListener();
     standaloneConsumer.registerAdaptrisMessageListener(jms);
     StandaloneProducer standaloneProducer = new StandaloneProducer(broker.getFailoverJmsConnection(true), new PtpProducer(
-        new ConfiguredProduceDestination(getName())));
+            new ConfiguredProduceDestination(testName.getMethodName())));
     try {
       broker.start();
       execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsConnectionErrorHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsConnectionErrorHandlerTest.java
@@ -22,7 +22,6 @@ import static com.adaptris.core.stubs.ObjectUtils.asSetters;
 import static com.adaptris.core.stubs.ObjectUtils.invokeSetter;
 import static junit.framework.TestCase.assertEquals;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -42,7 +41,6 @@ import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardWorkflow;
 import com.adaptris.core.StartedState;
 import com.adaptris.core.Workflow;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConnectionErrorHandler;
 import com.adaptris.core.jms.PasConsumer;
@@ -64,7 +62,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testConnectionErrorHandler() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName(), new JmsConnectionErrorHandler());
@@ -90,7 +88,7 @@ public class JmsConnectionErrorHandlerTest {
   // Tests INTERLOK-2063
   @Test
   public void testConnectionErrorHandler_WithRuntimeException() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker,
         new JmsConnectionCloseWithRuntimeException(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true)),
@@ -120,7 +118,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testConnectionErrorHandler_WithInitialiseException() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = new MockChannelFail(createChannel(activeMqBroker,
         activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
@@ -149,7 +147,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testConnectionErrorHandler_WithStartException() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = new MockChannelFail(createChannel(activeMqBroker,
         activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
@@ -176,7 +174,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testConnectionErrorHandler_NotSingleExecution() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName(), new JmsConnectionErrorHandler(false));
@@ -201,7 +199,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testConnectionErrorHandlerWithUnamedChannel() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(null, activeMqBroker,
         activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
@@ -227,7 +225,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testConnectionErrorHandlerWithJndi() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
@@ -255,7 +253,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testBug1926() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName(), new JmsConnectionErrorHandler());
@@ -280,7 +278,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testRestartSharedConnection() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     Adapter adapter = new Adapter();
     adapter.setUniqueId(testName.getMethodName());
@@ -331,7 +329,7 @@ public class JmsConnectionErrorHandlerTest {
 
   @Test
   public void testRestartSharedConnection_ChannelNotStarted() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     Adapter adapter = new Adapter();
     adapter.setUniqueId(testName.getMethodName());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsConnectionErrorHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsConnectionErrorHandlerTest.java
@@ -16,14 +16,20 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.MAX_WAIT;
+import static com.adaptris.core.BaseCase.waitForMessages;
 import static com.adaptris.core.stubs.ObjectUtils.asSetters;
 import static com.adaptris.core.stubs.ObjectUtils.invokeSetter;
-
+import static junit.framework.TestCase.assertEquals;
 import java.util.concurrent.TimeUnit;
-
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.ClosedState;
 import com.adaptris.core.ComponentState;
 import com.adaptris.core.ConfiguredConsumeDestination;
@@ -36,6 +42,7 @@ import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardWorkflow;
 import com.adaptris.core.StartedState;
 import com.adaptris.core.Workflow;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConnectionErrorHandler;
 import com.adaptris.core.jms.PasConsumer;
@@ -47,26 +54,20 @@ import com.adaptris.core.stubs.ObjectUtils;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.TimeInterval;
 
-public class JmsConnectionErrorHandlerTest extends BaseCase {
+public class JmsConnectionErrorHandlerTest {
 
   private static final long SLEEP_TIME_MS = 100L;
 
-  public JmsConnectionErrorHandlerTest(String name) {
-    super(name);
-  }
+  private Logger log = LoggerFactory.getLogger(this.getClass());
+  @Rule
+  public TestName testName = new TestName();
 
-  @Override
-  protected void setUp() throws Exception {
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-  }
-
+  @Test
   public void testConnectionErrorHandler() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
-        getName(), new JmsConnectionErrorHandler());
+        testName.getMethodName(), new JmsConnectionErrorHandler());
     try {
       activeMqBroker.start();
       channel.requestStart();
@@ -87,11 +88,14 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
   }
 
   // Tests INTERLOK-2063
+  @Test
   public void testConnectionErrorHandler_WithRuntimeException() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker,
         new JmsConnectionCloseWithRuntimeException(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true)),
-        getName(), new JmsConnectionErrorHandler() {
+        testName.getMethodName(), new JmsConnectionErrorHandler() {
+          @Override
           protected long retryWaitTimeMs() {
             return 500L;
           }
@@ -114,11 +118,14 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testConnectionErrorHandler_WithInitialiseException() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = new MockChannelFail(createChannel(activeMqBroker,
         activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
-        getName(), new JmsConnectionErrorHandler()), MockChannelFail.WhenToFail.INIT_AFTER_CLOSE);
+        testName.getMethodName(), new JmsConnectionErrorHandler()),
+        MockChannelFail.WhenToFail.INIT_AFTER_CLOSE);
     try {
       activeMqBroker.start();
       channel.requestStart();
@@ -140,11 +147,14 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testConnectionErrorHandler_WithStartException() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = new MockChannelFail(createChannel(activeMqBroker,
         activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
-        getName(), new JmsConnectionErrorHandler()), MockChannelFail.WhenToFail.START_AFTER_CLOSE);
+        testName.getMethodName(), new JmsConnectionErrorHandler()),
+        MockChannelFail.WhenToFail.START_AFTER_CLOSE);
     try {
       activeMqBroker.start();
       channel.requestStart();
@@ -164,10 +174,12 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testConnectionErrorHandler_NotSingleExecution() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
-        getName(), new JmsConnectionErrorHandler(false));
+        testName.getMethodName(), new JmsConnectionErrorHandler(false));
     try {
       activeMqBroker.start();
       channel.requestStart();
@@ -187,10 +199,13 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testConnectionErrorHandlerWithUnamedChannel() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(null, activeMqBroker,
-        activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true), getName());
+        activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
+        testName.getMethodName());
     try {
       activeMqBroker.start();
       channel.requestStart();
@@ -210,10 +225,12 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testConnectionErrorHandlerWithJndi() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     MockChannel channel = createChannel(activeMqBroker,
         activeMqBroker.getJndiPasConnection(new StandardJndiImplementation(), false, queueName, topicName), topicName,
         new JmsConnectionErrorHandler());
@@ -236,10 +253,12 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testBug1926() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
-        getName(), new JmsConnectionErrorHandler());
+        testName.getMethodName(), new JmsConnectionErrorHandler());
     try {
       activeMqBroker.start();
       channel.requestStart();
@@ -259,16 +278,19 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testRestartSharedConnection() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     Adapter adapter = new Adapter();
-    adapter.setUniqueId(getName());
+    adapter.setUniqueId(testName.getMethodName());
     JmsConnection connection = activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true);
     connection.setConnectionErrorHandler(new JmsConnectionErrorHandler());
-    connection.setUniqueId(getName());
+    connection.setUniqueId(testName.getMethodName());
     connection.setConnectionRetryInterval(new TimeInterval(5L, "SECONDS"));
     adapter.getSharedComponents().addConnection(connection);
-    MockChannel channel = createChannel(activeMqBroker, new SharedConnection(getName()), getName());
+    MockChannel channel = createChannel(activeMqBroker,
+        new SharedConnection(testName.getMethodName()), testName.getMethodName());
     MockMessageProducer producer = (MockMessageProducer) channel.getWorkflowList().get(0).getProducer();
     adapter.getChannelList().add(channel);
     try {
@@ -276,24 +298,28 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
       adapter.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       // Now try and send a message
-      ServiceCase.execute(createProducer(activeMqBroker, getName()), AdaptrisMessageFactory.getDefaultInstance().newMessage("ABC"));
+      ServiceCase.execute(createProducer(activeMqBroker, testName.getMethodName()),
+          AdaptrisMessageFactory.getDefaultInstance().newMessage("ABC"));
       waitForMessages(producer, 1);
 
       activeMqBroker.stop();
-      log.trace(getName() + ": Waiting for channel death (i.e. !StartedState)");
+      log.trace(testName.getMethodName() + ": Waiting for channel death (i.e. !StartedState)");
       long totalWaitTime = waitForChannelToChangeState(StartedState.getInstance(), channel);
-      log.trace(getName() + ": Channel appears to be not started now, and I waited for " + totalWaitTime);
+      log.trace(testName.getMethodName()
+          + ": Channel appears to be not started now, and I waited for " + totalWaitTime);
 
       activeMqBroker.start();
 
       totalWaitTime = waitForChannelToMatchState(StartedState.getInstance(), channel);
-      log.trace(getName() + ": Channel now started now, and I waited for " + totalWaitTime);
+      log.trace(testName.getMethodName() + ": Channel now started now, and I waited for "
+          + totalWaitTime);
 
       waitForChannelToMatchState(StartedState.getInstance(), channel);
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
 
       // Now try and send a message
-      ServiceCase.execute(createProducer(activeMqBroker, getName()), AdaptrisMessageFactory.getDefaultInstance().newMessage("ABC"));
+      ServiceCase.execute(createProducer(activeMqBroker, testName.getMethodName()),
+          AdaptrisMessageFactory.getDefaultInstance().newMessage("ABC"));
       waitForMessages(producer, 2);
 
     }
@@ -303,17 +329,21 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
     }
   }
 
+  @Test
   public void testRestartSharedConnection_ChannelNotStarted() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     Adapter adapter = new Adapter();
-    adapter.setUniqueId(getName());
+    adapter.setUniqueId(testName.getMethodName());
     JmsConnection connection = activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true);
     connection.setConnectionErrorHandler(new JmsConnectionErrorHandler());
-    connection.setUniqueId(getName());
+    connection.setUniqueId(testName.getMethodName());
     connection.setConnectionRetryInterval(new TimeInterval(5L, "SECONDS"));
     adapter.getSharedComponents().addConnection(connection);
-    MockChannel started = createChannel(activeMqBroker, new SharedConnection(getName()), getName());
-    MockChannel neverStarted = createChannel(activeMqBroker, new SharedConnection(getName()), getName() + "_2");
+    MockChannel started = createChannel(activeMqBroker,
+        new SharedConnection(testName.getMethodName()), testName.getMethodName());
+    MockChannel neverStarted = createChannel(activeMqBroker,
+        new SharedConnection(testName.getMethodName()), testName.getMethodName() + "_2");
     neverStarted.setAutoStart(false);
     MockMessageProducer producer = (MockMessageProducer) started.getWorkflowList().get(0).getProducer();
     adapter.getChannelList().add(started);
@@ -324,23 +354,27 @@ public class JmsConnectionErrorHandlerTest extends BaseCase {
       assertEquals(StartedState.getInstance(), started.retrieveComponentState());
       assertEquals(ClosedState.getInstance(), neverStarted.retrieveComponentState());
       // Now try and send a message
-      ServiceCase.execute(createProducer(activeMqBroker, getName()), AdaptrisMessageFactory.getDefaultInstance().newMessage("ABC"));
+      ServiceCase.execute(createProducer(activeMqBroker, testName.getMethodName()),
+          AdaptrisMessageFactory.getDefaultInstance().newMessage("ABC"));
       waitForMessages(producer, 1);
 
       activeMqBroker.stop();
-      log.trace(getName() + ": Waiting for channel death (i.e. !StartedState)");
+      log.trace(testName.getMethodName() + ": Waiting for channel death (i.e. !StartedState)");
       long totalWaitTime = waitForChannelToChangeState(StartedState.getInstance(), started);
-      log.trace(getName() + ": Channel appears to be not started now, and I waited for " + totalWaitTime);
+      log.trace(testName.getMethodName()
+          + ": Channel appears to be not started now, and I waited for " + totalWaitTime);
 
       activeMqBroker.start();
 
       totalWaitTime = waitForChannelToMatchState(StartedState.getInstance(), started);
-      log.trace(getName() + ": Channel now started now, and I waited for " + totalWaitTime);
+      log.trace(testName.getMethodName() + ": Channel now started now, and I waited for "
+          + totalWaitTime);
       assertEquals(StartedState.getInstance(), started.retrieveComponentState());
 
 
       // Now try and send a message
-      ServiceCase.execute(createProducer(activeMqBroker, getName()), AdaptrisMessageFactory.getDefaultInstance().newMessage("ABC"));
+      ServiceCase.execute(createProducer(activeMqBroker, testName.getMethodName()),
+          AdaptrisMessageFactory.getDefaultInstance().newMessage("ABC"));
       waitForMessages(producer, 2);
       assertEquals(ClosedState.getInstance(), neverStarted.retrieveComponentState());
       assertEquals(0, neverStarted.getInitCount());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsReplyToDestinationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsReplyToDestinationTest.java
@@ -19,16 +19,15 @@ package com.adaptris.core.jms.activemq;
 import javax.jms.Destination;
 import javax.jms.Queue;
 import javax.jms.Session;
-
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQSession;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ExampleProduceDestinationCase;
 import com.adaptris.core.ProduceDestination;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConstants;
 import com.adaptris.core.jms.JmsReplyToDestination;
 
@@ -57,6 +56,11 @@ public class JmsReplyToDestinationTest extends ExampleProduceDestinationCase {
   }
 
   public void testRetrieveDestination() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -72,6 +76,11 @@ public class JmsReplyToDestinationTest extends ExampleProduceDestinationCase {
 
 
   public void testRetrieveDestination_ByName() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -87,6 +96,11 @@ public class JmsReplyToDestinationTest extends ExampleProduceDestinationCase {
   }
 
   public void testGetDestination() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();
@@ -101,6 +115,11 @@ public class JmsReplyToDestinationTest extends ExampleProduceDestinationCase {
   }
 
   public void testGetDestination_MetadataDoesNotExist() throws Exception {
+    // This would be best, but we can't mix Junit3 with Junit4 assumptions.
+    // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    if (!JmsConfig.jmsTestsEnabled()) {
+      return;
+    }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     try {
       activeMqBroker.start();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsReplyToWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsReplyToWorkflowTest.java
@@ -21,7 +21,6 @@ import static com.adaptris.core.BaseCase.stop;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.fail;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -33,7 +32,6 @@ import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.NullConnectionErrorHandler;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.StandaloneRequestor;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsReplyToWorkflow;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
@@ -61,7 +59,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testInitWithNullProducerConsumer() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -80,7 +78,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testInitWithNullConsumer() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -101,7 +99,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testInitWithNullProducer() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -121,7 +119,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testInitWithMisMatchedProducer() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -142,7 +140,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testInit() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -162,7 +160,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testPtpWorkflow() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -192,7 +190,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testPasWorkflow() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -222,7 +220,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testWorkflow_SkipProducer_HasNoEffect() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
@@ -258,7 +256,7 @@ public class JmsReplyToWorkflowTest {
 
   @Test
   public void testWorkflowWithInterceptor() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     MockWorkflowInterceptor interceptor = new MockWorkflowInterceptor();
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsReplyToWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsReplyToWorkflowTest.java
@@ -16,17 +16,24 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.fail;
 import java.util.concurrent.TimeUnit;
-
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.Channel;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.NullConnectionErrorHandler;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.StandaloneRequestor;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsReplyToWorkflow;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
@@ -44,25 +51,17 @@ import com.adaptris.util.TimeInterval;
  * </p>
  */
 @SuppressWarnings("deprecation")
-public class JmsReplyToWorkflowTest extends BaseCase {
+public class JmsReplyToWorkflowTest {
 
   private static final String REQUEST_TEXT = "Hello World";
   private static final String REPLY_TEXT = "Goodbye Cruel World";
 
-  /**
-   * Constructor for JmsReplyToWorkflowTest.
-   *
-   * @param arg0
-   */
-  public JmsReplyToWorkflowTest(String arg0) {
-    super(arg0);
-  }
+  @Rule
+  public TestName testName = new TestName();
 
-  @Override
-  protected void setUp() throws Exception {
-  }
-
+  @Test
   public void testInitWithNullProducerConsumer() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -79,12 +78,15 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     broker.destroy();
   }
 
+  @Test
   public void testInitWithNullConsumer() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
     Channel channel = createChannel(broker);
-    workflow.setConsumer(new PtpConsumer(new ConfiguredConsumeDestination(getName())));
+    workflow
+        .setConsumer(new PtpConsumer(new ConfiguredConsumeDestination(testName.getMethodName())));
     channel.getWorkflowList().add(workflow);
     channel.prepare();
     try {
@@ -97,7 +99,9 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     broker.destroy();
   }
 
+  @Test
   public void testInitWithNullProducer() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -115,7 +119,9 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     broker.destroy();
   }
 
+  @Test
   public void testInitWithMisMatchedProducer() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
@@ -134,13 +140,16 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     broker.destroy();
   }
 
+  @Test
   public void testInit() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
     Channel channel = createChannel(broker);
     workflow.setProducer(new PtpProducer());
-    workflow.setConsumer(new PtpConsumer(new ConfiguredConsumeDestination(getName())));
+    workflow
+        .setConsumer(new PtpConsumer(new ConfiguredConsumeDestination(testName.getMethodName())));
     channel.getWorkflowList().add(workflow);
     channel.prepare();
     try {
@@ -151,18 +160,21 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     }
   }
 
+  @Test
   public void testPtpWorkflow() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
     Channel channel = createChannel(broker);
     workflow.setProducer(new PtpProducer());
-    workflow.setConsumer(new PtpConsumer(new ConfiguredConsumeDestination(getName())));
+    workflow
+        .setConsumer(new PtpConsumer(new ConfiguredConsumeDestination(testName.getMethodName())));
     workflow.setServiceCollection(createServiceList());
     channel.getWorkflowList().add(workflow);
     channel.prepare();
     StandaloneRequestor sender = new StandaloneRequestor(broker.getJmsConnection(), new PtpProducer(
-        new ConfiguredProduceDestination(getName())));
+        new ConfiguredProduceDestination(testName.getMethodName())));
     try {
       channel.requestStart();
       sender.setReplyTimeout(new TimeInterval(10L, TimeUnit.SECONDS));
@@ -178,18 +190,21 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     }
   }
 
+  @Test
   public void testPasWorkflow() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
     Channel channel = createChannel(broker);
     workflow.setProducer(new PasProducer());
-    workflow.setConsumer(new PasConsumer(new ConfiguredConsumeDestination(getName())));
+    workflow
+        .setConsumer(new PasConsumer(new ConfiguredConsumeDestination(testName.getMethodName())));
     workflow.setServiceCollection(createServiceList());
     channel.getWorkflowList().add(workflow);
     channel.prepare();
     StandaloneRequestor sender = new StandaloneRequestor(broker.getJmsConnection(), new PasProducer(
-        new ConfiguredProduceDestination(getName())));
+        new ConfiguredProduceDestination(testName.getMethodName())));
     try {
       channel.requestStart();
       sender.setReplyTimeout(new TimeInterval(10L, TimeUnit.SECONDS));
@@ -205,14 +220,17 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     }
   }
 
+  @Test
   public void testWorkflow_SkipProducer_HasNoEffect() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
     JmsReplyToWorkflow workflow = new JmsReplyToWorkflow();
     Channel channel = createChannel(broker);
     workflow.setProducer(new PtpProducer());
-    workflow.setConsumer(new PtpConsumer(new ConfiguredConsumeDestination(getName())));
+    workflow
+        .setConsumer(new PtpConsumer(new ConfiguredConsumeDestination(testName.getMethodName())));
 
     PayloadFromMetadataService pm = new PayloadFromMetadataService();
     pm.setTemplate(REPLY_TEXT);
@@ -222,7 +240,7 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     channel.getWorkflowList().add(workflow);
     channel.prepare();
     StandaloneRequestor sender = new StandaloneRequestor(broker.getJmsConnection(), new PtpProducer(
-        new ConfiguredProduceDestination(getName())));
+        new ConfiguredProduceDestination(testName.getMethodName())));
     try {
       start(channel);
       sender.setReplyTimeout(new TimeInterval(10L, TimeUnit.SECONDS));
@@ -238,7 +256,9 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     }
   }
 
+  @Test
   public void testWorkflowWithInterceptor() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     MockWorkflowInterceptor interceptor = new MockWorkflowInterceptor();
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
@@ -246,12 +266,13 @@ public class JmsReplyToWorkflowTest extends BaseCase {
     workflow.addInterceptor(interceptor);
     Channel channel = createChannel(broker);
     workflow.setProducer(new PasProducer());
-    workflow.setConsumer(new PasConsumer(new ConfiguredConsumeDestination(getName())));
+    workflow
+        .setConsumer(new PasConsumer(new ConfiguredConsumeDestination(testName.getMethodName())));
     workflow.setServiceCollection(createServiceList());
     channel.getWorkflowList().add(workflow);
     channel.prepare();
     StandaloneRequestor sender = new StandaloneRequestor(broker.getJmsConnection(), new PasProducer(
-        new ConfiguredProduceDestination(getName())));
+        new ConfiguredProduceDestination(testName.getMethodName())));
     try {
       channel.requestStart();
       sender.setReplyTimeout(new TimeInterval(10L, TimeUnit.SECONDS));

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPasProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPasProducerCase.java
@@ -16,15 +16,22 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.execute;
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-
-import com.adaptris.core.BaseCase;
+import static org.junit.Assert.fail;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
 import com.adaptris.core.jms.jndi.SimpleFactoryConfiguration;
@@ -33,20 +40,22 @@ import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
-public abstract class JndiPasProducerCase extends BaseCase {
+public abstract class JndiPasProducerCase {
 
-  public JndiPasProducerCase(String name) {
-    super(name);
-  }
+  @Rule
+  public TestName testName = new TestName();
 
   protected abstract StandardJndiImplementation createVendorImplementation();
 
+  @Test
   public void testProduceAndConsume() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
 
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(broker.getJndiPasConnection(recvVendorImp, false, queueName,
         topicName), new PasConsumer(new ConfiguredConsumeDestination(topicName)));
@@ -65,9 +74,11 @@ public abstract class JndiPasProducerCase extends BaseCase {
     }
   }
 
+  @Test
   public void testProduceAndConsume_ExtraConfig() throws Exception {
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     SimpleFactoryConfiguration sfc = new SimpleFactoryConfiguration();
     KeyValuePairSet kvps = new KeyValuePairSet();
     kvps.add(new KeyValuePair("ClientID", "testProduceAndConsume_ExtraConfig"));
@@ -97,9 +108,11 @@ public abstract class JndiPasProducerCase extends BaseCase {
     }
   }
 
+  @Test
   public void testProduceAndConsumeUsingJndiOnly() throws Exception {
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
@@ -122,9 +135,11 @@ public abstract class JndiPasProducerCase extends BaseCase {
 
   }
 
+  @Test
   public void testProduceJndiOnlyObjectNotFound() throws Exception {
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
     StandaloneProducer standaloneProducer = new StandaloneProducer(broker.getJndiPasConnection(sendVendorImp, true, queueName,
@@ -136,8 +151,7 @@ public abstract class JndiPasProducerCase extends BaseCase {
       standaloneProducer.produce(createMessage(null));
       fail("Expected ProduceException");
     }
-    catch (ProduceException e) {
-      log.trace("Expected Exception", e);
+    catch (ProduceException expected) {
     }
     finally {
       stop(standaloneProducer);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPasProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPasProducerCase.java
@@ -22,7 +22,6 @@ import static com.adaptris.core.BaseCase.stop;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
 import static org.junit.Assert.fail;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -31,7 +30,6 @@ import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PasConsumer;
 import com.adaptris.core.jms.PasProducer;
 import com.adaptris.core.jms.jndi.SimpleFactoryConfiguration;
@@ -49,7 +47,7 @@ public abstract class JndiPasProducerCase {
 
   @Test
   public void testProduceAndConsume() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
 
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
@@ -76,7 +74,7 @@ public abstract class JndiPasProducerCase {
 
   @Test
   public void testProduceAndConsume_ExtraConfig() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     SimpleFactoryConfiguration sfc = new SimpleFactoryConfiguration();
@@ -110,7 +108,7 @@ public abstract class JndiPasProducerCase {
 
   @Test
   public void testProduceAndConsumeUsingJndiOnly() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
@@ -137,7 +135,7 @@ public abstract class JndiPasProducerCase {
 
   @Test
   public void testProduceJndiOnlyObjectNotFound() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     EmbeddedActiveMq broker = new EmbeddedActiveMq();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPasProducerTest.java
@@ -20,10 +20,6 @@ import com.adaptris.core.jms.jndi.StandardJndiImplementation;
 
 public class JndiPasProducerTest extends JndiPasProducerCase {
 
-  public JndiPasProducerTest(String name) {
-    super(name);
-  }
-
   @Override
   protected StandardJndiImplementation createVendorImplementation() {
     return new StandardJndiImplementation();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPtpProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPtpProducerCase.java
@@ -16,15 +16,22 @@
 
 package com.adaptris.core.jms.activemq;
 
+import static com.adaptris.core.BaseCase.execute;
+import static com.adaptris.core.BaseCase.start;
+import static com.adaptris.core.BaseCase.stop;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
-
-import com.adaptris.core.BaseCase;
+import static org.junit.Assert.fail;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PtpConsumer;
 import com.adaptris.core.jms.PtpProducer;
 import com.adaptris.core.jms.jndi.SimpleFactoryConfiguration;
@@ -33,20 +40,21 @@ import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 
-public abstract class JndiPtpProducerCase extends BaseCase {
+public abstract class JndiPtpProducerCase {
 
-  public JndiPtpProducerCase(String name) {
-    super(name);
-  }
+  @Rule
+  public TestName testName = new TestName();
 
   protected abstract StandardJndiImplementation createVendorImplementation();
 
+  @Test
   public void testProduceAndConsume() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJndiPtpConnection(recvVendorImp, false,
         queueName, topicName), new PtpConsumer(new ConfiguredConsumeDestination(queueName)));
     MockMessageListener jms = new MockMessageListener();
@@ -63,14 +71,16 @@ public abstract class JndiPtpProducerCase extends BaseCase {
     }
   }
 
+  @Test
   public void testProduceAndConsume_ExtraConfig() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     SimpleFactoryConfiguration sfc = new SimpleFactoryConfiguration();
     KeyValuePairSet kvps = new KeyValuePairSet();
     kvps.add(new KeyValuePair("ClientID", "testProduceAndConsume_ExtraConfig"));
     kvps.add(new KeyValuePair("UseCompression", "true"));
     sfc.setProperties(kvps);
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
@@ -91,12 +101,14 @@ public abstract class JndiPtpProducerCase extends BaseCase {
     }
   }
 
+  @Test
   public void testProduceAndConsumeUsingJndiOnly() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
 
     PtpConsumer consumer = new PtpConsumer(new ConfiguredConsumeDestination(queueName));
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJndiPtpConnection(recvVendorImp, true,
@@ -116,10 +128,12 @@ public abstract class JndiPtpProducerCase extends BaseCase {
     }
   }
 
+  @Test
   public void testProduceJndiOnlyObjectNotFound() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJndiPtpConnection(sendVendorImp, true,
         queueName, topicName), new PtpProducer(new ConfiguredProduceDestination(this.getClass().getSimpleName())));
@@ -129,8 +143,7 @@ public abstract class JndiPtpProducerCase extends BaseCase {
       standaloneProducer.produce(createMessage(null));
       fail("Expected ProduceException");
     }
-    catch (ProduceException e) {
-      log.trace("Expected Exception", e);
+    catch (ProduceException expected) {
     }
     finally {
       stop(standaloneProducer);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPtpProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPtpProducerCase.java
@@ -22,7 +22,6 @@ import static com.adaptris.core.BaseCase.stop;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
 import static org.junit.Assert.fail;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -31,7 +30,6 @@ import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.PtpConsumer;
 import com.adaptris.core.jms.PtpProducer;
 import com.adaptris.core.jms.jndi.SimpleFactoryConfiguration;
@@ -49,7 +47,7 @@ public abstract class JndiPtpProducerCase {
 
   @Test
   public void testProduceAndConsume() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
@@ -73,7 +71,7 @@ public abstract class JndiPtpProducerCase {
 
   @Test
   public void testProduceAndConsume_ExtraConfig() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     SimpleFactoryConfiguration sfc = new SimpleFactoryConfiguration();
     KeyValuePairSet kvps = new KeyValuePairSet();
     kvps.add(new KeyValuePair("ClientID", "testProduceAndConsume_ExtraConfig"));
@@ -103,7 +101,7 @@ public abstract class JndiPtpProducerCase {
 
   @Test
   public void testProduceAndConsumeUsingJndiOnly() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
@@ -130,7 +128,7 @@ public abstract class JndiPtpProducerCase {
 
   @Test
   public void testProduceJndiOnlyObjectNotFound() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPtpProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPtpProducerTest.java
@@ -20,15 +20,6 @@ import com.adaptris.core.jms.jndi.StandardJndiImplementation;
 
 public class JndiPtpProducerTest extends JndiPtpProducerCase {
 
-  public JndiPtpProducerTest(String name) {
-    super(name);
-  }
-
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-  }
-
   @Override
   protected StandardJndiImplementation createVendorImplementation() {
     return new StandardJndiImplementation();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/RequiresCredentialsBroker.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/RequiresCredentialsBroker.java
@@ -18,7 +18,6 @@ package com.adaptris.core.jms.activemq;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-
 import org.apache.activemq.broker.BrokerPlugin;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.filter.DestinationMapEntry;
@@ -27,6 +26,8 @@ import org.apache.activemq.security.AuthorizationEntry;
 import org.apache.activemq.security.AuthorizationPlugin;
 import org.apache.activemq.security.DefaultAuthorizationMap;
 import org.apache.activemq.security.SimpleAuthenticationPlugin;
+import org.junit.Assume;
+import com.adaptris.core.jms.JmsConfig;
 
 public class RequiresCredentialsBroker extends EmbeddedActiveMq {
 
@@ -37,6 +38,7 @@ public class RequiresCredentialsBroker extends EmbeddedActiveMq {
 
   public RequiresCredentialsBroker() throws Exception {
     super();
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/jms/jndi/CachedDestinationJndiImplementationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/jndi/CachedDestinationJndiImplementationTest.java
@@ -18,10 +18,6 @@ package com.adaptris.core.jms.jndi;
 
 public class CachedDestinationJndiImplementationTest extends JndiImplementationCase {
 
-  public CachedDestinationJndiImplementationTest(String name) {
-    super(name);
-  }
-
   @Override
   protected StandardJndiImplementation createVendorImplementation() {
     return new CachedDestinationJndiImplementation();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/jndi/JndiImplementationCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/jndi/JndiImplementationCase.java
@@ -16,11 +16,20 @@
 
 package com.adaptris.core.jms.jndi;
 
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.util.concurrent.TimeUnit;
-
-import com.adaptris.core.BaseCase;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConnectionConfig;
 import com.adaptris.core.jms.PasProducer;
@@ -34,14 +43,14 @@ import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 import com.adaptris.util.TimeInterval;
 
-public abstract class JndiImplementationCase extends BaseCase {
-
-  public JndiImplementationCase(String name) {
-    super(name);
-  }
+public abstract class JndiImplementationCase {
 
   protected abstract StandardJndiImplementation createVendorImplementation();
 
+  @Rule
+  public TestName testName = new TestName();
+
+  @Test
   public void testSetEnableJndiForQueues() throws Exception {
     BaseJndiImplementation vendorImp = createVendorImplementation();
     assertNull(vendorImp.getUseJndiForQueues());
@@ -54,6 +63,7 @@ public abstract class JndiImplementationCase extends BaseCase {
     assertFalse(vendorImp.useJndiForQueues());
   }
 
+  @Test
   public void testSetEnableJndiForTopics() throws Exception {
     BaseJndiImplementation vendorImp = createVendorImplementation();
     assertNull(vendorImp.getUseJndiForTopics());
@@ -67,6 +77,7 @@ public abstract class JndiImplementationCase extends BaseCase {
 
   }
 
+  @Test
   public void testSetEnableEncodedPasswords() throws Exception {
     BaseJndiImplementation vendorImp = createVendorImplementation();
     assertNull(vendorImp.getEnableEncodedPasswords());
@@ -79,6 +90,7 @@ public abstract class JndiImplementationCase extends BaseCase {
     assertFalse(vendorImp.enableEncodedPasswords());
   }
 
+  @Test
   public void testSetNewContextOnException() throws Exception {
     BaseJndiImplementation jv = createVendorImplementation();
     assertNull(jv.getNewContextOnException());
@@ -92,6 +104,7 @@ public abstract class JndiImplementationCase extends BaseCase {
     assertFalse(jv.newContextOnException());
   }
 
+  @Test
   public void testSetJndiName() throws Exception {
     BaseJndiImplementation jv = createVendorImplementation();
     jv.setJndiName("ABCDE");
@@ -113,6 +126,7 @@ public abstract class JndiImplementationCase extends BaseCase {
     assertEquals("ABCDE", jv.getJndiName());
   }
 
+  @Test
   public void testSetExtraConfiguration() throws Exception {
     BaseJndiImplementation jv = createVendorImplementation();
     assertEquals(NoOpFactoryConfiguration.class, jv.getExtraFactoryConfiguration().getClass());
@@ -129,6 +143,7 @@ public abstract class JndiImplementationCase extends BaseCase {
   }
 
 
+  @Test
   public void testSetJndiParams() throws Exception {
     BaseJndiImplementation jv = createVendorImplementation();
     KeyValuePairSet set = new KeyValuePairSet();
@@ -143,9 +158,11 @@ public abstract class JndiImplementationCase extends BaseCase {
     assertEquals(set, jv.getJndiParams());
   }
   
+  @Test
   public void testInitialiseDefaultArtemisBroker() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedArtemis broker = new EmbeddedArtemis();
-    String topicName = getName() + "_topic";
+    String topicName = testName.getMethodName() + "_topic";
     
     PasProducer producer = new PasProducer(new ConfiguredProduceDestination(topicName));
     JmsConnection c = broker.getJmsConnection();
@@ -161,10 +178,12 @@ public abstract class JndiImplementationCase extends BaseCase {
     }
   }
 
+  @Test
   public void testInitialiseWithCredentials() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     PasProducer producer = new PasProducer(new ConfiguredProduceDestination(topicName));
     StandardJndiImplementation jv = createVendorImplementation();
     JmsConnection c = broker.getJndiPasConnection(jv, false, queueName, topicName);
@@ -182,10 +201,12 @@ public abstract class JndiImplementationCase extends BaseCase {
     }
   }
 
+  @Test
   public void testInitialiseWithEncryptedPassword_viaEncodedPasswordKeys() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     PasProducer producer = new PasProducer(new ConfiguredProduceDestination(queueName));
     StandardJndiImplementation jv = createVendorImplementation();
     JmsConnection c = broker.getJndiPasConnection(jv, false, queueName, topicName);
@@ -205,9 +226,11 @@ public abstract class JndiImplementationCase extends BaseCase {
     }
   }
 
+  @Test
   public void testInitialiseWithEncryptedPassword_withEnableEncodedPasswords() throws Exception {
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
     PasProducer producer = new PasProducer(new ConfiguredProduceDestination(queueName));
     StandardJndiImplementation jv = createVendorImplementation();
@@ -229,10 +252,12 @@ public abstract class JndiImplementationCase extends BaseCase {
     }
   }
 
+  @Test
   public void testInitialiseWithEncryptedPasswordNotSupported() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     PasProducer producer = new PasProducer(new ConfiguredProduceDestination(queueName));
     StandardJndiImplementation jv = createVendorImplementation();
     JmsConnection c = broker.getJndiPasConnection(jv, false, queueName, topicName);
@@ -253,10 +278,12 @@ public abstract class JndiImplementationCase extends BaseCase {
     }
   }
 
+  @Test
   public void testInitialiseWithTopicConnectionFactoryNotFound() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     PasProducer producer = new PasProducer(new ConfiguredProduceDestination(queueName));
     StandardJndiImplementation jv = createVendorImplementation();
     JmsConnection c = broker.getJndiPasConnection(jv, false, queueName, topicName);
@@ -277,10 +304,12 @@ public abstract class JndiImplementationCase extends BaseCase {
     }
   }
 
+  @Test
   public void testInitialiseWithQueueConnectionFactoryNotFound() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    String queueName = getName() + "_queue";
-    String topicName = getName() + "_topic";
+    String queueName = testName.getMethodName() + "_queue";
+    String topicName = testName.getMethodName() + "_topic";
     PasProducer producer = new PasProducer(new ConfiguredProduceDestination(topicName));
     StandardJndiImplementation jv = createVendorImplementation();
     JmsConnection c = broker.getJndiPtpConnection(jv, false, queueName, topicName);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/jndi/JndiImplementationCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/jndi/JndiImplementationCase.java
@@ -23,13 +23,11 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.JmsConfig;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConnectionConfig;
 import com.adaptris.core.jms.PasProducer;
@@ -160,7 +158,7 @@ public abstract class JndiImplementationCase {
   
   @Test
   public void testInitialiseDefaultArtemisBroker() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedArtemis broker = new EmbeddedArtemis();
     String topicName = testName.getMethodName() + "_topic";
     
@@ -180,7 +178,7 @@ public abstract class JndiImplementationCase {
 
   @Test
   public void testInitialiseWithCredentials() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
@@ -203,7 +201,7 @@ public abstract class JndiImplementationCase {
 
   @Test
   public void testInitialiseWithEncryptedPassword_viaEncodedPasswordKeys() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
@@ -228,7 +226,7 @@ public abstract class JndiImplementationCase {
 
   @Test
   public void testInitialiseWithEncryptedPassword_withEnableEncodedPasswords() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
@@ -254,7 +252,7 @@ public abstract class JndiImplementationCase {
 
   @Test
   public void testInitialiseWithEncryptedPasswordNotSupported() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
@@ -280,7 +278,7 @@ public abstract class JndiImplementationCase {
 
   @Test
   public void testInitialiseWithTopicConnectionFactoryNotFound() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
@@ -306,7 +304,7 @@ public abstract class JndiImplementationCase {
 
   @Test
   public void testInitialiseWithQueueConnectionFactoryNotFound() throws Exception {
-    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";

--- a/interlok-core/src/test/java/com/adaptris/core/jms/jndi/StandardJndiImplementationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/jndi/StandardJndiImplementationTest.java
@@ -18,10 +18,6 @@ package com.adaptris.core.jms.jndi;
 
 public class StandardJndiImplementationTest extends JndiImplementationCase {
 
-  public StandardJndiImplementationTest(String name) {
-    super(name);
-  }
-
   @Override
   protected StandardJndiImplementation createVendorImplementation() {
     return new StandardJndiImplementation();


### PR DESCRIPTION
Create/Edit build.properties:
```
junit.jms.tests.enabled=false
```
This modifies the resulting unit-tests.properties in `src/test/resources`

This will lead to something like ~213 tests skipped. It defaults to true, so no changes are required to CI (since they seem fine with that).
- A number of tests that were junit3 have been migrated to Junit4
- Those that can't be upgraded (ones that create examples) have a dodgy "if" statement that marks the test as successful.

_Since we export a number of the `Cases` into the stubs jar, I'm expecting some of the downstream optional tests to fail once merged_

- Tried to keep each checkin a logical set of tests; not sure if I succeeded.
