### PR TITLE
INTERLOK-3111 Made SyntaxIdentifier extend Condition

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/AlwaysMatchSyntaxIdentifier.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/AlwaysMatchSyntaxIdentifier.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core.services.routing;
 
+import com.adaptris.core.services.conditional.Condition;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 
@@ -24,11 +25,17 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * Always returns true when isThisSyntax() is used.
  * </p>
+ * <p>
+ * Since <strong>3.10.0</strong> this class implements {@link Condition} which means that it can be used as part of the conditional
+ * services; if used in such a manner, then configuration is contextual, get/setDestination will be ignored (but may still have to
+ * be configured due to validation
+ * </p>
  * 
+ * @author sellidge
  * @config routing-always-match-syntax-identifier
  */
 @XStreamAlias("routing-always-match-syntax-identifier")
-public class AlwaysMatchSyntaxIdentifier extends SyntaxIdentifierImpl {
+public class AlwaysMatchSyntaxIdentifier extends SyntaxIdentifierBase {
 
   public AlwaysMatchSyntaxIdentifier() {
     super();
@@ -47,4 +54,5 @@ public class AlwaysMatchSyntaxIdentifier extends SyntaxIdentifierImpl {
   public boolean isThisSyntax(String message) {
     return true;
   }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/RegexpSyntaxIdentifier.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/RegexpSyntaxIdentifier.java
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.conditional.Condition;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -30,11 +30,15 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * The regular expressions are the same as those in the <code>java.util.regex</code> package.
  * </p>
+ * <p>
+ * Since <strong>3.10.0</strong> this class implements {@link Condition} which means that it can be used as part of the conditional
+ * services; if used in such a manner, then configuration is contextual, get/setDestination will be ignored (but may still have to
+ * be configured due to validation
+ * </p>
  * 
  * @config routing-regexp-syntax-identifier
  * @see java.util.regex.Pattern
  * @author sellidge
- * @author $Author: lchan $
  */
 @XStreamAlias("routing-regexp-syntax-identifier")
 @DisplayOrder(order = {"destination", "patterns"})

--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/SyntaxIdentifier.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/SyntaxIdentifier.java
@@ -16,20 +16,27 @@
 
 package com.adaptris.core.services.routing;
 
-import java.util.List;
-
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.conditional.Condition;
 
-/** Interface used by SyntaxRoutingService.
- *  <p>The contract for this interface is such that
- *  <code>isThisSyntax(String)</code> should only return true, if and only
- *  if <b>ALL</b> the configured patterns are matched within the document.
- *  </p>
- *  @see SyntaxRoutingService
- * @author sellidge
- * @author $Author: phigginson $
+/**
+ * Interface used by SyntaxRoutingService.
+ * <p>
+ * The contract for this interface is such that <code>isThisSyntax(String)</code> should only return true, if and only if <b>ALL</b>
+ * the configured patterns are matched within the document.
+ * </p>
+ * <p>
+ * Since <strong>3.10.0</strong> this interface extends {@link Condition} which means that it can be used as part of the conditional
+ * services; if used in such a manner, then configuration is contextual, get/setDestination will be ignored (but may still have to
+ * be configured due to validation
+ * </p>
+ * 
+ * @see SyntaxRoutingService
+ * @see Condition
  */
-public interface SyntaxIdentifier {
+public interface SyntaxIdentifier extends Condition {
 
   /** Set the configured destination.
    *  <p>This is the value that will be stored against the metadata key
@@ -44,25 +51,6 @@ public interface SyntaxIdentifier {
    */
   String getDestination();
 
-  /** Add a pattern to the list of configured patterns used to match a
-   *  document.
-   * @param pattern a pattern.
-   * @throws ServiceException if the pattern could not be added.
-   */
-  void addPattern(String pattern) throws ServiceException;
-
-  /** Get a list of configured patterns.
-   *
-   * @return the list.
-   */
-  List<String> getPatterns();
-
-  /** Set a list of configured patterns.
-   *
-   * @param l the list.
-   */
-  void setPatterns(List<String> l);
-
   /** Determine if this SyntaxIdentifer considers the message to
    *  match all the configured patterns.
    *
@@ -71,4 +59,14 @@ public interface SyntaxIdentifier {
    * @throws ServiceException if there was an error with the pattern.
    */
   boolean isThisSyntax(String message) throws ServiceException;
+
+  /**
+   * Default implementation for {@link Condition}
+   * 
+   * @implNote the default implementation just calls {@link #isThisSyntax(String)} with the message content.
+   */
+  @Override
+  default boolean evaluate(AdaptrisMessage msg) throws CoreException {
+    return isThisSyntax(msg.getContent());
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/SyntaxIdentifierBase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/SyntaxIdentifierBase.java
@@ -16,23 +16,26 @@
 
 package com.adaptris.core.services.routing;
 
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import javax.validation.constraints.NotBlank;
+import com.adaptris.core.util.Args;
 
-public class AlwaysMatchSyntaxIdentifierTest {
+public abstract class SyntaxIdentifierBase implements SyntaxIdentifier {
+  @NotBlank
+  private String destination = null;
 
-  public static final String LINE = "The quick brown fox jumps over the lazy dog";
-
-
-  public AlwaysMatchSyntaxIdentifier createIdentifier() {
-    return new AlwaysMatchSyntaxIdentifier();
+  public SyntaxIdentifierBase() {
   }
 
-  @Test
-  public void testMatch() throws Exception {
-    AlwaysMatchSyntaxIdentifier ident = createIdentifier();
-    assertTrue("Matches regexp", ident.isThisSyntax(LINE));
+  /**
+   *  @see SyntaxIdentifier#setDestination(java.lang.String)
+   */
+  @Override
+  public void setDestination(String dest) {
+    destination = Args.notBlank(dest, "destination");
   }
 
-
+  @Override
+  public String getDestination() {
+    return destination;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/SyntaxIdentifierImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/SyntaxIdentifierImpl.java
@@ -18,15 +18,12 @@ package com.adaptris.core.services.routing;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
-public abstract class SyntaxIdentifierImpl implements SyntaxIdentifier {
-  @NotBlank
-  private String destination = null;
+public abstract class SyntaxIdentifierImpl extends SyntaxIdentifierBase {
   @XStreamImplicit(itemFieldName = "pattern")
   @AutoPopulated
   @NotNull
@@ -36,42 +33,14 @@ public abstract class SyntaxIdentifierImpl implements SyntaxIdentifier {
     patterns = new ArrayList<String>();
   }
 
-  /**
-   *  @see SyntaxIdentifier#setDestination(java.lang.String)
-   */
-  @Override
-  public void setDestination(String dest) {
-    destination = Args.notBlank(dest, "destination");
-  }
-
-  /**
-   *  @see SyntaxIdentifier#getDestination()
-   */
-  @Override
-  public String getDestination() {
-    return destination;
-  }
-
-  /**
-   *  @see SyntaxIdentifier#addPattern(java.lang.String)
-   */
-  @Override
   public void addPattern(String pattern) {
     patterns.add(Args.notBlank(pattern, "pattern"));
   }
 
-  /**
-   *  @see SyntaxIdentifier#getPatterns()
-   */
-  @Override
   public List<String> getPatterns() {
     return patterns;
   }
 
-  /**
-   *  @see SyntaxIdentifier#getPatterns()
-   */
-  @Override
   public void setPatterns(List<String> l) {
     patterns = Args.notNull(l, "patterns");
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/XpathNodeIdentifier.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/XpathNodeIdentifier.java
@@ -17,16 +17,14 @@
 package com.adaptris.core.services.routing;
 
 import java.util.List;
-
 import javax.xml.xpath.XPathConstants;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.conditional.Condition;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -43,11 +41,15 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * contain namespaces, then Saxon can cause merry havoc in the sense that {@code //NonNamespaceXpath} doesn't work if the document
  * has namespaces in it. We have included a shim so that behaviour can be toggled based on what you have configured.
  * </p>
+ * <p>
+ * Since <strong>3.10.0</strong> this class implements {@link Condition} which means that it can be used as part of the conditional
+ * services; if used in such a manner, then configuration is contextual, get/setDestination will be ignored (but may still have to
+ * be configured due to validation
+ * </p>
  * 
  * @see XPath#newXPathInstance(DocumentBuilderFactoryBuilder, NamespaceContext)
  * @config routing-xpath-node-syntax-identifier
  * 
- * @author $Author: lchan $
  */
 @XStreamAlias("routing-xpath-node-syntax-identifier")
 @DisplayOrder(order = {"destination", "patterns", "resolveAsNodeSet", "namespaceContext"})

--- a/interlok-core/src/main/java/com/adaptris/core/services/routing/XpathSyntaxIdentifier.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/routing/XpathSyntaxIdentifier.java
@@ -17,13 +17,11 @@
 package com.adaptris.core.services.routing;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import java.util.List;
-
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.conditional.Condition;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -36,12 +34,15 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * has namespaces in it. We have included a shim so that behaviour can be toggled based on what you have configured.
  * </p>
  * 
+ * <p>
+ * Since <strong>3.10.0</strong> this class implements {@link Condition} which means that it can be used as part of the conditional
+ * services; if used in such a manner, then configuration is contextual, get/setDestination will be ignored (but may still have to
+ * be configured due to validation
+ * </p>
+ * 
  * @see XPath#newXPathInstance(DocumentBuilderFactoryBuilder, NamespaceContext)
- * 
  * @config routing-xpath-syntax-identifier
- * 
  * @author sellidge
- * @author $Author: lchan $
  */
 @XStreamAlias("routing-xpath-syntax-identifier")
 @DisplayOrder(order = {"destination", "patterns", "namespaceContext"})

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/IfElseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/IfElseTest.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -40,6 +41,7 @@ import com.adaptris.core.services.conditional.conditions.ConditionMetadata;
 import com.adaptris.core.services.conditional.conditions.ConditionOr;
 import com.adaptris.core.services.conditional.operator.Equals;
 import com.adaptris.core.services.conditional.operator.NotNull;
+import com.adaptris.core.services.routing.AlwaysMatchSyntaxIdentifier;
 import com.adaptris.core.util.LifecycleHelper;
 
 public class IfElseTest extends ConditionalServiceExample {
@@ -166,6 +168,26 @@ public class IfElseTest extends ConditionalServiceExample {
     }
     
   }
+
+
+  @Test
+  public void testSyntaxIdentifier() throws Exception {
+    Service mockThen = Mockito.mock(Service.class);
+    Service mockElse = Mockito.mock(Service.class);
+    IfElse ifElse = new IfElse();
+    ifElse.getThen().setService(mockThen);
+    ifElse.getOtherwise().setService(mockElse);
+    ifElse.setCondition(new AlwaysMatchSyntaxIdentifier());
+    try {
+      LifecycleHelper.initAndStart(ifElse);
+      ifElse.doService(message);
+      verify(mockThen, times(1)).doService(message);
+      verify(mockElse, times(0)).doService(message);
+    } finally {
+      LifecycleHelper.stopAndClose(ifElse);
+    }
+  }
+
 
   @Override
   protected Object retrieveObjectForSampleConfig() {

--- a/interlok-core/src/test/java/com/adaptris/core/services/routing/RegexpSyntaxIdentifierTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/routing/RegexpSyntaxIdentifierTest.java
@@ -40,7 +40,7 @@ public class RegexpSyntaxIdentifierTest extends SyntaxIdentifierCase {
 
   @Test
   public void testIllegalPattern() throws Exception {
-    SyntaxIdentifier ident = createIdentifier();
+    RegexpSyntaxIdentifier ident = createIdentifier();
     ident.addPattern("\\");
     try {
       ident.isThisSyntax(LINE);
@@ -53,7 +53,7 @@ public class RegexpSyntaxIdentifierTest extends SyntaxIdentifierCase {
 
   @Test
   public void testSingleMatchingRegexp() throws Exception {
-    SyntaxIdentifier ident = createIdentifier();
+    RegexpSyntaxIdentifier ident = createIdentifier();
     ident.addPattern(MATCHING_1);
     assertTrue("Matches regexp", ident.isThisSyntax(LINE));
     assertTrue("Matches regexp", ident.isThisSyntax(LINE));
@@ -61,7 +61,7 @@ public class RegexpSyntaxIdentifierTest extends SyntaxIdentifierCase {
 
   @Test
   public void testMultipleMatchingRegexp() throws Exception {
-    SyntaxIdentifier ident = createIdentifier();
+    RegexpSyntaxIdentifier ident = createIdentifier();
     ident.addPattern(MATCHING_1);
     ident.addPattern(MATCHING_2);
     assertTrue("Matches regexp", ident.isThisSyntax(LINE));
@@ -69,7 +69,7 @@ public class RegexpSyntaxIdentifierTest extends SyntaxIdentifierCase {
 
   @Test
   public void testMatchingAndUnmatchedRegexp() throws Exception {
-    SyntaxIdentifier ident = createIdentifier();
+    RegexpSyntaxIdentifier ident = createIdentifier();
     ident.addPattern(MATCHING_1);
     ident.addPattern(UNMATCHED_1);
     assertTrue("Does not match regexp", !ident.isThisSyntax(LINE));
@@ -77,7 +77,7 @@ public class RegexpSyntaxIdentifierTest extends SyntaxIdentifierCase {
 
   @Test
   public void testSingleUnMatchingRegexp() throws Exception {
-    SyntaxIdentifier ident = createIdentifier();
+    RegexpSyntaxIdentifier ident = createIdentifier();
     ident.addPattern(UNMATCHED_1);
     assertTrue("Does not match regexp", !ident.isThisSyntax(LINE));
   }

--- a/interlok-core/src/test/java/com/adaptris/core/services/routing/SyntaxIdentifierCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/routing/SyntaxIdentifierCase.java
@@ -33,11 +33,11 @@ public abstract class SyntaxIdentifierCase extends BaseCase {
     return true;
   }
 
-  public abstract SyntaxIdentifier createIdentifier();
+  public abstract <T extends SyntaxIdentifierImpl> T createIdentifier();
 
   @Test
   public void testSetPatterns() throws Exception {
-    SyntaxIdentifier si = createIdentifier();
+    SyntaxIdentifierImpl si = createIdentifier();
     si.addPattern("ABC");
     si.addPattern("DEF");
     assertEquals(2, si.getPatterns().size());
@@ -62,7 +62,7 @@ public abstract class SyntaxIdentifierCase extends BaseCase {
 
   @Test
   public void testSetDestination() throws Exception {
-    SyntaxIdentifier si = createIdentifier();
+    SyntaxIdentifierImpl si = createIdentifier();
     si.setDestination("ABC");
     assertEquals("ABC", si.getDestination());
     try {


### PR DESCRIPTION
- Remove patterns from the SyntaxIdentifier interface
- Restructured the hierarchy so there's an extra SyntaxBase to add Destination
- AlwaysMatch just extends SyntaxBase, others extend SyntaxImp as they still need patterns
- Add explicit test into IfElse to test syntax identifiers as conditions.