### PR TITLE
Feature/INTERLOK-3051

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/MimeEncoderImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MimeEncoderImpl.java
@@ -97,29 +97,6 @@ public abstract class MimeEncoderImpl extends AdaptrisMessageEncoderImp {
     }
   }
 
-  protected void addPartsToMessage(BodyPartIterator input, MultiPayloadAdaptrisMessage msg) throws IOException, MessagingException {
-    for (int i = 0; i < input.size(); i++) {
-      MimeBodyPart payloadPart = Args.notNull(input.getBodyPart(i), "payload");
-      String id = payloadPart.getContentID();
-      if (!id.startsWith(PAYLOAD_CONTENT_ID)) {
-        continue;
-      }
-      id = id.substring(PAYLOAD_CONTENT_ID.length() + 1);
-      msg.switchPayload(id);
-      try (InputStream payloadIn = payloadPart.getInputStream();
-           OutputStream out = msg.getOutputStream()) {
-        IOUtils.copy(payloadIn, out);
-      }
-    }
-    MimeBodyPart metadataPart = Args.notNull(input.getBodyPart(METADATA_CONTENT_ID), "metadata");
-    try (InputStream metadata = metadataPart.getInputStream()) {
-      msg.setMetadata(getMetadataSet(metadata));
-    }
-    if (retainUniqueId()) {
-      msg.setUniqueId(input.getMessageID());
-    }
-  }
-
   /**
    * <p>
    * Returns the payload MIME encoding.

--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessage.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessage.java
@@ -19,6 +19,7 @@ package com.adaptris.core;
 import javax.validation.constraints.NotNull;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Set;
 
 /**
  * Interface for Adaptris messages that support multiple payloads, referenced by
@@ -57,6 +58,13 @@ public interface MultiPayloadAdaptrisMessage extends AdaptrisMessage {
    * @return The payload ID.
    */
   String getCurrentPayloadId();
