### PR TITLE
INTERLOK-2858 Switch to cmmons-collections4

### DIFF
--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -7,7 +7,6 @@ dependencies {
 
   compile project(':interlok-core-apt')
   compile ("com.thoughtworks.xstream:xstream:$xstreamVersion")
-  compile ("commons-collections:commons-collections:3.2.2")
   compile ("commons-io:commons-io:2.6")
   compile ("commons-net:commons-net:3.6")
   compile ("commons-pool:commons-pool:1.6")

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -60,13 +60,13 @@ dependencies {
   compile ("javax.validation:validation-api:2.0.1.Final")
   compile ("org.hibernate.validator:hibernate-validator:6.1.2.Final")
   compile ("org.glassfish:javax.el:3.0.1-b11")
-  compile ("commons-collections:commons-collections:3.2.2")
   compile ("commons-io:commons-io:2.6")
   compile ("org.apache.commons:commons-lang3:3.9")
   compile ("commons-net:commons-net:3.6")
   compile ("org.apache.commons:commons-pool2:2.8.0")
   compile ("org.apache.commons:commons-exec:1.3")
   compile ("org.apache.commons:commons-text:1.8")
+  compile ("org.apache.commons:commons-collections4:4.3")
   compile ("org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion")
   compile ("org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion")
   compile ("org.bouncycastle:bcmail-jdk15on:$bouncyCastleVersion")
@@ -99,7 +99,7 @@ dependencies {
   testCompile ("junit:junit:4.13")
   testCompile ("org.apache.activemq:artemis-jms-server:$artemisVersion")
   testCompile ("oro:oro:2.0.8")
-  
+
   testCompile ("org.awaitility:awaitility:3.0.0")
 
   testCompile ("org.apache.activemq:activemq-broker:$activeMqVersion")

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/WorkflowManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/WorkflowManager.java
@@ -17,7 +17,6 @@
 package com.adaptris.core.runtime;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -26,16 +25,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
-
 import javax.management.MBeanNotificationInfo;
 import javax.management.MalformedObjectNameException;
 import javax.management.Notification;
 import javax.management.ObjectName;
-
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ComponentState;

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/RetryMessageErrorHandlerMonitorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/RetryMessageErrorHandlerMonitorTest.java
@@ -26,7 +26,7 @@ import javax.management.JMX;
 import javax.management.ObjectName;
 import javax.naming.Context;
 import javax.naming.InitialContext;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.Adapter;


### PR DESCRIPTION
- Anything that depends on beanutils will pull in commons-collections3 however we don't explicitly depend on it any longer.