### PR TITLE
INTERLOK-3214 New Metadata service Escape Single and Escape Double quotes

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeDoubleQuote.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeDoubleQuote.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("metadata-value-escape-double-quote")
 @AdapterComponent
-@ComponentProfile(summary = "Changes matching metadata double quote into escaped double quote", tag = "service,metadata,string,escape,quote")
+@ComponentProfile(summary = "Changes matching metadata double quote into escaped double quote", tag = "service,metadata,string,escape,quote,double")
 @DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class MetadataValueEscapeDoubleQuote extends ReformatMetadata {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeDoubleQuote.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeDoubleQuote.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("metadata-value-escape-double-quote")
 @AdapterComponent
-@ComponentProfile(summary = "Changes matching metadata double quote into escaped double quote", tag = "service,metadata,string,escape,quote,double")
+@ComponentProfile(summary = "Changes matching metadata double quote into escaped double quote", tag = "service,metadata", since = "3.10.1")
 @DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class MetadataValueEscapeDoubleQuote extends ReformatMetadata {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeDoubleQuote.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeDoubleQuote.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Takes a metadata value and escapes double quote.
+ * <p>
+ * Each matching metadata key from {@link ReformatMetadata#getMetadataKeyRegexp()} will be changed to escaped double quote
+ * </p>
+ * 
+ * @config metadata-value-escape-double-quote
+ * 
+ * 
+ */
+@XStreamAlias("metadata-value-escape-double-quote")
+@AdapterComponent
+@ComponentProfile(summary = "Changes matching metadata double quote into escaped double quote", tag = "service,metadata,string,escape,quote")
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
+public class MetadataValueEscapeDoubleQuote extends ReformatMetadata {
+
+  public MetadataValueEscapeDoubleQuote() {
+    super();
+  }
+
+  @Override
+  public String reformat(String toChange, String msgCharset) {
+    return toChange.replaceAll("\"", "\\\\\"");
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeSingleQuote.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeSingleQuote.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("metadata-value-escape-single-quote")
 @AdapterComponent
-@ComponentProfile(summary = "Changes matching metadata single quote into escaped single quote", tag = "service,metadata,string,escape,quote,single")
+@ComponentProfile(summary = "Changes matching metadata single quote into escaped single quote", tag = "service,metadata", since = "3.10.1")
 @DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class MetadataValueEscapeSingleQuote extends ReformatMetadata {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeSingleQuote.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeSingleQuote.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("metadata-value-escape-single-quote")
 @AdapterComponent
-@ComponentProfile(summary = "Changes matching metadata single quote into escaped single quote", tag = "service,metadata,string,escape,quote")
+@ComponentProfile(summary = "Changes matching metadata single quote into escaped single quote", tag = "service,metadata,string,escape,quote,single")
 @DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
 public class MetadataValueEscapeSingleQuote extends ReformatMetadata {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeSingleQuote.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataValueEscapeSingleQuote.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Takes a metadata value and escapes single quote.
+ * <p>
+ * Each matching metadata key from {@link ReformatMetadata#getMetadataKeyRegexp()} will be changed to escaped single quote
+ * </p>
+ * 
+ * @config metadata-value-escape-single-quote
+ * 
+ * 
+ */
+@XStreamAlias("metadata-value-escape-single-quote")
+@AdapterComponent
+@ComponentProfile(summary = "Changes matching metadata single quote into escaped single quote", tag = "service,metadata,string,escape,quote")
+@DisplayOrder(order = {"metadataKeyRegexp", "metadataLogger"})
+public class MetadataValueEscapeSingleQuote extends ReformatMetadata {
+
+  public MetadataValueEscapeSingleQuote() {
+    super();
+  }
+
+  @Override
+  public String reformat(String toChange, String msgCharset) {
+    return toChange.replaceAll("'", "\\\\'");
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataValueEscapeDoubleQuoteTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataValueEscapeDoubleQuoteTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+
+public class MetadataValueEscapeDoubleQuoteTest extends MetadataServiceExample {
+
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
+
+  private AdaptrisMessage createMessage() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("The quick brown fox jumps over the lazy dog");
+    msg.addMetadata("key", "val\\\"\"ue \" \"\"");
+    msg.addMetadata("twoKey", "");
+    return msg;
+  }
+
+  @Test
+  public void testEscapeDoubleQuoteCase() throws Exception {
+    MetadataValueEscapeDoubleQuote service = new MetadataValueEscapeDoubleQuote();
+    service.setMetadataKeyRegexp("key");
+    AdaptrisMessage msg = createMessage();
+    execute(service, msg);
+    String result = msg.getMetadataValue("key");
+    assertEquals("val\\\\\"\\\"ue \\\" \\\"\\\"", result);
+  }
+  
+  @Test
+  public void testEscapeDoubleQuoteNullValue() throws Exception {
+    MetadataValueEscapeDoubleQuote service = new MetadataValueEscapeDoubleQuote();
+    service.setMetadataKeyRegexp("twoKey");
+    AdaptrisMessage msg = createMessage();
+    execute(service, msg);
+    String result = msg.getMetadataValue("twoKey");
+    assertEquals("", result);
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    MetadataValueEscapeDoubleQuote service = new MetadataValueEscapeDoubleQuote();
+    service.setMetadataKeyRegexp(".*MetadataKeyRegularExpression.*");
+    return service;
+  }
+  
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataValueEscapeSingleQuoteTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataValueEscapeSingleQuoteTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+
+public class MetadataValueEscapeSingleQuoteTest extends MetadataServiceExample {
+
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
+
+  private AdaptrisMessage createMessage() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("The quick brown fox jumps over the lazy dog");
+    msg.addMetadata("key", "val\\''ue ' ''");
+    msg.addMetadata("twoKey", "");
+    return msg;
+  }
+
+  @Test
+  public void testEscapeSingleQuoteCase() throws Exception {
+    MetadataValueEscapeSingleQuote service = new MetadataValueEscapeSingleQuote();
+    service.setMetadataKeyRegexp("key");
+    AdaptrisMessage msg = createMessage();
+    execute(service, msg);
+    String result = msg.getMetadataValue("key");
+    assertEquals("val\\\\\'\\\'ue \\\' \\\'\\\'", result);
+  }
+  
+  @Test
+  public void testEscapeSingleQuoteNullValue() throws Exception {
+    MetadataValueEscapeSingleQuote service = new MetadataValueEscapeSingleQuote();
+    service.setMetadataKeyRegexp("twoKey");
+    AdaptrisMessage msg = createMessage();
+    execute(service, msg);
+    String result = msg.getMetadataValue("twoKey");
+    assertEquals("", result);
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    MetadataValueEscapeSingleQuote service = new MetadataValueEscapeSingleQuote();
+    service.setMetadataKeyRegexp(".*MetadataKeyRegularExpression.*");
+    return service;
+  }
+  
+}


### PR DESCRIPTION
## Motivation

Why am I doing this

New services for escaping the single and double quote characters in metadata values were requested.

## Modification

What did I change

I created two new services in the core-services-metadata which escape the single and double quote characters adding a backslash before them.
Complimenting tests were also added for these two new services.

## Result

What's the end result for the user

The user may now add a service for escaping their metadata's values of single or double quote characters.

## Testing

How can I test this if I'm reviewing this.

There are two ways to test. The first would be to run the added Junit tests and the second to build the core with the new services and drop the jars into a working instance of an Interlok adapter and add the service and use them.
