### PR TITLE
INTERLOK-2860 Add RemoteBlobFilter and implementation

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/interlok/cloud/RemoteBlobFilter.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/cloud/RemoteBlobFilter.java
@@ -1,0 +1,14 @@
+package com.adaptris.interlok.cloud;
+
+/**
+ * Similar to {@link FileFilter} allowing you filter a remote blob
+ * 
+ */
+@FunctionalInterface
+public interface RemoteBlobFilter {
+
+  /**
+   * Whether the given file is accepted by this filter.
+   */
+  boolean accept(RemoteBlob blob);
+}

--- a/interlok-common/src/main/java/com/adaptris/interlok/cloud/RemoteBlobFilterWrapper.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/cloud/RemoteBlobFilterWrapper.java
@@ -1,0 +1,93 @@
+package com.adaptris.interlok.cloud;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import java.io.FileFilter;
+import java.lang.reflect.Constructor;
+import javax.validation.constraints.NotBlank;
+import com.adaptris.interlok.util.Args;
+
+/**
+ * Wraps a {@link FileFilter} instance and allows you to use that as your filter.
+ * <p>
+ * The file filter implementation is configured as a classname, and is expected to have a String constructor (the filter-expression)
+ * is used as that parameter; this is because not all FileFilter implementations will have aliases and configuration that are
+ * appropriate for marshalling.
+ * </p>
+ * <p>
+ * Since a {@link RemoteBlob} does not expose possible methods of {@link java.io.File}, it is wrapped as a {@link RemoteFile}. If
+ * your filter uses anything other than the filename / size / lastmodified, then results will be undefined.
+ * </p>
+ */
+public class RemoteBlobFilterWrapper implements RemoteBlobFilter {
+
+  @NotBlank
+  private String fileFilterImp;
+  @NotBlank
+  private String filterExpression;
+
+  private transient FileFilter fileFilter;
+
+  @Override
+  public boolean accept(RemoteBlob blob) {
+    if (fileFilter == null) {
+      fileFilter = createFilter(getFilterExpression(), getFileFilterImp());
+    }
+    return fileFilter.accept(blob.toFile());
+  }
+
+  public String getFileFilterImp() {
+    return fileFilterImp;
+  }
+
+  /**
+   * Specify the file filter classname that will be used.
+   * 
+   * @param fileFilterImp the classname; may not be null.
+   */
+  public void setFileFilterImp(String fileFilterImp) {
+    this.fileFilterImp = Args.notNull(fileFilterImp, "file-filter-imp");
+  }
+
+  public RemoteBlobFilterWrapper withFilterImp(String s) {
+    setFileFilterImp(s);
+    return this;
+  }
+
+  public String getFilterExpression() {
+    return filterExpression;
+  }
+
+
+  /**
+   * Specify the file filter expression that will be used.
+   * 
+   * @param filterExpression the expression; may not be null.
+   */
+  public void setFilterExpression(String filterExpression) {
+    this.filterExpression = Args.notNull(filterExpression, "filter-expression");
+  }
+
+  public RemoteBlobFilterWrapper withFilterExpression(String expression) {
+    setFilterExpression(expression);
+    return this;
+  }
+
+  // Copied from FsHelper which makes me a little bit sad.
+  private static FileFilter createFilter(String filterExpression, String filterImpl) {
+    FileFilter result = null;
+    try {
+      if (isEmpty(filterExpression)) {
+        result = (filePath) -> true;
+      } else {
+        Class[] paramTypes = {String.class};
+        Object[] args = {filterExpression};
+        Class c = Class.forName(filterImpl);
+        Constructor cnst = c.getDeclaredConstructor(paramTypes);
+        result = (FileFilter) cnst.newInstance(args);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+}

--- a/interlok-common/src/main/java/com/adaptris/interlok/cloud/RemoteFile.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/cloud/RemoteFile.java
@@ -8,6 +8,8 @@ import java.io.File;
 // we should be OK.
 public class RemoteFile extends File {
 
+  private static final long serialVersionUID = 2019100801L;
+
   private long length = -1;
   private long lastModified = -1;
   private boolean isDirectory;

--- a/interlok-common/src/main/java/com/adaptris/interlok/util/Args.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/util/Args.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.interlok.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+public abstract class Args {
+
+  /**
+   * Convenience to throw an {@link IllegalArgumentException} if the associated argument null.
+   * 
+   * @param argument the argument.
+   * @param member the member name associated with this argument.
+   * @return the argument
+   */
+  public static <T> T notNull(final T argument, final String member) {
+    if (argument == null) {
+      throw new IllegalArgumentException(member + " may not be null");
+    }
+    return argument;
+  }
+
+  /**
+   * Convenience to throw an {@link IllegalArgumentException} if the associated argument is the
+   * empty string (or null) as defined by {@link StringUtils#isEmpty(String)}.
+   * 
+   * @param argument the argument.
+   * @param member the member name associated with this argument.
+   * @return the argument
+   */
+  public static String notEmpty(String argument, final String member) {
+    if (StringUtils.isEmpty(argument)) {
+      throw new IllegalArgumentException(member + " is empty/null");
+    }
+    return argument;
+  }
+
+  /**
+   * Convenience to throw an {@link IllegalArgumentException} if the associated argument is the
+   * blank string as defined by {@link StringUtils#isBlank(String)}.
+   * 
+   * @param argument the argument.
+   * @param member the member name associated with this argument.
+   * @return the argument
+   */
+  public static String notBlank(final String argument, final String member) {
+    if (StringUtils.isBlank(argument)) {
+      throw new IllegalArgumentException(member + " may not be blank/empty/null");
+    }
+    return argument;
+  }
+}
+

--- a/interlok-common/src/main/java/com/adaptris/interlok/util/package-info.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/util/package-info.java
@@ -1,0 +1,1 @@
+package com.adaptris.interlok.util;

--- a/interlok-common/src/test/java/com/adaptris/interlok/cloud/RemoteBlobFilterWrapperTest.java
+++ b/interlok-common/src/test/java/com/adaptris/interlok/cloud/RemoteBlobFilterWrapperTest.java
@@ -1,0 +1,41 @@
+package com.adaptris.interlok.cloud;
+
+import static org.junit.Assert.assertTrue;
+import java.util.Date;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.junit.Test;
+
+public class RemoteBlobFilterWrapperTest {
+
+  @Test
+  public void testAccept() throws Exception {
+    RemoteBlobFilterWrapper wrapper = new RemoteBlobFilterWrapper()
+        .withFilterImp(RegexFileFilter.class.getCanonicalName()).withFilterExpression(".*");
+    RemoteBlob blob = new RemoteBlob.Builder().setBucket("bucket").setName("blob1")
+        .setLastModified(new Date().getTime()).setSize(0).build();
+    RemoteBlob blob2 = new RemoteBlob.Builder().setBucket("bucket").setName("blob2")
+        .setLastModified(new Date().getTime()).setSize(0).build();
+    assertTrue(wrapper.accept(blob));
+    assertTrue(wrapper.accept(blob2));
+  }
+
+  @Test
+  public void testAccept_NoFilterExpression() throws Exception {
+    RemoteBlobFilterWrapper wrapper = new RemoteBlobFilterWrapper();
+    RemoteBlob blob = new RemoteBlob.Builder().setBucket("bucket").setName("blob1")
+        .setLastModified(new Date().getTime()).setSize(0).build();
+    RemoteBlob blob2 = new RemoteBlob.Builder().setBucket("bucket").setName("blob2")
+        .setLastModified(new Date().getTime()).setSize(0).build();
+    assertTrue(wrapper.accept(blob));
+    assertTrue(wrapper.accept(blob2));
+  }
+
+
+  @Test(expected = RuntimeException.class)
+  public void testAccept_NoFileFilterImp() {
+    RemoteBlobFilterWrapper wrapper = new RemoteBlobFilterWrapper().withFilterExpression(".*");
+    RemoteBlob blob = new RemoteBlob.Builder().setBucket("bucket").setName("blob1")
+        .setLastModified(new Date().getTime()).setSize(0).build();
+    wrapper.accept(blob);
+  }
+}

--- a/interlok-common/src/test/java/com/adaptris/interlok/util/ArgsTest.java
+++ b/interlok-common/src/test/java/com/adaptris/interlok/util/ArgsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.adaptris.interlok.util;
+
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class ArgsTest extends Args {
+
+  @Test
+  public void testNotNull() {
+    try {
+      notNull(null, "");
+      fail();
+    } catch (IllegalArgumentException expected) {
+
+    }
+    notNull("", "");
+  }
+
+  @Test
+  public void testNotEmpty() {
+    try {
+      notEmpty(null, "");
+      fail();
+    } catch (IllegalArgumentException expected) {
+
+    }
+    notEmpty("xxx", "");
+  }
+
+  @Test
+  public void testNotBlank() {
+    try {
+      notBlank("", "");
+      fail();
+    } catch (IllegalArgumentException expected) {
+
+    }
+    notBlank("xxx", "");
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/util/Args.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/Args.java
@@ -16,52 +16,14 @@
 
 package com.adaptris.core.util;
 
-import org.apache.commons.lang3.StringUtils;
+/**
+ * 
+ *
+ */
+// Not deprecated because it's madness, also because really interlok-common probably shouldn't exist.
+// @Deprecated
+// @Removal(version = "4.0", message = "Use com.adaptris.interlok.util.Args instead")
+public abstract class Args extends com.adaptris.interlok.util.Args {
 
-public abstract class Args {
-
-  /**
-   * Convenience to throw an {@link IllegalArgumentException} if the associated argument null.
-   * 
-   * @param argument the argument.
-   * @param member the member name associated with this argument.
-   * @return the argument
-   */
-  public static <T> T notNull(final T argument, final String member) {
-    if (argument == null) {
-      throw new IllegalArgumentException(member + " may not be null");
-    }
-    return argument;
-  }
-
-  /**
-   * Convenience to throw an {@link IllegalArgumentException} if the associated argument is the
-   * empty string (or null) as defined by {@link StringUtils#isEmpty(String)}.
-   * 
-   * @param argument the argument.
-   * @param member the member name associated with this argument.
-   * @return the argument
-   */
-  public static String notEmpty(String argument, final String member) {
-    if (StringUtils.isEmpty(argument)) {
-      throw new IllegalArgumentException(member + " is empty/null");
-    }
-    return argument;
-  }
-
-  /**
-   * Convenience to throw an {@link IllegalArgumentException} if the associated argument is the
-   * blank string as defined by {@link StringUtils#isBlank(String)}.
-   * 
-   * @param argument the argument.
-   * @param member the member name associated with this argument.
-   * @return the argument
-   */
-  public static String notBlank(final String argument, final String member) {
-    if (StringUtils.isBlank(argument)) {
-      throw new IllegalArgumentException(member + " may not be blank/empty/null");
-    }
-    return argument;
-  }
 }
 


### PR DESCRIPTION
- Add RemoteBlobFilter and RemoteBlobFilterWrapper which wraps a FileFilter (for easy filtering).
- Moved com.adaptris.core.util.Args into com.adaptris.interlok.util however, not deprecating it because of excessive use, but we have to consider what happens in 4.0 since interlok-common probably shouldn't exist as a sub-project.