+
+  /**
+   * Get the payload IDs used within this message.
+   *
+   * @return The payload IDs.
+   */
+  Set<String> getPayloadIDs();
 
   /**
    * Update the ID of the current payload. This does not change the current

--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -103,6 +104,14 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
   @Override
   public String getCurrentPayloadId() {
     return currentPayloadId;
+  }
+
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  public Set<String> getPayloadIDs() {
+    return payloads.keySet();
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadMessageMimeEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadMessageMimeEncoder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core;
+
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.util.text.mime.BodyPartIterator;
+import com.adaptris.util.text.mime.MultiPartFileInput;
+import com.adaptris.util.text.mime.MultiPartOutput;
+import org.apache.commons.io.IOUtils;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeBodyPart;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class MultiPayloadMessageMimeEncoder extends MimeEncoderImpl {
+
+  public MultiPayloadMessageMimeEncoder() {
+    super();
+    registerMessageFactory(new MultiPayloadMessageFactory());
+  }
+
+  @Override
+  public void writeMessage(AdaptrisMessage msg, Object target) throws CoreException {
+    try {
+      File baseFile = asFile(target);
+      MultiPartOutput output = new MultiPartOutput(msg.getUniqueId());
+      if (msg instanceof MultiPayloadAdaptrisMessage) {
+        MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage)msg;
+        for (String id : message.getPayloadIDs()) {
+          message.switchPayload(id);
+          output.addPart(payloadAsMimePart(message), PAYLOAD_CONTENT_ID + "/" + id);
+        }
+      } else {
+        output.addPart(payloadAsMimePart(msg), PAYLOAD_CONTENT_ID);
+      }
+      output.addPart(getMetadata(msg), getMetadataEncoding(), METADATA_CONTENT_ID);
+      if (msg.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION)) {
+        output.addPart(asMimePart((Exception) msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION)), EXCEPTION_CONTENT_ID);
+      }
+      try (OutputStream out = new FileOutputStream(baseFile)) {
+        output.writeTo(out);
+      }
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
+  }
+
+  @Override
+  public AdaptrisMessage readMessage(Object source) throws CoreException {
+    try {
+      MultiPayloadAdaptrisMessage msg = (MultiPayloadAdaptrisMessage)currentMessageFactory().newMessage();
+      File baseFile = asFile(source);
+      MultiPartFileInput input = new MultiPartFileInput(baseFile);
+      addPartsToMessage(input, msg);
+      return msg;
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
+  }
+
+  protected void addPartsToMessage(BodyPartIterator input, MultiPayloadAdaptrisMessage message) throws IOException, MessagingException {
+    for (int i = 0; i < input.size(); i++) {
+      MimeBodyPart payloadPart = Args.notNull(input.getBodyPart(i), "payload");
+      String id = payloadPart.getContentID();
+      if (!id.startsWith(PAYLOAD_CONTENT_ID)) {
+        continue;
+      }
+      id = id.substring(PAYLOAD_CONTENT_ID.length() + 1);
+      message.switchPayload(id);
+      try (InputStream payloadIn = payloadPart.getInputStream();
+           OutputStream out = message.getOutputStream()) {
+        IOUtils.copy(payloadIn, out);
+      }
+    }
+    MimeBodyPart metadataPart = Args.notNull(input.getBodyPart(METADATA_CONTENT_ID), "metadata");
+    try (InputStream metadata = metadataPart.getInputStream()) {
+      message.setMetadata(getMetadataSet(metadata));
+    }
+    if (retainUniqueId()) {
+      message.setUniqueId(input.getMessageID());
+    }
+  }
+
+  private File asFile(Object o) {
+    if (!(o instanceof File)) {
+      throw new IllegalArgumentException("MultiPayloadMessageMimeEncoderImpl can only encode/decode to/from a File");
+    }
+    return (File)o;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMimeEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMimeEncoder.java
@@ -16,23 +16,16 @@
 
 package com.adaptris.core.lms;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.util.Set;
-
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.CoreConstants;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.MimeEncoderImpl;
-import com.adaptris.core.MultiPayloadAdaptrisMessage;
-import com.adaptris.core.MultiPayloadMessageFactory;
+import com.adaptris.core.*;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.util.text.mime.MultiPartFileInput;
 import com.adaptris.util.text.mime.MultiPartOutput;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
 
 /**
  * Implementation of {@code AdaptrisMessageEncoder} that stores payload and metadata as a mime-encoded multipart message.
@@ -60,15 +53,7 @@ public class FileBackedMimeEncoder extends MimeEncoderImpl {
       // Use the message unique id as the message id.
       MultiPartOutput output = new MultiPartOutput(msg.getUniqueId());
       AdaptrisMessageFactory factory = currentMessageFactory();
-      if (msg instanceof MultiPayloadAdaptrisMessage) {
-        MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage)msg;
-        for (String id : message.getPayloadIDs()) {
-          message.switchPayload(id);
-          output.addPart(payloadAsMimePart(message), PAYLOAD_CONTENT_ID + "/" + id);
-        }
-      } else {
-        output.addPart(payloadAsMimePart(msg), PAYLOAD_CONTENT_ID);
-      }
+      output.addPart(payloadAsMimePart(msg), PAYLOAD_CONTENT_ID);
       output.addPart(getMetadata(msg), getMetadataEncoding(), METADATA_CONTENT_ID);
       if (msg.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION)) {
         output.addPart(asMimePart((Exception) msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION)),

--- a/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMimeEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMimeEncoder.java
@@ -28,6 +28,7 @@ import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MimeEncoderImpl;
 import com.adaptris.core.MultiPayloadAdaptrisMessage;
+import com.adaptris.core.MultiPayloadMessageFactory;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.util.text.mime.MultiPartFileInput;
 import com.adaptris.util.text.mime.MultiPartOutput;
@@ -94,8 +95,17 @@ public class FileBackedMimeEncoder extends MimeEncoderImpl {
       msg = currentMessageFactory().newMessage();
       File baseFile = asFile(source);
       MultiPartFileInput input = new MultiPartFileInput(baseFile);
-      /* TODO iff there are multiple payloads, switch to MultiPayloadAdaptrisMessage */
-      addPartsToMessage(input, msg);
+      try
+      {
+        addPartsToMessage(input, msg);
+      } catch (IllegalArgumentException e) {
+        if (!e.getMessage().equals("payload may not be null")) {
+          throw e;
+        }
+        // there wasn't a payload, but maybe there are multiple payloads...
+        msg = new MultiPayloadMessageFactory().newMessage();
+        addPartsToMessage(input, (MultiPayloadAdaptrisMessage)msg);
+      }
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }

