### PR TITLE
INTERLOK-2972 - Add createConnection() method to VendorImplementation

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/FailoverJmsConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/FailoverJmsConnection.java
@@ -183,8 +183,7 @@ public class FailoverJmsConnection extends JmsConnection {
   }
 
   @Override
-  protected void createConnection(ConnectionFactory factory)
-      throws JMSException {
+  protected void createConnection(ConnectionFactory factory) throws Exception {
     current.createConnection(factory);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnection.java
@@ -16,7 +16,6 @@
 
 package com.adaptris.core.jms;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
@@ -37,8 +36,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.jms.jndi.StandardJndiImplementation;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.interlok.resolver.ExternalResolver;
-import com.adaptris.security.password.Password;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -216,22 +213,8 @@ public class JmsConnection extends AllowsRetriesConnection implements JmsConnect
     return result;
   }
 
-  protected void createConnection(ConnectionFactory factory) throws JMSException {
-    try {
-      if (isEmpty(configuredUserName())) {
-        connection = factory.createConnection();
-      }
-      else {
-        connection = factory.createConnection(configuredUserName(),
-            Password.decode(ExternalResolver.resolve(configuredPassword())));
-      }
-    }
-    catch (JMSException e) {
-      throw e;
-    }
-    catch (Exception e) {
-      JmsUtils.rethrowJMSException(e);
-    }
+  protected void createConnection(ConnectionFactory factory) throws Exception {
+    connection = configuredVendorImplementation().createConnection(factory, this);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsPollingConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsPollingConsumerImpl.java
@@ -41,8 +41,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.jms.jndi.StandardJndiImplementation;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.LifecycleHelper;
-import com.adaptris.interlok.resolver.ExternalResolver;
-import com.adaptris.security.password.Password;
 import com.adaptris.util.TimeInterval;
 
 /**
@@ -142,7 +140,7 @@ public abstract class JmsPollingConsumerImpl extends AdaptrisPollingConsumer imp
   private void initialiseConnection() throws Exception {
     long start = System.currentTimeMillis();
     ConnectionFactory factory = createConnectionFactory();
-    connection = createConnection(factory, userName, Password.decode(ExternalResolver.resolve(configuredPassword())));
+    connection = configuredVendorImplementation().createConnection(factory, this);
 
     if (clientId != null) {
       connection.setClientID(clientId);

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsPollingConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsPollingConsumerImpl.java
@@ -117,23 +117,12 @@ public abstract class JmsPollingConsumerImpl extends AdaptrisPollingConsumer imp
     messageHandler = new OnMessageHandler(this);
   }
 
-  protected ConnectionFactory createConnectionFactory() throws CoreException {
-    try {
-      return getVendorImplementation().createConnectionFactory();
-    }
-    catch (JMSException e) {
-      throw new CoreException(e);
-    }
+  protected ConnectionFactory createConnectionFactory() throws Exception {
+    return configuredVendorImplementation().createConnectionFactory();
   }
-
-
-  protected Connection createConnection(ConnectionFactory factory, String user, String password) throws JMSException {
-    return factory.createConnection(user, password);
-  }
-
 
   protected Session createSession(Connection connection, int acknowledgeMode, boolean transacted) throws JMSException {
-    return getVendorImplementation().createSession(connection, transacted, acknowledgeMode);
+    return configuredVendorImplementation().createSession(connection, transacted, acknowledgeMode);
   }
 
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/VendorImplementation.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/VendorImplementation.java
@@ -52,8 +52,8 @@ public interface VendorImplementation extends VendorImplementationBase {
    *           or not; this should be appropriate for all JMS 1.1 specifications.
    * @param factory the jms connection factory.
    * @param cfg the connection configuration (i.e. username/password)
-   * @return
-   * @throws Exception
+   * @return a {@code javax.jms.Connection} instance
+   * @throws Exception on exception
    */
   default Connection createConnection(ConnectionFactory factory, JmsConnectionConfig cfg) throws Exception {
     Connection jmsConnection = null;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/VendorImplementation.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/VendorImplementation.java
@@ -16,8 +16,12 @@
 
 package com.adaptris.core.jms;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.security.password.Password;
 
 /**
  * <p>
@@ -27,12 +31,39 @@ import javax.jms.JMSException;
 public interface VendorImplementation extends VendorImplementationBase {
 
   /**
-   * <p>
-   * Returns a <code>ConnectionFactory</code>.
+   * Returns a {@code ConnectionFactory}.
    * 
    * @return an instance of <code>ConnectionFactory</code>
    * @throws JMSException if any occurs
    */
   ConnectionFactory createConnectionFactory() throws JMSException;
+
+  /**
+   * Create a connection based on the factory and configuration.
+   * 
+   * <p>
+   * If the vendor in question doesn't support the JMS 1.1 API specification (i.e. ConnectionFactory
+   * doesn't expose a {@code createConnection()} method, this method should be explicitly overriden by
+   * the concrete implementations to do the right thing.
+   * </p>
+   * 
+   * @implNote the default implementation just calls {@code createConnection()} or
+   *           {@code createConnection(String,String)} depending on whether a username is configured
+   *           or not; this should be appropriate for all JMS 1.1 specifications.
+   * @param factory the jms connection factory.
+   * @param cfg the connection configuration (i.e. username/password)
+   * @return
+   * @throws Exception
+   */
+  default Connection createConnection(ConnectionFactory factory, JmsConnectionConfig cfg) throws Exception {
+    Connection jmsConnection = null;
+    if (isEmpty(cfg.configuredUserName())) {
+      jmsConnection = factory.createConnection();
+    } else {
+      jmsConnection =
+          factory.createConnection(cfg.configuredUserName(), Password.decode(ExternalResolver.resolve(cfg.configuredPassword())));
+    }
+    return jmsConnection;
+  }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
@@ -68,8 +68,9 @@ public class JmsConsumerTest extends JmsConsumerCase {
     when(mockVendor.getBrokerUrl())
         .thenReturn("vm://" + activeMqBroker.getName());
     
-    when(mockVendor.createConnectionFactory())
-        .thenReturn(new ActiveMQConnectionFactory("vm://" + activeMqBroker.getName()));
+    ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://" + activeMqBroker.getName());
+    when(mockVendor.createConnectionFactory()).thenReturn(factory);
+    when(mockVendor.createConnection(any(), any())).thenReturn(factory.createConnection());
     
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
@@ -90,7 +91,7 @@ public class JmsConsumerTest extends JmsConsumerCase {
 
       LifecycleHelper.initAndStart(standaloneConsumer);
       
-      verify(mockVendor).createConsumer((any(JmsDestination.class)), any(String.class), any(JmsActorConfig.class));
+      verify(mockVendor).createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class));
       
       LifecycleHelper.stopAndClose(standaloneConsumer);
       
@@ -137,7 +138,7 @@ public class JmsConsumerTest extends JmsConsumerCase {
         LifecycleHelper.initAndStart(standaloneConsumer);
       } catch (Exception ex) {}
       
-      verify(mockVendor, times(0)).createConsumer((any(JmsDestination.class)), any(String.class), any(JmsActorConfig.class));
+      verify(mockVendor, times(0)).createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class));
       
       LifecycleHelper.stopAndClose(standaloneConsumer);
       


### PR DESCRIPTION
- Add a default createConnection() method to VendorImplementation which is appropriate for JMS1.1
- Concrete Imps (like OracleAQ) can override it as required.
- Make sure we call the new vendor-imp method in the connection / polling consumer.
- Fix JmsConsumer mock test

Am not entirely happy with all the instance variables being used by JmsConnection (it seems a bit lame).