### PR TITLE
Fix typo for deleteAggregatedFiles in @DisplayOrder

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ftp/AggregatingFtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/AggregatingFtpConsumer.java
@@ -18,11 +18,15 @@ package com.adaptris.core.ftp;
 
 import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
@@ -61,7 +65,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("aggregating-ftp-consumer")
 @DisplayOrder(order =
 {
-    "destination", "messageAggregator", "filterFilterImp", "deleteAggrgatedFiles", "encoder"
+    "destination", "messageAggregator", "filterFilterImp", "deleteAggregatedFiles", "encoder"
 })
 public class AggregatingFtpConsumer extends AggregatingConsumerImpl<AggregatingFtpConsumeService> {
   private static final String DEFAULT_FILE_FILTER_IMP = "org.apache.commons.io.filefilter.RegexFileFilter";


### PR DESCRIPTION
Just fixed a typo for the property deleteAggregatedFiles in @DisplayOrder annotation.