### PR TITLE
Deprecate payload-from-metadata

### DIFF
--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
   compile ("com.thoughtworks.xstream:xstream:$xstreamVersion")
   compile ("org.codehaus.jettison:jettison:1.2")
-  compile ("io.github.classgraph:classgraph:4.8.64")
+  compile ("io.github.classgraph:classgraph:4.8.60")
   compile ("net.jodah:expiringmap:0.5.9")
   compile ("javax.activation:activation:1.1.1")
   compile ("org.apache.activemq:activemq-client:$activeMqVersion") {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromMetadataService.java
@@ -17,69 +17,49 @@
 package com.adaptris.core.services.metadata;
 
 import java.util.regex.Matcher;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.MarshallingCDATA;
-import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceImp;
-import com.adaptris.interlok.types.InterlokMessage;
-import com.adaptris.util.KeyValuePair;
-import com.adaptris.util.KeyValuePairSet;
+import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Replaces the payload with something built from metadata.
+ * Replaces the payload with something else.
  * <p>
- * Takes the template stored in {@link #setTemplate(String)} and replaces parts of the template with values from various metadata
- * keys specified in {@link #setMetadataTokens(KeyValuePairSet)} to create a new payload.
- * </p>
- * <p>
- * Uses the JDK regular expression engine, take care when replacing special regular expression values.
+ * This follows the configuration for {@link PayloadFromTemplateService} with 2 exceptions
+ * <ul>
+ * <li>escape-backslash is still available to be configured but deprecated</li>
+ * <li>multi-line-expression defaults to FALSE in the constructor for backwards compatibility reasons</li>
+ * </ul>
  * </p>
  * 
  * @config payload-from-metadata-service
- * 
- * 
- * @author lchan
- * @author $Author: lchan $
+ * @deprecated since 3.10.0 use {@link PayloadFromTemplateService} or {@link MetadataToPayloadService} instead; most of the time
+ *             you're abusing it...
  */
+@Deprecated
 @XStreamAlias("payload-from-metadata-service")
 @AdapterComponent
 @ComponentProfile(summary = "Construct a new payload based on metadata and a template", tag = "service,metadata")
-@DisplayOrder(order = {"template", "metadataTokens", "dotAll", "escapeBackslash", "quiet"})
-public class PayloadFromMetadataService extends ServiceImp {
+@DisplayOrder(order = {"template", "metadataTokens", "multiLineExpression", "quoteReplacement", "escapeBackslash", "quiet"})
+@Removal(version = "4.0", message = "use payload-from-template or metadata-to-payload instead")
+public class PayloadFromMetadataService extends PayloadFromTemplateService {
   
-  @NotNull
-  @AutoPopulated
-  @Valid
-  private KeyValuePairSet metadataTokens;
-  @MarshallingCDATA
-  @InputFieldDefault(value = "")
-  @InputFieldHint(expression = true, style="BLANKABLE")
-  private String template = null;
   @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "true")
+  @Deprecated
+  @Removal(version = "3.12.0", message = "use quote-replacement instead")
   private Boolean escapeBackslash;
-  @AdvancedConfig(rare = true)
-  @InputFieldDefault(value = "false")
-  private Boolean quiet;
-  @AdvancedConfig
-  @InputFieldDefault(value = "false")
-  private Boolean multiLineExpression;
+
+  private boolean warningLogged = false;
 
   public PayloadFromMetadataService() {
-    setMetadataTokens(new KeyValuePairSet());
+    setMultiLineExpression(Boolean.FALSE);
   }
 
   public PayloadFromMetadataService(String template) {
@@ -87,85 +67,22 @@ public class PayloadFromMetadataService extends ServiceImp {
     setTemplate(template);
   }
 
-  /**
-   * @see com.adaptris.core.Service#doService(com.adaptris.core.AdaptrisMessage)
-   */
   @Override
-  public void doService(AdaptrisMessage msg) throws ServiceException {
-    String payload = msg.resolve(StringUtils.defaultIfEmpty(template, ""), dotAll());
-    for (KeyValuePair kvp : getMetadataTokens().getKeyValuePairs()) {
-      if (msg.getMetadataValue(kvp.getKey()) != null) {
-        if (!quiet()) {
-          log.trace("Replacing {} with {}", kvp.getValue(), msg.getMetadataValue(kvp.getKey()));
-        }
-        payload = payload.replaceAll(kvp.getValue(), munge(msg.getMetadataValue(kvp.getKey())));
-      }
-      else {
-        if (!quiet()) {
-          log.trace("{} returns no value; no substitution", kvp.getKey());
-        }
-      }
-    }
-    msg.setContent(payload, msg.getContentEncoding());
-  }
-  
-
-  private String munge(String s) {
-    String result = s;
-    if (escapeBackslash()) {
-//      result = s.replaceAll("\\\\", "\\\\\\\\");
-      result = Matcher.quoteReplacement(s);
-    }
-    return result;
+  public void prepare() throws CoreException {
+    LoggingHelper.logWarning(warningLogged, () -> {
+      warningLogged = true;
+    }, "[{}] is a payload-from-metadata-service; use payload-from-template or metadata-to-payload instead.",
+        LoggingHelper.friendlyName(this));
+    super.prepare();
   }
 
-  @Override
-  protected void initService() throws CoreException {
-  }
-
-  @Override
-  protected void closeService() {
-
-  }
 
   /**
-   * @return the metadataTokens
+   * 
+   * @deprecated since 3.10.0, use {@link #setQuoteReplacement(Boolean)} instead.
    */
-  public KeyValuePairSet getMetadataTokens() {
-    return metadataTokens;
-  }
-
-  /**
-   * Set the metadata tokens that will be used to perform metadata substitution.
-   * <p>
-   * For the purposes of this service, the key to the key-value-pair is the
-   * metadata key, and the value is the token that will be replaced within the
-   * template
-   * </p>
-   *
-   * @param metadataTokens the metadataTokens to set
-   */
-  public void setMetadataTokens(KeyValuePairSet metadataTokens) {
-    this.metadataTokens = metadataTokens;
-  }
-
-  /**
-   * @return the template
-   */
-  public String getTemplate() {
-    return template;
-  }
-
-  /**
-   * Set the template document that will be used as the template for generating a new document.
-   *
-   * @param s the template to set (supports metadata expansion via {@code %message{key}}).
-   */
-  public void setTemplate(String s) {
-    template = s;
-  }
-
-
+  @Deprecated
+  @Removal(version = "3.12.0", message = "use quote-replacement instead")
   public Boolean getEscapeBackslash() {
     return escapeBackslash;
   }
@@ -175,82 +92,34 @@ public class PayloadFromMetadataService extends ServiceImp {
    * <p>
    * Set this flag to make sure that special characters are treated literally by the regular expression engine.
    * <p>
-   *
+   * 
+   * @deprecated since 3.10.0, use {@link #setQuoteReplacement(Boolean)} instead.
    * @see Matcher#quoteReplacement(String)
    * @param b the value to set
    */
+  @Deprecated
+  @Removal(version = "3.12.0", message = "use quote-replacement instead")
   public void setEscapeBackslash(Boolean b) {
     escapeBackslash = b;
   }
-  
+
+  /**
+   * 
+   * @deprecated since 3.10.0, use {@link #setQuoteReplacement(Boolean)} instead.
+   */
+  @Deprecated
+  @Removal(version = "3.12.0", message = "use quote-replacement instead")
   public PayloadFromMetadataService withEscapeBackslash(Boolean b) {
     setEscapeBackslash(b); 
     return this;
   }
 
-  private boolean escapeBackslash() {
-    return BooleanUtils.toBooleanDefaultIfNull(getEscapeBackslash(), true);
-  }
-
-  public Boolean getQuiet() {
-    return quiet;
-  }
-
-  /**
-   * Normally this service logs everything that is being replaced; set to true to stop it.
-   * 
-   * @param quiet true or false, default false if not specified.
-   */
-  public void setQuiet(Boolean quiet) {
-    this.quiet = quiet;
-  }
-
-  public PayloadFromMetadataService withQuietMode(Boolean quiet) {
-    setQuiet(quiet);
-    return this;
-  }
-  
-  private boolean quiet() {
-    return BooleanUtils.toBooleanDefaultIfNull(getQuiet(), false);
-  }
-
-  public Boolean getMultiLineExpression() {
-    return multiLineExpression;
-  }
-
-  /**
-   * Whether or not to handle expressions using {@code Pattern#DOTALL} mode for matching.
-   * 
-   * <p>
-   * The value here is passed to {@link InterlokMessage#resolve(String, boolean)}. True will allow you to do replacements on
-   * multi-line templates; for backwards compatiblity reasons, it defaults to false. Setting it to true means that multi-line 
-   * templates along the lines of will be supported.
-   * <pre>
-   * {@code {
-   *   "key": "%message{metadataKey}",
-   *   "key2: "%message{anotherMetadatKey}",
-   * }
-   * }
-   * </p>
-   * 
-   * @param b true, default is false if not specified.
-   * @since 3.8.3
-   */
-  public void setMultiLineExpression(Boolean b) {
-    this.multiLineExpression = b;
-  }
-  
-  public PayloadFromMetadataService withMultiLineExpression(Boolean b) {
-    setMultiLineExpression(b); 
-    return this;
-  }
-  
-  private boolean dotAll() {
-    return BooleanUtils.toBooleanDefaultIfNull(getMultiLineExpression(), false);
-  }
-  
   @Override
-  public void prepare() throws CoreException {
+  protected boolean quoteReplacement() {
+    if (getEscapeBackslash() != null) {
+      return BooleanUtils.toBooleanDefaultIfNull(getEscapeBackslash(), true);
+    }
+    return super.quoteReplacement();
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromTemplateService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromTemplateService.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.MarshallingCDATA;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.adaptris.interlok.util.Args;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Replaces the payload with something built from a template and optional metadata keys.
+ * <p>
+ * Takes the template stored in {@link #setTemplate(String)} and replaces parts of the template either by resolving the
+ * {@code %message} expression language or with values from various metadata keys specified in
+ * {@link #setMetadataTokens(KeyValuePairSet)} to create a new payload. This replaces {@link PayloadFromMetadataService}.
+ * </p>
+ * <p>
+ * Since under the covers it uses the JDK regular expression engine, take care when your replacement may contain special regular
+ * expression characters (such as {@code \} and {@code $}
+ * </p>
+ * 
+ * @config payload-from-template
+ * 
+ */
+@XStreamAlias("payload-from-template")
+@AdapterComponent
+@ComponentProfile(summary = "Construct a new payload based on metadata and a template", tag = "service,metadata", since = "3.10.0")
+@DisplayOrder(order = {"template", "metadataTokens", "multiLineExpression", "quoteReplacement", "quiet"})
+public class PayloadFromTemplateService extends ServiceImp {
+  
+  @NotNull
+  @AutoPopulated
+  @Valid
+  private KeyValuePairSet metadataTokens;
+  @MarshallingCDATA
+  @InputFieldDefault(value = "")
+  @InputFieldHint(expression = true, style="BLANKABLE")
+  private String template = null;
+  @AdvancedConfig(rare = true)
+  @InputFieldDefault(value = "true")
+  private Boolean quoteReplacement;
+  @AdvancedConfig(rare = true)
+  @InputFieldDefault(value = "false")
+  private Boolean quiet;
+  @AdvancedConfig
+  @InputFieldDefault(value = "true")
+  private Boolean multiLineExpression;
+
+  public PayloadFromTemplateService() {
+    setMetadataTokens(new KeyValuePairSet());
+  }
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    String payload = msg.resolve(StringUtils.defaultIfEmpty(template, ""), multiLineExpression());
+    for (KeyValuePair kvp : getMetadataTokens().getKeyValuePairs()) {
+      if (msg.getMetadataValue(kvp.getKey()) != null) {
+        if (!quiet()) {
+          log.trace("Replacing {} with {}", kvp.getValue(), msg.getMetadataValue(kvp.getKey()));
+        }
+        payload = payload.replaceAll(kvp.getValue(), munge(msg.getMetadataValue(kvp.getKey())));
+      }
+      else {
+        if (!quiet()) {
+          log.trace("{} returns no value; no substitution", kvp.getKey());
+        }
+      }
+    }
+    msg.setContent(payload, msg.getContentEncoding());
+  }
+  
+
+  private String munge(String s) {
+    return quoteReplacement() ? Matcher.quoteReplacement(s) : s;
+  }
+
+  @Override
+  protected void initService() throws CoreException {}
+
+  @Override
+  protected void closeService() {}
+
+  @Override
+  public void prepare() throws CoreException {}
+
+  /**
+   * @return the metadataTokens
+   */
+  public KeyValuePairSet getMetadataTokens() {
+    return metadataTokens;
+  }
+
+  /**
+   * Set the metadata tokens that will be used to perform metadata substitution.
+   * <p>
+   * For the purposes of this service, the key to the key-value-pair is the
+   * metadata key, and the value is the token that will be replaced within the
+   * template
+   * </p>
+   *
+   * @param metadataTokens the metadataTokens to set
+   */
+  public void setMetadataTokens(KeyValuePairSet metadataTokens) {
+    this.metadataTokens = Args.notNull(metadataTokens, "metadata-tokens");
+  }
+
+  public <T extends PayloadFromTemplateService> T withMetadataTokens(KeyValuePairSet tokens) {
+    setMetadataTokens(tokens);
+    return (T) this;
+  }
+
+  public <T extends PayloadFromTemplateService> T withMetadataTokens(Map<String, String> tokens) {
+    return withMetadataTokens(new KeyValuePairSet(tokens));
+  }
+
+  /**
+   * @return the template
+   */
+  public String getTemplate() {
+    return template;
+  }
+
+  /**
+   * Set the template document that will be used as the template for generating a new document.
+   *
+   * @param s the template to set (supports metadata expansion via {@code %message{key}}).
+   */
+  public void setTemplate(String s) {
+    template = s;
+  }
+
+  public <T extends PayloadFromTemplateService> T withTemplate(String b) {
+    setTemplate(b);
+    return (T) this;
+  }
+
+
+  public Boolean getQuoteReplacement() {
+    return quoteReplacement;
+  }
+
+  /**
+   * If any metadata value contains special characters then ensure that they are escaped.
+   * <p>
+   * Set this flag to make sure that special characters are treated literally by the regular expression engine.
+   * <p>
+   *
+   * @see Matcher#quoteReplacement(String)
+   * @param b the value to set, defaults to true if not explicitly configured.
+   */
+  public void setQuoteReplacement(Boolean b) {
+    quoteReplacement = b;
+  }
+  
+  public <T extends PayloadFromTemplateService> T withQuoteReplacement(Boolean b) {
+    setQuoteReplacement(b); 
+    return (T) this;
+  }
+
+  protected boolean quoteReplacement() {
+    return BooleanUtils.toBooleanDefaultIfNull(getQuoteReplacement(), true);
+  }
+
+  public Boolean getQuiet() {
+    return quiet;
+  }
+
+  /**
+   * Normally this service logs everything that is being replaced with can lead to excessive logging.
+   * 
+   * @param quiet true or false, default false if not specified.
+   */
+  public void setQuiet(Boolean quiet) {
+    this.quiet = quiet;
+  }
+
+  public <T extends PayloadFromTemplateService> T withQuietMode(Boolean quiet) {
+    setQuiet(quiet);
+    return (T) this;
+  }
+  
+  private boolean quiet() {
+    return BooleanUtils.toBooleanDefaultIfNull(getQuiet(), false);
+  }
+
+  public Boolean getMultiLineExpression() {
+    return multiLineExpression;
+  }
+
+  /**
+   * Whether or not to handle expressions using {@code Pattern#DOTALL} mode for matching.
+   * 
+   * <p>
+   * The value here is passed to {@link InterlokMessage#resolve(String, boolean)}. True will allow you to do replacements on
+   * multi-line templates; It defaults to false. Setting it to true means that multi-line templates along the lines of will be
+   * supported.
+   * 
+   * <pre>
+   * {@code 
+   * { 
+   *   "key": "%message{metadataKey}", 
+   *   "key2: "%message{anotherMetadatKey}", 
+   * } 
+   * }
+   * </pre>
+   * </p>
+   * 
+   * @param b true/false, default is true if not specified.
+   */
+  public void setMultiLineExpression(Boolean b) {
+    this.multiLineExpression = b;
+  }
+  
+  public <T extends PayloadFromTemplateService> T withMultiLineExpression(Boolean b) {
+    setMultiLineExpression(b); 
+    return (T) this;
+  }
+  
+  protected boolean multiLineExpression() {
+    return BooleanUtils.toBooleanDefaultIfNull(getMultiLineExpression(), true);
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromTemplateService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromTemplateService.java
@@ -225,8 +225,7 @@ public class PayloadFromTemplateService extends ServiceImp {
    * 
    * <p>
    * The value here is passed to {@link InterlokMessage#resolve(String, boolean)}. True will allow you to do replacements on
-   * multi-line templates; It defaults to false. Setting it to true means that multi-line templates along the lines of will be
-   * supported.
+   * multi-line templates; It defaults to true which means that multi-line templates along the lines of will be supported.
    * 
    * <pre>
    * {@code 

--- a/interlok-core/src/main/java/com/adaptris/util/KeyValuePairSet.java
+++ b/interlok-core/src/main/java/com/adaptris/util/KeyValuePairSet.java
@@ -19,12 +19,11 @@ package com.adaptris.util;
 import java.io.Serializable;
 import java.util.AbstractSet;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
@@ -45,7 +44,7 @@ public class KeyValuePairSet extends KeyValuePairBag implements Set<KeyValuePair
   private static final long serialVersionUID = 2013111201L;
 
   @XStreamImplicit(itemFieldName = "key-value-pair")
-  private Set<KeyValuePair> set;
+  private LinkedHashSet<KeyValuePair> set;
 
   /**
    * <p>
@@ -54,7 +53,7 @@ public class KeyValuePairSet extends KeyValuePairBag implements Set<KeyValuePair
    */
   public KeyValuePairSet() {
     super();
-    set = new HashSet<KeyValuePair>();
+    set = new LinkedHashSet<KeyValuePair>();
   }
 
   public KeyValuePairSet(Collection<KeyValuePair> pairs) {

--- a/interlok-core/src/test/java/com/adaptris/core/MultiProducerWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiProducerWorkflowTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import com.adaptris.core.services.exception.ConfiguredException;
 import com.adaptris.core.services.exception.ThrowExceptionService;
-import com.adaptris.core.services.metadata.PayloadFromMetadataService;
+import com.adaptris.core.services.metadata.PayloadFromTemplateService;
 import com.adaptris.core.stubs.MockChannel;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.stubs.MockSkipProducerService;
@@ -58,7 +58,7 @@ public class MultiProducerWorkflowTest extends ExampleWorkflowCase {
         mock1, mock2
     }), Arrays.asList(new Service[]
     {
-      new PayloadFromMetadataService(MODIFIED_PAYLOAD)
+        new PayloadFromTemplateService().withTemplate(MODIFIED_PAYLOAD)
     }));
     MultiProducerWorkflow workflow = (MultiProducerWorkflow) channel.getWorkflowList().get(0);
     assertNotNull(workflow.toString());
@@ -73,7 +73,7 @@ public class MultiProducerWorkflowTest extends ExampleWorkflowCase {
         mock1, mock2
     }), Arrays.asList(new Service[]
     {
-      new PayloadFromMetadataService(MODIFIED_PAYLOAD)
+        new PayloadFromTemplateService().withTemplate(MODIFIED_PAYLOAD)
     }));
     try {
       MultiProducerWorkflow workflow = (MultiProducerWorkflow) channel.getWorkflowList().get(0);
@@ -101,7 +101,7 @@ public class MultiProducerWorkflowTest extends ExampleWorkflowCase {
         mock1, mock2
     }), Arrays.asList(new Service[]
     {
-      new PayloadFromMetadataService(MODIFIED_PAYLOAD)
+        new PayloadFromTemplateService().withTemplate(MODIFIED_PAYLOAD)
     }));
     try {
       MultiProducerWorkflow workflow = (MultiProducerWorkflow) channel.getWorkflowList().get(0);
@@ -141,7 +141,7 @@ public class MultiProducerWorkflowTest extends ExampleWorkflowCase {
         mock1, mock2
     }), Arrays.asList(new Service[]
     {
-      new PayloadFromMetadataService(MODIFIED_PAYLOAD)
+        new PayloadFromTemplateService().withTemplate(MODIFIED_PAYLOAD)
     }));
     try {
       MultiProducerWorkflow workflow = (MultiProducerWorkflow) channel.getWorkflowList().get(0);
@@ -202,7 +202,7 @@ public class MultiProducerWorkflowTest extends ExampleWorkflowCase {
         mock1, mock2
     }), Arrays.asList(new Service[]
     {
-      new PayloadFromMetadataService(MODIFIED_PAYLOAD)
+        new PayloadFromTemplateService().withTemplate(MODIFIED_PAYLOAD)
     }));
     try {
       MultiProducerWorkflow workflow = (MultiProducerWorkflow) channel.getWorkflowList().get(0);
@@ -269,7 +269,7 @@ public class MultiProducerWorkflowTest extends ExampleWorkflowCase {
         mock1, mock2
     }), Arrays.asList(new Service[]
     {
-      new PayloadFromMetadataService(MODIFIED_PAYLOAD)
+        new PayloadFromTemplateService().withTemplate(MODIFIED_PAYLOAD)
     }));
     channel.setMessageErrorHandler(new StandardProcessingExceptionHandler(
     		new ServiceList(new ArrayList(Arrays.asList(new Service[]
@@ -323,7 +323,7 @@ public class MultiProducerWorkflowTest extends ExampleWorkflowCase {
         mock1, mock2
     }), Arrays.asList(new Service[]
     {
-      new PayloadFromMetadataService(MODIFIED_PAYLOAD)
+        new PayloadFromTemplateService().withTemplate(MODIFIED_PAYLOAD)
     }));
     try {
       MultiProducerWorkflow workflow = (MultiProducerWorkflow) channel.getWorkflowList().get(0);
@@ -351,7 +351,7 @@ public class MultiProducerWorkflowTest extends ExampleWorkflowCase {
         mock1, mock2
     }), Arrays.asList(new Service[]
     {
-      new PayloadFromMetadataService(MODIFIED_PAYLOAD)
+        new PayloadFromTemplateService().withTemplate(MODIFIED_PAYLOAD)
 
     }));
     channel.setMessageErrorHandler(new StandardProcessingExceptionHandler(

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/HttpHelper.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/HttpHelper.java
@@ -19,7 +19,6 @@ package com.adaptris.core.http.client.net;
 import static com.adaptris.core.http.jetty.JettyHelper.createChannel;
 import static com.adaptris.core.http.jetty.JettyHelper.createConsumer;
 import static com.adaptris.core.http.jetty.JettyHelper.createWorkflow;
-
 import com.adaptris.core.Channel;
 import com.adaptris.core.ComponentLifecycle;
 import com.adaptris.core.ConfiguredProduceDestination;
@@ -34,7 +33,7 @@ import com.adaptris.core.http.jetty.MetadataHeaderHandler;
 import com.adaptris.core.http.jetty.StandardResponseProducer;
 import com.adaptris.core.http.server.HttpStatusProvider;
 import com.adaptris.core.http.server.HttpStatusProvider.HttpStatus;
-import com.adaptris.core.services.metadata.PayloadFromMetadataService;
+import com.adaptris.core.services.metadata.PayloadFromTemplateService;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.util.LifecycleHelper;
 
@@ -74,7 +73,8 @@ public class HttpHelper {
     HttpConnection jc = createConnection();
     Channel c = createChannel(jc, createWorkflow(mc, mock, new ServiceList(new Service[]
     {
-        new PayloadFromMetadataService(replyPayload), new StandaloneProducer(new StandardResponseProducer(status))
+        new PayloadFromTemplateService().withTemplate(replyPayload),
+        new StandaloneProducer(new StandardResponseProducer(status))
     })));
     start(c);
     return c;

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/HttpRequestServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/HttpRequestServiceTest.java
@@ -48,7 +48,7 @@ import com.adaptris.core.http.jetty.SecurityConstraint;
 import com.adaptris.core.http.jetty.StandardResponseProducer;
 import com.adaptris.core.http.server.HttpStatusProvider.HttpStatus;
 import com.adaptris.core.metadata.RegexMetadataFilter;
-import com.adaptris.core.services.metadata.PayloadFromMetadataService;
+import com.adaptris.core.services.metadata.PayloadFromTemplateService;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.util.LifecycleHelper;
 
@@ -127,10 +127,9 @@ public class HttpRequestServiceTest extends HttpServiceExample {
     MockMessageProducer mock = new MockMessageProducer();
     HttpConnection jc = HttpHelper.createConnection();
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
-    Channel c = createChannel(jc, createWorkflow(mc, mock, new ServiceList(new Service[]
-        {
-            new PayloadFromMetadataService(TEXT), new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200))
-          })));
+    Channel c = createChannel(jc,
+        createWorkflow(mc, mock, new ServiceList(new Service[] {new PayloadFromTemplateService().withTemplate(TEXT),
+            new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200))})));
 
     HttpRequestService service =
         new HttpRequestService(HttpHelper.createProduceDestination(c).getDestination())
@@ -155,10 +154,9 @@ public class HttpRequestServiceTest extends HttpServiceExample {
     MockMessageProducer mock = new MockMessageProducer();
     HttpConnection jc = HttpHelper.createConnection();
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
-    Channel c = createChannel(jc, createWorkflow(mc, mock, new ServiceList(new Service[]
-        {
-            new PayloadFromMetadataService(TEXT), new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200))
-        })));
+    Channel c = createChannel(jc,
+        createWorkflow(mc, mock, new ServiceList(new Service[] {new PayloadFromTemplateService().withTemplate(TEXT),
+            new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200))})));
 
     HttpRequestService service =
         new HttpRequestService(HttpHelper.createProduceDestination(c).getDestination())
@@ -185,7 +183,8 @@ public class HttpRequestServiceTest extends HttpServiceExample {
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
     Channel c = createChannel(jc, createWorkflow(mc, mock, new ServiceList(new Service[]
         {
-            new PayloadFromMetadataService(TEXT), new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200))
+        new PayloadFromTemplateService().withTemplate(TEXT),
+        new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200))
         })));
 
     HttpRequestService service =
@@ -291,7 +290,8 @@ public class HttpRequestServiceTest extends HttpServiceExample {
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
     Channel c = createChannel(jc, createWorkflow(mc, mock, new ServiceList(new Service[]
     {
-        new PayloadFromMetadataService(TEXT), new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200))
+        new PayloadFromTemplateService().withTemplate(TEXT),
+        new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200))
     })));
 
     HttpRequestService service = new HttpRequestService(HttpHelper.createProduceDestination(c).getDestination())
@@ -319,7 +319,8 @@ public class HttpRequestServiceTest extends HttpServiceExample {
 
     Channel c = createChannel(jc, createWorkflow(mc, mock, new ServiceList(new Service[]
     {
-        new PayloadFromMetadataService(TEXT), new StandaloneProducer(new StandardResponseProducer(HttpStatus.UNAUTHORIZED_401))
+        new PayloadFromTemplateService().withTemplate(TEXT),
+        new StandaloneProducer(new StandardResponseProducer(HttpStatus.UNAUTHORIZED_401))
     })));
     HttpRequestService service =
         new HttpRequestService(HttpHelper.createProduceDestination(c).getDestination())

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/StandardHttpProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/StandardHttpProducerTest.java
@@ -72,7 +72,7 @@ import com.adaptris.core.http.jetty.StandardResponseProducer;
 import com.adaptris.core.http.server.HttpStatusProvider.HttpStatus;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 import com.adaptris.core.services.WaitService;
-import com.adaptris.core.services.metadata.PayloadFromMetadataService;
+import com.adaptris.core.services.metadata.PayloadFromTemplateService;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.security.password.Password;
 import com.adaptris.util.KeyValuePair;
@@ -172,8 +172,7 @@ public class StandardHttpProducerTest extends HttpProducerExample {
     HttpConnection jc = HttpHelper.createConnection();
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
     ServiceList sl = new ServiceList();
-    PayloadFromMetadataService pms = new PayloadFromMetadataService();
-    pms.setTemplate(TEXT);
+    PayloadFromTemplateService pms = new PayloadFromTemplateService().withTemplate(TEXT);
     sl.add(pms);
     sl.add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
     Channel c = createChannel(jc, createWorkflow(mc, mock, sl));
@@ -205,8 +204,7 @@ public class StandardHttpProducerTest extends HttpProducerExample {
     HttpConnection jc = HttpHelper.createConnection();
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
     ServiceList sl = new ServiceList();
-    PayloadFromMetadataService pms = new PayloadFromMetadataService();
-    pms.setTemplate(TEXT);
+    PayloadFromTemplateService pms = new PayloadFromTemplateService().withTemplate(TEXT);
     sl.add(pms);
     sl.add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
     Channel c = createChannel(jc, createWorkflow(mc, mock, sl));
@@ -238,8 +236,7 @@ public class StandardHttpProducerTest extends HttpProducerExample {
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
     Channel c = createChannel(jc, createWorkflow(mc, mock, new ServiceList()));
     StandardWorkflow workflow = (StandardWorkflow) c.getWorkflowList().get(0);
-    PayloadFromMetadataService pms = new PayloadFromMetadataService();
-    pms.setTemplate(TEXT);
+    PayloadFromTemplateService pms = new PayloadFromTemplateService().withTemplate(TEXT);
     workflow.getServiceCollection().add(pms);
     workflow.getServiceCollection().add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
     StandardHttpProducer stdHttp = new StandardHttpProducer(HttpHelper.createProduceDestination(c));
@@ -269,8 +266,7 @@ public class StandardHttpProducerTest extends HttpProducerExample {
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
     Channel c = createChannel(jc, createWorkflow(mc, mock, new ServiceList()));
     StandardWorkflow workflow = (StandardWorkflow) c.getWorkflowList().get(0);
-    PayloadFromMetadataService pms = new PayloadFromMetadataService();
-    pms.setTemplate(TEXT);
+    PayloadFromTemplateService pms = new PayloadFromTemplateService().withTemplate(TEXT);
     workflow.getServiceCollection().add(pms);
     workflow.getServiceCollection().add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
 
@@ -446,7 +442,7 @@ public class StandardHttpProducerTest extends HttpProducerExample {
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
 
     ServiceList services = new ServiceList();
-    services.add(new PayloadFromMetadataService(TEXT));
+    services.add(new PayloadFromTemplateService().withTemplate(TEXT));
     services.add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.UNAUTHORIZED_401)));
     Channel c = createChannel(jc, createWorkflow(mc, mock, services));
     StandardHttpProducer stdHttp = new StandardHttpProducer(HttpHelper.createProduceDestination(c));
@@ -825,7 +821,7 @@ public class StandardHttpProducerTest extends HttpProducerExample {
     JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
     mc.setSendProcessingInterval(new TimeInterval(100L, TimeUnit.MILLISECONDS));
     ServiceList services = new ServiceList();
-    services.add(new PayloadFromMetadataService(TEXT));
+    services.add(new PayloadFromTemplateService().withTemplate(TEXT));
     services.add(new WaitService(new TimeInterval(2L, TimeUnit.SECONDS)));
     services.add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
     

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/JettyAsyncWorkflowInterceptorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/JettyAsyncWorkflowInterceptorTest.java
@@ -37,7 +37,7 @@ import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardWorkflow;
 import com.adaptris.core.WorkflowImp;
 import com.adaptris.core.http.client.net.HttpRequestService;
-import com.adaptris.core.services.metadata.PayloadFromMetadataService;
+import com.adaptris.core.services.metadata.PayloadFromTemplateService;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.TimeInterval;
@@ -106,7 +106,7 @@ public class JettyAsyncWorkflowInterceptorTest extends ExampleWorkflowCase {
     StandardWorkflow receivingWF = new StandardWorkflow();
     MockMessageProducer producer = new MockMessageProducer();
     receivingWF.addInterceptor(new JettyAsyncWorkflowInterceptor().withMode(JettyAsyncWorkflowInterceptor.Mode.REQUEST));
-    receivingWF.getServiceCollection().add(new PayloadFromMetadataService("hello world"));
+    receivingWF.getServiceCollection().add(new PayloadFromTemplateService().withTemplate("hello world"));
     receivingWF.getServiceCollection().add(new StandaloneProducer(producer));
     receivingWF.getServiceCollection().add(new JettyResponseService(200, "text/plain"));
     receivingWF.getServiceCollection().add(new ShortCutJettyResponse());
@@ -142,7 +142,7 @@ public class JettyAsyncWorkflowInterceptorTest extends ExampleWorkflowCase {
     // Mainly to keep track of the msgID. we use a standard workflow so new objects aren't created.
     MockMessageProducer producer = new MockMessageProducer();
     respondingWF.addInterceptor(new JettyAsyncWorkflowInterceptor().withMode(JettyAsyncWorkflowInterceptor.Mode.RESPONSE));
-    respondingWF.getServiceCollection().add(new PayloadFromMetadataService("hello world"));
+    respondingWF.getServiceCollection().add(new PayloadFromTemplateService().withTemplate("hello world"));
     respondingWF.getServiceCollection().add(new JettyResponseService(200, "text/plain"));
     respondingWF.getServiceCollection().add(new StandaloneProducer(producer));
 
@@ -183,7 +183,7 @@ public class JettyAsyncWorkflowInterceptorTest extends ExampleWorkflowCase {
     MockMessageProducer producer = new MockMessageProducer();
     respondingWF.addInterceptor(
         new JettyAsyncWorkflowInterceptor().withMode(JettyAsyncWorkflowInterceptor.Mode.RESPONSE).withCacheKey(cacheKey));
-    respondingWF.getServiceCollection().add(new PayloadFromMetadataService("hello world"));
+    respondingWF.getServiceCollection().add(new PayloadFromTemplateService().withTemplate("hello world"));
     respondingWF.getServiceCollection().add(new JettyResponseService(200, "text/plain"));
     respondingWF.getServiceCollection().add(new StandaloneProducer(producer));
 

--- a/interlok-core/src/test/java/com/adaptris/core/marshaller/xstream/PrettyStaxDriverTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/marshaller/xstream/PrettyStaxDriverTest.java
@@ -17,7 +17,6 @@ package com.adaptris.core.marshaller.xstream;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -27,12 +26,10 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashSet;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import com.adaptris.annotation.AnnotationConstants;
-import com.adaptris.core.services.metadata.PayloadFromMetadataService;
+import com.adaptris.core.services.metadata.PayloadFromTemplateService;
 import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
 
 public class PrettyStaxDriverTest {
@@ -72,21 +69,21 @@ public class PrettyStaxDriverTest {
   public void testPrettyPrintWriter() throws Exception {
     PrettyStaxDriver driver = new PrettyStaxDriver(cdata, true);
     // service
-    //      <payload-from-metadata-service>
+    //      <payload-from-template-service>
     //        <unique-id>naughty-hodgkin</unique-id>
     //        <template><![CDATA[Hello World]]></template>
-    //      </payload-from-metadata-service>
+    //      </payload-from-template-service>
     StringWriter writer = new StringWriter();
     try (Writer w = writer) {
       PrettyPrintWriter printWriter = (PrettyPrintWriter) driver.createWriter(w);
-      printWriter.startNode("payload-from-metadata-service", PayloadFromMetadataService.class);
+      printWriter.startNode("payload-from-template-service", PayloadFromTemplateService.class);
       printWriter.startNode("unique-id", String.class);
       printWriter.setValue("naughty-hodgkin");
       printWriter.endNode(); // unique-id
       printWriter.startNode("template", String.class);
       printWriter.setValue("Hello World");
       printWriter.endNode(); // template
-      printWriter.endNode(); // payload-from-metadata-service
+      printWriter.endNode(); // payload-from-template-service
     }
     System.err.println(writer.toString());
     assertTrue(writer.toString().contains("CDATA"));


### PR DESCRIPTION
- Add a payload-from-template service instead.
- Modify payload-from-metadata javadocs to indicate that you're abusing it