### PR TITLE
INTERLOK-3170 Switch to using java.util.Base64

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/Base64DecodeService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/Base64DecodeService.java
@@ -16,16 +16,13 @@
 
 package com.adaptris.core.services;
 
-import javax.mail.internet.MimeUtility;
-
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.commons.io.IOUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
-import com.adaptris.util.stream.StreamUtil;
-import com.adaptris.util.text.mime.MimeConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -38,31 +35,16 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("base64-decode-service")
 @AdapterComponent
 @ComponentProfile(summary = "Base64 decode the message", tag = "service,base64")
-public class Base64DecodeService extends ServiceImp {
+public class Base64DecodeService extends Base64Service {
 
-  /**
-   * @see com.adaptris.core.Service#doService(com.adaptris.core.AdaptrisMessage)
-   */
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
-
-    try {
-      StreamUtil.copyAndClose(MimeUtility.decode(msg.getInputStream(), MimeConstants.ENCODING_BASE64), msg.getOutputStream());
+    try (InputStream in = style().decoder().wrap(msg.getInputStream()); OutputStream out = msg.getOutputStream()) {
+      IOUtils.copy(in, out);
     }
     catch (Exception e) {
       throw new ServiceException(e);
     }
-  }
-
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-  }
-
-  @Override
-  public void prepare() throws CoreException {
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/Base64EncodeService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/Base64EncodeService.java
@@ -16,16 +16,13 @@
 
 package com.adaptris.core.services;
 
-import javax.mail.internet.MimeUtility;
-
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.commons.io.IOUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
-import com.adaptris.util.stream.StreamUtil;
-import com.adaptris.util.text.mime.MimeConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -37,30 +34,16 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("base64-encode-service")
 @AdapterComponent
 @ComponentProfile(summary = "Base64 encode the message", tag = "service,base64")
-public class Base64EncodeService extends ServiceImp {
+public class Base64EncodeService extends Base64Service {
 
-  /**
-   * @see com.adaptris.core.Service#doService(com.adaptris.core.AdaptrisMessage)
-   */
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
-    try {
-      StreamUtil.copyAndClose(msg.getInputStream(), MimeUtility.encode(msg.getOutputStream(), MimeConstants.ENCODING_BASE64));
+    try (InputStream in = msg.getInputStream(); OutputStream out = style().encoder().wrap(msg.getOutputStream())) {
+      IOUtils.copy(in, out);
     }
     catch (Exception e) {
       throw new ServiceException(e);
     }
-  }
-
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-  }
-
-  @Override
-  public void prepare() throws CoreException {
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/Base64Service.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/Base64Service.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services;
+
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.EncodingHelper.Base64Encoding;
+
+public abstract class Base64Service extends ServiceImp {
+
+  @InputFieldDefault(value = "MIME")
+  private Base64Encoding style = null;
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+  public Base64Encoding getStyle() {
+    return style;
+  }
+
+  public void setStyle(Base64Encoding style) {
+    this.style = style;
+  }
+
+  protected Base64Encoding style() {
+    return ObjectUtils.defaultIfNull(getStyle(), Base64Encoding.MIME);
+  }
+
+  public <T extends Base64Service> T withStyle(Base64Encoding style) {
+    setStyle(style);
+    return (T) this;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64DecodeMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64DecodeMetadataService.java
@@ -17,17 +17,13 @@
 package com.adaptris.core.services.metadata;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.util.text.Base64ByteTranslator;
-import com.adaptris.util.text.ByteTranslator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -39,16 +35,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  * @config metadata-base64-decode
  * 
- * 
- * 
  */
 @XStreamAlias("metadata-base64-decode")
 @AdapterComponent
 @ComponentProfile(summary = "Base64 decode an item of metadata", tag = "service,metadata,base64")
 @DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
-public class Base64DecodeMetadataService extends ReformatMetadata {
-
-  private transient ByteTranslator byteTranslator = new Base64ByteTranslator();
+public class Base64DecodeMetadataService extends Base64MetadataService {
 
   public Base64DecodeMetadataService() {
     super();
@@ -60,8 +52,7 @@ public class Base64DecodeMetadataService extends ReformatMetadata {
 
   @Override
   public String reformat(String s, String charEncoding) throws Exception {
-    byte[] debased = byteTranslator.translate(s);
-    return toString(debased, charEncoding);
+    return toString(style().decoder().decode(s), charEncoding);
   }
 
   private String toString(byte[] metadataValue, String charset) throws UnsupportedEncodingException {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64EncodeMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64EncodeMetadataService.java
@@ -17,14 +17,10 @@
 package com.adaptris.core.services.metadata;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import java.io.UnsupportedEncodingException;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.util.text.Base64ByteTranslator;
-import com.adaptris.util.text.ByteTranslator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -36,16 +32,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  * @config metadata-base64-decode
  * 
- * 
- * 
  */
 @XStreamAlias("metadata-base64-encode")
 @AdapterComponent
 @ComponentProfile(summary = "Base64 encode an item of metadata", tag = "service,metadata,base64")
 @DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
-public class Base64EncodeMetadataService extends ReformatMetadata {
-
-  private transient ByteTranslator byteTranslator = new Base64ByteTranslator();
+public class Base64EncodeMetadataService extends Base64MetadataService {
 
   public Base64EncodeMetadataService() {
     super();
@@ -57,7 +49,7 @@ public class Base64EncodeMetadataService extends ReformatMetadata {
 
   @Override
   public String reformat(String s, String charEncoding) throws Exception {
-    return byteTranslator.translate(toBytes(s, charEncoding));
+    return style().encoder().encodeToString(toBytes(s, charEncoding));
   }
 
   private byte[] toBytes(String metadataValue, String charset) throws UnsupportedEncodingException {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64MetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/Base64MetadataService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.util.EncodingHelper.Base64Encoding;
+
+public abstract class Base64MetadataService extends ReformatMetadata {
+
+  @InputFieldDefault(value = "BASIC")
+  private Base64Encoding style = null;
+
+  public Base64MetadataService() {
+    super();
+  }
+
+  public Base64MetadataService(String regexp) {
+    super(regexp);
+  }
+
+  public Base64Encoding getStyle() {
+    return style;
+  }
+
+  public void setStyle(Base64Encoding style) {
+    this.style = style;
+  }
+
+  protected Base64Encoding style() {
+    return ObjectUtils.defaultIfNull(getStyle(), Base64Encoding.BASIC);
+  }
+
+
+  public <T extends Base64MetadataService> T withStyle(Base64Encoding style) {
+    setStyle(style);
+    return (T) this;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataToPayloadService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataToPayloadService.java
@@ -18,11 +18,12 @@ package com.adaptris.core.services.metadata;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.StringReader;
 import java.nio.charset.Charset;
 import javax.mail.MessagingException;
-import javax.mail.internet.MimeUtility;
 import javax.validation.constraints.NotBlank;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdapterComponent;
@@ -37,8 +38,8 @@ import com.adaptris.core.ServiceImp;
 import com.adaptris.core.UnresolvedMetadataException;
 import com.adaptris.core.metadata.MetadataResolver;
 import com.adaptris.core.util.Args;
+import com.adaptris.core.util.EncodingHelper.Encoding;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.util.stream.StreamUtil;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -112,34 +113,6 @@ public class MetadataToPayloadService extends ServiceImp {
     abstract InputStream getInputStream(AdaptrisMessage msg, String key) throws MessagingException;
   };
 
-  // Looking at the source of MimeUtility, 7bit/8bit don't do anything, and x-uuenc are just semaphores for uuencode.
-  /**
-   * The types of encoding supported.
-   * 
-   * @see MimeUtility#decode(InputStream, String)
-   */
-  public enum Encoding {
-    Base64("base64"),
-    Quoted_Printable("quoted-printable"),
-    UUEncode("uuencode"),
-    None(null) {
-      @Override
-      InputStream unwrap(InputStream orig) {
-        return orig;
-      }
-    };
-    private String mimeEncoding;
-
-    Encoding(String encoding) {
-      mimeEncoding = encoding;
-    }
-
-    InputStream unwrap(InputStream orig) throws MessagingException {
-      return MimeUtility.decode(orig, mimeEncoding);
-    }
-  }
-
-
 
   @NotBlank
   @InputFieldHint(expression = true)
@@ -161,10 +134,8 @@ public class MetadataToPayloadService extends ServiceImp {
 
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
-    // MimeUtility should return the original InputStream stream if getContentEncoding is null.
-    try {
-      StreamUtil.copyAndClose(encoding().unwrap(source().getInputStream(msg, getKey())),
-          msg.getOutputStream());
+    try (InputStream in = encoding().wrap(source().getInputStream(msg, getKey())); OutputStream out = msg.getOutputStream();) {
+      IOUtils.copy(in, out);
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
     }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadToMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadToMetadataService.java
@@ -17,12 +17,14 @@
 package com.adaptris.core.services.metadata;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeUtility;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
@@ -33,8 +35,8 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.Args;
+import com.adaptris.core.util.EncodingHelper.Encoding;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.util.stream.StreamUtil;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -89,33 +91,6 @@ public class PayloadToMetadataService extends ServiceImp {
     abstract void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value);
   };
 
-  // Looking at the source of MimeUtility, 7bit/8bit don't do anything, and x-uuenc are just semaphores for uuencode.
-  /**
-   * The types of encoding supported.
-   * 
-   * @see MimeUtility#encode(OutputStream, String)
-   * 
-   */
-  public enum Encoding {
-    Base64("base64"),
-    Quoted_Printable("quoted-printable"),
-    UUEncode("uuencode"),
-    None(null) {
-      @Override
-      OutputStream wrap(OutputStream orig) {
-        return orig;
-      }
-    };
-    private String mimeEncoding;
-    Encoding(String encoding) {
-      mimeEncoding = encoding;
-    }
-
-    OutputStream wrap(OutputStream orig) throws MessagingException {
-      return MimeUtility.encode(orig, mimeEncoding);
-    }
-  }
-
 
   @NotBlank
   @AffectsMetadata
@@ -124,13 +99,11 @@ public class PayloadToMetadataService extends ServiceImp {
   @AutoPopulated
   @InputFieldDefault(value = "Standard")
   private MetadataTarget metadataTarget;
-  @NotNull
-  @AutoPopulated
+  @AdvancedConfig
   @InputFieldDefault(value = "None")
   private Encoding encoding;
 
   public PayloadToMetadataService() {
-    setEncoding(Encoding.None);
     setMetadataTarget(MetadataTarget.Standard);
   }
 
@@ -143,9 +116,8 @@ public class PayloadToMetadataService extends ServiceImp {
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-    // MimeUtility should return the original output stream if getContentEncoding is null.
-    try  {
-      StreamUtil.copyAndClose(msg.getInputStream(), getEncoding().wrap(bytesOut));
+    try (InputStream in = msg.getInputStream(); OutputStream out = encoding().wrap(bytesOut)) {
+      IOUtils.copy(in, out);
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
     }
@@ -200,4 +172,9 @@ public class PayloadToMetadataService extends ServiceImp {
   public void setEncoding(Encoding enc) {
     this.encoding = Args.notNull(enc, "Encoding");
   }
+
+  private Encoding encoding() {
+    return ObjectUtils.defaultIfNull(getEncoding(), Encoding.None);
+  }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/EncodingHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/EncodingHelper.java
@@ -1,0 +1,190 @@
+package com.adaptris.core.util;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.mail.internet.MimeUtility;
+import com.adaptris.annotation.Removal;
+import com.adaptris.util.text.mime.MimeConstants;
+
+public class EncodingHelper {
+
+  /**
+   * Standard supported encodings
+   */
+  public enum Encoding {
+    @Deprecated
+    @Removal(version="3.11.0", message="Use Base64_MIME / Base64_URL / Base64_Basic instead")
+    Base64 {
+      @Override
+      public OutputStream wrap(OutputStream orig) throws Exception {
+        return MimeUtility.encode(orig, MimeConstants.ENCODING_BASE64);
+      }
+
+      @Override
+      public InputStream wrap(InputStream orig) throws Exception {
+        return MimeUtility.decode(orig, MimeConstants.ENCODING_BASE64);
+      }
+    },
+    /**
+     * Base64 sing the MIME type base64 scheme.
+     * <p>
+     * Uses {@link java.util.Base64} under the covers
+     * </p>
+     */
+    MIME_Base64 {
+      @Override
+      public OutputStream wrap(OutputStream orig) throws Exception {
+        return java.util.Base64.getEncoder().wrap(orig);
+      }
+
+      @Override
+      public InputStream wrap(InputStream orig) throws Exception {
+        return java.util.Base64.getDecoder().wrap(orig);
+      }
+    },
+    /**
+     * 'quoted-printable' encoding MIME style.
+     * <p>
+     * Uses {@link MimeUtility} as the encoder / decoder.
+     * </p>
+     */
+    Quoted_Printable {
+      @Override
+      public OutputStream wrap(OutputStream orig) throws Exception {
+        return MimeUtility.encode(orig, MimeConstants.ENCODING_QUOTED);
+      }
+
+      @Override
+      public InputStream wrap(InputStream orig) throws Exception {
+        return MimeUtility.decode(orig, MimeConstants.ENCODING_QUOTED);
+      }
+
+    },
+    /**
+     * 'uuencode' encoding MIME style.
+     * <p>
+     * Uses {@link MimeUtility} as the encoder / decoder.
+     * </p>
+     */
+    UUEncode {
+      @Override
+      public OutputStream wrap(OutputStream orig) throws Exception {
+        return MimeUtility.encode(orig, MimeConstants.ENCODING_UUENCODE);
+      }
+
+      @Override
+      public InputStream wrap(InputStream orig) throws Exception {
+        return MimeUtility.decode(orig, MimeConstants.ENCODING_UUENCODE);
+      }
+    },
+    /**
+     * Base64 using URL and Filename safe type base64 scheme.
+     * <p>
+     * Uses {@link java.util.Base64} under the covers
+     * </p>
+     */
+    URL_Base64 {
+      @Override
+      public OutputStream wrap(OutputStream orig) throws Exception {
+        return java.util.Base64.getUrlEncoder().wrap(orig);
+      }
+
+      @Override
+      public InputStream wrap(InputStream orig) throws Exception {
+        return java.util.Base64.getUrlDecoder().wrap(orig);
+      }
+    },
+    /**
+     * Base64 using the Basic type base64 encoding scheme.
+     * <p>
+     * Uses {@link java.util.Base64} under the covers
+     * </p>
+     */
+    Basic_Base64 {
+      @Override
+      public OutputStream wrap(OutputStream orig) throws Exception {
+        return java.util.Base64.getEncoder().wrap(orig);
+      }
+
+      @Override
+      public InputStream wrap(InputStream orig) throws Exception {
+        return java.util.Base64.getDecoder().wrap(orig);
+      }
+    },
+    /**
+     * No Encoding.
+     * 
+     */
+    None {
+      @Override
+      public OutputStream wrap(OutputStream orig) {
+        return orig;
+      }
+
+      @Override
+      public InputStream wrap(InputStream orig) {
+        return orig;
+      }
+    };
+
+    public abstract OutputStream wrap(OutputStream out) throws Exception;
+
+    public abstract InputStream wrap(InputStream in) throws Exception;
+  }
+
+
+  /**
+   * Just the supported Base64 styles which are available via {@link java.util.Base64}
+   * 
+   */
+  public enum Base64Encoding {
+    /**
+     * Base64 sing the MIME type base64 scheme.
+     */
+    MIME {
+      @Override
+      public java.util.Base64.Decoder decoder() {
+        return java.util.Base64.getMimeDecoder();
+      }
+
+      @Override
+      public java.util.Base64.Encoder encoder() {
+        return java.util.Base64.getMimeEncoder();
+      }
+
+    },
+    /**
+     * Base64 using URL and Filename safe type base64 scheme.
+     */
+    URL {
+      @Override
+      public java.util.Base64.Decoder decoder() {
+        return java.util.Base64.getUrlDecoder();
+      }
+
+      @Override
+      public java.util.Base64.Encoder encoder() {
+        return java.util.Base64.getUrlEncoder();
+      }
+    },
+    /**
+     * Base64 using the Basic type base64 encoding scheme.
+     */
+    BASIC {
+      @Override
+      public java.util.Base64.Decoder decoder() {
+        return java.util.Base64.getDecoder();
+      }
+
+      @Override
+      public java.util.Base64.Encoder encoder() {
+        return java.util.Base64.getEncoder();
+      }
+
+    };
+
+    public abstract java.util.Base64.Decoder decoder();
+
+    public abstract java.util.Base64.Encoder encoder();
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/util/text/Base64ByteTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/Base64ByteTranslator.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.util.text;
 
+import java.util.Base64;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -38,7 +39,7 @@ public class Base64ByteTranslator extends ByteTranslator {
    */
   @Override
   public byte[] translate(String s) {
-    return Conversion.base64StringToByteArray(s);
+    return Base64.getDecoder().decode(s);
   }
 
   /**
@@ -47,6 +48,6 @@ public class Base64ByteTranslator extends ByteTranslator {
    */
   @Override
   public String translate(byte[] bytes) {
-    return Conversion.byteArrayToBase64String(bytes);
+    return Base64.getEncoder().encodeToString(bytes);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/Conversion.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/Conversion.java
@@ -19,12 +19,13 @@ package com.adaptris.util.text;
 import java.io.IOException;
 
 
-/** Simple Data Conversion methods.
- *  <p>Only small amounts of data should be converted using this class, to
- *  write a large number of bytes as a Base64 String, an alternative method
- *  such as IAIK's Base64OutputStream should be used, or
- *  javax.mail.internet.MimeUtility.
- *  @author $Author: lchan $
+/**
+ * Simple Data Conversion methods.
+ * <p>
+ * Only small amounts of data should be converted using this class, to write a large number of bytes as a Base64 String, an
+ * alternative method such as IAIK's Base64OutputStream should be used, or javax.mail.internet.MimeUtility.
+ * </p>
+ * 
  */
 public final class Conversion {
 
@@ -83,11 +84,15 @@ public final class Conversion {
     return result;
   }
 
-  /** Convert a byte array to a base 64 string (see RFC 1421).
-   *  @param b the bytes
-   *  @param len the length
-   *  @return the hex String
+  /**
+   * Convert a byte array to a base 64 string (see RFC 1421).
+   * 
+   * @param b the bytes
+   * @param len the length
+   * @return the hex String
+   * @deprecated since 3.10, use {@link java.util.Base64} instead.
    */
+  @Deprecated
   public static String byteArrayToBase64String(byte[] b, int len) {
 
     String s = "";
@@ -126,15 +131,20 @@ public final class Conversion {
     return result;
   }
 
-  /** Convert a byte array to a base 64 string (see RFC 1421).
-   *  @param b the bytes
-   *  @return the String
+  /**
+   * Convert a byte array to a base 64 string (see RFC 1421).
+   * 
+   * @param b the bytes
+   * @return the String
+   * @deprecated since 3.10, use {@link java.util.Base64} instead.
    */
+  @Deprecated
   public static String byteArrayToBase64String(byte[] b) {
     return byteArrayToBase64String(b, b.length);
   }
 
   // Perform the base64 transformation
+  @Deprecated
   private static String toBase64(byte b1, byte b2, byte b3) {
 
     int[] digit = new int[4];
@@ -155,6 +165,7 @@ public final class Conversion {
   }
 
   /** Perform a padded base64 transformation. */
+  @Deprecated
   private static String toBase64(byte b1, byte b2) {
 
     int[] digit = new int[3];
@@ -175,6 +186,7 @@ public final class Conversion {
   }
 
   /** Perform a padded base64 transformation */
+  @Deprecated
   private static String toBase64(byte b1) {
 
     int[] digit = new int[2];
@@ -192,6 +204,7 @@ public final class Conversion {
     return result;
   }
 
+  @Deprecated
   private static char base64Digit(int i) {
     if (i < 26) {
       return (char) ('A' + i);
@@ -213,11 +226,15 @@ public final class Conversion {
     }
   }
 
-  /** Convert a base 64 string to a byte array (see RFC 1421).
-   *  @param s the string
-   *  @return the byte array
-   *  @throws NumberFormatException if the stirng is invalid base64
+  /**
+   * Convert a base 64 string to a byte array (see RFC 1421).
+   * 
+   * @param s the string
+   * @return the byte array
+   * @throws NumberFormatException if the stirng is invalid base64
+   * @deprecated since 3.10, use {@link java.util.Base64} instead.
    */
+  @Deprecated
   public static byte[] base64StringToByteArray(String s)
     throws NumberFormatException {
 
@@ -283,6 +300,7 @@ public final class Conversion {
   }
 
   // Convert string to bytes
+  @Deprecated
   private static byte[] base64ToBytes(String s) {
 
     int len = 0;

--- a/interlok-core/src/test/java/com/adaptris/core/security/SymmetricKeyCryptographyServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/SymmetricKeyCryptographyServiceTest.java
@@ -24,6 +24,7 @@ import com.adaptris.util.text.Conversion;
 /**
  * @author mwarman
  */
+@SuppressWarnings("deprecation")
 public class SymmetricKeyCryptographyServiceTest extends SecurityServiceExample {
 
   private static final String ALGORITHM = "AES";

--- a/interlok-core/src/test/java/com/adaptris/core/services/Base64ServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/Base64ServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.GeneralServiceExample;
+import com.adaptris.core.util.EncodingHelper.Base64Encoding;
 
 public class Base64ServiceTest extends GeneralServiceExample {
 
@@ -37,7 +38,7 @@ public class Base64ServiceTest extends GeneralServiceExample {
   public void testBase64Service() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(
         LINE.getBytes());
-    execute(new Base64EncodeService(), msg);
+    execute(new Base64EncodeService().withStyle(Base64Encoding.MIME), msg);
     execute(new Base64DecodeService(), msg);
 
     assertEquals("base64 then debase64 gives same result", LINE, msg

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/MetadataStatementCreatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/MetadataStatementCreatorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 
+@SuppressWarnings("deprecation")
 public class MetadataStatementCreatorTest extends JdbcQueryServiceCase {
 
   protected static final String QUERY_SQL_2 =

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/Base64MetadataDecodeTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/Base64MetadataDecodeTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotSame;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.util.EncodingHelper.Base64Encoding;
 import com.adaptris.util.text.Base64ByteTranslator;
 
 public class Base64MetadataDecodeTest extends MetadataServiceExample {
@@ -34,7 +35,7 @@ public class Base64MetadataDecodeTest extends MetadataServiceExample {
 
   @Test
   public void testService() throws Exception {
-    Base64DecodeMetadataService service = new Base64DecodeMetadataService(METADATA_KEY);
+    Base64DecodeMetadataService service = new Base64DecodeMetadataService(METADATA_KEY).withStyle(Base64Encoding.BASIC);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("asdfghjk");
 
     String metadataValue = new Base64ByteTranslator().translate("Hello World".getBytes());

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataToPayloadTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataToPayloadTest.java
@@ -22,10 +22,11 @@ import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.services.metadata.MetadataToPayloadService.Encoding;
 import com.adaptris.core.services.metadata.MetadataToPayloadService.MetadataSource;
+import com.adaptris.core.util.EncodingHelper.Encoding;
 import com.adaptris.util.text.Conversion;
 
+@SuppressWarnings("deprecation")
 public class MetadataToPayloadTest extends MetadataServiceExample {
 
   private static final String DEFAULT_PAYLOAD = "zzzzzzzz";
@@ -87,7 +88,7 @@ public class MetadataToPayloadTest extends MetadataServiceExample {
   @Test
   public void testService_Metadata_Encoded() throws Exception {
     MetadataToPayloadService service = createService(MetadataSource.Standard);
-    service.setEncoding(Encoding.Base64);
+    service.setEncoding(Encoding.Basic_Base64);
     AdaptrisMessage msg = createMessage(true);
     execute(service, msg);
     assertEquals(DEFAULT_PAYLOAD, msg.getContent());

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/PayloadToMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/PayloadToMetadataTest.java
@@ -25,10 +25,10 @@ import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.services.metadata.PayloadToMetadataService.Encoding;
 import com.adaptris.core.services.metadata.PayloadToMetadataService.MetadataTarget;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
+import com.adaptris.core.util.EncodingHelper.Encoding;
 
 @SuppressWarnings("deprecation")
 public class PayloadToMetadataTest extends MetadataServiceExample {
@@ -74,7 +74,7 @@ public class PayloadToMetadataTest extends MetadataServiceExample {
   @Test
   public void testService_Metadata_Encoded() throws Exception {
     PayloadToMetadataService service = createService(MetadataTarget.Standard);
-    service.setEncoding(Encoding.Base64);
+    service.setEncoding(Encoding.Basic_Base64);
     AdaptrisMessage msg = createMessage();
     execute(service, msg);
     assertTrue(msg.containsKey(DEFAULT_METADATA_KEY));

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitJoinServiceFilterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitJoinServiceFilterTest.java
@@ -32,6 +32,7 @@ import com.adaptris.util.text.xml.InsertNode;
 import com.adaptris.util.text.xml.XPath;
 
 
+@SuppressWarnings("deprecation")
 public class SplitJoinServiceFilterTest extends SplitterServiceExample {
   private static Log logR = LogFactory.getLog(SplitJoinServiceFilterTest.class);
 

--- a/interlok-core/src/test/java/com/adaptris/core/util/EncodingHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/EncodingHelperTest.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.util;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import org.junit.Test;
+
+public class EncodingHelperTest extends EncodingHelper {
+
+  @Test
+  public void testEncoding() throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+    for (Encoding e : Encoding.values()) {
+      assertNotNull(e.wrap(in));
+      assertNotNull(e.wrap(out));
+      if (e != Encoding.None) {
+        assertNotEquals(ByteArrayInputStream.class, e.wrap(in).getClass());
+        assertNotEquals(ByteArrayOutputStream.class, e.wrap(out).getClass());
+      }
+    }
+  }
+
+
+  @Test
+  public void testBase64Encoding() throws Exception {
+    for (Base64Encoding e : Base64Encoding.values()) {
+      assertNotNull(e.encoder());
+      assertNotNull(e.decoder());
+    }
+  }
+
+
+}

--- a/interlok-core/src/test/java/com/adaptris/util/text/ByteTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/ByteTranslatorTest.java
@@ -23,6 +23,7 @@ import java.security.MessageDigest;
 import org.junit.Test;
 import com.adaptris.util.GuidGenerator;
 
+@SuppressWarnings("deprecation")
 public class ByteTranslatorTest {
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/util/text/ConversionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/ConversionTest.java
@@ -20,12 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.security.MessageDigest;
-
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class ConversionTest {
 
   private static final String TEXT = "The Quick Brown Fox Jumps Over The Lazy Dog";


### PR DESCRIPTION
- Add EncodingHelper that wraps the various MimeUtility / Base64 wrappers.
- EncodingHelper also wraps an enum for the Base64 style
- Deprecate Conversion#base64 operations
- Base64ByteTranslator now uses java.util.Base64
- MetadataToPayload / PayloadToMetadata switched to use EncodingHelper.Encoding enum
- Base64Encode / Decode / EncodeMetadata / DecodeMetadata now uses one of the Base64 styles.

It's arguable that Conversion#base64 methods should just delegate to Base64.getEncoder/getDecoder so happy to do that to avoid lots of deprecation warnings...
