### PR TITLE
INTERLOK-3008 Add build.info into version report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,26 @@ ext.jacocoEnabled = { subproject ->
   return !subproject.name.equals("interlok-core-apt")
 }
 
+
+ext.gitBranchNameOrTimestamp = { branchName ->
+  if (branchName.equals("HEAD") || branchName.equals("develop") || branchName.startsWith("release")) {
+    return new Date().format('HH:mm:ss z');
+  }
+  return branchName;
+}
+
+ext.buildInfo = { ->
+   new ByteArrayOutputStream().withStream { os ->
+      exec {
+        executable = "git"
+        args = ["rev-parse", "--abbrev-ref", "HEAD"]
+        standardOutput = os
+      }
+      def branchName = os.toString().replaceAll("\r", "").replaceAll("\n", "").trim();
+      return gitBranchNameOrTimestamp(branchName);
+    }
+}
+
 task clean(type: Delete) {
   delete project.buildDir
 }
@@ -118,6 +138,7 @@ subprojects { subproject ->
         entry(key: 'groupId', value: project.group)
         entry(key: 'artifactId', value: project.name)
         entry(key: 'build.date', value: new Date().format('yyyy-MM-dd'))
+        entry(key: 'build.info', value: buildInfo())
       }
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/management/VersionReportTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/VersionReportTest.java
@@ -16,16 +16,26 @@
 
 package com.adaptris.core.management;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-
+import java.io.IOException;
 import java.util.Collection;
-
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Test;
 
 public class VersionReportTest {
 
+
+  @Test
+  public void testSingleton() throws Exception {
+    VersionReport report = VersionReport.getInstance();
+    VersionReport r2 = VersionReport.getInstance();
+    assertSame(report, r2);
+  }
 
   @Test
   public void testBuildVersion() throws Exception {
@@ -46,9 +56,40 @@ public class VersionReportTest {
   public void testGetArtifactIdentifiers() throws Exception {
     VersionReport report = VersionReport.getInstance();
     Collection<String> components = report.getArtifactIdentifiers();
-    System.err.println(components);
     // Should be at least core+common+apt
     assertTrue(components.size() > 1);
   }
 
+  @Test
+  public void testJarName() throws Exception {
+    String url = "jar:file:/path/to/interlok-common-3.8-SNAPSHOT.jar!/META-INF/adaptris-version";
+    assertEquals("interlok-common-3.8-SNAPSHOT.jar", VersionReport.jarName(url));
+    String url2 = "/META-INF/adaptris-version";
+    assertEquals("/META-INF/adaptris-version", VersionReport.jarName(url2));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testBuildReport_Broken() throws Exception {
+    new BrokenVersionReport();
+  }
+
+  @Test
+  public void testBuildReport_Empty() throws Exception {
+    Collection<String> report = new EmptyVersionReport().getReport();
+    assertEquals(1, report.size());
+  }
+
+  private class BrokenVersionReport extends VersionReport {
+    @Override
+    protected Set<ComponentVersion> buildFromVersionFile() throws IOException {
+      throw new IOException();
+    }
+  }
+
+  private class EmptyVersionReport extends VersionReport {
+    @Override
+    protected Set<ComponentVersion> buildFromVersionFile() throws IOException {
+      return new HashSet<>();
+    }
+  }
 }


### PR DESCRIPTION
- Remove XStreamAlias since it never had a public constructor, it was not usable
- Add build.info support when generating the version,
- Use chomp() to remove the last linefeed
- Refactor VersionReport for testability.
- Add tests for 100% coverage.

Merge target is post 3.9.2