### PR TITLE
INTERLOK-3056 AdaptrisMessageListener callback

### DIFF
--- a/docs/adr/0006-workflow-callback.md
+++ b/docs/adr/0006-workflow-callback.md
@@ -36,7 +36,7 @@ Chosen option: Modify AdaptrisMessageListener to have callbacks.
 
 ### Modify AdaptrisMessageListener to have callbacks.
 
-If we change AdaptrisMessageListener to be this : 
+If we change AdaptrisMessageListener to be this :
 
 ```
 default void onAdaptrisMessage(AdaptrisMessage msg) {
@@ -46,7 +46,7 @@ default void onAdaptrisMessage(AdaptrisMessage msg) {
 void onAdaptrisMessage(AdaptrisMessage msg, java.util.function.Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure);
 ```
 
-Then we can effectively make our SQS polling consumer this : 
+Then we can effectively make our SQS polling consumer this :
 ```
 for (Message message : messages) {
   try {
@@ -74,3 +74,7 @@ for (Message message : messages) {
 * Bad, because it's a callback, and it happens at some point in the future... is the session/queue whatever still valid.
 * Bad, because threadsafe is hard.
 * Neutral, all workflows have to change (and message listener stub implementations).
+
+### Note 2020-02-12
+
+The API change is going to be `void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success);` since the semantics of how the failure will be handled (or where it should be fired) isn't clear at the moment. As of the next major release (v4); we are proposing a different way of handling things like this, since asynchronous callbacks are becoming ever more popular.

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageListener.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageListener.java
@@ -42,10 +42,10 @@ public interface AdaptrisMessageListener {
    * </p>
    * 
    * @param msg the <code>AdaptrisMessage</code> to process
-   * @implNote the default implementation just calls {@link #onAdaptrisMessage(AdaptrisMessage, Consumer, Consumer)}.
+   * @implNote the default implementation just calls {@link #onAdaptrisMessage(AdaptrisMessage, Consumer)}.
    */
   default void onAdaptrisMessage(AdaptrisMessage msg) {
-    onAdaptrisMessage(msg, (s) -> {}, (f) -> { });
+    onAdaptrisMessage(msg, (s) -> {});
   }
 
   /**
@@ -53,10 +53,8 @@ public interface AdaptrisMessageListener {
    * 
    * @param msg the message
    * @param success called on success
-   * @param failure called on successfully handling a failed message, which depends on semantics of your configuration.
    */
-  void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
-      Consumer<AdaptrisMessage> failure);
+  void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success);
 
   /**
    * Get the friendly name for this component.

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageListener.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageListener.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+import java.util.function.Consumer;
 
 /**
  * <p>
@@ -31,20 +32,31 @@ public interface AdaptrisMessageListener {
 
   /**
    * <p>
-   * It is the responsibility of implementations of this interface to ensure 
-   * that all <code>Exception</code>s, including <code>RuntimeException</code>s,
-   * are handled.  Failure to handle any <code>Exception</code> will result in 
-   * undefined behaviour.  Throwing a <code>RuntimeException</code> to this 
-   * method is considered a bug.  
-   * </p><p>
-   * Although most clients of implementations of this interface are likely to 
-   * be single-threaded, if implementations are not guaranteed to be thread 
-   * safe, they should be <code>synchronized</code> or use some other locking
-   * mechanism. 
+   * It is the responsibility of implementations of this interface to ensure that all <code>Exception</code>s, including
+   * <code>RuntimeException</code>s, are handled. Failure to handle any <code>Exception</code> will result in undefined behaviour.
+   * Throwing a <code>RuntimeException</code> to this method is considered a bug.
    * </p>
+   * <p>
+   * Although most clients of implementations of this interface are likely to be single-threaded, if implementations are not
+   * guaranteed to be thread safe, they should be <code>synchronized</code> or use some other locking mechanism.
+   * </p>
+   * 
    * @param msg the <code>AdaptrisMessage</code> to process
+   * @implNote the default implementation just calls {@link #onAdaptrisMessage(AdaptrisMessage, Consumer, Consumer)}.
    */
-  void onAdaptrisMessage(AdaptrisMessage msg);
+  default void onAdaptrisMessage(AdaptrisMessage msg) {
+    onAdaptrisMessage(msg, (s) -> {}, (f) -> { });
+  }
+
+  /**
+   * Handle a message with call back actions if a message is successful or failed.
+   * 
+   * @param msg the message
+   * @param success called on success
+   * @param failure called on successfully handling a failed message, which depends on semantics of your configuration.
+   */
+  void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
+      Consumer<AdaptrisMessage> failure);
 
   /**
    * Get the friendly name for this component.
@@ -52,4 +64,6 @@ public interface AdaptrisMessageListener {
    * @return the friendly name.
    */
   String friendlyName();
+
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -403,4 +403,17 @@ public abstract class CoreConstants {
    */
   public static final String MESSAGE_CONSUME_LOCATION = "_interlokMessageConsumedFrom";
 
+  /**
+   * Object metadata that stores the on success callback.
+   * 
+   * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer, java.util.function.Consumer)
+   */
+  public static final String OBJ_METADATA_ON_SUCCESS_CALLBACK = "_onSuccessCallback";
+  /**
+   * Object metadata that stores the on failure callback.
+   * 
+   * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer, java.util.function.Consumer)
+   */
+  public static final String OBJ_METADATA_ON_FAILURE_CALLBACK = "_onFailureCallback";
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -409,11 +409,5 @@ public abstract class CoreConstants {
    * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer, java.util.function.Consumer)
    */
   public static final String OBJ_METADATA_ON_SUCCESS_CALLBACK = "_onSuccessCallback";
-  /**
-   * Object metadata that stores the on failure callback.
-   * 
-   * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer, java.util.function.Consumer)
-   */
-  public static final String OBJ_METADATA_ON_FAILURE_CALLBACK = "_onFailureCallback";
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
@@ -59,12 +59,11 @@ public abstract class FailedMessageRetrierImp implements FailedMessageRetrier {
   }
 
   @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
-      Consumer<AdaptrisMessage> failure) {
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
     try {
       Workflow workflow = getWorkflow(msg);
       updateRetryCountMetadata(msg);
-      workflow.onAdaptrisMessage(msg, success, failure); // workflow.onAM is sync'd...
+      workflow.onAdaptrisMessage(msg, success); // workflow.onAM is sync'd...
     }
     catch (Exception e) { // inc. runtime, exc. Workflow
       log.error("exception retrying message", e);

--- a/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
@@ -57,19 +58,13 @@ public abstract class FailedMessageRetrierImp implements FailedMessageRetrier {
     setStandaloneConsumer(new StandaloneConsumer());
   }
 
-  /**
-   * <p>
-   * This method is <code>synchronized</code> in case client code is multi-threaded.
-   * </p>
-   * 
-   * @see com.adaptris.core.AdaptrisMessageListener #onAdaptrisMessage(com.adaptris.core.AdaptrisMessage)
-   */
   @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg) {
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
+      Consumer<AdaptrisMessage> failure) {
     try {
       Workflow workflow = getWorkflow(msg);
       updateRetryCountMetadata(msg);
-      workflow.onAdaptrisMessage(msg); // workflow.onAM is sync'd...
+      workflow.onAdaptrisMessage(msg, success, failure); // workflow.onAM is sync'd...
     }
     catch (Exception e) { // inc. runtime, exc. Workflow
       log.error("exception retrying message", e);

--- a/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
@@ -6,13 +6,13 @@ import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import java.util.function.Consumer;
 
 public class ListenerCallbackHelper {
-
+  
   public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess,
       Consumer<AdaptrisMessage> onFailure) {
     // since msg.clone() copies object metadata, we're good doing this, since the consumer
     // object should be preserved across clones
     msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK, onSuccess);
-    msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK, onFailure);
+    msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK, onFailure);
     return msg;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
@@ -1,31 +1,21 @@
 package com.adaptris.core;
 
-import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import java.util.function.Consumer;
 
 public class ListenerCallbackHelper {
   
-  public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess,
-      Consumer<AdaptrisMessage> onFailure) {
+  public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess) {
     // since msg.clone() copies object metadata, we're good doing this, since the consumer
     // object should be preserved across clones
     msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK, onSuccess);
-    msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK, onFailure);
     return msg;
   }
 
 
   public static AdaptrisMessage handleSuccessCallback(AdaptrisMessage msg) {
     Consumer c = defaultIfNull((Consumer) msg.getObjectHeaders().get(OBJ_METADATA_ON_SUCCESS_CALLBACK), (o) -> {   });
-    c.accept(msg);
-    return msg;
-  }
-
-
-  public static AdaptrisMessage handleFailureCallback(AdaptrisMessage msg) {
-    Consumer c = defaultIfNull((Consumer) msg.getObjectHeaders().get(OBJ_METADATA_ON_FAILURE_CALLBACK), (o) -> {    });
     c.accept(msg);
     return msg;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
@@ -1,0 +1,32 @@
+package com.adaptris.core;
+
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK;
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import java.util.function.Consumer;
+
+public class ListenerCallbackHelper {
+
+  public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess,
+      Consumer<AdaptrisMessage> onFailure) {
+    // since msg.clone() copies object metadata, we're good doing this, since the consumer
+    // object should be preserved across clones
+    msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK, onSuccess);
+    msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK, onFailure);
+    return msg;
+  }
+
+
+  public static AdaptrisMessage handleSuccessCallback(AdaptrisMessage msg) {
+    Consumer c = defaultIfNull((Consumer) msg.getObjectHeaders().get(OBJ_METADATA_ON_SUCCESS_CALLBACK), (o) -> {   });
+    c.accept(msg);
+    return msg;
+  }
+
+
+  public static AdaptrisMessage handleFailureCallback(AdaptrisMessage msg) {
+    Consumer c = defaultIfNull((Consumer) msg.getObjectHeaders().get(OBJ_METADATA_ON_FAILURE_CALLBACK), (o) -> {    });
+    c.accept(msg);
+    return msg;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
@@ -70,17 +70,11 @@ public class MultiProducerWorkflow extends StandardWorkflow {
   }
 
   /**
-   * <p>
-   * This method is <code>synchronized</code> in case client code is
-   * multi-threaded.
-   * </p>
-   *
    * @see AdaptrisMessageListener#onAdaptrisMessage(AdaptrisMessage)
    */
   @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
-      Consumer<AdaptrisMessage> failure) {
-    ListenerCallbackHelper.prepare(msg, success, failure);
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
+    ListenerCallbackHelper.prepare(msg, success);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg); // make pluggable?
     }

--- a/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
@@ -18,6 +18,7 @@ package com.adaptris.core;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.BooleanUtils;
@@ -77,7 +78,9 @@ public class MultiProducerWorkflow extends StandardWorkflow {
    * @see AdaptrisMessageListener#onAdaptrisMessage(AdaptrisMessage)
    */
   @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg) {
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
+      Consumer<AdaptrisMessage> failure) {
+    ListenerCallbackHelper.prepare(msg, success, failure);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg); // make pluggable?
     }
@@ -104,6 +107,7 @@ public class MultiProducerWorkflow extends StandardWorkflow {
       getServiceCollection().doService(wip);
       doProduce(wip);
       sendProcessedMessage(wip, msg); // only if produce succeeds
+      ListenerCallbackHelper.handleSuccessCallback(wip);
       logSuccess(msg, start);
     }
     catch (ServiceException e) {

--- a/interlok-core/src/main/java/com/adaptris/core/NoRetries.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NoRetries.java
@@ -60,7 +60,8 @@ public class NoRetries implements FailedMessageRetrier {
   public void stop() {
   }
 
-  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/NoRetries.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NoRetries.java
@@ -18,7 +18,7 @@ package com.adaptris.core;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
+import java.util.function.Consumer;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.util.LoggingHelper;
@@ -39,28 +39,35 @@ public class NoRetries implements FailedMessageRetrier {
   
   private String uniqueId;
 
+  @Override
   public void addWorkflow(Workflow workflow) {
     ;
   }
 
+  @Override
   public void close() {
   }
 
+  @Override
   public void init() throws CoreException {
   }
 
+  @Override
   public void start() throws CoreException {
   }
 
+  @Override
   public void stop() {
   }
 
-  public void onAdaptrisMessage(AdaptrisMessage msg) {
+  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
   }
 
+  @Override
   public void clearWorkflows() {
   }
 
+  @Override
   public Collection<String> registeredWorkflowIds() {
     return new ArrayList<String>();
   }
@@ -70,6 +77,7 @@ public class NoRetries implements FailedMessageRetrier {
 
   }
 
+  @Override
   public String getUniqueId() {
     return uniqueId;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -307,8 +307,8 @@ public class PoolingWorkflow extends WorkflowImp {
    * @param msg the AdaptrisMessage.
    */
   @Override
-  public void onAdaptrisMessage(final AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
-    ListenerCallbackHelper.prepare(msg, success, failure);
+  public void onAdaptrisMessage(final AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
+    ListenerCallbackHelper.prepare(msg, success);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg);
     }

--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -306,7 +307,8 @@ public class PoolingWorkflow extends WorkflowImp {
    * @param msg the AdaptrisMessage.
    */
   @Override
-  public void onAdaptrisMessage(final AdaptrisMessage msg) {
+  public void onAdaptrisMessage(final AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+    ListenerCallbackHelper.prepare(msg, success, failure);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg);
     }
@@ -759,6 +761,9 @@ public class PoolingWorkflow extends WorkflowImp {
         wip.addEvent(getConsumer(), true);
         sc.doService(wip);
         doProduce(wip);
+        // handle success callback here.
+        // failure callback will be handled by the message-error-handler that's configured...
+        ListenerCallbackHelper.handleSuccessCallback(wip);
         logSuccess(wip, start);
       }
       catch (ProduceException e) {

--- a/interlok-core/src/main/java/com/adaptris/core/RootProcessingExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RootProcessingExceptionHandler.java
@@ -64,6 +64,9 @@ public abstract class RootProcessingExceptionHandler implements ProcessingExcept
     else {
       // Get the digester and add our stuff to it.
       addErrorToDigest(message);
+      // no-one left to notify, so we're done, we've successfully handled the failure
+      // however we've handled it.
+      ListenerCallbackHelper.handleFailureCallback(message);
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/RootProcessingExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RootProcessingExceptionHandler.java
@@ -64,9 +64,6 @@ public abstract class RootProcessingExceptionHandler implements ProcessingExcept
     else {
       // Get the digester and add our stuff to it.
       addErrorToDigest(message);
-      // no-one left to notify, so we're done, we've successfully handled the failure
-      // however we've handled it.
-      ListenerCallbackHelper.handleFailureCallback(message);
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
@@ -59,13 +59,11 @@ public class StandardWorkflow extends StandardWorkflowImpl {
   }
 
   @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
-      Consumer<AdaptrisMessage> failure) {
-    ListenerCallbackHelper.prepare(msg, success, failure);
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
+    ListenerCallbackHelper.prepare(msg, success);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg); // make pluggable?
-    }
-    else {
+    } else {
       handleMessage(msg, true);
     }
   }
@@ -97,23 +95,17 @@ public class StandardWorkflow extends StandardWorkflowImpl {
       // failure callback will be handled by the message-error-handler that's configured...
       ListenerCallbackHelper.handleSuccessCallback(wip);
       logSuccess(wip, start);
-    }
-    catch (ServiceException e) {
+    } catch (ServiceException e) {
       handleBadMessage("Exception from ServiceCollection", e, copyExceptionHeaders(wip, msg));
-    }
-    catch (ProduceException e) {
+    } catch (ProduceException e) {
       wip.addEvent(getProducer(), false); // generate event
       handleBadMessage("Exception producing msg", e, copyExceptionHeaders(wip, msg));
       handleProduceException();
-    }
-    catch (Exception e) { // all other Exc. inc. runtime
+    } catch (Exception e) { // all other Exc. inc. runtime
       handleBadMessage("Exception processing message", e, copyExceptionHeaders(wip, msg));
-    }
-    finally {
+    } finally {
       sendMessageLifecycleEvent(wip);
     }
     workflowEnd(msg, wip);
   }
-
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeMessageWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeMessageWorkflow.java
@@ -16,10 +16,12 @@
 
 package com.adaptris.core.lms;
 
+import java.util.function.Consumer;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ListenerCallbackHelper;
 import com.adaptris.core.StandardWorkflow;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -55,7 +57,9 @@ public class LargeMessageWorkflow extends StandardWorkflow {
   }
 
   @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg) {
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
+      Consumer<AdaptrisMessage> failure) {
+    ListenerCallbackHelper.prepare(msg, success, failure);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg); // make pluggable?
     }

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeMessageWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeMessageWorkflow.java
@@ -57,9 +57,8 @@ public class LargeMessageWorkflow extends StandardWorkflow {
   }
 
   @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
-      Consumer<AdaptrisMessage> failure) {
-    ListenerCallbackHelper.prepare(msg, success, failure);
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
+    ListenerCallbackHelper.prepare(msg, success);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg); // make pluggable?
     }

--- a/interlok-core/src/test/java/com/adaptris/core/PoolingWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/PoolingWorkflowTest.java
@@ -37,7 +37,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
-import com.adaptris.core.services.AlwaysFailService;
 import com.adaptris.core.services.WaitService;
 import com.adaptris.core.services.exception.ConfiguredException;
 import com.adaptris.core.services.exception.ThrowExceptionService;
@@ -578,7 +577,6 @@ public class PoolingWorkflowTest extends ExampleWorkflowCase {
   @Test 
   public void testOnMessage_SuccessCallback() throws Exception {
     AtomicBoolean onSuccess = new AtomicBoolean(false);
-    AtomicBoolean onFailure = new AtomicBoolean(false);
     MockChannel channel = createChannel();
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
     PoolingWorkflow wf = (PoolingWorkflow) channel.getWorkflowList().get(0);
@@ -587,45 +585,15 @@ public class PoolingWorkflowTest extends ExampleWorkflowCase {
       start(channel);
       wf.onAdaptrisMessage(msg, (m) -> {
         onSuccess.set(true);
-      }, (m) -> {
-        onFailure.set(true);
       });
       waitForMessages(prod, 1);
       assertTrue(onSuccess.get());
-      assertFalse(onFailure.get());
     } finally {
       stop(channel);
     }
     
   }
   
-  
-  @Test 
-  public void testOnMessage_FailureCallback() throws Exception {
-    AtomicBoolean onSuccess = new AtomicBoolean(false);
-    AtomicBoolean onFailure = new AtomicBoolean(false);
-    MockMessageProducer prod = new MockMessageProducer();
-    StandardProcessingExceptionHandler errorHandler = new StandardProcessingExceptionHandler(new StandaloneProducer(prod));
-    MockChannel channel = createChannel(errorHandler, Arrays.asList(new Service[] {new AlwaysFailService()}));
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
-    PoolingWorkflow wf = (PoolingWorkflow) channel.getWorkflowList().get(0);
-    try {
-      start(channel);
-      wf.onAdaptrisMessage(msg, (m) -> {
-        onSuccess.set(true);
-      }, (m) -> {
-        onFailure.set(true);
-      });
-      waitForMessages(prod, 1);      
-      assertFalse(onSuccess.get());
-      assertTrue(onFailure.get());
-    } finally {
-      stop(channel);
-    }
-    
-  }
-  
-
   private void submitMessages(PoolingWorkflow wf, int number) throws Exception {
     MockMessageConsumer m = (MockMessageConsumer) wf.getConsumer();
     for (int i = 0; i < number; i++) {

--- a/interlok-core/src/test/java/com/adaptris/core/StandardWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/StandardWorkflowTest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.adaptris.core.services.AlwaysFailService;
 import com.adaptris.core.services.exception.ConfiguredException;
 import com.adaptris.core.services.exception.ThrowExceptionService;
 import com.adaptris.core.services.metadata.AddMetadataService;
@@ -544,7 +543,6 @@ public class StandardWorkflowTest extends ExampleWorkflowCase {
   @Test 
   public void testOnMessage_SuccessCallback() throws Exception {
     AtomicBoolean onSuccess = new AtomicBoolean(false);
-    AtomicBoolean onFailure = new AtomicBoolean(false);
     MockChannel channel = createChannel(new MockMessageProducer(), Arrays.asList(new Service[] {new NullService()}));
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
     StandardWorkflow workflow = (StandardWorkflow) channel.getWorkflowList().get(0);
@@ -552,39 +550,14 @@ public class StandardWorkflowTest extends ExampleWorkflowCase {
       start(channel);
       workflow.onAdaptrisMessage(msg, (m) -> {
         onSuccess.set(true);
-      }, (m) -> {
-        onFailure.set(true);
       });
       assertTrue(onSuccess.get());
-      assertFalse(onFailure.get());
     } finally {
       stop(channel);
     }
     
   }
-  
-  @Test 
-  public void testOnMessage_FailureCallback() throws Exception {
-    AtomicBoolean onSuccess = new AtomicBoolean(false);
-    AtomicBoolean onFailure = new AtomicBoolean(false);
-    MockChannel channel = createChannel(new MockMessageProducer(), Arrays.asList(new Service[] {new AlwaysFailService()}));
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
-    StandardWorkflow workflow = (StandardWorkflow) channel.getWorkflowList().get(0);
-    try {
-      start(channel);
-      workflow.onAdaptrisMessage(msg, (m) -> {
-        onSuccess.set(true);
-      }, (m) -> {
-        onFailure.set(true);
-      });
-      assertFalse(onSuccess.get());
-      assertTrue(onFailure.get());
-    } finally {
-      stop(channel);
-    }
     
-  }
-  
   @Override
   protected Object retrieveObjectForSampleConfig() {
     Channel c = new Channel();

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
@@ -45,14 +45,13 @@ public class MockMessageListener implements AdaptrisMessageListener, MessageCoun
   }
 
   @Override
-  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
-    ListenerCallbackHelper.prepare(msg, success, failure);
+  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
+    ListenerCallbackHelper.prepare(msg, success);
     try {
       producer.produce(msg);
       ListenerCallbackHelper.handleSuccessCallback(msg);
     }
     catch (ProduceException e) {
-      ListenerCallbackHelper.handleFailureCallback(msg);
     }
     if (waitTime != -1) {
       try {

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
@@ -17,9 +17,10 @@
 package com.adaptris.core.stubs;
 
 import java.util.List;
-
+import java.util.function.Consumer;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
+import com.adaptris.core.ListenerCallbackHelper;
 import com.adaptris.core.ProduceException;
 
 /**
@@ -43,12 +44,15 @@ public class MockMessageListener implements AdaptrisMessageListener, MessageCoun
     this.waitTime = waitTime;
   }
 
-  public void onAdaptrisMessage(AdaptrisMessage msg) {
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+    ListenerCallbackHelper.prepare(msg, success, failure);
     try {
       producer.produce(msg);
+      ListenerCallbackHelper.handleSuccessCallback(msg);
     }
     catch (ProduceException e) {
-      ;
+      ListenerCallbackHelper.handleFailureCallback(msg);
     }
     if (waitTime != -1) {
       try {
@@ -61,10 +65,12 @@ public class MockMessageListener implements AdaptrisMessageListener, MessageCoun
 
   }
 
+  @Override
   public List<AdaptrisMessage> getMessages() {
     return producer.getMessages();
   }
 
+  @Override
   public int messageCount() {
     return producer.messageCount();
   }


### PR DESCRIPTION
- Interface changed to `onAdaptrisMessage(AdaptrisMessage, Consumer<AdaptrisMessage> onSuccess)`, onFailure is not considered in scope for this PR since it adds too much complexity (we need to handle properly in v4).
- Add a helper class to handle the callbacks
- Modify workflows to call successCallback

Tests aren't broken (which is good); but anything with Workflows will be broken
- profiler (if it only profiles onAdaptrisMessage() )
- interlok-client (maybe)
- vertx