### PR TITLE
INTERLOK-3124 Added Management Components to JMX

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentFactory.java
@@ -68,7 +68,7 @@ public class ManagementComponentFactory {
       try {
         manCompInfo.getInstance().init(bootstrapProperties);
       } catch (Exception e) {
-        log.error("Failed to initialize management component []", manCompInfo.getName(), e);
+        log.error("Failed to initialize management component {}", manCompInfo.getName(), e);
       }
     }
   }
@@ -78,7 +78,7 @@ public class ManagementComponentFactory {
       try {
         manCompInfo.getInstance().start();
       } catch (Exception e) {
-        log.error("Failed to start management component []", manCompInfo.getName(), e);
+        log.error("Failed to start management component {}", manCompInfo.getName(), e);
       }
     }
   }
@@ -88,7 +88,7 @@ public class ManagementComponentFactory {
       try {
         manCompInfo.getInstance().stop();
       } catch (Exception e) {
-        log.error("Failed to stop management component []", manCompInfo.getName(), e);
+        log.error("Failed to stop management component {}", manCompInfo.getName(), e);
       }
     }
   }
@@ -98,7 +98,7 @@ public class ManagementComponentFactory {
       try {
         manCompInfo.getInstance().destroy();
       } catch (Exception e) {
-        log.error("Failed to destroy management component []", manCompInfo.getName(), e);
+        log.error("Failed to destroy management component {}", manCompInfo.getName(), e);
       }
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentFactory.java
@@ -22,8 +22,6 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +32,7 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.adaptris.core.ClosedState;
 import com.adaptris.core.management.classloader.ClassLoaderFactory;
 
 /**
@@ -43,7 +42,7 @@ import com.adaptris.core.management.classloader.ClassLoaderFactory;
  */
 public class ManagementComponentFactory {
 
-  private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+  private static transient Logger log = LoggerFactory.getLogger(ManagementComponentFactory.class.getName());
 
   private static final String COMPONENT_SEPARATOR = ":";
   private static final String PROPERTY_KEY = "class";
@@ -51,100 +50,92 @@ public class ManagementComponentFactory {
   private static final String CLASSLOADER_KEY = "classloader";
   private static final ManagementComponentFactory INSTANCE = new ManagementComponentFactory();
 
-  private final Map<Properties, List<Object>> managementComponents = new HashMap<>();
-
+  private final Map<Properties, List<ManagementComponentInfo>> managementComponents = new HashMap<>();
+  
   private ManagementComponentFactory() {
   }
 
-  public static List<Object> create(final BootstrapProperties p) throws Exception {
+  public static List<ManagementComponentInfo> create(final BootstrapProperties p) throws Exception {
     if (!INSTANCE.getManagementComponents().containsKey(p)) {
-      List<Object> obj = INSTANCE.createComponents(p);
-      INSTANCE.getManagementComponents().put(p,obj );
+      List<ManagementComponentInfo> manCompInfo = INSTANCE.createComponents(p);
+      INSTANCE.getManagementComponents().put(p,manCompInfo );
     }
     return INSTANCE.getManagementComponents().get(p);
   }
 
-  public static void initCreated(BootstrapProperties p) {
-    INSTANCE.invokeInit(p, INSTANCE.getManagementComponents().get(p));
+  public static void initCreated(BootstrapProperties bootstrapProperties) {
+    for(ManagementComponentInfo manCompInfo : INSTANCE.getManagementComponents().get(bootstrapProperties)) {
+      try {
+        manCompInfo.getInstance().init(bootstrapProperties);
+      } catch (Exception e) {
+        log.error("Failed to initialize management component []", manCompInfo.getName(), e);
+      }
+    }
   }
 
-  public static void startCreated(BootstrapProperties p) {
-    INSTANCE.invoke(INSTANCE.getManagementComponents().get(p), "start", new Class[0], new Object[0]);
+  public static void startCreated(BootstrapProperties bootstrapProperties) {
+    for(ManagementComponentInfo manCompInfo : INSTANCE.getManagementComponents().get(bootstrapProperties)) {
+      try {
+        manCompInfo.getInstance().start();
+      } catch (Exception e) {
+        log.error("Failed to start management component []", manCompInfo.getName(), e);
+      }
+    }
   }
 
-  public static void stopCreated(BootstrapProperties p, boolean reverseOrder) {
-    INSTANCE.invoke(reverseOrder(INSTANCE.getManagementComponents().get(p), reverseOrder), "stop", new Class[0], new Object[0]);
+  public static void stopCreated(BootstrapProperties bootstrapProperties, boolean reverseOrder) {
+    for(ManagementComponentInfo manCompInfo : reverseOrder(INSTANCE.getManagementComponents().get(bootstrapProperties), reverseOrder)) {
+      try {
+        manCompInfo.getInstance().stop();
+      } catch (Exception e) {
+        log.error("Failed to stop management component []", manCompInfo.getName(), e);
+      }
+    }
   }
 
-  public static void closeCreated(BootstrapProperties p, boolean reverseOrder) {
-    INSTANCE.invoke(reverseOrder(INSTANCE.getManagementComponents().get(p), reverseOrder), "destroy", new Class[0], new Object[0]);
+  public static void closeCreated(BootstrapProperties bootstrapProperties, boolean reverseOrder) {
+    for(ManagementComponentInfo manCompInfo : reverseOrder(INSTANCE.getManagementComponents().get(bootstrapProperties), reverseOrder)) {
+      try {
+        manCompInfo.getInstance().destroy();
+      } catch (Exception e) {
+        log.error("Failed to destroy management component []", manCompInfo.getName(), e);
+      }
+    }
   }
 
-  private static List<Object> reverseOrder(List<Object> list, boolean reverseOrder) {
-    List<Object> newList = new ArrayList<>(list);
+  private static List<ManagementComponentInfo> reverseOrder(List<ManagementComponentInfo> list, boolean reverseOrder) {
+    List<ManagementComponentInfo> newList = new ArrayList<>(list);
     if (reverseOrder) {
       Collections.reverse(newList);
     }
     return newList;
   }
 
-  private Map<Properties, List<Object>> getManagementComponents() {
+  private Map<Properties, List<ManagementComponentInfo>> getManagementComponents() {
     return managementComponents;
   }
 
-  private List<Object> createComponents(final BootstrapProperties p) throws Exception {
-    List<Object> result = new ArrayList<>();
-    final String componentList = getPropertyIgnoringCase(p, CFG_KEY_MANAGEMENT_COMPONENT, "");
+  private List<ManagementComponentInfo> createComponents(final BootstrapProperties bootstropProperties) throws Exception {
+    List<ManagementComponentInfo> result = new ArrayList<>();
+    final String componentList = getPropertyIgnoringCase(bootstropProperties, CFG_KEY_MANAGEMENT_COMPONENT, "");
     if (!isEmpty(componentList)) {
       final String components[] = componentList.split(COMPONENT_SEPARATOR);
-      for (final String c : components) {
-        result.add(resolve(c, p));
+      for (final String componentName : components) {
+        ManagementComponent resolvedComponent = resolve(componentName, bootstropProperties);
+        
+        ManagementComponentInfo mcInfo = new ManagementComponentInfo();
+        mcInfo.setClassName(resolvedComponent.getClass().getName());
+        mcInfo.setState(ClosedState.getInstance());
+        mcInfo.setName(componentName);
+        mcInfo.setInstance(resolvedComponent);
+        
+        result.add(mcInfo);
       }
     }
     return result;
   }
 
-  private void invokeInit(Properties initProperties, List<Object> mgmtComponents) {
-    invoke(mgmtComponents, "init", new Class[] {
-      Properties.class
-    }, new Properties[] {
-        initProperties
-    });
-  }
-
-  private void invoke(List<Object> objects, final String methodName, final Class[] paramTypes, final Object[] params) {
-    if (objects == null) {
-      return;
-    }
-    for (final Object o : objects) {
-      invokeMethod(o, methodName, paramTypes, params);
-    }
-  }
-
-  private void invokeMethod(final Object o, final String methodName, final Class[] paramTypes, final Object[] params) {
-    final Class<? extends Object> clas = o.getClass();
-    List<String> types = paramTypes(paramTypes);
-    try {
-      log.trace("{}#{}({})", clas.getName(), methodName, (types.size() > 0 ? types : ""));
-      final Method method = clas.getMethod(methodName, paramTypes);
-      method.setAccessible(true);
-      method.invoke(o, params);
-    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-      log.trace("FAILED: {}#{}({})", clas, methodName, (types.size() > 0 ? types : ""), e);
-    }
-  }
-
-  private static List<String> paramTypes(Class[] params) {
-    List<String> result = new ArrayList<>();
-    for (Class p : params) {
-      if (p != null) {
-        result.add(p.getCanonicalName());
-      }
-    }
-    return result;
-  }
-
-  private Object resolve(final String name, BootstrapProperties bootstrapProperties) throws Exception {
+  private ManagementComponent resolve(final String name, BootstrapProperties bootstrapProperties) throws Exception {
     final ClassLoader originalContectClassLoader = Thread.currentThread().getContextClassLoader();
     ClassLoader classLoader = getClass().getClassLoader();
     try (final InputStream in = classLoader.getResourceAsStream(RESOURCE_PATH + name)) {
@@ -161,17 +152,13 @@ public class ManagementComponentFactory {
           classLoader = classLoaderFactory.create(classLoader);
           Thread.currentThread().setContextClassLoader(classLoader);
         }
-        final Object component = Class.forName(p.getProperty(PROPERTY_KEY), true, classLoader).newInstance();
+        final ManagementComponent component = (ManagementComponent) Class.forName(p.getProperty(PROPERTY_KEY), true, classLoader).newInstance();
         if (classloaderProperty != null) {
-          invokeMethod(component, "setClassLoader", new Class[] {
-            ClassLoader.class
-          }, new ClassLoader[] {
-            classLoader
-          });
+          component.setClassLoader(classLoader);
         }
         return component;
       }
-      return Class.forName(name).newInstance();
+      return (ManagementComponent) Class.forName(name).newInstance();
     } finally {
       Thread.currentThread().setContextClassLoader(originalContectClassLoader);
     }

--- a/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentInfo.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentInfo.java
@@ -1,0 +1,50 @@
+package com.adaptris.core.management;
+
+import com.adaptris.core.ComponentState;
+
+public class ManagementComponentInfo {
+  
+  private String name;
+    
+  private String className;
+  
+  private ComponentState state;
+  
+  private ManagementComponent instance;
+  
+  public ManagementComponentInfo() {
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public void setClassName(String className) {
+    this.className = className;
+  }
+
+  public ComponentState getState() {
+    return state;
+  }
+
+  public void setState(ComponentState state) {
+    this.state = state;
+  }
+
+  public ManagementComponent getInstance() {
+    return instance;
+  }
+
+  public void setInstance(ManagementComponent instance) {
+    this.instance = instance;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/UnifiedBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/UnifiedBootstrap.java
@@ -114,7 +114,7 @@ public class UnifiedBootstrap {
     bootstrapProperties.getConfigManager().syncAdapterConfiguration(adapter);
     adapterRegistry = bootstrapProperties.getConfigManager().getAdapterRegistry();
     bootstrapProperties.setProperty(Constants.CFG_JMX_LOCAL_ADAPTER_UID, adapter.getUniqueId());
-    ManagementComponentFactory.create(bootstrapProperties);
+    adapterRegistry.setManagementComponentInfo(ManagementComponentFactory.create(bootstrapProperties));
     ManagementComponentFactory.initCreated(bootstrapProperties);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterRegistry.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterRegistry.java
@@ -58,6 +58,7 @@ import com.adaptris.core.EventFactory;
 import com.adaptris.core.XStreamJsonMarshaller;
 import com.adaptris.core.event.AdapterShutdownEvent;
 import com.adaptris.core.fs.FsHelper;
+import com.adaptris.core.management.ManagementComponentInfo;
 import com.adaptris.core.util.JmxHelper;
 import com.adaptris.util.URLString;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -87,6 +88,7 @@ public class AdapterRegistry implements AdapterRegistryMBean {
   private transient Map<ObjectName, AdapterBuilder> builderByObjectName = new HashMap<>();
   private transient Map<Properties, AdapterBuilder> builderByProps = new HashMap<>();
   private transient AdapterBuilder defaultBuilder;
+  private transient List<ManagementComponentInfo> managementComponentInfo = new ArrayList<>();
 
   private AdapterRegistry() throws MalformedObjectNameException {
     mBeanServer = JmxHelper.findMBeanServer();
@@ -566,5 +568,18 @@ public class AdapterRegistry implements AdapterRegistryMBean {
 
   Set<AdapterBuilder> builders() {
     return new HashSet<AdapterBuilder>(builderByProps.values());
+  }
+
+  public void addManagementComponentInfo(ManagementComponentInfo componentInfo) {
+    this.getManagementComponentInfo().add(componentInfo);
+  }
+  
+  @Override
+  public List<ManagementComponentInfo> getManagementComponentInfo() {
+    return this.managementComponentInfo;
+  }
+
+  public void setManagementComponentInfo(List<ManagementComponentInfo> managementComponentInfo) {
+    this.managementComponentInfo = managementComponentInfo;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterRegistryMBean.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterRegistryMBean.java
@@ -18,6 +18,7 @@ package com.adaptris.core.runtime;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -26,6 +27,7 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 import com.adaptris.core.CoreException;
+import com.adaptris.core.management.ManagementComponentInfo;
 import com.adaptris.util.URLString;
 
 /**
@@ -447,5 +449,18 @@ public interface AdapterRegistryMBean extends BaseComponentMBean {
    * @return all the available builders.
    */
   Set<ObjectName> getBuilders();
+  
+  /**
+   * Will return a Map of {@link ManagementComponentInfo}'s.  The key to the map
+   * is the name of the configured management component.  
+   * 
+   * @return Basic information on configured management components
+   */
+  List<ManagementComponentInfo> getManagementComponentInfo();
+  
+  /**
+   * Set the list of configured management components.  
+   */
+  void setManagementComponentInfo(List<ManagementComponentInfo> manComps);
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/management/AlwaysFailDummyManagementComponent.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/AlwaysFailDummyManagementComponent.java
@@ -1,0 +1,27 @@
+package com.adaptris.core.management;
+
+import java.util.Properties;
+
+public class AlwaysFailDummyManagementComponent implements ManagementComponent {
+
+  @Override
+  public void init(final Properties config) throws Exception {
+    throw new Exception("Expected");
+  }
+
+  @Override
+  public void start() throws Exception {
+    throw new Exception("Expected");
+  }
+
+  @Override
+  public void stop() throws Exception {
+    throw new Exception("Expected");
+  }
+
+  @Override
+  public void destroy() throws Exception {
+    throw new Exception("Expected");
+  }
+  
+}


### PR DESCRIPTION
## Motivation

We can configure management components in the bootstrap.properties, but then they are forgotten.  Almost like mini programs that run in the background.  What if we later want to know what management components are running?  Or even if they all started up correctly?

## Modification

Firstly I have had to modify the ManagementComponentFactory such that it returns a list of information on running management components; a new class ManagementComponentInfo.

I've also taken the time to make the ManagementComponentFactory less rubbish, by  removing all the reflection.

## Result

The AdapterRegistry exposes a bunch of JMX endpoints, it also now exposes a list of management components, including their current state; init, start, stop and closed.

## Testing

You'll need to start the adapter with at least one management component, then simply check jconsole for the AdapterRegistry, which should now give you a getManagementComponentInfo().
It's a list of ManagementComponentInfo's.
