### PR TITLE
INTERLOK-3025 Throw RTE when we fail to create a filter.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/fs/CompositeFileFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/CompositeFileFilter.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -144,15 +143,12 @@ public class CompositeFileFilter implements FileFilter {
     for (String filterString : filterItems) {
       int pos = filterString.indexOf(FILTER_KEY_SEPARATOR);
       if (pos == -1) {
-        log.warn("Ignoring invalid filter [{}]", filterString);
+        throw new RuntimeException("Invalid filter [ " + filterString + "]");
       }
       else {
         String key = filterString.substring(0, pos);
         String value = filterString.substring(pos + 1);
-        FileFilter ff = create(key, value);
-        if (ff != null) {
-          filters.add(ff);
-        }
+        filters.add(create(key, value));
       }
     }
   }
@@ -172,11 +168,11 @@ public class CompositeFileFilter implements FileFilter {
   private FileFilter newInstance(String clazzname, String expr) {
     FileFilter result = null;
     try {
-      log.trace("Trying to use : {}", clazzname);
+      log.trace("Trying to create filter from : {}", clazzname);
       result = FsHelper.createFilter(expr, clazzname);
     }
     catch (Exception e) {
-      log.trace("Error encounted attempting to use {}, ignoring", clazzname, e);
+      throw new RuntimeException("Invalid filter classname [ " + clazzname + "]", e);
     }
     return result;
   }

--- a/interlok-core/src/test/java/com/adaptris/core/fs/CompositeFileFilterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/CompositeFileFilterTest.java
@@ -18,11 +18,9 @@ package com.adaptris.core.fs;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
@@ -33,9 +31,9 @@ import org.junit.Test;
  */
 public class CompositeFileFilterTest {
   protected transient Log logR = LogFactory.getLog(this.getClass());
-  private static final String FILTER_SIZE = "SizeGT=1024__@@__Perl=.*\\.xml";
-  private static final String FILTER_CUSTOM = "SizeGT=1024__@@__Perl=.*\\.xml__@@__com.adaptris.core.fs.YesOrNo=false";
-  private static final String FILTER_N0CLASSDEF = "SizeGT=1024__@@__Perl=.*\\.xml__@@__com.adaptris.core.fs.Blah=false";
+  private static final String FILTER_SIZE = "SizeGT=1024__@@__Regex=.*\\.xml";
+  private static final String FILTER_CUSTOM = "SizeGT=1024__@@__Regex=.*\\.xml__@@__com.adaptris.core.fs.YesOrNo=false";
+  private static final String FILTER_N0CLASSDEF = "SizeGT=1024__@@__Regex=.*\\.xml__@@__com.adaptris.core.fs.Blah=false";
 
   private static final String[] FILTER_STRINGS = {
       "NewerThan=-PT1H",
@@ -45,7 +43,6 @@ public class CompositeFileFilterTest {
       "SizeLT=1024",
       "SizeLTE=1024",
       "com.adaptris.core.fs.YesOrNo=false",
-      "IWon'tWork"
   };
 
   @Test
@@ -53,6 +50,11 @@ public class CompositeFileFilterTest {
     for (String filter : FILTER_STRINGS) {
       CompositeFileFilter df = new CompositeFileFilter(filter, true);
     }
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testCreate_Invalid() throws Exception {
+    CompositeFileFilter df = new CompositeFileFilter("IWon'tWork", true);
   }
 
   @Test
@@ -88,15 +90,9 @@ public class CompositeFileFilterTest {
     assertFalse(text, accepted);
   }
 
-  @Test
+  @Test(expected = RuntimeException.class)
   public void testCustomFilterNoClassDef() throws Exception {
-    File src = File.createTempFile(this.getClass().getSimpleName(), ".xml");
-    write(2048, src);
     CompositeFileFilter df = new CompositeFileFilter(FILTER_N0CLASSDEF);
-    boolean accepted = df.accept(src);
-    String text = src + ", size=" + src.length() + " should match, custom filefilter ignored.";
-    src.delete();
-    assertTrue(text, accepted);
   }
 
   private void write(long size, File f) throws IOException {


### PR DESCRIPTION
- Wherever we just log the exception; now throw a RuntimeException
- Modify the tests to cope with the new exceptions.