--- a/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMimeEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMimeEncoder.java
@@ -89,27 +89,15 @@ public class FileBackedMimeEncoder extends MimeEncoderImpl {
 
   @Override
   public AdaptrisMessage readMessage(Object source) throws CoreException {
-    AdaptrisMessage msg = null;
-
     try {
-      msg = currentMessageFactory().newMessage();
+      AdaptrisMessage msg = currentMessageFactory().newMessage();
       File baseFile = asFile(source);
       MultiPartFileInput input = new MultiPartFileInput(baseFile);
-      try
-      {
-        addPartsToMessage(input, msg);
-      } catch (IllegalArgumentException e) {
-        if (!e.getMessage().equals("payload may not be null")) {
-          throw e;
-        }
-        // there wasn't a payload, but maybe there are multiple payloads...
-        msg = new MultiPayloadMessageFactory().newMessage();
-        addPartsToMessage(input, (MultiPayloadAdaptrisMessage)msg);
-      }
+      addPartsToMessage(input, msg);
+      return msg;
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
-    return msg;
   }
 
   private File asFile(Object o) {

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
@@ -91,6 +91,7 @@ public class MultiPayloadMessageMimeEncoderTest extends TestCase {
     assertEquals(STANDARD_PAYLOAD[0], result.getContent());
   }
 
+  @Test
   public void testEncodeNonOutputStream() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD[0]);
     msg.addMetadata(METADATA_KEY, METADATA_VALUE);
@@ -102,6 +103,7 @@ public class MultiPayloadMessageMimeEncoderTest extends TestCase {
     }
   }
 
+  @Test
   public void testDecodeNonInputStream() {
     try {
       mimeEncoder.readMessage(new StringWriter());
@@ -111,20 +113,7 @@ public class MultiPayloadMessageMimeEncoderTest extends TestCase {
     }
   }
 
-  /*
-  public void testRoundTrip_WithOddChars() throws Exception {
-
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD_NON_JUST_ALPHA);
-    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    mimeEncoder.writeMessage(msg, out);
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    AdaptrisMessage result = mimeEncoder.readMessage(in);
-    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
-    assertEquals(STANDARD_PAYLOAD_NON_JUST_ALPHA, result.getContent());
-    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD_NON_JUST_ALPHA.getBytes(), result.getPayload()));
-  }*/
-
+  @Test
   public void testRoundTripWithException() throws Exception {
     AdaptrisMessage message = messageFactory.newMessage(PAYLOAD_ID[0], STANDARD_PAYLOAD[0], ENCODING);
     message.addMetadata(METADATA_KEY, METADATA_VALUE);
@@ -137,125 +126,4 @@ public class MultiPayloadMessageMimeEncoderTest extends TestCase {
     assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD[0].getBytes(), result.getPayload()));
     assertFalse(result.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION));
   }
