### PR TITLE
INTERLOK-2904 Upgrade to mockito 3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ ext {
   slf4jVersion = '1.7.28'
   log4j2Version = "2.12.1"
   xstreamVersion = '1.4.11.1'
+  mockitoVersion = '3.1.0'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
   testCompile ("log4j:log4j:1.2.17")
   testCompile ("junit:junit:4.12")
-  testCompile ("org.mockito:mockito-all:1.10.19")
+  testCompile "org.mockito:mockito-core:3.+"
 
 }
 

--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 
   testCompile ("log4j:log4j:1.2.17")
   testCompile ("junit:junit:4.12")
-  testCompile "org.mockito:mockito-core:3.+"
-
+  testCompile ("org.mockito:mockito-core:$mockitoVersion")
+  testCompile ("org.mockito:mockito-inline:$mockitoVersion")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -108,7 +108,7 @@ dependencies {
 
   testCompile ("org.jruby:jruby-complete:9.2.8.0")
   testCompile ("org.mockftpserver:MockFtpServer:2.7.1")
-  testCompile ("org.mockito:mockito-all:1.10.19")
+  testCompile "org.mockito:mockito-core:3.+"
 
   testCompile("net.sourceforge.jtds:jtds:1.3.1")
   testCompile("com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8")

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -108,8 +108,8 @@ dependencies {
 
   testCompile ("org.jruby:jruby-complete:9.2.8.0")
   testCompile ("org.mockftpserver:MockFtpServer:2.7.1")
-  testCompile "org.mockito:mockito-core:3.+"
-
+  testCompile ("org.mockito:mockito-core:$mockitoVersion")
+  testCompile ("org.mockito:mockito-inline:$mockitoVersion")
   testCompile("net.sourceforge.jtds:jtds:1.3.1")
   testCompile("com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8")
   testCompile ("mysql:mysql-connector-java:5.1.47")

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumer.java
@@ -96,8 +96,7 @@ public class JmsConsumer extends JmsConsumerImpl {
     JmsDestination destination = vendor.createDestination(rfc6167, this);
 
     if (deferConsumerCreationToVendor()) {
-      MessageConsumer mc = vendor.createConsumer(destination, filterExp, this);
-      return mc;
+      return vendor.createConsumer(destination, filterExp, this);
     } else {
       MessageConsumer consumer = null;
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumer.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,9 +58,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <li>jms:topic:MyTopicName?subscriptionId=mySubscriptionId&sharedConsumerId=mySharedConsumerId</li>
  * </ul>
  * </p>
- * 
+ *
  * @config jms-consumer
- * 
+ *
  */
 @XStreamAlias("jms-consumer")
 @AdapterComponent
@@ -68,7 +68,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
     recommended = {JmsConnection.class})
 @DisplayOrder(order = {"destination", "acknowledgeMode", "messageTranslator"})
 public class JmsConsumer extends JmsConsumerImpl {
-  
+
   @AdvancedConfig(rare = true)
   @AutoPopulated
   @InputFieldDefault(value = "false")
@@ -91,44 +91,45 @@ public class JmsConsumer extends JmsConsumerImpl {
   protected MessageConsumer createConsumer() throws JMSException, CoreException {
     String rfc6167 = getDestination().getDestination();
     String filterExp = getDestination().getFilterExpression();
-    
+
     VendorImplementation vendor = retrieveConnection(JmsConnection.class).configuredVendorImplementation();
     JmsDestination destination = vendor.createDestination(rfc6167, this);
-    
-    if(deferConsumerCreationToVendor())
-      return vendor.createConsumer(destination, filterExp, this);
-    else {
+
+    if (deferConsumerCreationToVendor()) {
+      MessageConsumer mc = vendor.createConsumer(destination, filterExp, this);
+      return mc;
+    } else {
       MessageConsumer consumer = null;
-      
+
       if(destination.destinationType().equals(DestinationType.TOPIC)) {
         if(!isEmpty(destination.subscriptionId())) {  // then durable, maybe shared
           if(!isEmpty(destination.sharedConsumerId()))  {
             log.trace("Creating new shared durable consumer.");
-            consumer = ((ConsumerCreator) 
+            consumer = ((ConsumerCreator)
                 (session, dest, filterExpression) -> session.createSharedDurableConsumer((Topic) dest.getDestination(), dest.subscriptionId(), filterExpression)
             ).createConsumer(currentSession(), destination, filterExp);
           }
           else {
             log.trace("Creating new durable consumer.");
-            consumer = ((ConsumerCreator) 
+            consumer = ((ConsumerCreator)
                 (session, dest, filterExpression) -> session.createDurableSubscriber((Topic) dest.getDestination(), filterExpression)
             ).createConsumer(currentSession(), destination, filterExp);
           }
         } else if (!isEmpty(destination.sharedConsumerId())) {
           log.trace("Creating new shared consumer.");
-          consumer = ((ConsumerCreator) 
+          consumer = ((ConsumerCreator)
               (session, dest, filterExpression) -> session.createSharedConsumer((Topic) dest.getDestination(), dest.sharedConsumerId(), filterExpression)
           ).createConsumer(currentSession(), destination, filterExp);
         }
       }
-  
+
       if(consumer == null) {
         log.trace("Creating new standard consumer.");
-        consumer = ((ConsumerCreator) 
+        consumer = ((ConsumerCreator)
             (session, dest, filterExpression) -> session.createConsumer(dest.getDestination(), filterExpression)
         ).createConsumer(currentSession(), destination, filterExp);
       }
-      
+
       return consumer;
     }
   }
@@ -136,10 +137,10 @@ public class JmsConsumer extends JmsConsumerImpl {
   protected Boolean deferConsumerCreationToVendor() {
     return this.getDeferConsumerCreationToVendor() == null ? false : this.getDeferConsumerCreationToVendor();
   }
-  
+
   /**
    * <p>
-   * Returns a boolean value which determines if the JMS message consumer should be created by the configured vendor implementation or not. 
+   * Returns a boolean value which determines if the JMS message consumer should be created by the configured vendor implementation or not.
    * </p>
    * <p>
    * Generally this will be false or null, such is the default.  When false/null a standard JMS message consumer will be created.

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
@@ -1,5 +1,6 @@
 package com.adaptris.core.jms;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -74,7 +75,7 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   
   public void testSendFails() throws Exception {
     doThrow(new JMSException("expected"))
-      .when(mockMessageProducer).send(any(Destination.class), any(Message.class), any(CompletionListener.class));
+      .when(mockMessageProducer).send(eq(null), eq(mockMessage), any(CompletionListener.class));
       
     try {
       producer.produce(adaptrisMessage, mockJmsDestination);
@@ -87,14 +88,14 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   public void testSendPerMessageProperties() throws Exception {
     producer.produce(adaptrisMessage, mockJmsDestination);
     
-    verify(mockMessageProducer).send(any(Destination.class), any(Message.class), any(int.class), any(int.class), any(long.class), any(CompletionListener.class));
+    verify(mockMessageProducer).send(eq(null), eq(mockMessage), any(int.class), any(int.class), any(long.class), any(CompletionListener.class));
   }
   
   public void testSendNotPerMessageProperties() throws Exception {
     producer.setPerMessageProperties(false);
     producer.produce(adaptrisMessage, mockJmsDestination);
     
-    verify(mockMessageProducer).send(any(Destination.class), any(Message.class), any(CompletionListener.class));
+    verify(mockMessageProducer).send(eq(null), eq(mockMessage), any(JmsAsyncProducer.class));
   }
   
   public void testCaptureOutgoingMessageProperties() throws Exception {
@@ -139,7 +140,7 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   public void testExceptionHandler() throws Exception {
     producer.onException(mockMessage, new Exception());
     
-    verify(mockExceptionHandler).handleProcessingException(any(AdaptrisMessage.class));
+    verify(mockExceptionHandler).handleProcessingException(null);
   }
   
   public void testSuccessHandler() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
@@ -75,7 +75,7 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   
   public void testSendFails() throws Exception {
     doThrow(new JMSException("expected"))
-      .when(mockMessageProducer).send(eq(null), eq(mockMessage), any(CompletionListener.class));
+      .when(mockMessageProducer).send(any(), eq(mockMessage), any(CompletionListener.class));
       
     try {
       producer.produce(adaptrisMessage, mockJmsDestination);
@@ -88,14 +88,14 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   public void testSendPerMessageProperties() throws Exception {
     producer.produce(adaptrisMessage, mockJmsDestination);
     
-    verify(mockMessageProducer).send(eq(null), eq(mockMessage), any(int.class), any(int.class), any(long.class), any(CompletionListener.class));
+    verify(mockMessageProducer).send(any(), eq(mockMessage), any(int.class), any(int.class), any(long.class), any(CompletionListener.class));
   }
   
   public void testSendNotPerMessageProperties() throws Exception {
     producer.setPerMessageProperties(false);
     producer.produce(adaptrisMessage, mockJmsDestination);
     
-    verify(mockMessageProducer).send(eq(null), eq(mockMessage), any(JmsAsyncProducer.class));
+    verify(mockMessageProducer).send(any(), eq(mockMessage), any(JmsAsyncProducer.class));
   }
   
   public void testCaptureOutgoingMessageProperties() throws Exception {
@@ -140,7 +140,7 @@ public class JmsAsyncProducerTest extends JmsProducerExample {
   public void testExceptionHandler() throws Exception {
     producer.onException(mockMessage, new Exception());
     
-    verify(mockExceptionHandler).handleProcessingException(null);
+    verify(mockExceptionHandler).handleProcessingException(any());
   }
   
   public void testSuccessHandler() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@ package com.adaptris.core.jms;
 import static com.adaptris.core.jms.JmsConfig.MESSAGE_TRANSLATOR_LIST;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,7 +41,7 @@ import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.core.util.LifecycleHelper;
 
 public class JmsConsumerTest extends JmsConsumerCase {
-  
+
   @Mock private BasicActiveMqImplementation mockVendor;
   @Mock MessageConsumer mockMessageConsumer;
 
@@ -48,7 +49,7 @@ public class JmsConsumerTest extends JmsConsumerCase {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
   }
-  
+
   public JmsConsumerTest(String name) {
     super(name);
   }
@@ -61,17 +62,17 @@ public class JmsConsumerTest extends JmsConsumerCase {
       return;
     }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    
+
     when(mockVendor.createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class)))
         .thenReturn(mockMessageConsumer);
-    
+
     when(mockVendor.getBrokerUrl())
         .thenReturn("vm://" + activeMqBroker.getName());
-    
+
     ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://" + activeMqBroker.getName());
     when(mockVendor.createConnectionFactory()).thenReturn(factory);
     when(mockVendor.createConnection(any(), any())).thenReturn(factory.createConnection());
-    
+
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
     try {
@@ -80,26 +81,27 @@ public class JmsConsumerTest extends JmsConsumerCase {
       JmsConsumer consumer = new JmsConsumer(new ConfiguredConsumeDestination(rfc6167));
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
       consumer.setDeferConsumerCreationToVendor(true);
-      
+
       JmsConnection jmsConnection = activeMqBroker.getJmsConnection();
       jmsConnection.setVendorImplementation(mockVendor);
-      
+
       StandaloneConsumer standaloneConsumer = new StandaloneConsumer(jmsConnection, consumer);
 
       MockMessageListener jms = new MockMessageListener();
       standaloneConsumer.registerAdaptrisMessageListener(jms);
 
+      when(mockVendor.createConsumer(eq(null), eq(null), any(JmsActorConfig.class))).thenReturn(mockMessageConsumer);
       LifecycleHelper.initAndStart(standaloneConsumer);
-      
-      verify(mockVendor).createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class));
-      
+
+      verify(mockVendor).createConsumer(eq(null), eq(null), any(JmsConsumer.class));
+
       LifecycleHelper.stopAndClose(standaloneConsumer);
-      
+
     } finally {
       activeMqBroker.destroy();
     }
   }
-  
+
   public void testDefaultFalseDeferConsumerCreationToVendor() throws Exception {
     // This would be best, but we can't mix Junit3 with Junit4 assumptions.
     // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
@@ -107,13 +109,13 @@ public class JmsConsumerTest extends JmsConsumerCase {
       return;
     }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    
+
     when(mockVendor.createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class)))
         .thenReturn(mockMessageConsumer);
 
     when(mockVendor.getBrokerUrl())
         .thenReturn("vm://" + activeMqBroker.getName());
-    
+
     when(mockVendor.createConnectionFactory())
         .thenReturn(new ActiveMQConnectionFactory("vm://" + activeMqBroker.getName()));
 
@@ -125,10 +127,10 @@ public class JmsConsumerTest extends JmsConsumerCase {
       JmsConsumer consumer = new JmsConsumer(new ConfiguredConsumeDestination(rfc6167));
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
 //      consumer.setDeferConsumerCreationToVendor(true);
-      
+
       JmsConnection jmsConnection = activeMqBroker.getJmsConnection();
       jmsConnection.setVendorImplementation(mockVendor);
-      
+
       StandaloneConsumer standaloneConsumer = new StandaloneConsumer(jmsConnection, consumer);
 
       MockMessageListener jms = new MockMessageListener();
@@ -137,16 +139,16 @@ public class JmsConsumerTest extends JmsConsumerCase {
       try {
         LifecycleHelper.initAndStart(standaloneConsumer);
       } catch (Exception ex) {}
-      
+
       verify(mockVendor, times(0)).createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class));
-      
+
       LifecycleHelper.stopAndClose(standaloneConsumer);
-      
+
     } finally {
       activeMqBroker.destroy();
     }
   }
-  
+
   public void testDurableTopicConsume() throws Exception {
     // This would be best, but we can't mix Junit3 with Junit4 assumptions.
     // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
@@ -176,7 +178,7 @@ public class JmsConsumerTest extends JmsConsumerCase {
     }
 
   }
-  
+
   public void testSharedDurableTopicConsume() throws Exception {
     // This would be best, but we can't mix Junit3 with Junit4 assumptions.
     // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
@@ -206,7 +208,7 @@ public class JmsConsumerTest extends JmsConsumerCase {
     }
 
   }
-  
+
   public void testSharedTopicConsume() throws Exception {
     // This would be best, but we can't mix Junit3 with Junit4 assumptions.
     // Assume.assumeTrue(JmsConfig.jmsTestsEnabled());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
@@ -63,8 +63,7 @@ public class JmsConsumerTest extends JmsConsumerCase {
     }
     EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
 
-    when(mockVendor.createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class)))
-        .thenReturn(mockMessageConsumer);
+    when(mockVendor.createConsumer(any(), any(), any(JmsActorConfig.class))).thenReturn(mockMessageConsumer);
 
     when(mockVendor.getBrokerUrl())
         .thenReturn("vm://" + activeMqBroker.getName());
@@ -90,10 +89,9 @@ public class JmsConsumerTest extends JmsConsumerCase {
       MockMessageListener jms = new MockMessageListener();
       standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      when(mockVendor.createConsumer(eq(null), eq(null), any(JmsActorConfig.class))).thenReturn(mockMessageConsumer);
       LifecycleHelper.initAndStart(standaloneConsumer);
 
-      verify(mockVendor).createConsumer(eq(null), eq(null), any(JmsConsumer.class));
+      verify(mockVendor).createConsumer(any(), any(), any(JmsConsumer.class));
 
       LifecycleHelper.stopAndClose(standaloneConsumer);
 


### PR DESCRIPTION
One of the changes between v1 and later versions or Mockito is the handling of null values when setting expectations or verifying behaviour - ````any(…)```` used to be fine with null but not any more. Either ````eq(null)```` or ````any()```` need to be used instead.