### PR TITLE
removed the AdvancedConfig annotation for the comments field in the C…

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/Channel.java
+++ b/interlok-core/src/main/java/com/adaptris/core/Channel.java
@@ -71,7 +71,6 @@ public class Channel implements ComponentLifecycleExtension, StateManagedCompone
   @InputFieldDefault(value = "true")
   private Boolean autoStart;
   @MarshallingCDATA
-  @AdvancedConfig(rare = true)
   private String comments;
 
   private transient boolean available;

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
@@ -72,7 +72,6 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
   @Valid
   private List<Service> services;
   @MarshallingCDATA
-  @AdvancedConfig(rare = true)
   private String comments;
   
   private transient FifoMutexLock lock = new FifoMutexLock();

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -111,7 +111,6 @@ public abstract class WorkflowImp implements Workflow {
   @InputFieldDefault(value = "message-logger-default")
   private MessageLogger messageLogger;
   @MarshallingCDATA
-  @AdvancedConfig(rare = true)
   private String comments;
   
   // not marshalled


### PR DESCRIPTION
I have removed the AdvancedConfig annotation for the comments field in the Channel, WorkflowImp and ServiceCollectionImp classes.

This can be merged now, and the ui changes are under review :
https://bitbucket.org/adaptris/interlok-ui/pull-requests/97