-
-  /*public void testRoundTrip_Encoded() throws Exception {
-
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    mimeEncoder.writeMessage(msg, out);
-    mimeEncoder.setPayloadEncoding("base64");
-    mimeEncoder.setMetadataEncoding("base64");
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    AdaptrisMessage result = mimeEncoder.readMessage(in);
-    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
-    assertEquals(STANDARD_PAYLOAD, result.getContent());
-    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
-  }
-
-  public void testRoundTrip_EncodedEncodePlainDecoder() throws Exception {
-
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    mimeEncoder.writeMessage(msg, out);
-    mimeEncoder.setPayloadEncoding("base64");
-    mimeEncoder.setMetadataEncoding("base64");
-    MimeEncoder roundtripper = new MimeEncoder();
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    AdaptrisMessage result = roundtripper.readMessage(in);
-    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
-    assertEquals(STANDARD_PAYLOAD, result.getContent());
-    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
-  }
-
-  public void testRoundTrip_EncodeMetadataWithBackslash() throws Exception {
-
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    msg.addMetadata(METADATA_KEY, "blah\\blah");
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-    mimeEncoder.writeMessage(msg, out);
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    msg = mimeEncoder.readMessage(in);
-    assertEquals("blah\\blah", msg.getMetadataValue(METADATA_KEY));
-  }
-
-  public void testRoundTrip_PreserveUniqueId() throws Exception {
-
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    mimeEncoder.setRetainUniqueId(true);
-    mimeEncoder.writeMessage(msg, out);
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    AdaptrisMessage result = mimeEncoder.readMessage(in);
-    assertEquals(msg.getUniqueId(), result.getUniqueId());
-  }
-
-  public void testRoundTrip_NoPreserveUniqueId() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    msg.setUniqueId("abc-123");
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    mimeEncoder.writeMessage(msg, out);
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    AdaptrisMessage result = mimeEncoder.readMessage(in);
-    assertTrue(!"abc-123".equals(result.getUniqueId()));
-  }
-
-  public void testRoundTrip_UseConvenienceMethods() throws Exception {
-
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
-    AdaptrisMessage result = mimeEncoder.decode(mimeEncoder.encode(msg));
-    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
-    assertEquals(STANDARD_PAYLOAD, result.getContent());
-    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
-  }
-
-  public void testDecode_IgnoreExtraParts() throws Exception {
-    AdaptrisMessage result = mimeEncoder.decode(createMimeOutput(true, true));
-    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
-    assertEquals(STANDARD_PAYLOAD, result.getContent());
-    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
-  }
-
-  public void testDecode_NoPayloadPart() throws Exception {
-
-    try {
-      mimeEncoder.decode(createMimeOutput(false, true));
-      fail();
-    }
-    catch (CoreException e) {
-    }
-  }
-
-  public void testDecode_NoMetadataPart() throws Exception {
-
-    try {
-      mimeEncoder.decode(createMimeOutput(true, false));
-      fail();
-    }
-    catch (CoreException e) {
-    }
-  }
-
-  private static byte[] createMimeOutput(boolean includePayloadPart, boolean includeMetadataPart) throws Exception {
-    MultiPartOutput output = new MultiPartOutput(new GuidGenerator().getUUID());
-    if (includePayloadPart) {
-      output.addPart(STANDARD_PAYLOAD.getBytes(), "base64", "AdaptrisMessage/payload");
-    }
-    if (includeMetadataPart) {
-      Properties p = new Properties();
-      p.setProperty(METADATA_KEY, METADATA_VALUE);
-      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-      p.store(bytes, "");
-      bytes.close();
-      output.addPart(bytes.toByteArray(), "base64", "AdaptrisMessage/metadata");
-    }
-    output.addPart(STANDARD_PAYLOAD_NON_JUST_ALPHA.getBytes(), "base64", "Dude/SomeOtherPart");
-    return output.getBytes();
-  }
-
-   */
 }

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core;
+
+import com.adaptris.core.lms.FileBackedMimeEncoder;
+import com.adaptris.core.stubs.TempFileUtils;
+import com.adaptris.util.GuidGenerator;
+import com.adaptris.util.text.mime.MultiPartOutput;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.StringWriter;
+import java.security.MessageDigest;
+import java.util.Properties;
+
+public class MultiPayloadMessageMimeEncoderTest extends TestCase {
+
+  private static final String METADATA_VALUE = "value";
+  private static final String METADATA_KEY = "key";
+  private static final String STANDARD_PAYLOAD_1 = "Cupcake ipsum dolor sit amet bonbon cotton candy ice cream. Pudding chocolate sweet lemon drops carrot cake pastry sweet roll. Wafer cheesecake lemon drops. Fruitcake tiramisu chocolate cake dessert gummies fruitcake bear claw brownie. Bear claw dessert marshmallow chocolate bar. Gummies bonbon oat cake tootsie roll. Tiramisu topping jelly beans powder soufflé carrot cake. Gummi bears gingerbread tart pie. Oat cake danish gummies fruitcake. Cake icing sweet roll. Sweet roll cake cheesecake gingerbread. Cake brownie pastry. Lemon drops apple pie caramels sweet jelly beans oat cake jujubes dessert wafer. Oat cake sweet roll fruitcake croissant gummies sweet halvah croissant dessert.";
+  private static final String STANDARD_PAYLOAD_2 = "Bacon ipsum dolor amet tri-tip bacon kielbasa flank rump pork belly. Pastrami pork t-bone ground round tenderloin, capicola bresaola ham turducken. Rump turkey boudin biltong, doner short loin swine t-bone buffalo pastrami capicola pork loin alcatra beef ribs jerky. Landjaeger chicken cupim corned beef venison. Jerky turducken pork chop burgdoggen. Landjaeger shankle chislic alcatra flank ribeye, short loin swine corned beef drumstick ham hock tri-tip filet mignon. Pastrami boudin turkey, tongue landjaeger ham hock ball tip cupim ground round ribeye pork loin pig sirloin shoulder.";
+
+  private MimeEncoder mimeEncoder;
+
+  public MultiPayloadMessageMimeEncoderTest(String name) {
+    super(name);
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    mimeEncoder = new MimeEncoder();
+    mimeEncoder.registerMessageFactory(new DefaultMessageFactory());
+  }
+
+  @Test
+  public void testMultiPayloadRoundTrip() throws Exception {
+    MultiPayloadMessageFactory mf = new MultiPayloadMessageFactory();
+    mf.setDefaultPayloadId("payload-1");
+    MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage)mf.newMessage(STANDARD_PAYLOAD_1);
+    message.addContent("payload-2", STANDARD_PAYLOAD_2);
+    message.addMetadata(METADATA_KEY, METADATA_VALUE);
+
+    MultiPayloadMessageMimeEncoder mimeEncoder = new MultiPayloadMessageMimeEncoder();
+    mimeEncoder.setRetainUniqueId(true);
+    File outputFile = TempFileUtils.createTrackedFile(message);
+    mimeEncoder.writeMessage(message, outputFile);
+
+    AdaptrisMessage result = mimeEncoder.readMessage(outputFile);
+    assertEquals(message.getUniqueId(), result.getUniqueId());
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD_1, result.getContent());
+  }
+
+  public void testEncode_NonOutputStream() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD_1);
+    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    try {
+      mimeEncoder.writeMessage(msg, new StringWriter());
+      fail();
+    }
+    catch (CoreException e) {
+    }
+  }
+
+  public void testDecode_NonInputStream() throws Exception {
+    try {
+      mimeEncoder.readMessage(new StringWriter());
+      fail();
+    }
+    catch (CoreException e) {
+    }
+  }
+
+  /*
+  public void testRoundTrip_WithOddChars() throws Exception {
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD_NON_JUST_ALPHA);
+    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mimeEncoder.writeMessage(msg, out);
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    AdaptrisMessage result = mimeEncoder.readMessage(in);
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD_NON_JUST_ALPHA, result.getContent());
+    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD_NON_JUST_ALPHA.getBytes(), result.getPayload()));
+  }
+
+  public void testRoundTrip_WithException() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
+    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    msg.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, new Exception(getName()));
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mimeEncoder.writeMessage(msg, out);
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    AdaptrisMessage result = mimeEncoder.readMessage(in);
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD, result.getContent());
+    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
+    assertFalse(result.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION));
+  }
+
+  public void testRoundTrip_Encoded() throws Exception {
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
+    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mimeEncoder.writeMessage(msg, out);
+    mimeEncoder.setPayloadEncoding("base64");
+    mimeEncoder.setMetadataEncoding("base64");
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    AdaptrisMessage result = mimeEncoder.readMessage(in);
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD, result.getContent());
+    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
+  }
+
+  public void testRoundTrip_EncodedEncodePlainDecoder() throws Exception {
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
+    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mimeEncoder.writeMessage(msg, out);
+    mimeEncoder.setPayloadEncoding("base64");
+    mimeEncoder.setMetadataEncoding("base64");
+    MimeEncoder roundtripper = new MimeEncoder();
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    AdaptrisMessage result = roundtripper.readMessage(in);
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD, result.getContent());
+    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
+  }
+
+  public void testRoundTrip_EncodeMetadataWithBackslash() throws Exception {
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
+    msg.addMetadata(METADATA_KEY, "blah\\blah");
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    mimeEncoder.writeMessage(msg, out);
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    msg = mimeEncoder.readMessage(in);
+    assertEquals("blah\\blah", msg.getMetadataValue(METADATA_KEY));
+  }
+
+  public void testRoundTrip_PreserveUniqueId() throws Exception {
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
+    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mimeEncoder.setRetainUniqueId(true);
+    mimeEncoder.writeMessage(msg, out);
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    AdaptrisMessage result = mimeEncoder.readMessage(in);
+    assertEquals(msg.getUniqueId(), result.getUniqueId());
+  }
+
+  public void testRoundTrip_NoPreserveUniqueId() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
+    msg.setUniqueId("abc-123");
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mimeEncoder.writeMessage(msg, out);
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    AdaptrisMessage result = mimeEncoder.readMessage(in);
+    assertTrue(!"abc-123".equals(result.getUniqueId()));
+  }
+
+  public void testRoundTrip_UseConvenienceMethods() throws Exception {
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
+    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    AdaptrisMessage result = mimeEncoder.decode(mimeEncoder.encode(msg));
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD, result.getContent());
+    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
+  }
+
+  public void testDecode_IgnoreExtraParts() throws Exception {
+    AdaptrisMessage result = mimeEncoder.decode(createMimeOutput(true, true));
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD, result.getContent());
+    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
+  }
+
+  public void testDecode_NoPayloadPart() throws Exception {
+
+    try {
+      mimeEncoder.decode(createMimeOutput(false, true));
+      fail();
+    }
+    catch (CoreException e) {
+    }
+  }
+
+  public void testDecode_NoMetadataPart() throws Exception {
+
+    try {
+      mimeEncoder.decode(createMimeOutput(true, false));
+      fail();
+    }
+    catch (CoreException e) {
+    }
+  }
+
+  private static byte[] createMimeOutput(boolean includePayloadPart, boolean includeMetadataPart) throws Exception {
+    MultiPartOutput output = new MultiPartOutput(new GuidGenerator().getUUID());
+    if (includePayloadPart) {
+      output.addPart(STANDARD_PAYLOAD.getBytes(), "base64", "AdaptrisMessage/payload");
+    }
+    if (includeMetadataPart) {
+      Properties p = new Properties();
+      p.setProperty(METADATA_KEY, METADATA_VALUE);
+      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+      p.store(bytes, "");
+      bytes.close();
+      output.addPart(bytes.toByteArray(), "base64", "AdaptrisMessage/metadata");
+    }
+    output.addPart(STANDARD_PAYLOAD_NON_JUST_ALPHA.getBytes(), "base64", "Dude/SomeOtherPart");
+    return output.getBytes();
+  }
+
+   */
+}

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.StringWriter;
+import java.security.MessageDigest;
 
 public class MultiPayloadMessageMimeEncoderTest extends TestCase {
 
@@ -122,23 +123,22 @@ public class MultiPayloadMessageMimeEncoderTest extends TestCase {
     assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
     assertEquals(STANDARD_PAYLOAD_NON_JUST_ALPHA, result.getContent());
     assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD_NON_JUST_ALPHA.getBytes(), result.getPayload()));
