### PR TITLE
INTERLOK-3003 Add support for primitives in FileFilter constructors

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/interlok/cloud/RemoteBlobFilterWrapper.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/cloud/RemoteBlobFilterWrapper.java
@@ -1,11 +1,10 @@
 package com.adaptris.interlok.cloud;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import java.io.FileFilter;
-import java.lang.reflect.Constructor;
 import javax.validation.constraints.NotBlank;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.interlok.util.Args;
+import com.adaptris.interlok.util.FileFilterBuilder;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -44,7 +43,7 @@ public class RemoteBlobFilterWrapper implements RemoteBlobFilter {
   @Override
   public boolean accept(RemoteBlob blob) {
     if (fileFilter == null) {
-      fileFilter = createFilter(getFilterExpression(), getFileFilterImp());
+      fileFilter = FileFilterBuilder.build(getFilterExpression(), getFileFilterImp());
     }
     return fileFilter.accept(blob.toFile());
   }
@@ -86,22 +85,4 @@ public class RemoteBlobFilterWrapper implements RemoteBlobFilter {
     return this;
   }
 
-  // Copied from FsHelper which makes me a little bit sad.
-  private static FileFilter createFilter(String filterExpression, String filterImpl) {
-    FileFilter result = null;
-    try {
-      if (isEmpty(filterExpression)) {
-        result = (filePath) -> true;
-      } else {
-        Class[] paramTypes = {String.class};
-        Object[] args = {filterExpression};
-        Class c = Class.forName(filterImpl);
-        Constructor cnst = c.getDeclaredConstructor(paramTypes);
-        result = (FileFilter) cnst.newInstance(args);
-      }
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-    return result;
-  }
 }

--- a/interlok-common/src/main/java/com/adaptris/interlok/util/FileFilterBuilder.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/util/FileFilterBuilder.java
@@ -1,0 +1,75 @@
+package com.adaptris.interlok.util;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import java.io.FileFilter;
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.commons.lang3.BooleanUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class FileFilterBuilder {
+
+  private static transient Logger log = LoggerFactory.getLogger(FileFilterBuilder.class);
+  
+  protected static final Map<Class, Function<String, Object>> SUPPORTED_CNST_ARGS;
+
+  static {
+    Map<Class, Function<String, Object>> map = new LinkedHashMap<>(12);
+    map.put(String.class, (s) -> s);
+    map.put(int.class, (s) -> Integer.parseInt(s));
+    map.put(long.class, (s) -> Long.parseLong(s));
+    map.put(boolean.class, (s) -> BooleanUtils.toBoolean(s));
+    map.put(float.class, (s) -> Float.parseFloat(s));
+    map.put(double.class, (s) -> Double.parseDouble(s));
+
+    map.put(Integer.class, (s) -> Integer.parseInt(s));
+    map.put(Long.class, (s) -> Long.parseLong(s));
+    map.put(Boolean.class, (s) -> BooleanUtils.toBoolean(s));
+    map.put(Float.class, (s) -> Float.parseFloat(s));
+    map.put(Double.class, (s)-> Double.parseDouble(s));    
+    SUPPORTED_CNST_ARGS = Collections.unmodifiableMap(map);
+  }
+
+  public static FileFilter build(String filterExpression, String filterImpl) {
+    FileFilter result = null;
+    try {
+      if (isEmpty(filterExpression)) {
+        result = (file) -> true;
+      } else {
+        Class filterClass = Class.forName(filterImpl);
+        for (Map.Entry<Class, Function<String, Object>> converter : SUPPORTED_CNST_ARGS.entrySet()) {
+          if (hasConstructor(converter.getKey(), filterClass)) {
+            // It has a constructor, we try it, bearing in mind that the converter
+            // may fail to convert so
+            // If someone passes in "a-string" with SizeFileFilter; then we will
+            // fail to convert to a long and throw an exception at this point.
+            Object constructorArg = converter.getValue().apply(filterExpression);
+            Constructor constructor = filterClass.getDeclaredConstructor(new Class[] {converter.getKey()});
+            result = (FileFilter) constructor.newInstance(new Object[] {constructorArg});
+            break;
+          }
+        }
+      }
+      if (result == null) {
+        throw new InstantiationException(filterImpl + " could not be created with [" + filterExpression + "]");
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+  
+  private static boolean hasConstructor(Class arg, Class filterClass) {
+    try {
+      filterClass.getDeclaredConstructor(new Class[] {arg});
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+}

--- a/interlok-common/src/test/java/com/adaptris/interlok/util/FileFilterBuilderTest.java
+++ b/interlok-common/src/test/java/com/adaptris/interlok/util/FileFilterBuilderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.adaptris.interlok.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.io.FileFilter;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.commons.io.filefilter.DelegateFileFilter;
+import org.apache.commons.io.filefilter.SizeFileFilter;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.junit.Test;
+
+public class FileFilterBuilderTest extends FileFilterBuilder {
+
+  @Test
+  public void testEmptyExpression() throws Exception {
+    FileFilter f = build("", "");      
+    assertNotNull(f);
+    assertTrue(f.accept(null));
+  }
+
+  @Test
+  public void testLongConstructor() throws Exception {
+    FileFilter f = build("12", SizeFileFilter.class.getCanonicalName());
+    assertEquals(SizeFileFilter.class, f.getClass());
+  }
+
+  @Test
+  public void testStringConstructor() throws Exception {
+    FileFilter f = build("*test*.java~*~", WildcardFileFilter.class.getCanonicalName());
+    assertEquals(WildcardFileFilter.class, f.getClass());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testNonPrimitiveConstructor() throws Exception {
+    FileFilter f = build("*test*.java~*~", DelegateFileFilter.class.getCanonicalName());
+  }
+
+  @Test
+  public void testConverters() throws Exception {
+    for (Map.Entry<Class, Function<String, Object>> converter : SUPPORTED_CNST_ARGS.entrySet()) {
+      assertNotNull(converter.getKey());
+      assertNotNull(converter.getValue());
+      try {
+        // This is just for coverage!
+        converter.getValue().apply("12");
+      } catch (Exception ignored) {
+
+      }
+    }
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -17,25 +17,22 @@
 package com.adaptris.core.fs;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.fs.FsException;
 import com.adaptris.fs.FsFilenameExistsException;
 import com.adaptris.fs.FsWorker;
+import com.adaptris.interlok.util.FileFilterBuilder;
 
 /**
  */
@@ -154,24 +151,7 @@ public abstract class FsHelper {
   }
 
   public static FileFilter createFilter(String filterExpression, String filterImpl) throws Exception {
-    FileFilter result = null;
-    if (isEmpty(filterExpression)) {
-      result = new NoOpFileFilter();
-    }
-    else {
-      Class[] paramTypes =
-      {
-          filterExpression.getClass()
-      };
-      Object[] args =
-      {
-          filterExpression
-      };
-      Class c = Class.forName(filterImpl);
-      Constructor cnst = c.getDeclaredConstructor(paramTypes);
-      result = (FileFilter) cnst.newInstance(args);
-    }
-    return logWarningIfRequired(result);
+    return logWarningIfRequired(FileFilterBuilder.build(filterExpression, filterImpl));
   }
 
   public static FileFilter logWarningIfRequired(FileFilter f) {
@@ -222,13 +202,5 @@ public abstract class FsHelper {
       return url.replaceAll("\\\\", "/");
     }
     return url;
-  }
-
-  private static class NoOpFileFilter implements FileFilter {
-    @Override
-    public boolean accept(File pathname) {
-      return true;
-    }
-
   }
 }


### PR DESCRIPTION
- Add FileFilterBuilder to create the FileFilter instances.
- Switch FsHelper to use the new builder.