### PR TITLE
INTERLOK-3143 Allow payload-only message logging

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/util/PayloadMessageLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/PayloadMessageLogger.java
@@ -20,6 +20,7 @@ import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MessageLoggerImpl;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -32,20 +33,20 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class PayloadMessageLogger extends MessageLoggerImpl {
 
   @InputFieldDefault(value = "true")
-  private Boolean includeMetadata = true;
+  private Boolean includeMetadata;
 
   public void setIncludeMetadata(Boolean includeMetadata) {
     this.includeMetadata = Args.notNull(includeMetadata, "Include metadata cannot be null");
   }
 
   public Boolean getIncludeMetadata() {
-    return includeMetadata;
+    return BooleanUtils.toBooleanDefaultIfNull(includeMetadata, true);
   }
 
   @Override
   public String toString(AdaptrisMessage m) {
     ToStringBuilder builder = builder(m);
-    if (includeMetadata) {
+    if (this.getIncludeMetadata()) {
       builder.append(FIELD_METADATA, format(m.getMetadata()));
     }
     builder.append(FIELD_PAYLOAD, m.getPayloadForLogging());

--- a/interlok-core/src/main/java/com/adaptris/core/util/PayloadMessageLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/PayloadMessageLogger.java
@@ -16,9 +16,11 @@
 package com.adaptris.core.util;
 
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MessageLoggerImpl;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * MessageLogger implementation that that logs unique-id, metadata and payload.
@@ -29,9 +31,24 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Log metadata and payload", since = "3.8.4")
 public class PayloadMessageLogger extends MessageLoggerImpl {
 
+  @InputFieldDefault(value = "true")
+  private Boolean includeMetadata = true;
+
+  public void setIncludeMetadata(Boolean includeMetadata) {
+    this.includeMetadata = Args.notNull(includeMetadata, "Include metadata cannot be null");
+  }
+
+  public Boolean getIncludeMetadata() {
+    return includeMetadata;
+  }
+
   @Override
   public String toString(AdaptrisMessage m) {
-    return builder(m).append(FIELD_METADATA, format(m.getMetadata()))
-        .append(FIELD_PAYLOAD, m.getPayloadForLogging()).toString();
+    ToStringBuilder builder = builder(m);
+    if (includeMetadata) {
+      builder.append(FIELD_METADATA, format(m.getMetadata()));
+    }
+    builder.append(FIELD_PAYLOAD, m.getPayloadForLogging());
+    return builder.toString();
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/PayloadMessageLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/PayloadMessageLogger.java
@@ -36,20 +36,24 @@ public class PayloadMessageLogger extends MessageLoggerImpl {
   private Boolean includeMetadata;
 
   public void setIncludeMetadata(Boolean includeMetadata) {
-    this.includeMetadata = Args.notNull(includeMetadata, "Include metadata cannot be null");
+    this.includeMetadata = includeMetadata;
   }
 
   public Boolean getIncludeMetadata() {
-    return BooleanUtils.toBooleanDefaultIfNull(includeMetadata, true);
+    return includeMetadata;
   }
 
   @Override
   public String toString(AdaptrisMessage m) {
     ToStringBuilder builder = builder(m);
-    if (this.getIncludeMetadata()) {
+    if (includeMetadata()) {
       builder.append(FIELD_METADATA, format(m.getMetadata()));
     }
     builder.append(FIELD_PAYLOAD, m.getPayloadForLogging());
     return builder.toString();
+  }
+
+  private Boolean includeMetadata() {
+    return BooleanUtils.toBooleanDefaultIfNull(includeMetadata, true);
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/util/MessageLoggerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/MessageLoggerTest.java
@@ -46,12 +46,25 @@ public class MessageLoggerTest {
 
 
   @Test
-  public void testPayloadLogger() {
+  public void testPayloadLoggerIncludeMetadata() {
     AdaptrisMessage msg = createMessage();
     String s = new PayloadMessageLogger().toString(msg);
     System.err.println("testPayloadLogger:: " + s);
     assertNotNull(s);
     assertTrue(s.contains("The quick brown fox jumps over the lazy dog"));
+    assertFalse(s.contains("MessageLifecycleEvent"));
+    assertTrue(s.contains("hello world"));
+  }
+
+  @Test
+  public void testPayloadLoggerWithoutMetadata() {
+    AdaptrisMessage msg = createMessage();
+    PayloadMessageLogger payloadMessageLogger = new PayloadMessageLogger();
+    payloadMessageLogger.setIncludeMetadata(false);
+    String s = payloadMessageLogger.toString(msg);
+    System.err.println("testPayloadLogger:: " + s);
+    assertNotNull(s);
+    assertFalse(s.contains("The quick brown fox jumps over the lazy dog"));
     assertFalse(s.contains("MessageLifecycleEvent"));
     assertTrue(s.contains("hello world"));
   }

--- a/interlok-core/src/test/java/com/adaptris/core/util/MessageLoggerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/MessageLoggerTest.java
@@ -2,6 +2,7 @@ package com.adaptris.core.util;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
@@ -55,7 +56,7 @@ public class MessageLoggerTest {
     assertTrue(s.contains("The quick brown fox jumps over the lazy dog"));
     assertFalse(s.contains("MessageLifecycleEvent"));
     assertTrue(s.contains("hello world"));
-    assertTrue(payloadMessageLogger.getIncludeMetadata());
+    assertNull(payloadMessageLogger.getIncludeMetadata());
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/util/MessageLoggerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/MessageLoggerTest.java
@@ -48,12 +48,14 @@ public class MessageLoggerTest {
   @Test
   public void testPayloadLoggerIncludeMetadata() {
     AdaptrisMessage msg = createMessage();
-    String s = new PayloadMessageLogger().toString(msg);
+    PayloadMessageLogger payloadMessageLogger = new PayloadMessageLogger();
+    String s = payloadMessageLogger.toString(msg);
     System.err.println("testPayloadLogger:: " + s);
     assertNotNull(s);
     assertTrue(s.contains("The quick brown fox jumps over the lazy dog"));
     assertFalse(s.contains("MessageLifecycleEvent"));
     assertTrue(s.contains("hello world"));
+    assertTrue(payloadMessageLogger.getIncludeMetadata());
   }
 
   @Test
@@ -67,6 +69,7 @@ public class MessageLoggerTest {
     assertFalse(s.contains("The quick brown fox jumps over the lazy dog"));
     assertFalse(s.contains("MessageLifecycleEvent"));
     assertTrue(s.contains("hello world"));
+    assertFalse(payloadMessageLogger.getIncludeMetadata());
   }
 
   @Test


### PR DESCRIPTION
Add option that allows the payload message logger to only log the payload, excluding metadata (which remains the default).