### PR TITLE
Feature/interlok 3113 xml transform service caching params

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformParameter.java
@@ -42,5 +42,5 @@ public interface XmlTransformParameter {
    * @param existingParams any existing parameters that might already be configured, null otherwise.
    * @return the parameters to pass into the transform.
    */
-  Map createParameters(AdaptrisMessage msg, Map existingParams) throws ServiceException;
+  Map<Object, Object> createParameters(AdaptrisMessage msg, Map<Object, Object> existingParams) throws ServiceException;
 }

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
@@ -180,7 +180,7 @@ public class XmlTransformService extends ServiceImp {
     }
     // INTERLOK-2022 Let the XML parser do its thing, rather than using a reader/writer.
     try (InputStream input = msg.getInputStream(); OutputStream output = msg.getOutputStream()) {
-      Map parameters = getParameterBuilder().createParameters(msg, null);
+      Map<Object, Object> parameters = getParameterBuilder().createParameters(msg, null);
       xmlTransformerImpl.transform(transformer, input, output, urlToUse, parameters);
       if (!StringUtils.isBlank(getOutputMessageEncoding())) {
         msg.setContentEncoding(getOutputMessageEncoding());

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
@@ -102,7 +102,7 @@ public class XmlTransformService extends ServiceImp {
   public XmlTransformService() {
     setMetadataKey(CoreConstants.TRANSFORM_OVERRIDE);
     xmlTransformerFactory = new XsltTransformerFactory();
-    transforms = new HashMap<String, Transformer>();
+    this.setTransforms(new HashMap<String, Transformer>());
   }
 
   @Override
@@ -192,10 +192,10 @@ public class XmlTransformService extends ServiceImp {
   }
 
   private Transformer cacheAndGetTransformer(String urlToUse, XmlTransformerFactory xmlTransformerFactory) throws Exception {
-    if (this.transforms.containsKey(urlToUse)) return this.transforms.get(urlToUse);
+    if (this.getTransforms().containsKey(urlToUse)) return this.getTransforms().get(urlToUse);
     else {
       Transformer transformer = xmlTransformerFactory.createTransformer(urlToUse);
-      this.transforms.put(urlToUse, transformer);
+      this.getTransforms().put(urlToUse, transformer);
       return transformer;
     }
   }
@@ -354,5 +354,13 @@ public class XmlTransformService extends ServiceImp {
 
   private XmlTransformParameter getParameterBuilder() {
     return getTransformParameter() != null ? getTransformParameter() : new IgnoreMetadataParameter();
+  }
+
+  HashMap<String, Transformer> getTransforms() {
+    return transforms;
+  }
+
+  void setTransforms(HashMap<String, Transformer> transforms) {
+    this.transforms = transforms;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformer.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformer.java
@@ -17,13 +17,14 @@
 package com.adaptris.util.text.xml;
 
 import static com.adaptris.core.util.DocumentBuilderFactoryBuilder.newInstanceIfNull;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
-import java.util.Iterator;
 import java.util.Map;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
@@ -31,10 +32,12 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 
 /**
@@ -64,14 +67,12 @@ public class XmlTransformer {
    * stylesheet.
    * @throws Exception in the event of parsing / transform errors
    */
-  public void transform(Transformer transformer, Source xmlIn, Result xmlOut, String xsl, Map properties) throws Exception {
-    if (properties != null) {
-      transformer.clearParameters();
-      Iterator<String> iter = properties.keySet().iterator();
-      while (iter.hasNext()) {
-        Object o = iter.next();
-        transformer.setParameter(o.toString(), properties.get(o));
-      }
+  public void transform(Transformer transformer, Source xmlIn, Result xmlOut, String xsl, Map<Object, Object> properties) throws Exception {
+    transformer.clearParameters();
+    if (properties != null) {  
+      properties.forEach((key, value) -> {
+        transformer.setParameter(key.toString(), value);
+      });
     }
     transformer.transform(xmlIn, xmlOut);
   }
@@ -87,7 +88,7 @@ public class XmlTransformer {
    * stylesheet.
    * @throws Exception in the event of parsing / transform errors
    */
-  public void transform(Transformer transformer, InputStream xmlIn, OutputStream xmlOut, String xsl, Map properties) throws Exception {
+  public void transform(Transformer transformer, InputStream xmlIn, OutputStream xmlOut, String xsl, Map<Object, Object> properties) throws Exception {
     transform(transformer, createSource(xmlIn), new StreamResult(xmlOut), xsl, properties);
   }
 
@@ -102,7 +103,7 @@ public class XmlTransformer {
    * stylesheet.
    * @throws Exception in the event of parsing / transform errors
    */
-  public void transform(Transformer transformer, Reader xmlIn, Writer xmlOut, String xsl, Map properties) throws Exception {
+  public void transform(Transformer transformer, Reader xmlIn, Writer xmlOut, String xsl, Map<Object, Object> properties) throws Exception {
     transform(transformer, createSource(xmlIn), new StreamResult(xmlOut), xsl, properties);
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
@@ -394,6 +394,29 @@ public class XmlTransformServiceTest extends TransformServiceExample {
       stop(service);
     }
   }
+  
+  // INTERLOK-3113
+  public void testOutputWithCacheResetsParameters() throws Exception {
+    AdaptrisMessage m1 = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    m1.addMessageHeader("myKey", "myValue");
+    AdaptrisMessage m2 = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+
+    XmlTransformService service = new XmlTransformService();
+    service.setUrl(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL));
+    service.setCacheTransforms(true);
+    service.setTransformParameter(new StringMetadataParameter(new String[] {"myKey"}, new String[0]));
+    try {
+      start(service);
+      service.doService(m1);
+      assertNotNull(service.getTransforms().get(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL)).getParameter("myKey"));
+      service.doService(m2);
+      assertNull(service.getTransforms().get(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL)).getParameter("myKey"));
+      
+    }
+    finally {
+      stop(service);
+    }
+  }
 
   public void testOutputWithNoCache() throws Exception {
     AdaptrisMessage m1 = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));


### PR DESCRIPTION
If a second message executing this service does not include a metadata item previously used as a parameter then it is not cleared from the transformer and will be passed in the second time.

Clear parameters is now called for every invocation, new test added to prove.