-  }
+  }*/
 
-  public void testRoundTrip_WithException() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
-    msg.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, new Exception(getName()));
+  public void testRoundTripWithException() throws Exception {
+    AdaptrisMessage message = messageFactory.newMessage(PAYLOAD_ID[0], STANDARD_PAYLOAD[0], ENCODING);
+    message.addMetadata(METADATA_KEY, METADATA_VALUE);
+    message.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, new Exception(getName()));
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    mimeEncoder.writeMessage(msg, out);
-    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-    AdaptrisMessage result = mimeEncoder.readMessage(in);
+    mimeEncoder.writeMessage(message, out);
+    AdaptrisMessage result = mimeEncoder.readMessage(new ByteArrayInputStream(out.toByteArray()));
     assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
-    assertEquals(STANDARD_PAYLOAD, result.getContent());
-    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
+    assertEquals(STANDARD_PAYLOAD[0], result.getContent());
+    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD[0].getBytes(), result.getPayload()));
     assertFalse(result.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION));
   }
 
-  public void testRoundTrip_Encoded() throws Exception {
+  /*public void testRoundTrip_Encoded() throws Exception {
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
     msg.addMetadata(METADATA_KEY, METADATA_VALUE);

--- a/interlok-core/src/test/java/com/adaptris/core/lms/FileBackedMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/lms/FileBackedMimeEncoderTest.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Properties;
 
+import com.adaptris.core.MultiPayloadAdaptrisMessage;
+import com.adaptris.core.MultiPayloadMessageFactory;
 import org.junit.Test;
 
 import com.adaptris.core.AdaptrisMessage;
@@ -66,6 +68,25 @@ public class FileBackedMimeEncoderTest {
 
     AdaptrisMessage result = mimeEncoder.readMessage(outputFile);
     assertEquals(msg.getUniqueId(), result.getUniqueId());
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD, result.getContent());
+  }
+
+  @Test
+  public void testMultiPayloadRoundTrip() throws Exception {
+    MultiPayloadMessageFactory mf = new MultiPayloadMessageFactory();
+    mf.setDefaultPayloadId("payload-1");
+    MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage)mf.newMessage(STANDARD_PAYLOAD);
+    message.addContent("payload-2", STANDARD_PAYLOAD_NON_JUST_ALPHA);
+    message.addMetadata(METADATA_KEY, METADATA_VALUE);
+
+    FileBackedMimeEncoder mimeEncoder = new FileBackedMimeEncoder();
+    mimeEncoder.setRetainUniqueId(true);
+    File outputFile = TempFileUtils.createTrackedFile(message);
+    mimeEncoder.writeMessage(message, outputFile);
+
+    AdaptrisMessage result = mimeEncoder.readMessage(outputFile);
+    assertEquals(message.getUniqueId(), result.getUniqueId());
     assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
     assertEquals(STANDARD_PAYLOAD, result.getContent());
   }

--- a/interlok-core/src/test/java/com/adaptris/core/lms/FileBackedMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/lms/FileBackedMimeEncoderTest.java
@@ -73,25 +73,6 @@ public class FileBackedMimeEncoderTest {
   }
 
   @Test
-  public void testMultiPayloadRoundTrip() throws Exception {
-    MultiPayloadMessageFactory mf = new MultiPayloadMessageFactory();
-    mf.setDefaultPayloadId("payload-1");
-    MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage)mf.newMessage(STANDARD_PAYLOAD);
-    message.addContent("payload-2", STANDARD_PAYLOAD_NON_JUST_ALPHA);
-    message.addMetadata(METADATA_KEY, METADATA_VALUE);
-
-    FileBackedMimeEncoder mimeEncoder = new FileBackedMimeEncoder();
-    mimeEncoder.setRetainUniqueId(true);
-    File outputFile = TempFileUtils.createTrackedFile(message);
-    mimeEncoder.writeMessage(message, outputFile);
-
-    AdaptrisMessage result = mimeEncoder.readMessage(outputFile);
-    assertEquals(message.getUniqueId(), result.getUniqueId());
-    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
-    assertEquals(STANDARD_PAYLOAD, result.getContent());
-  }
-
-  @Test
   public void testRoundTrip_FileBackedFactory() throws Exception {
     FileBackedMimeEncoder mimeEncoder = new FileBackedMimeEncoder();
     mimeEncoder.registerMessageFactory(new FileBackedMessageFactory());


### PR DESCRIPTION
Allow multi-payload messages to be MIME encoded/serialized for storage and retrieval.