### PR TITLE
Revert "Bump jetty to 9.4.21"

### DIFF
--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   compile "org.slf4j:jcl-over-slf4j:$slf4jVersion", optional
   compile "org.slf4j:slf4j-log4j12:$slf4jVersion", optional
   compile "org.slf4j:jul-to-slf4j:$slf4jVersion", optional
-  compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.21.v20190926")
+  compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.20.v20190813")
   compile ("javax.servlet:javax.servlet-api:4.0.1")
 
   annotationProcessor project(':interlok-core-apt')

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -75,7 +75,7 @@ dependencies {
   compile ("org.glassfish.external:opendmk_jdmkrt_jar:1.0-b01-ea")
   compile ("javax.xml.bind:jaxb-api:2.3.1")
   compile ("com.jcraft:jsch:0.1.55")
-  compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.21.v20190926")
+  compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.20.v20190813")
   compile ("javax.servlet:javax.servlet-api:4.0.1")
   compile ("net.sf.joost:joost:0.9.1")
   compile ("org.quartz-scheduler:quartz:2.3.1") {

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/ServletWrapperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/ServletWrapperTest.java
@@ -19,7 +19,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import javax.servlet.http.HttpServlet;
+
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.After;
 import org.junit.Before;
@@ -46,11 +48,7 @@ public class ServletWrapperTest {
     MyServlet servlet = new MyServlet();
     ServletWrapper wrapper = new ServletWrapper(servlet, "/url");
     assertNotNull(wrapper.getServletHolder());
-    // As of jetty-all.9.4.21.v20190926 the internals of getServlet/setServlet has changed
-    // Previously setServlet set _servlet to be what you passed in, and getServlet would return it
-    // Now setServlet doesn't do that exactly, and getServlet returns you the initialised servlet.
-    // which in this case is null (since we aren't initialising).
-    // assertEquals(servlet, wrapper.getServletHolder().getServlet());
+    assertEquals(servlet, wrapper.getServletHolder().getServlet());
   }
 
   @Test


### PR DESCRIPTION
This reverts commit 3126b22b7f674f1769b3560cbe7698606c97763d.

I'm reverting jetty to 9.4.20.v20190813 as 9.4.21.v20190926 is not working well with Shiro in the UI.
At least until we find a good fix or either Shiro or Jetty fix the issue.

The UI start ok but as soon as we request an html page we get a:

`javax.servlet.ServletException: javax.servlet.ServletException: java.lang.ClassCastException: org.apache.shiro.web.servlet.ShiroHttpServletRequest cannot be cast to org.eclipse.jetty.server.Request
    at org.eclipse.jetty.server.handler.HandlerCollection.handle (HandlerCollection.java:162)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle (HandlerWrapper.java:127)
    at org.eclipse.jetty.server.Server.handle (Server.java:500)
    at org.eclipse.jetty.server.HttpChannel.lambda$handle$1 (HttpChannel.java:386)
    at org.eclipse.jetty.server.HttpChannel.dispatch (HttpChannel.java:560)
    at org.eclipse.jetty.server.HttpChannel.handle (HttpChannel.java:378)
    at org.eclipse.jetty.server.HttpConnection.onFillable (HttpConnection.java:268)
    at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded (AbstractConnection.java:311)
    at org.eclipse.jetty.io.FillInterest.fillable (FillInterest.java:103)
    at org.eclipse.jetty.io.ChannelEndPoint$2.run (ChannelEndPoint.java:117)
    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob (QueuedThreadPool.java:782)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run (QueuedThreadPool.java:914)
    at java.lang.Thread.run (Thread.java:844)
Caused by: javax.servlet.ServletException: java.lang.ClassCastException: org.apache.shiro.web.servlet.ShiroHttpServletRequest cannot be cast to org.eclipse.jetty.server.Request
    at org.apache.shiro.web.servlet.AdviceFilter.cleanup (AdviceFilter.java:196)
    at org.apache.shiro.web.filter.authc.AuthenticatingFilter.cleanup (AuthenticatingFilter.java:155)
    at org.apache.shiro.web.servlet.AdviceFilter.doFilterInternal (AdviceFilter.java:148)
    at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter (OncePerRequestFilter.java:125)
    at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter (ProxiedFilterChain.java:66)
    at org.apache.shiro.web.servlet.AbstractShiroFilter.executeChain (AbstractShiroFilter.java:449)
    at org.apache.shiro.web.servlet.AbstractShiroFilter$1.call (AbstractShiroFilter.java:365)
    at org.apache.shiro.subject.support.SubjectCallable.doCall (SubjectCallable.java:90)
    at org.apache.shiro.subject.support.SubjectCallable.call (SubjectCallable.java:83)
    at org.apache.shiro.subject.support.DelegatingSubject.execute (DelegatingSubject.java:387)
    at org.apache.shiro.web.servlet.AbstractShiroFilter.doFilterInternal (AbstractShiroFilter.java:362)
    at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter (OncePerRequestFilter.java:125)
    at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate (DelegatingFilterProxy.java:347)
    at org.springframework.web.filter.DelegatingFilterProxy.doFilter (DelegatingFilterProxy.java:263)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter (ServletHandler.java:1604)
    at org.eclipse.jetty.servlet.ServletHandler.doHandle (ServletHandler.java:545)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle (ScopedHandler.java:143)
    at org.eclipse.jetty.security.SecurityHandler.handle (SecurityHandler.java:536)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle (HandlerWrapper.java:127)
    at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle (ScopedHandler.java:235)
    at org.eclipse.jetty.server.session.SessionHandler.doHandle (SessionHandler.java:1589)
    at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle (ScopedHandler.java:233)
    at org.eclipse.jetty.server.handler.ContextHandler.doHandle (ContextHandler.java:1296)
    at org.eclipse.jetty.server.handler.ScopedHandler.nextScope (ScopedHandler.java:188)
    at org.eclipse.jetty.servlet.ServletHandler.doScope (ServletHandler.java:485)
    at org.eclipse.jetty.server.session.SessionHandler.doScope (SessionHandler.java:1559)
    at org.eclipse.jetty.server.handler.ScopedHandler.nextScope (ScopedHandler.java:186)
    at org.eclipse.jetty.server.handler.ContextHandler.doScope (ContextHandler.java:1211)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle (ScopedHandler.java:141)
    at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle (ContextHandlerCollection.java:221)
    at org.eclipse.jetty.server.handler.HandlerCollection.handle (HandlerCollection.java:146)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle (HandlerWrapper.java:127)
    at org.eclipse.jetty.server.Server.handle (Server.java:500)
    at org.eclipse.jetty.server.HttpChannel.lambda$handle$1 (HttpChannel.java:386)
    at org.eclipse.jetty.server.HttpChannel.dispatch (HttpChannel.java:560)
    at org.eclipse.jetty.server.HttpChannel.handle (HttpChannel.java:378)
    at org.eclipse.jetty.server.HttpConnection.onFillable (HttpConnection.java:268)
    at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded (AbstractConnection.java:311)
    at org.eclipse.jetty.io.FillInterest.fillable (FillInterest.java:103)
    at org.eclipse.jetty.io.ChannelEndPoint$2.run (ChannelEndPoint.java:117)
    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob (QueuedThreadPool.java:782)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run (QueuedThreadPool.java:914)
    at java.lang.Thread.run (Thread.java:844)
Caused by: java.lang.ClassCastException: org.apache.shiro.web.servlet.ShiroHttpServletRequest cannot be cast to org.eclipse.jetty.server.Request
    at org.eclipse.jetty.servlet.ServletHolder$NotAsyncServlet.service (ServletHolder.java:1395)
    at org.eclipse.jetty.servlet.ServletHolder.handle (ServletHolder.java:760)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter (ServletHandler.java:1617)
    at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter (WebSocketUpgradeFilter.java:283)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter (ServletHandler.java:1604)
    at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter (ProxiedFilterChain.java:61)
    at org.apache.shiro.web.servlet.AdviceFilter.executeChain (AdviceFilter.java:108)
    at org.apache.shiro.web.servlet.AdviceFilter.doFilterInternal (AdviceFilter.java:137)
    at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter (OncePerRequestFilter.java:125)
    at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter (ProxiedFilterChain.java:66)
    at org.apache.shiro.web.servlet.AbstractShiroFilter.executeChain (AbstractShiroFilter.java:449)
    at org.apache.shiro.web.servlet.AbstractShiroFilter$1.call (AbstractShiroFilter.java:365)
    at org.apache.shiro.subject.support.SubjectCallable.doCall (SubjectCallable.java:90)
    at org.apache.shiro.subject.support.SubjectCallable.call (SubjectCallable.java:83)
    at org.apache.shiro.subject.support.DelegatingSubject.execute (DelegatingSubject.java:387)
    at org.apache.shiro.web.servlet.AbstractShiroFilter.doFilterInternal (AbstractShiroFilter.java:362)
    at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter (OncePerRequestFilter.java:125)
    at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate (DelegatingFilterProxy.java:347)
    at org.springframework.web.filter.DelegatingFilterProxy.doFilter (DelegatingFilterProxy.java:263)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter (ServletHandler.java:1604)
    at org.eclipse.jetty.servlet.ServletHandler.doHandle (ServletHandler.java:545)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle (ScopedHandler.java:143)
    at org.eclipse.jetty.security.SecurityHandler.handle (SecurityHandler.java:536)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle (HandlerWrapper.java:127)
    at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle (ScopedHandler.java:235)
    at org.eclipse.jetty.server.session.SessionHandler.doHandle (SessionHandler.java:1589)
    at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle (ScopedHandler.java:233)
    at org.eclipse.jetty.server.handler.ContextHandler.doHandle (ContextHandler.java:1296)
    at org.eclipse.jetty.server.handler.ScopedHandler.nextScope (ScopedHandler.java:188)
    at org.eclipse.jetty.servlet.ServletHandler.doScope (ServletHandler.java:485)
    at org.eclipse.jetty.server.session.SessionHandler.doScope (SessionHandler.java:1559)
    at org.eclipse.jetty.server.handler.ScopedHandler.nextScope (ScopedHandler.java:186)
    at org.eclipse.jetty.server.handler.ContextHandler.doScope (ContextHandler.java:1211)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle (ScopedHandler.java:141)
    at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle (ContextHandlerCollection.java:221)
    at org.eclipse.jetty.server.handler.HandlerCollection.handle (HandlerCollection.java:146)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle (HandlerWrapper.java:127)
    at org.eclipse.jetty.server.Server.handle (Server.java:500)
    at org.eclipse.jetty.server.HttpChannel.lambda$handle$1 (HttpChannel.java:386)
    at org.eclipse.jetty.server.HttpChannel.dispatch (HttpChannel.java:560)
    at org.eclipse.jetty.server.HttpChannel.handle (HttpChannel.java:378)
    at org.eclipse.jetty.server.HttpConnection.onFillable (HttpConnection.java:268)
    at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded (AbstractConnection.java:311)
    at org.eclipse.jetty.io.FillInterest.fillable (FillInterest.java:103)
    at org.eclipse.jetty.io.ChannelEndPoint$2.run (ChannelEndPoint.java:117)
    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob (QueuedThreadPool.java:782)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run (QueuedThreadPool.java:914)
    at java.lang.Thread.run (Thread.java:844)
`
It seems to work with the rest api request though.

I did a bit of digging into the problem and it seems that a **NotAsyncServlet** servlet wrapper cast a ServletRequest to a Jetty Request but the ServletRequest  was actually an instance of ShiroHttpServletRequest.
One way to not have this issue would be to have _asyncSupported=true_ for all Servlet and filter (which I tried in our web.xml) but the DefaultServlet from jetty still is _asyncSupported=false_.
