### PR TITLE
INTERLOK-2829 Add null checks and unit test

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/StandaloneRequestor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandaloneRequestor.java
@@ -73,6 +73,7 @@ public class StandaloneRequestor extends StandaloneProducer {
       // now enforces the return type to be the same object that was passed in
       // I suppose we can't guarantee that ppl haven't implemented their
       // own.
+      
       if (reply != null && m != null && reply != m) {
         log.trace("Copying reply message into original message");
         copy(reply, m);

--- a/interlok-core/src/main/java/com/adaptris/core/StandaloneRequestor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandaloneRequestor.java
@@ -73,7 +73,7 @@ public class StandaloneRequestor extends StandaloneProducer {
       // now enforces the return type to be the same object that was passed in
       // I suppose we can't guarantee that ppl haven't implemented their
       // own.
-      if (reply != m) {
+      if (reply != null && m != null && reply != m) {
         log.trace("Copying reply message into original message");
         copy(reply, m);
       }

--- a/interlok-core/src/test/java/com/adaptris/core/StandaloneRequestorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/StandaloneRequestorTest.java
@@ -21,6 +21,11 @@ import java.util.concurrent.TimeUnit;
 import com.adaptris.core.stubs.MockNonStandardRequestReplyProducer;
 import com.adaptris.core.stubs.MockRequestReplyProducer;
 import com.adaptris.util.TimeInterval;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("deprecation")
 public class StandaloneRequestorTest extends GeneralServiceExample {
@@ -102,6 +107,20 @@ public class StandaloneRequestorTest extends GeneralServiceExample {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("XYZ");
     execute(service, msg);
     // all we care here is that a NPE isn't thrown (see INTERLOK-2829)
+  }
+
+  public void testNullMessage() throws Exception {
+    StandaloneRequestor service = new StandaloneRequestor();
+    service.doService(null);
+  }
+
+  public void testConsumerProducer() throws Exception {
+    AdaptrisMessageProducer mp = mock(AdaptrisMessageProducer.class);
+    StandaloneRequestor service = new StandaloneRequestor(mp);
+    service.setReplyTimeout(new TimeInterval(-1L, TimeUnit.MILLISECONDS));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("XYZ");
+    doReturn(msg).when(mp).request(msg);
+    execute(service, msg);
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/StandaloneRequestorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/StandaloneRequestorTest.java
@@ -97,6 +97,13 @@ public class StandaloneRequestorTest extends GeneralServiceExample {
     assertEquals(service.getProducer().createQualifier(), service.createQualifier());
   }
 
+  public void testNullProducer() throws Exception {
+    StandaloneRequestor service = new StandaloneRequestor();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("XYZ");
+    execute(service, msg);
+    // all we care here is that a NPE isn't thrown (see INTERLOK-2829)
+  }
+
   @Override
   protected Object retrieveObjectForSampleConfig() {
     return new StandaloneRequestor();

--- a/interlok-core/src/test/java/com/adaptris/core/StandaloneRequestorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/StandaloneRequestorTest.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import com.adaptris.core.stubs.MockNonStandardRequestReplyProducer;
@@ -24,6 +25,7 @@ import com.adaptris.util.TimeInterval;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -121,6 +123,31 @@ public class StandaloneRequestorTest extends GeneralServiceExample {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("XYZ");
     doReturn(msg).when(mp).request(msg);
     execute(service, msg);
+  }
+  
+  public void testConsumerProducerCopyFails() throws Exception {
+    AdaptrisMessageProducer mp = mock(AdaptrisMessageProducer.class);
+    StandaloneRequestor service = new StandaloneRequestor(mp);
+    service.setReplyTimeout(new TimeInterval(-1L, TimeUnit.MILLISECONDS));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("XYZ");
+    AdaptrisMessage reply = mock(AdaptrisMessage.class);
+    doReturn(reply).when(mp).request(msg);
+    doThrow(new IOException("expected")).when(reply).getInputStream();
+    try {
+      service.doService(msg);
+      fail("Output stream on the message should thrpow an error and be caught.");
+    } catch (CoreException ex) {
+      // expected
+    }
+  }
+  
+  public void testConsumerProducerNullMessageWithReply() throws Exception {
+    AdaptrisMessageProducer mp = mock(AdaptrisMessageProducer.class);
+    StandaloneRequestor service = new StandaloneRequestor(mp);
+    service.setReplyTimeout(new TimeInterval(-1L, TimeUnit.MILLISECONDS));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("XYZ");
+    doReturn(msg).when(mp).request(null);
+    service.doService(null);
   }
 
   @Override


### PR DESCRIPTION
Add null checks for messages and a unit test that confirmed the bug and then the fix.