### PR TITLE
INTERLOK-3201 Support spaces in path when creating jetty.xml URL

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/jetty/FromXmlConfig.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/jetty/FromXmlConfig.java
@@ -91,7 +91,7 @@ final class FromXmlConfig extends ServerBuilder {
   private static URL relativeConfig(URI uri) throws Exception {
     String pwd = backslashToSlash(System.getProperty("user.dir"));
     String path = pwd + "/" + uri;
-    URL result = new URL("file:///" + path);
+    URL result = new URL("file:///" + new URI(null, path, null).toASCIIString());
     return result;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/jetty/FromXmlConfig.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/jetty/FromXmlConfig.java
@@ -91,7 +91,7 @@ final class FromXmlConfig extends ServerBuilder {
   private static URL relativeConfig(URI uri) throws Exception {
     String pwd = backslashToSlash(System.getProperty("user.dir"));
     String path = pwd + "/" + uri;
-    URL result = new URL("file:///" + new URI(null, path, null).toASCIIString());
+    URL result = new URL(new URI("file", path, null).toASCIIString());
     return result;
   }
 


### PR DESCRIPTION
## Motivation

If your installation directory contains a space, then you get a URISyntaxException when you attempt to start the jetty component

## Modification

Use new URI().toAsciiString() so that we get an encoded string we can just append to "file:///"

## Result

No functional change if you don't have spaces in your install dir.
Working jetty if you do.

## Testing

Install to a directory with spaces (why would you, spaces are bad).
