### PR TITLE
INTERLOK-3211 Remove double generics

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataInputStreamWrapper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataInputStreamWrapper.java
@@ -17,7 +17,6 @@
 package com.adaptris.core.common;
 
 import java.io.InputStream;
-
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.interlok.types.InterlokMessage;
@@ -33,8 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-input-stream-wrapper")
 @DisplayOrder(order = {"metadataKey", "contentEncoding"})
 @ComponentProfile(summary = "MessageWrapper implementation wraps a metadata value as an InputStream", since = "3.9.0")
-public class MetadataInputStreamWrapper extends MetadataStreamInputParameter
-    implements MessageWrapper<InputStream> {
+public class MetadataInputStreamWrapper extends MetadataStreamParameter implements MessageWrapper<InputStream> {
 
   public MetadataInputStreamWrapper() {
     super();
@@ -47,7 +45,6 @@ public class MetadataInputStreamWrapper extends MetadataStreamInputParameter
 
   @Override
   public InputStream wrap(InterlokMessage m) throws Exception {
-    return extract(m);
+    return toInputStream(m, getMetadataKey(), getContentEncoding());
   }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataOutputStreamWrapper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataOutputStreamWrapper.java
@@ -42,8 +42,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @DisplayOrder(order = {"metadataKey", "contentEncoding"})
 @ComponentProfile(summary = "MessageWrapper implementation wraps a metadata value as an Outputstream", since = "3.9.0")
 @Removal(version = "4.0", message = "Use metadata-stream-output instead")
-public class MetadataOutputStreamWrapper extends MetadataStreamOutputParameter
-    implements MessageWrapper<OutputStream> {
+public class MetadataOutputStreamWrapper extends MetadataStreamParameter implements MessageWrapper<OutputStream> {
     
   private transient boolean warningLogged = false;
 

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamInputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamInputParameter.java
@@ -17,14 +17,8 @@
 package com.adaptris.core.common;
 
 import static com.adaptris.core.common.MetadataDataInputParameter.DEFAULT_METADATA_KEY;
-
 import java.io.InputStream;
-import java.io.StringReader;
-
-import org.apache.commons.io.input.ReaderInputStream;
-
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.core.util.Args;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.types.InterlokMessage;
@@ -52,9 +46,7 @@ public class MetadataStreamInputParameter extends MetadataStreamParameter
 
   @Override
   public InputStream extract(InterlokMessage m) throws InterlokException {
-    Args.notBlank(getMetadataKey(), "metadataKey");
-    String data= m.getMessageHeaders().get(getMetadataKey());
-    return new ReaderInputStream(new StringReader(data), charset(getContentEncoding()));
+    return toInputStream(m, getMetadataKey(), getContentEncoding());
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamOutputParameter.java
@@ -18,14 +18,11 @@ package com.adaptris.core.common;
 
 import static com.adaptris.core.common.MetadataDataOutputParameter.DEFAULT_METADATA_KEY;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.StringBuilderWriter;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.interlok.InterlokException;

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamParameter.java
@@ -1,10 +1,15 @@
 package com.adaptris.core.common;
 
+import java.io.InputStream;
+import java.io.StringReader;
 import java.nio.charset.Charset;
 import javax.validation.constraints.NotBlank;
+import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.core.util.Args;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.types.InterlokMessage;
 
 public abstract class MetadataStreamParameter {
 
@@ -45,5 +50,11 @@ public abstract class MetadataStreamParameter {
 
   public static Charset charset(String charset) {
     return StringUtils.isBlank(charset) ? Charset.defaultCharset() : Charset.forName(charset);
+  }
+
+  protected static InputStream toInputStream(InterlokMessage m, String key, String charset) throws InterlokException {
+    Args.notBlank(key, "metadataKey");
+    String data = m.getMessageHeaders().get(key);
+    return new ReaderInputStream(new StringReader(data), charset(charset));
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataOutputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataOutputParameterTest.java
@@ -20,17 +20,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
@@ -126,6 +123,7 @@ public class MetadataStreamDataOutputParameterTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testWrap_WithCharset() throws Exception {
     MetadataOutputStreamWrapper p = new MetadataOutputStreamWrapper().withMetadataKey("myMetadataKey")
             .withContentEncoding(UTF_8);


### PR DESCRIPTION
## Motivation

The handling by the UI of generics and how they build up the templates isn't great; there are some classes that implement multiple generic interfaces which breaks the UI and you have click a "refresh" button to make them come up.

I'm using the MessageWrapper interface for the new KMS services so am affected by this a fair amount.

## Modification

Changed the hierarchy of MetadataOutputStreamWrapper / MetadataInputStreamWrapper so that
they don't extend the corresponding parameter versions.

## Result

Since MetadataOutputStreamWrapper no longer extends MetadataOutputStreamParameter; it can't be used as a DataOutputParameter
Since MetadataInputStreamWrapper no longer extends MetadataInputStreamParameter it cannot be used as a DataInputParameter

Both those *may break configuration*; however, given the name, this is unlikely (the only service that currently has a formal message-wrapper that can be configured are :

SymmetricKeyCryptoService (@mcwarman)
InlineMimePartBuilder
jq.JsonPatchService 
jq.GenerateDiffService

## Testing

Hopefully we'll see better behaviour in the UI.

