### PR TITLE
INTERLOK-2981 Add --jettyonly as a mode.

### DIFF
--- a/interlok-boot/src/main/java/com/adaptris/interlok/boot/InterlokLauncher.java
+++ b/interlok-boot/src/main/java/com/adaptris/interlok/boot/InterlokLauncher.java
@@ -66,6 +66,7 @@ public class InterlokLauncher extends Launcher {
   private static final boolean DEBUG = Boolean.getBoolean("adp.bootstrap.debug") || Boolean.getBoolean("interlok.bootstrap.debug");
 
   static final String INTERLOK_MAIN_CLASS = "com.adaptris.core.management.SimpleBootstrap";
+  static final String JETTY_ONLY_MAIN_CLASS = "com.adaptris.core.management.NoAdapterBootstrap";
   static final String INTERLOK_FAILOVER_MAIN_CLASS = "com.adaptris.failover.SimpleBootstrap";
   static final String INTERLOK_CONTAINER_MAIN_CLASS = "com.adaptris.management.aar.SimpleBootstrap";
   static final String SERVICE_TEST_MAIN_CLASS = "com.adaptris.tester.runners.TestExecutor";
@@ -94,6 +95,10 @@ public class InterlokLauncher extends Launcher {
   private static final String[] ARG_PASSWORD = new String[]
       {
           "-password", "--password"
+      };
+  private static final String[] ARG_JETTY_ONLY = new String[]
+      {
+          "-jettyonly", "--jettyonly", "-jetty-only", "--jetty-only"
       };
 
 
@@ -130,6 +135,12 @@ public class InterlokLauncher extends Launcher {
         return cmdLine.hasArgument(ARG_PASSWORD);
       }
 
+    },
+    JETTY_ONLY(JETTY_ONLY_MAIN_CLASS) {
+      @Override
+      boolean matches(CommandLineArgs cmdLine) {
+        return cmdLine.hasArgument(ARG_JETTY_ONLY);
+      }
     },
     // Last so it's the default.
     INTERLOK(INTERLOK_MAIN_CLASS) {

--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -100,7 +100,12 @@ abstract class CmdLineBootstrap {
     boolean startQuietly = bootProperties.isEnabled(CFG_KEY_START_QUIETLY);
     final UnifiedBootstrap bootstrap = new UnifiedBootstrap(bootProperties);
     if (!configCheckOnly()) {
-      bootstrap.init(jettyOnly ? null : bootstrap.createAdapter());
+      if (jettyOnly) {
+        System.err.println("Starting Jetty/UI without a local adapter");
+        bootstrap.init(null);
+      } else {
+        bootstrap.init(bootstrap.createAdapter());
+      }
       Runtime.getRuntime().addShutdownHook(new ShutdownHandler(bootProperties));
       launchAdapter(bootstrap, startQuietly);
     }

--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -41,28 +41,32 @@ abstract class CmdLineBootstrap {
   private static final String[] ARG_CONFIG_CHECK = new String[]
   {
       "-configtest", "-configcheck", "--configtest", "--configcheck"
-
   };
 
   private static final String[] ARG_VERSION = new String[]
   {
       "-version", "--version"
-
   };
 
   private static final String[] ARG_BOOTSTRAP_PROPERTIES = new String[]
   {
       "-file", "--file"
+  };
 
+  private static final String[] ARG_JETTY_ONLY = new String[]
+  {
+    "--jettyonly"
   };
 
   private transient String bootstrapResource;
   private transient ArgUtil arguments;
   private transient boolean configCheckOnly = false;
+  private transient boolean jettyOnly = false;
 
   protected boolean configCheckOnly() {
     return configCheckOnly;
   }
+
 
   protected String getBootstrapResource() {
     return bootstrapResource;
@@ -95,7 +99,7 @@ abstract class CmdLineBootstrap {
   protected void startAdapter(BootstrapProperties bootProperties) throws Exception {
     boolean startQuietly = bootProperties.isEnabled(CFG_KEY_START_QUIETLY);
     final UnifiedBootstrap bootstrap = new UnifiedBootstrap(bootProperties);
-    AdapterManagerMBean adapter = bootstrap.createAdapter();
+    AdapterManagerMBean adapter = jettyOnly ? null : bootstrap.createAdapter();
     if (!configCheckOnly()) {
       bootstrap.init(adapter);
       Runtime.getRuntime().addShutdownHook(new ShutdownHandler(bootProperties));
@@ -146,6 +150,7 @@ abstract class CmdLineBootstrap {
       }
       configCheckOnly = true;
     }
+    jettyOnly = arguments.hasArgument(ARG_JETTY_ONLY);
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -99,16 +99,15 @@ abstract class CmdLineBootstrap {
   protected void startAdapter(BootstrapProperties bootProperties) throws Exception {
     boolean startQuietly = bootProperties.isEnabled(CFG_KEY_START_QUIETLY);
     final UnifiedBootstrap bootstrap = new UnifiedBootstrap(bootProperties);
-    AdapterManagerMBean adapter = jettyOnly ? null : bootstrap.createAdapter();
     if (!configCheckOnly()) {
-      bootstrap.init(adapter);
+      bootstrap.init(jettyOnly ? null : bootstrap.createAdapter());
       Runtime.getRuntime().addShutdownHook(new ShutdownHandler(bootProperties));
       launchAdapter(bootstrap, startQuietly);
     }
     else {
       // This seems a bit cheaty, but we're going to exit anyway, so
       // calling prepare probably makes no difference.
-      Adapter clonedAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(adapter.getConfiguration());
+      Adapter clonedAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(bootstrap.createAdapter().getConfiguration());
       LifecycleHelper.prepare(clonedAdapter);
 
       // INTERLOK-1455 Shutdown the logging subsystem if we're only just doing a config check.

--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -55,7 +55,7 @@ abstract class CmdLineBootstrap {
 
   private static final String[] ARG_JETTY_ONLY = new String[]
   {
-    "--jettyonly"
+          "-jettyonly", "--jettyonly", "-jetty-only", "--jetty-only"
   };
 
   private transient String bootstrapResource;

--- a/interlok-core/src/main/java/com/adaptris/core/management/NoAdapterBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/NoAdapterBootstrap.java
@@ -17,6 +17,8 @@
 package com.adaptris.core.management;
 
 import com.adaptris.core.management.logging.LoggingConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Entry point into an adapter from the command line.
@@ -27,12 +29,16 @@ import com.adaptris.core.management.logging.LoggingConfigurator;
  */
 public class NoAdapterBootstrap extends CmdLineBootstrap {
 
+  private transient Logger log = LoggerFactory.getLogger(NoAdapterBootstrap.class.getName());
+
   public NoAdapterBootstrap(String[] argv) throws Exception {
     super(argv);
   }
 
   @Override
   public void boot() throws Exception {
+    log.info("Starting Jetty/UI without a local adapter");
+
     logVersionInformation();
     // standard boot
     LoggingConfigurator.newConfigurator().defaultInitialisation();
@@ -48,7 +54,6 @@ public class NoAdapterBootstrap extends CmdLineBootstrap {
 
     // don't launch adapter
     ManagementComponentFactory.startCreated(bootProperties);
-
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/management/NoAdapterBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/NoAdapterBootstrap.java
@@ -19,12 +19,11 @@ package com.adaptris.core.management;
 import com.adaptris.core.management.logging.LoggingConfigurator;
 
 /**
- * Entry point into an adapter from the commandline.
- * <p>
- * Basically the same as StandardBootstrap but without the classpath initialization.
- * </p>
+ * Entry point into an adapter from the command line.
  *
- * @author gcsiki
+ * Basically the same as {@SimpleBootstrap} but without the Adapter being started.
+ *
+ * @author aanderson
  */
 public class NoAdapterBootstrap extends CmdLineBootstrap {
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/NoAdapterBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/NoAdapterBootstrap.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.management;
+
+import com.adaptris.core.management.logging.LoggingConfigurator;
+
+/**
+ * Entry point into an adapter from the commandline.
+ * <p>
+ * Basically the same as StandardBootstrap but without the classpath initialization.
+ * </p>
+ *
+ * @author gcsiki
+ */
+public class NoAdapterBootstrap extends CmdLineBootstrap {
+
+  public NoAdapterBootstrap(String[] argv) throws Exception {
+    super(argv);
+  }
+
+  @Override
+  public void boot() throws Exception {
+    logVersionInformation();
+    // standard boot
+    LoggingConfigurator.newConfigurator().defaultInitialisation();
+    BootstrapProperties bootProperties = new BootstrapProperties(getBootstrapResource());
+    SystemPropertiesUtil.addSystemProperties(bootProperties);
+    SystemPropertiesUtil.addJndiProperties(bootProperties);
+    ProxyAuthenticator.register(bootProperties);
+
+    // don't start adapter
+    ManagementComponentFactory.create(bootProperties);
+    ManagementComponentFactory.initCreated(bootProperties);
+    Runtime.getRuntime().addShutdownHook(new ShutdownHandler(bootProperties));
+
+    // don't launch adapter
+    ManagementComponentFactory.startCreated(bootProperties);
+
+  }
+
+  /**
+   * <p>
+   * Entry point to program.
+   * </p>
+   *
+   * @param argv - Command line arguments
+   *
+   * @throws Exception upon some unrecoverable error.
+   */
+  public static void main(String[] argv) throws Exception {
+    try {
+      new NoAdapterBootstrap(argv).boot();
+    }
+    catch (Exception e) {
+      LoggingConfigurator.newConfigurator().requestShutdown();
+      throw e;
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/UnifiedBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/UnifiedBootstrap.java
@@ -111,16 +111,20 @@ public class UnifiedBootstrap {
   }
 
   public void init(AdapterManagerMBean adapter) throws Exception {
-    bootstrapProperties.getConfigManager().syncAdapterConfiguration(adapter);
-    adapterRegistry = bootstrapProperties.getConfigManager().getAdapterRegistry();
-    bootstrapProperties.setProperty(Constants.CFG_JMX_LOCAL_ADAPTER_UID, adapter.getUniqueId());
+    if (adapter != null) {
+      bootstrapProperties.getConfigManager().syncAdapterConfiguration(adapter);
+      adapterRegistry = bootstrapProperties.getConfigManager().getAdapterRegistry();
+      bootstrapProperties.setProperty(Constants.CFG_JMX_LOCAL_ADAPTER_UID, adapter.getUniqueId());
+    }
     ManagementComponentFactory.create(bootstrapProperties);
     ManagementComponentFactory.initCreated(bootstrapProperties);
   }
 
   public void start() throws Exception {
     ManagementComponentFactory.startCreated(bootstrapProperties);
-    tryStart(adapterRegistry.getAdapters());
+    if (adapterRegistry != null) {
+      tryStart(adapterRegistry.getAdapters());
+    }
   }
 
   private void tryStart(Set<ObjectName> adapters) throws Exception {


### PR DESCRIPTION
## Motivation

This set of changes allow for the UI to be started without starting a local adapter. This can be useful in situations where a local adapter is not necessary, and the UI is only to connect to remote instances.

## Modification

There are actually two sets of changes here, depending on which is deemed the more suitable:

1. A new bootstrap class that sets everything up but doesn't start an adapter
2. A command line option for the existing bootstrap that indicates the user wants Jetty only

What we need is a poll for which solution is the preferred one.

## Result

The end result, either way, is the same: the UI is started without a local adapter.

## Testing

To test, fire it all up with something similar to either of the following:

    java … com.adaptris.core.management.NoAdapterBootstrap

or

    java … com.adaptris.core.management.SimpleBootstrap --jettyonly

The UI should start, and there should not be a local adapter instance to connect to.