### PR TITLE
feature/INTERLOK-3078_IndexOutOfBoundsException_On_marshalling_ThrottlingInterceptor

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/interceptor/TimeSliceDefaultCacheProvider.java
+++ b/interlok-core/src/main/java/com/adaptris/core/interceptor/TimeSliceDefaultCacheProvider.java
@@ -34,7 +34,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("time-slice-default-cache-provider")
 public class TimeSliceDefaultCacheProvider extends TimeSliceAbstractCacheProvider {
 
-  private TimeSlicePersistence persistence;
+  private transient TimeSlicePersistence persistence;
 
   @Override
   public void start() throws CoreException {

--- a/interlok-core/src/test/java/com/adaptris/core/SharedConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/SharedConnectionTest.java
@@ -193,6 +193,7 @@ public class SharedConnectionTest {
     }
   }
 
+  @Test
   public void testCloneForTesting() throws Exception {
     Adapter a = createAndStart();
     NullConnection nc = (NullConnection) a.getSharedComponents().getConnections().get(0);

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/DoubleColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/DoubleColumnTranslatorTest.java
@@ -35,6 +35,7 @@ public class DoubleColumnTranslatorTest {
     translator = new DoubleColumnTranslator();
   }
 
+  @Test
   public void testFormattedFloat() throws Exception {
     translator.setFormat("%f");
     Float floatVal = new Float("123");


### PR DESCRIPTION
Make the persistence member a transient as that causes an issue when marshaling the TimeSliceDefaultCacheProvider when it's started.

I also added two missing @Test annotation but that had nothing to do with this issue.