### PR TITLE
INTERLOK-3010 Move protected methods out of StandardWorkflow

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/StandardWorkflowImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardWorkflowImpl.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+import java.util.function.Consumer;
 import com.adaptris.core.util.LifecycleHelper;
 
 public abstract class StandardWorkflowImpl extends WorkflowImp {
@@ -70,4 +71,54 @@ public abstract class StandardWorkflowImpl extends WorkflowImp {
     // Consumers / services / producers already prepared.
   }
 
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
+    ListenerCallbackHelper.prepare(msg, success);
+    if (!obtainChannel().isAvailable()) {
+      handleChannelUnavailable(msg); // make pluggable?
+    } else {
+      handleMessage(msg, true);
+    }
+  }
+
+  /**
+   * @see WorkflowImp#resubmitMessage(com.adaptris.core.AdaptrisMessage)
+   */
+  @Override
+  protected void resubmitMessage(AdaptrisMessage msg) {
+    handleMessage(msg, true);
+  }
+
+  protected void handleMessage(final AdaptrisMessage msg, boolean clone) {
+    AdaptrisMessage wip = addConsumeLocation(msg);
+    workflowStart(msg);
+    processingStart(msg);
+    try {
+      long start = System.currentTimeMillis();
+      log.debug("start processing msg [{}]", messageLogger().toString(msg));
+      if (clone) {
+        wip = (AdaptrisMessage) msg.clone(); // retain orig. for error handling
+      }
+      wip.getMessageLifecycleEvent().setChannelId(obtainChannel().getUniqueId());
+      wip.getMessageLifecycleEvent().setWorkflowId(obtainWorkflowId());
+      wip.addEvent(getConsumer(), true); // initial receive event
+      getServiceCollection().doService(wip);
+      doProduce(wip);
+      // handle success callback here.
+      // failure callback will be handled by the message-error-handler that's configured...
+      ListenerCallbackHelper.handleSuccessCallback(wip);
+      logSuccess(wip, start);
+    } catch (ServiceException e) {
+      handleBadMessage("Exception from ServiceCollection", e, copyExceptionHeaders(wip, msg));
+    } catch (ProduceException e) {
+      wip.addEvent(getProducer(), false); // generate event
+      handleBadMessage("Exception producing msg", e, copyExceptionHeaders(wip, msg));
+      handleProduceException();
+    } catch (Exception e) { // all other Exc. inc. runtime
+      handleBadMessage("Exception processing message", e, copyExceptionHeaders(wip, msg));
+    } finally {
+      sendMessageLifecycleEvent(wip);
+    }
+    workflowEnd(msg, wip);
+  }
 }


### PR DESCRIPTION
Move protected methods out of StandardWorkflow into StandardWorkflowImp which means that you can get all the behavioural characteristics of
StandardWorkflow w/o having to override the synchronised onAM (which code analyzers don't like).