### PR TITLE
INTERLOK-3167 Add new byte[] output parameter

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayPayloadDataOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayPayloadDataOutputParameter.java
@@ -45,7 +45,7 @@ public class ByteArrayPayloadDataOutputParameter implements DataOutputParameter<
   public void insert(byte[] data, InterlokMessage msg) throws InterlokException {
     try (OutputStream os = msg.getOutputStream()) {
       os.write(data);
-    } catch (IOException e) {
+    } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayPayloadDataOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/ByteArrayPayloadDataOutputParameter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.common;
+
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.config.DataOutputParameter;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * This {@code DataOutputParameter} is used when you want to write data to the {@link com.adaptris.core.AdaptrisMessage} payload.
+ * <p>
+ * An example might be specifying that the XML content required for the {@link com.adaptris.core.services.path.XPathService} can be
+ * found in the payload of an {@link com.adaptris.core.AdaptrisMessage}.
+ * </p>
+ * 
+ * @author andersonam
+ * @config byte-array-payload-data-output-parameter
+ * 
+ */
+@XStreamAlias("byte-array-payload-data-output-parameter")
+@DisplayOrder(order = {"contentEncoding"})
+public class ByteArrayPayloadDataOutputParameter implements DataOutputParameter<byte[]> {
+
+  @Override
+  public void insert(byte[] data, InterlokMessage msg) throws InterlokException {
+    try (OutputStream os = msg.getOutputStream()) {
+      os.write(data);
+    } catch (IOException e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/common/MultiPayloadByteArrayOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MultiPayloadByteArrayOutputParameter.java
@@ -15,7 +15,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @config multi-payload-byte-array-output-parameter
  */
 @XStreamAlias("multi-payload-byte-array-output-parameter")
-public class MultiPayloadByteArrayOutputParameter implements DataOutputParameter<byte[]>
+public class MultiPayloadByteArrayOutputParameter extends ByteArrayPayloadDataOutputParameter implements DataOutputParameter<byte[]>
 {
   @InputFieldHint(expression=true)
   private String payloadId;

--- a/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayPayloadDataOutputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayPayloadDataOutputParameterTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
 
 public class ByteArrayPayloadDataOutputParameterTest
 {
@@ -22,5 +23,18 @@ public class ByteArrayPayloadDataOutputParameterTest
     AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
     parameter.insert(PAYLOAD, message);
     assertArrayEquals(PAYLOAD, message.getPayload());
+  }
+
+  @Test
+  public void testException() throws Exception
+  {
+    try {
+      ByteArrayPayloadDataOutputParameter parameter = new ByteArrayPayloadDataOutputParameter();
+      AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
+      parameter.insert(null, message);
+      fail();
+    } catch (Exception e) {
+      // expected
+    }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayPayloadDataOutputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayPayloadDataOutputParameterTest.java
@@ -1,0 +1,26 @@
+package com.adaptris.core.common;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class ByteArrayPayloadDataOutputParameterTest
+{
+  private static final byte[] PAYLOAD = "Bacon ipsum dolor amet short loin porchetta ham turducken chicken tail meatball frankfurter. Rump t-bone flank kielbasa ribeye strip steak landjaeger fatback capicola pastrami cow brisket leberkas jerky. Ham pork chop chislic ground round prosciutto. Sirloin porchetta ribeye, spare ribs strip steak fatback cupim short loin burgdoggen landjaeger. Ground round tri-tip sirloin pig jowl shoulder pork loin cow jerky picanha pastrami. Pork rump bacon strip steak pig bresaola kielbasa ball tip tongue drumstick t-bone. Boudin kevin filet mignon prosciutto tongue short loin spare ribs.".getBytes();
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Test
+  public void testInsert() throws Exception
+  {
+    ByteArrayPayloadDataOutputParameter parameter = new ByteArrayPayloadDataOutputParameter();
+    AdaptrisMessage message = DefaultMessageFactory.getDefaultInstance().newMessage();
+    parameter.insert(PAYLOAD, message);
+    assertArrayEquals(PAYLOAD, message.getPayload());
+  }
+}


### PR DESCRIPTION
Add new byte[] output parameter that the multi-payload byte[] output parameter can extend.