### PR TITLE
INTERLOK-2761 Allow %message{%payload} to resolve entire payload

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageImp.java
@@ -89,7 +89,6 @@ public abstract class AdaptrisMessageImp implements AdaptrisMessage, Cloneable {
 
   private enum Resolvers {
     UniqueId {
-
       @Override
       String resolve(String key, AdaptrisMessage msg) {
         if ("%uniqueId".equalsIgnoreCase(key)) {
@@ -107,14 +106,21 @@ public abstract class AdaptrisMessageImp implements AdaptrisMessage, Cloneable {
         return null;
       }
     },
+    Payload {
+      @Override
+      String resolve(String key, AdaptrisMessage msg) {
+        if ("%payload".equalsIgnoreCase(key)) {
+          return msg.getContent();
+        }
+        return null;
+      }
+    },
     Metadata {
       @Override
       String resolve(String key, AdaptrisMessage msg) {
         return msg.getMetadataValue(key);
       }
-      
     };
-    
     abstract String resolve(String key, AdaptrisMessage msg);
   }
 
@@ -401,7 +407,7 @@ public abstract class AdaptrisMessageImp implements AdaptrisMessage, Cloneable {
       String metadataValue = internalResolve(key);
       // Optional<String> metadataValue = (Optional<String>) Optional.ofNullable(internalResolve(key));
       if (metadataValue == null) {
-        throw new UnresolvedMetadataException("Could not resolve [" + key + "] as metadata/uniqueId/size");
+        throw new UnresolvedMetadataException("Could not resolve [" + key + "] as metadata/uniqueId/size/payload");
       }
       String toReplace = "%message{" + key + "}";
       result = result.replace(toReplace, metadataValue);

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageCase.java
@@ -601,6 +601,7 @@ public abstract class AdaptrisMessageCase {
     assertEquals(VAL1, msg.resolve("%message{nestedKey}"));
     assertEquals(PAYLOAD.length(), Integer.parseInt(msg.resolve("%message{%size}")));
     assertEquals(msg.getUniqueId(), msg.resolve("%message{%uniqueId}"));
+    assertEquals(msg.getContent(), msg.resolve("%message{%payload}"));
 
     assertEquals(String.format("%s_%s_%s", VAL1, VAL2, "val3"), msg.resolve("%message{key1}_%message{key2}_%message{key*3}"));
     assertEquals(String.format("%s_%s_%s", VAL1, VAL1, "val3"), msg.resolve("%message{key1}_%message{key1}_%message{key*3}"));


### PR DESCRIPTION
Noticed that the ticket has a comment that suggests getting the payload through “%payload”, so add that capability.