### PR TITLE
INTERLOK-3211 Add a metadata-stream-output that includes a translator

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataOutputStreamWrapper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataOutputStreamWrapper.java
@@ -17,16 +17,15 @@
 package com.adaptris.core.common;
 
 import static com.adaptris.core.common.MetadataDataOutputParameter.DEFAULT_METADATA_KEY;
-
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
-
 import org.apache.commons.io.output.WriterOutputStream;
-
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.types.InterlokMessage;
 import com.adaptris.interlok.types.MessageWrapper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -36,13 +35,18 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  * @config metadata-output-stream-wrapper
  * @since 3.9.0
+ * @deprecated since 3.10.1
  */
+@Deprecated
 @XStreamAlias("metadata-output-stream-wrapper")
 @DisplayOrder(order = {"metadataKey", "contentEncoding"})
 @ComponentProfile(summary = "MessageWrapper implementation wraps a metadata value as an Outputstream", since = "3.9.0")
+@Removal(version = "4.0", message = "Use metadata-stream-output instead")
 public class MetadataOutputStreamWrapper extends MetadataStreamOutputParameter
     implements MessageWrapper<OutputStream> {
     
+  private transient boolean warningLogged = false;
+
   public MetadataOutputStreamWrapper() {
     super();
     this.setMetadataKey(DEFAULT_METADATA_KEY);
@@ -50,6 +54,8 @@ public class MetadataOutputStreamWrapper extends MetadataStreamOutputParameter
   
   @Override
   public OutputStream wrap(InterlokMessage m) throws Exception {
+    LoggingHelper.logDeprecation(warningLogged, () -> warningLogged = true, this.getClass().getSimpleName(),
+        MetadataStreamOutput.class.getCanonicalName());
     return new MetadataOutputStream(m, new StringWriter());
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamOutput.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamOutput.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adaptris.core.common;
+
+import static com.adaptris.core.common.MetadataDataOutputParameter.DEFAULT_METADATA_KEY;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.util.Args;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.adaptris.interlok.types.MessageWrapper;
+import com.adaptris.util.text.ByteTranslator;
+import com.adaptris.util.text.SimpleByteTranslator;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * {@link MessageWrapper} implementation wraps a metadata value as an {@link OutputStream} along with a {@link ByteTranslator}
+ * 
+ * <p>
+ * This can be used in a functionally equivalent way to {@link MetadataOutputStreamWrapper} and can be regarded as its replacement.
+ * </p>
+ * 
+ * @config metadata-stream-output
+ * @since 3.10.1
+ */
+@XStreamAlias("metadata-stream-output")
+@DisplayOrder(order = {"metadataKey", "translator"})
+@ComponentProfile(summary = "MessageWrapper implementation wraps a metadata value as an Outputstream", since = "3.10.1")
+public class MetadataStreamOutput implements MessageWrapper<OutputStream> {
+
+  @NotBlank
+  private String metadataKey;
+  @AdvancedConfig
+  @Valid
+  @InputFieldDefault(value = "SimpleByteTranslator")
+  private ByteTranslator translator;
+
+  public MetadataStreamOutput() {
+    super();
+    this.setMetadataKey(DEFAULT_METADATA_KEY);
+  }
+
+  @Override
+  public OutputStream wrap(InterlokMessage m) throws Exception {
+    return new MetadataOutputStream(m, new ByteArrayOutputStream());
+  }
+
+
+  public String getMetadataKey() {
+    return metadataKey;
+  }
+
+  public void setMetadataKey(String key) {
+    this.metadataKey = Args.notBlank(key, "metadata key");
+  }
+
+  public <T extends MetadataStreamOutput> T withMetadataKey(String e) {
+    setMetadataKey(e);
+    return (T) this;
+  }
+  
+
+  public ByteTranslator getTranslator() {
+    return translator;
+  }
+
+  /**
+   * Set the translator that will give us bytes.
+   * 
+   * @param t
+   */
+  public void setTranslator(ByteTranslator t) {
+    this.translator = t;
+  }
+
+  private ByteTranslator translator() {
+    return ObjectUtils.defaultIfNull(getTranslator(), new SimpleByteTranslator());
+  }
+
+
+  public <T extends MetadataStreamOutput> T withTranslator(ByteTranslator s) {
+    setTranslator(s);
+    return (T) this;
+  }
+
+
+  private class MetadataOutputStream extends FilterOutputStream {
+
+    private InterlokMessage msg;
+    private ByteArrayOutputStream byteOut;
+
+    public MetadataOutputStream(InterlokMessage msg, ByteArrayOutputStream out) {
+      super(out);
+      this.msg = msg;
+      this.byteOut = out;
+    }
+
+    @Override
+    public void close() throws IOException {
+      super.close();
+      msg.addMessageHeader(getMetadataKey(), translator().translate(byteOut.toByteArray()));
+    }
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/ByteArrayMetadataTest.java
@@ -22,6 +22,7 @@ import java.security.MessageDigest;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.util.text.SimpleByteTranslator;
 
 public class ByteArrayMetadataTest {
 
@@ -33,7 +34,7 @@ public class ByteArrayMetadataTest {
   public void testWrapString() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     msg.addMetadata(KEY, HELLO_WORLD);
-    byte[] wrapped = new ByteArrayFromMetadata().withKey(KEY).wrap(msg);
+    byte[] wrapped = new ByteArrayFromMetadata().withTranslator(new SimpleByteTranslator()).withKey(KEY).wrap(msg);
     assertTrue(MessageDigest.isEqual(BYTE_ARRAY, wrapped));
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamOutputTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamOutputTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adaptris.core.common;
+
+import static com.adaptris.core.common.MetadataDataOutputParameter.DEFAULT_METADATA_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.util.Base64;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.util.text.Base64ByteTranslator;
+
+public class MetadataStreamOutputTest {
+  private static final String TEXT = "Hello World";
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Test
+  public void testMetadataKey() throws Exception {
+    MetadataStreamOutput p = new MetadataStreamOutput();
+    assertEquals(DEFAULT_METADATA_KEY, p.getMetadataKey());
+    p.setMetadataKey("myKey");
+    assertEquals("myKey", p.getMetadataKey());
+    try {
+      p.setMetadataKey("");
+      fail();
+    } catch (IllegalArgumentException e) {
+
+    }
+    assertEquals("myKey", p.getMetadataKey());
+  }
+
+  @Test
+  public void testInsert_DefaultTranslator() throws Exception {
+    MetadataStreamOutput p = new MetadataStreamOutput().withMetadataKey(DEFAULT_METADATA_KEY);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try (ByteArrayInputStream in = new ByteArrayInputStream(TEXT.getBytes()); OutputStream out = p.wrap(msg)) {
+      IOUtils.copy(in, out);
+    }
+    assertNotSame(TEXT, msg.getContent());
+    assertEquals(TEXT, msg.getMetadataValue(DEFAULT_METADATA_KEY));
+  }
+
+  @Test
+  public void testInsert_Encoding() throws Exception {
+    String base64 = Base64.getEncoder().encodeToString(TEXT.getBytes());
+    MetadataStreamOutput p = new MetadataStreamOutput().withTranslator(new Base64ByteTranslator());
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try (ByteArrayInputStream in = new ByteArrayInputStream(TEXT.getBytes()); OutputStream out = p.wrap(msg)) {
+      IOUtils.copy(in, out);
+    }
+    assertNotSame(base64, msg.getContent());
+    assertEquals(base64, msg.getMetadataValue(DEFAULT_METADATA_KEY));
+  }
+
+}


### PR DESCRIPTION


## Motivation

Since AWS-KMS has a 4096 byte restriction on what you can sign; you're expected to generally use the DIGEST type (i.e. do a hash first of the payload you want to sign) which means that your usage chain is probably going to be 

```
<payload-hashing-service>
  <hash-algorithm>SHA-256</hash-algorithm>
  <byte-translator class="base64-byte-translator"/>
  <metadata-key>payload-hash</metadata-key>
</payload-hashing-service>
... the KMS stuffs.
```

When signing whatever it is you're going to sign, you get a ByteBuffer back from the request, which we would want to store it as metadata; since it would be rather obtuse to "overwrite the payload with a cryptographic signature". The current message-wrapper implementations for metadata don't support auto-translating bytes into base64 or whatever; and since metadata is a string, we need to turn the non-textual data into a string.

So we add a `metadata-stream-output` as a message wrapper implementation that allows you to configure a byte-translator which is then used to translate the signature bytes into a String.

This is effectively the reverse of byte-array-from-metadata...

## Modification

- Added a MetadataStreamOutput which includes a translator so that we can auto-translate it into base64 as required.
- Deprecate MetadataOutputStreamWrapper since this can be achieved with MetadataStreamOutput with a CharsetByteTranslator.

## Result

New feature; existing users of MetadataOutputStreamWrapper will be "warned" (there probably aren't any users of that feature, only symmetric-key-crypto + mime-part-builder use it at the moment.

## Testing

Configure a service that requires a MessageWrapper<OutputStream> and use it (probably symmetric-key-crypto-service) with a translator.
