### PR TITLE
Allow adding workflow, channel, messageid and any other message data to MDC

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -77,6 +77,27 @@ public abstract class CoreConstants {
 
   /**
    * <p>
+   * A channel's id is stored against this key in the logger's Mapped Diagnostic Context
+   * </p>
+   */
+  public static final String CHANNEL_ID_KEY = "channelid";
+
+  /**
+   * <p>
+   * A workflow's id is stored against this key in the logger's Mapped Diagnostic Context
+   * </p>
+   */
+  public static final String WORKFLOW_ID_KEY = "workflowid";
+
+  /**
+   * <p>
+   * A message's unique ID is stored against this key in various places
+   * </p>
+   */
+  public static final String MESSAGE_UNIQUE_ID_KEY = "messageuniqueid";
+
+  /**
+   * <p>
    * Metadata key which <code>MessageSplitterService</code> uses to store the unique ID of the original parent message on the split,
    * child message.
    * </p>

--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -703,6 +703,7 @@ public class PoolingWorkflow extends WorkflowImp {
       Thread.currentThread().setName(getThreadName());
       AdaptrisMessage result = null;
       try {
+        processingStart(message);
         result = worker.handleMessage(message);
         workflowEnd(message, result);
         objectPool.returnObject(worker);
@@ -749,7 +750,6 @@ public class PoolingWorkflow extends WorkflowImp {
     public AdaptrisMessage handleMessage(AdaptrisMessage msg) {
       AdaptrisMessage wip = null;
       try {
-        putMDC(msg);
         long start = System.currentTimeMillis();
         log.debug("start processing msg [{}]", messageLogger().toString(msg));
         wip = (AdaptrisMessage) msg.clone();
@@ -771,7 +771,6 @@ public class PoolingWorkflow extends WorkflowImp {
       }
       finally {
         sendMessageLifecycleEvent(wip);
-        removeMDC();
       }
       return wip;
     }

--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -749,6 +749,7 @@ public class PoolingWorkflow extends WorkflowImp {
     public AdaptrisMessage handleMessage(AdaptrisMessage msg) {
       AdaptrisMessage wip = null;
       try {
+        putMDC(msg);
         long start = System.currentTimeMillis();
         log.debug("start processing msg [{}]", messageLogger().toString(msg));
         wip = (AdaptrisMessage) msg.clone();
@@ -770,6 +771,7 @@ public class PoolingWorkflow extends WorkflowImp {
       }
       finally {
         sendMessageLifecycleEvent(wip);
+        removeMDC();
       }
       return wip;
     }

--- a/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
@@ -79,6 +79,7 @@ public class StandardWorkflow extends StandardWorkflowImpl {
     AdaptrisMessage wip = addConsumeLocation(msg);
     workflowStart(msg);
     try {
+      putMDC(msg);
       long start = System.currentTimeMillis();
       log.debug("start processing msg [{}]", messageLogger().toString(msg));
       if (clone) {
@@ -104,6 +105,7 @@ public class StandardWorkflow extends StandardWorkflowImpl {
     }
     finally {
       sendMessageLifecycleEvent(wip);
+      removeMDC();
     }
     workflowEnd(msg, wip);
   }

--- a/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
@@ -78,8 +78,8 @@ public class StandardWorkflow extends StandardWorkflowImpl {
   protected void handleMessage(final AdaptrisMessage msg, boolean clone) {
     AdaptrisMessage wip = addConsumeLocation(msg);
     workflowStart(msg);
+    processingStart(msg);
     try {
-      putMDC(msg);
       long start = System.currentTimeMillis();
       log.debug("start processing msg [{}]", messageLogger().toString(msg));
       if (clone) {
@@ -105,7 +105,6 @@ public class StandardWorkflow extends StandardWorkflowImpl {
     }
     finally {
       sendMessageLifecycleEvent(wip);
-      removeMDC();
     }
     workflowEnd(msg, wip);
   }

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -45,7 +45,6 @@ import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.util.PlainIdGenerator;
 import com.adaptris.util.TimeInterval;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import org.slf4j.MDC;
 
 /**
  * Partial implementation of <code>Workflow</code>.
@@ -86,9 +85,6 @@ public abstract class WorkflowImp implements Workflow {
   @AdvancedConfig
   @InputFieldDefault(value = "true")
   private Boolean sendEvents;
-  @AdvancedConfig
-  @InputFieldDefault(value = "true")
-  private Boolean useMappedDiagnosticContext;
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   @Deprecated
@@ -470,23 +466,6 @@ public abstract class WorkflowImp implements Workflow {
     return obtainWorkflowId();
   }
 
-
-  protected void putMDC(AdaptrisMessage message) {
-    if(useMappedDiagnosticContext()) {
-      MDC.put(CoreConstants.CHANNEL_ID_KEY, obtainChannel().getUniqueId());
-      MDC.put(CoreConstants.WORKFLOW_ID_KEY, getUniqueId());
-      MDC.put(CoreConstants.MESSAGE_UNIQUE_ID_KEY, message.getUniqueId());
-    }
-  }
-
-  protected void removeMDC() {
-    if(useMappedDiagnosticContext()) {
-      MDC.remove(CoreConstants.CHANNEL_ID_KEY);
-      MDC.remove(CoreConstants.WORKFLOW_ID_KEY);
-      MDC.remove(CoreConstants.MESSAGE_UNIQUE_ID_KEY);
-    }
-  }
-
   /**
    * <p>
    * Sets the <code>ServiceCollection</code> to use. May not be null.
@@ -609,38 +588,6 @@ public abstract class WorkflowImp implements Workflow {
 
   /**
    * <p>
-   * Sets whether to write channel, workflow and message id into the Mapped Diagnostic Context. The following
-   * keys will be added for each message:
-   * </p>
-   * <ul>
-   *     <li>channelid</li>
-   *     <li>workflowid</li>
-   *     <li>messageuniqueid</li>
-   * </ul>
-   *
-   * @param useMappedDiagnosticContext whether to populate the Mapped Diagnostic Context
-   */
-  public void setUseMappedDiagnosticContext(Boolean useMappedDiagnosticContext) {
-    this.useMappedDiagnosticContext = useMappedDiagnosticContext;
-  }
-
-  /**
-   * <p>
-   * Return whether the Mapped Diagnostic Context will be populated
-   * </p>
-   *
-   * @return whether the Mapped Diagnostic Context will be populated
-   */
-  public Boolean getUseMappedDiagnosticContext() {
-    return useMappedDiagnosticContext;
-  }
-
-  boolean useMappedDiagnosticContext() {
-    return BooleanUtils.toBooleanDefaultIfNull(getUseMappedDiagnosticContext(), true);
-  }
-
-  /**
-   * <p>
    * Returns true if payload should be logged.
    * </p>
    *
@@ -759,7 +706,7 @@ public abstract class WorkflowImp implements Workflow {
   }
 
   /**
-   * Mark the workflow having started processing on a message.
+   * Mark the workflow having accepted a message.
    *
    * @param msg the input message
    * @see WorkflowInterceptor
@@ -767,6 +714,18 @@ public abstract class WorkflowImp implements Workflow {
   protected void workflowStart(AdaptrisMessage msg) {
     for (WorkflowInterceptor i : getInterceptors()) {
       i.workflowStart(msg);
+    }
+  }
+
+  /**
+   * Mark the workflow having started processing a message.
+   *
+   * @param msg the input message
+   * @see WorkflowInterceptor
+   */
+  protected void processingStart(AdaptrisMessage msg) {
+    for (WorkflowInterceptor i : getInterceptors()) {
+      i.processingStart(msg);
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowInterceptor.java
@@ -33,7 +33,7 @@ public interface WorkflowInterceptor extends AdaptrisComponent, ComponentLifecyc
 
   /**
    * Mark the start of processing a message. This method may be called on a different thread
-   * from {#workflowStart}
+   * from {@code #workflowStart}
    *
    * @param inputMsg
    */

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowInterceptor.java
@@ -24,11 +24,20 @@ package com.adaptris.core;
 public interface WorkflowInterceptor extends AdaptrisComponent, ComponentLifecycleExtension {
 
   /**
-   * Mark the start of a workflow.
+   * Mark the start of a workflow. This doesn't mean the message has started processing
+   * but only that the message will - at some point - be processed by the workflow.
    *
    * @param inputMsg the message that will be processed by this workflow.
    */
   void workflowStart(AdaptrisMessage inputMsg);
+
+  /**
+   * Mark the start of processing a message. This method may be called on a different thread
+   * from {#workflowStart}
+   *
+   * @param inputMsg
+   */
+  default void processingStart(AdaptrisMessage inputMsg) { }
 
   /**
    * Mark the end of a workflow.

--- a/interlok-core/src/main/java/com/adaptris/core/interceptor/LoggingContextWorkflowInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/interceptor/LoggingContextWorkflowInterceptor.java
@@ -32,7 +32,6 @@ import com.adaptris.util.GuidGenerator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import javax.validation.constraints.NotNull;
-import javax.xml.crypto.dsig.keyinfo.KeyValue;
 
 /**
  * WorkflowInterceptor implementation that adds a mapped diagnostic context via {@code org.slf4j.MDC#put(String, String)}.

--- a/interlok-core/src/main/java/com/adaptris/core/interceptor/LoggingContextWorkflowInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/interceptor/LoggingContextWorkflowInterceptor.java
@@ -18,26 +18,27 @@ package com.adaptris.core.interceptor;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import com.adaptris.annotation.*;
+import com.adaptris.core.*;
+import com.adaptris.core.util.Args;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairList;
+import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.MDC;
 
-import com.adaptris.annotation.AdapterComponent;
-import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.PoolingWorkflow;
-import com.adaptris.core.StandardWorkflow;
 import com.adaptris.core.services.AddLoggingContext;
 import com.adaptris.core.services.RemoveLoggingContext;
 import com.adaptris.util.GuidGenerator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import javax.validation.constraints.NotNull;
+import javax.xml.crypto.dsig.keyinfo.KeyValue;
+
 /**
- * WorkflowInterceptor implementation that adds a mapped diagnotic context via {@code org.slf4j.MDC#put(String, String)}.
+ * WorkflowInterceptor implementation that adds a mapped diagnostic context via {@code org.slf4j.MDC#put(String, String)}.
  * <p>
- * Because the diagnostic logging context is thread based; this will only be useful when used as part of a single threaded workflow
- * such as {@link StandardWorkflow}; in {@link PoolingWorkflow} the context will be lost as the message enters the threadpool for
- * processing. A better alternative might be {@link AddLoggingContext} and {@link RemoveLoggingContext} as part of the service
- * execution chain.
+ * An alternative to this interceptor might be {@link AddLoggingContext} and {@link RemoveLoggingContext} as part of the
+ * service execution chain.
  * </p>
  * 
  * @config logging-context-workflow-interceptor
@@ -53,14 +54,25 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
 
   private static final GuidGenerator GUID = new GuidGenerator();
 
-  private String key;
-  private String value;
+  @AdvancedConfig
+  @InputFieldDefault(value = "true")
+  private Boolean useDefaultKeys;
 
-  private transient String keyToUse;
-  private transient String valueToUse;
+  @NotNull
+  @AutoPopulated
+  @InputFieldHint(expression = true)
+  private KeyValuePairList valuesToSet;
+
+  @Deprecated
+  private String key;
+
+  @Deprecated
+  @InputFieldHint(expression = true)
+  private String value;
 
   public LoggingContextWorkflowInterceptor() {
     super();
+    valuesToSet = new KeyValuePairList();
   }
 
   public LoggingContextWorkflowInterceptor(String uid) {
@@ -69,19 +81,51 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
   }
 
   @Override
-  public synchronized void workflowStart(AdaptrisMessage inputMsg) {
-    MDC.put(keyToUse, valueToUse);
+  public synchronized void workflowStart(AdaptrisMessage inputMsg) { }
+
+  @Override
+  public synchronized void processingStart(AdaptrisMessage inputMsg) {
+    if(useDefaultKeys()) {
+      if(!isEmpty(parentChannel().getUniqueId()))
+        MDC.put(CoreConstants.CHANNEL_ID_KEY, parentChannel().getUniqueId());
+      if(!isEmpty(parentWorkflow().getUniqueId()))
+        MDC.put(CoreConstants.WORKFLOW_ID_KEY, parentWorkflow().getUniqueId());
+      MDC.put(CoreConstants.MESSAGE_UNIQUE_ID_KEY, inputMsg.getUniqueId());
+    }
+
+    String keyToUse = resolve(key, inputMsg);
+    if(!isEmpty(keyToUse)) {
+      String valueToUse = resolve(value, inputMsg);
+      if(!isEmpty(valueToUse)) {
+        MDC.put(keyToUse, valueToUse);
+      }
+    }
+
+    for(KeyValuePair pair: getValuesToSet()) {
+      MDC.put(pair.getKey(), inputMsg.resolve(pair.getValue()));
+    }
   }
 
   @Override
   public synchronized void workflowEnd(AdaptrisMessage inputMsg, AdaptrisMessage outputMsg) {
-    MDC.remove(keyToUse);
+    for(KeyValuePair pair: getValuesToSet()) {
+      MDC.remove(pair.getKey());
+    }
+
+    String keyToUse = resolve(key, inputMsg);
+    if(!isEmpty(keyToUse)) {
+      MDC.remove(keyToUse);
+    }
+
+    if(useDefaultKeys()) {
+      MDC.remove(CoreConstants.CHANNEL_ID_KEY);
+      MDC.remove(CoreConstants.WORKFLOW_ID_KEY);
+      MDC.remove(CoreConstants.MESSAGE_UNIQUE_ID_KEY);
+    }
   }
 
   @Override
   public void init() throws CoreException {
-    keyToUse = resolve(getKey());
-    valueToUse = resolve(getValue());
   }
 
   @Override
@@ -93,6 +137,7 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
   @Override
   public void close() {}
 
+  @Deprecated
   public String getKey() {
     return key;
   }
@@ -111,13 +156,14 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
    * 
    * @param key the contextKey to set.
    */
+  @Deprecated
   public void setKey(String key) {
     this.key = key;
   }
 
-  private String resolve(String s) {
+  private String resolve(String s, AdaptrisMessage msg) {
     if (!isEmpty(s))
-      return s;
+      return msg == null ? s : msg.resolve(s);
     if (!isEmpty(getUniqueId())) {
       return getUniqueId();
     }
@@ -130,6 +176,7 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
     return GUID.safeUUID();
   }
 
+  @Deprecated
   public String getValue() {
     return value;
   }
@@ -148,8 +195,53 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
    * 
    * @param val the contextValue to set
    */
+  @Deprecated
   public void setValue(String val) {
     this.value = val;
   }
 
+  public KeyValuePairList getValuesToSet() {
+    return valuesToSet;
+  }
+
+  /**
+   * Set the list of values to set
+   *
+   * @param values the mapping to add
+   */
+  public void setValuesToSet(KeyValuePairList values) {
+    valuesToSet = Args.notNull(values, "values");
+  }
+
+  /**
+   * <p>
+   * Sets whether to write channel, workflow and message id into the Mapped Diagnostic Context. The following
+   * keys will be added for each message:
+   * </p>
+   * <ul>
+   *     <li>channelid</li>
+   *     <li>workflowid</li>
+   *     <li>messageuniqueid</li>
+   * </ul>
+   *
+   * @param useDefaultKeys whether to populate the Mapped Diagnostic Context
+   */
+  public void setUseDefaultKeys(Boolean useDefaultKeys) {
+    this.useDefaultKeys = useDefaultKeys;
+  }
+
+  /**
+   * <p>
+   * Return whether the default keys will be populated
+   * </p>
+   *
+   * @return whether the default keys will be populated
+   */
+  public Boolean getUseDefaultKeys() {
+    return useDefaultKeys;
+  }
+
+  boolean useDefaultKeys() {
+    return BooleanUtils.toBooleanDefaultIfNull(getUseDefaultKeys(), true);
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/interceptor/LoggingContextWorkflowInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/interceptor/LoggingContextWorkflowInterceptor.java
@@ -92,9 +92,9 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
       MDC.put(CoreConstants.MESSAGE_UNIQUE_ID_KEY, inputMsg.getUniqueId());
     }
 
-    String keyToUse = resolve(key, inputMsg);
+    String keyToUse = resolve(getKey(), inputMsg);
     if(!isEmpty(keyToUse)) {
-      String valueToUse = resolve(value, inputMsg);
+      String valueToUse = resolve(getValue(), inputMsg);
       if(!isEmpty(valueToUse)) {
         MDC.put(keyToUse, valueToUse);
       }
@@ -111,7 +111,7 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
       MDC.remove(pair.getKey());
     }
 
-    String keyToUse = resolve(key, inputMsg);
+    String keyToUse = resolve(getKey(), inputMsg);
     if(!isEmpty(keyToUse)) {
       MDC.remove(keyToUse);
     }
@@ -162,7 +162,7 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
 
   private String resolve(String s, AdaptrisMessage msg) {
     if (!isEmpty(s))
-      return msg == null ? s : msg.resolve(s);
+      return msg.resolve(s);
     if (!isEmpty(getUniqueId())) {
       return getUniqueId();
     }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConstants.java
@@ -25,12 +25,6 @@ package com.adaptris.core.jms;
 public final class JmsConstants {
 
   /**
-   * <p>
-   * A message's unique ID is stored against this key in JMS properties.
-   * </p>
-   */
-  public static final String MESSAGE_UNIQUE_ID_KEY = "messageuniqueid";
-  /**
    * Key used to store the JMSCorrelationID header property.
    *
    */

--- a/interlok-core/src/main/java/com/adaptris/core/jms/MetadataHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/MetadataHandler.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core.jms;
 
+import static com.adaptris.core.CoreConstants.MESSAGE_UNIQUE_ID_KEY;
 import static com.adaptris.core.jms.JmsConstants.JMS_CORRELATION_ID;
 import static com.adaptris.core.jms.JmsConstants.JMS_DELIVERY_MODE;
 import static com.adaptris.core.jms.JmsConstants.JMS_DESTINATION;
@@ -26,7 +27,6 @@ import static com.adaptris.core.jms.JmsConstants.JMS_REDELIVERED;
 import static com.adaptris.core.jms.JmsConstants.JMS_REPLY_TO;
 import static com.adaptris.core.jms.JmsConstants.JMS_TIMESTAMP;
 import static com.adaptris.core.jms.JmsConstants.JMS_TYPE;
-import static com.adaptris.core.jms.JmsConstants.MESSAGE_UNIQUE_ID_KEY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.util.Arrays;

--- a/interlok-core/src/test/java/com/adaptris/core/interceptor/LoggingContextInterceptorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/interceptor/LoggingContextInterceptorTest.java
@@ -18,7 +18,11 @@ package com.adaptris.core.interceptor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import java.util.Map;
+
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -89,6 +93,112 @@ public class LoggingContextInterceptorTest {
       Map<String, String> metadata = prod.getMessages().get(0).getMessageHeaders();
       assertTrue(metadata.containsKey("MyInterceptor"));
       assertEquals("MyInterceptor", metadata.get("MyInterceptor"));
+    } finally {
+      BaseCase.stop(c);
+    }
+  }
+
+  @Test
+  public void testInterceptor_KVP() throws Exception {
+    KeyValuePairList kvp = new KeyValuePairList();
+    kvp.add(new KeyValuePair("key1", "value1"));
+    kvp.add(new KeyValuePair("key2", "value2"));
+    LoggingContextWorkflowInterceptor interceptor = new LoggingContextWorkflowInterceptor(null);
+    interceptor.setValuesToSet(kvp);
+    StandardWorkflow wf = StatisticsMBeanCase.createWorkflow("workflowName", interceptor);
+    MockMessageProducer prod = new MockMessageProducer();
+    wf.setProducer(prod);
+    wf.getServiceCollection().add(new LoggingContextToMetadata());
+    MockChannel c = new MockChannel();
+    c.setUniqueId("channelName");
+    c.getWorkflowList().add(wf);
+    try {
+      BaseCase.start(c);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      wf.onAdaptrisMessage(msg);
+      Map<String, String> metadata = prod.getMessages().get(0).getMessageHeaders();
+      assertTrue(metadata.containsKey("key1"));
+      assertEquals("value1", metadata.get("key1"));
+    } finally {
+      BaseCase.stop(c);
+    }
+  }
+
+  @Test
+  public void testInterceptor_KVP_Expression() throws Exception {
+    KeyValuePairList kvp = new KeyValuePairList();
+    kvp.add(new KeyValuePair("key1", "%message{mk1}"));
+    kvp.add(new KeyValuePair("key2", "%message{mk2}"));
+    LoggingContextWorkflowInterceptor interceptor = new LoggingContextWorkflowInterceptor(null);
+    interceptor.setValuesToSet(kvp);
+    StandardWorkflow wf = StatisticsMBeanCase.createWorkflow("workflowName", interceptor);
+    MockMessageProducer prod = new MockMessageProducer();
+    wf.setProducer(prod);
+    wf.getServiceCollection().add(new LoggingContextToMetadata());
+    MockChannel c = new MockChannel();
+    c.setUniqueId("channelName");
+    c.getWorkflowList().add(wf);
+    try {
+      BaseCase.start(c);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      msg.addMetadata("mk1", "mv1");
+      msg.addMetadata("mk2", "mv2");
+      wf.onAdaptrisMessage(msg);
+      Map<String, String> metadata = prod.getMessages().get(0).getMessageHeaders();
+      assertTrue(metadata.containsKey("key1"));
+      assertEquals("mv1", metadata.get("key1"));
+      assertTrue(metadata.containsKey("key2"));
+      assertEquals("mv2", metadata.get("key2"));
+    } finally {
+      BaseCase.stop(c);
+    }
+  }
+
+  @Test
+  public void testInterceptor_Defaults() throws Exception {
+    LoggingContextWorkflowInterceptor interceptor = new LoggingContextWorkflowInterceptor(null);
+    StandardWorkflow wf = StatisticsMBeanCase.createWorkflow("workflowName", interceptor);
+    MockMessageProducer prod = new MockMessageProducer();
+    wf.setProducer(prod);
+    wf.getServiceCollection().add(new LoggingContextToMetadata());
+    MockChannel c = new MockChannel();
+    c.setUniqueId("channelName");
+    c.getWorkflowList().add(wf);
+    try {
+      BaseCase.start(c);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      wf.onAdaptrisMessage(msg);
+      Map<String, String> metadata = prod.getMessages().get(0).getMessageHeaders();
+      assertTrue(metadata.containsKey(CoreConstants.CHANNEL_ID_KEY));
+      assertEquals("channelName", metadata.get(CoreConstants.CHANNEL_ID_KEY));
+      assertTrue(metadata.containsKey(CoreConstants.WORKFLOW_ID_KEY));
+      assertEquals("workflowName", metadata.get(CoreConstants.WORKFLOW_ID_KEY));
+      assertTrue(metadata.containsKey(CoreConstants.MESSAGE_UNIQUE_ID_KEY));
+      assertEquals(msg.getUniqueId(), metadata.get(CoreConstants.MESSAGE_UNIQUE_ID_KEY));
+    } finally {
+      BaseCase.stop(c);
+    }
+  }
+
+  @Test
+  public void testInterceptor_NoDefaults() throws Exception {
+    LoggingContextWorkflowInterceptor interceptor = new LoggingContextWorkflowInterceptor(null);
+    interceptor.setUseDefaultKeys(false);
+    StandardWorkflow wf = StatisticsMBeanCase.createWorkflow("workflowName", interceptor);
+    MockMessageProducer prod = new MockMessageProducer();
+    wf.setProducer(prod);
+    wf.getServiceCollection().add(new LoggingContextToMetadata());
+    MockChannel c = new MockChannel();
+    c.setUniqueId("channelName");
+    c.getWorkflowList().add(wf);
+    try {
+      BaseCase.start(c);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      wf.onAdaptrisMessage(msg);
+      Map<String, String> metadata = prod.getMessages().get(0).getMessageHeaders();
+      assertFalse(metadata.containsKey(CoreConstants.CHANNEL_ID_KEY));
+      assertFalse(metadata.containsKey(CoreConstants.WORKFLOW_ID_KEY));
+      assertFalse(metadata.containsKey(CoreConstants.MESSAGE_UNIQUE_ID_KEY));
     } finally {
       BaseCase.stop(c);
     }


### PR DESCRIPTION
This can be used in combination with an appropriate logging Appender to log message id and such to ElasticSearch for better tracing of a message.