### PR TITLE
INTERLOK-3158 per item cache expiry

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/cache/Cache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/cache/Cache.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.List;
 import com.adaptris.core.ComponentLifecycle;
 import com.adaptris.core.CoreException;
+import com.adaptris.util.TimeInterval;
 
 /**
  * Interface that defines basic general cache operations for use within the adapter.
@@ -36,7 +37,7 @@ public interface Cache extends ComponentLifecycle {
   void put(String key, Serializable value) throws CoreException;
 
   /**
-   * Puts any object into the cache.
+   * Puts any object into the cache (optional operation).
    * <p>
    * Not guaranteed to be supported by all cache implementations as some persistent caches require serialization.
    * </p>
@@ -44,12 +45,78 @@ public interface Cache extends ComponentLifecycle {
    * @param key key to store the value against
    * @param value value to be stored
    * @implNote The default implementation throws an instance of {@link UnsupportedOperationException} and performs no other action.
-   * @throws UnsupportedOperationException if the {@code put(String,Object)} operation is not supported by this cache instance
+   * @throws UnsupportedOperationException if the operation is not supported by this cache instance
    * @throws CoreException if there was an exception accessing the cache.
    */
   default void put(String key, Object value) throws CoreException {
     throw new UnsupportedOperationException("put(String,Object)");
+  }
 
+  /**
+   * Puts a serializable object into the cache, specifying a expiration (optional operation).
+   * <p>
+   * Since JSR107 doesn't define per item cache expiry; this may not be supported by all cache implementations.
+   * </p>
+   * 
+   * @param key key to store the value against
+   * @param value value to be stored
+   * @param expiry the expiry expressed as a {@link TimeInterval}
+   * @implNote The default implementation just calls {@link #put(String, Serializable, long)}
+   * @throws CoreException if there was an exception accessing the cache.
+   */
+  default void put(String key, Serializable value, TimeInterval expiry) throws CoreException {
+    put(key, value, expiry.toMilliseconds());
+  }
+
+  /**
+   * Puts a serializable object into the cache, specifying a expiration (optional operation).
+   * <p>
+   * Since JSR107 doesn't define per item cache expiry; this may not be supported by all cache implementations.
+   * </p>
+   * 
+   * @param key key to store the value against
+   * @param value value to be stored
+   * @param ttl the TTL in milliseconds.
+   * @implNote The default implementation throws an instance of {@link UnsupportedOperationException} and performs no other action.
+   * @throws UnsupportedOperationException if the this operation is not supported by this cache instance
+   * @throws CoreException if there was an exception accessing the cache.
+   */
+  default void put(String key, Serializable value, long ttl) throws CoreException {
+    throw new UnsupportedOperationException("put(String,Serializable,long)");
+  }
+
+  /**
+   * Puts an object into the cache, specifying a expiration (optional operation).
+   * <p>
+   * Since JSR107 doesn't define per item cache expiry; this may not be supported by all cache implementations.
+   * </p>
+   * 
+   * @param key key to store the value against
+   * @param value value to be stored
+   * @param expiry the expiry specified as a TimeInterval
+   * @implNote The default implementation just calls {@link #put(String, Object, long)}
+   * @throws CoreException if there was an exception accessing the cache.
+   */
+  default void put(String key, Object value, TimeInterval expiry) throws CoreException {
+    put(key, value, expiry.toMilliseconds());
+  }
+
+
+  /**
+   * Puts an object into the cache, specifying a expiration (optional operation).
+   * <p>
+   * Since JSR107 doesn't define per item cache expiry; this may not be supported by all cache implementations.
+   * </p>
+   * 
+   * @param key key to store the value against
+   * @param value value to be stored
+   * @param ttl the TTL in milliseconds.
+   * @implNote The default implementation throws an instance of {@link UnsupportedOperationException} and performs no other action.
+   * @throws UnsupportedOperationException if the this operation is not supported by this cache instance
+   * @throws CoreException if there was an exception accessing the cache.
+   */
+  default void put(String key, Object value, long ttl) throws CoreException {
+    throw new UnsupportedOperationException("put(String,Object,long)");
   }
 
   /**
@@ -70,10 +137,10 @@ public interface Cache extends ComponentLifecycle {
   void remove(String key) throws CoreException;
 
   /**
-   * Retrieves a List of all the keys in the cache
+   * Retrieves a List of all the keys in the cache (optional operation).
    * 
    * @implNote The default implementation throws an instance of {@link UnsupportedOperationException} and performs no other action.
-   * @throws UnsupportedOperationException if the {@code getKeys} operation is not supported by this cache instance
+   * @throws UnsupportedOperationException if the operation is not supported by this cache instance
    * @return a List<String> of all the keys in the cache
    * @throws CoreException if there was an exception accessing the cache.
    */
@@ -82,10 +149,10 @@ public interface Cache extends ComponentLifecycle {
   }
 
   /**
-   * Clears all entries from the cache
+   * Clears all entries from the cache (optional operation).
    * 
    * @implNote The default implementation throws an instance of {@link UnsupportedOperationException} and performs no other action.
-   * @throws UnsupportedOperationException if the {@code clear} operation is not supported by this cache instance
+   * @throws UnsupportedOperationException if the operation is not supported by this cache instance
    * @throws CoreException if there was an exception accessing the cache.
    */
   default void clear() throws CoreException {
@@ -93,25 +160,12 @@ public interface Cache extends ComponentLifecycle {
   }
   
   /**
-   * @return the number of items in the cache
+   * @return the number of items in the cache (optional operation).
    * @implNote The default implementation throws an instance of {@link UnsupportedOperationException} and performs no other action.
-   * @throws UnsupportedOperationException if the {@code size} operation is not supported by this cache instance
+   * @throws UnsupportedOperationException if the operation is not supported by this cache instance
    * @throws CoreException if there was an exception accessing the cache.
    */
   default int size() throws CoreException {
     throw new UnsupportedOperationException("size");
   }
-
-  @Override
-  default void init() throws CoreException {}
-
-  @Override
-  default void start() throws CoreException {}
-
-  @Override
-  default void stop() {}
-
-  @Override
-  default void close() {}
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/cache/CacheEventLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/core/cache/CacheEventLogger.java
@@ -1,0 +1,43 @@
+package com.adaptris.core.cache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Implementation that implements {@link CacheEventListener} and logs all the events.
+ * 
+ * @config cache-event-logger
+ *
+ */
+@XStreamAlias("cache-event-logger")
+public class CacheEventLogger implements CacheEventListener {
+
+  private transient Logger log = LoggerFactory.getLogger(this.getClass());
+
+  @Override
+  public void itemEvicted(String key, Object value) {
+    log.trace("Key [{}] evicted", key);
+  }
+
+  @Override
+  public void itemExpired(String key, Object value) {
+    log.trace("Key [{}] expired", key);
+  }
+
+  @Override
+  public void itemPut(String key, Object value) {
+    log.trace("Key [{}] put", key);
+  }
+
+  @Override
+  public void itemRemoved(String key, Object value) {
+    log.trace("Key [{}] removed", key);
+  }
+
+  @Override
+  public void itemUpdated(String key, Object value) {
+    log.trace("Key [{}] updated", key);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/cache/ExpiringMapCacheListener.java
+++ b/interlok-core/src/main/java/com/adaptris/core/cache/ExpiringMapCacheListener.java
@@ -17,18 +17,14 @@ package com.adaptris.core.cache;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-
 import net.jodah.expiringmap.ExpirationListener;
 
 /**
@@ -54,10 +50,8 @@ public class ExpiringMapCacheListener implements ExpirationListener<String, Obje
   }
 
   @Override
-  public void expired(String key, Object value) {
-    for (CacheEventListener listener : getListeners()) {
-      listener.itemExpired(key, value);
-    }
+  public void expired(final String key, final Object value) {
+    getListeners().forEach((l) -> l.itemExpired(key, value));
   }
 
   public Set<CacheEventListener> getListeners() {

--- a/interlok-core/src/main/java/com/adaptris/core/cache/NullCacheImplementation.java
+++ b/interlok-core/src/main/java/com/adaptris/core/cache/NullCacheImplementation.java
@@ -18,8 +18,6 @@ package com.adaptris.core.cache;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.adaptris.core.CoreException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -35,28 +33,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 public class NullCacheImplementation implements Cache {
 
   @Override
-  public void init() throws CoreException {
-  }
+  public void put(String key, Serializable value) {}
 
   @Override
-  public void start() throws CoreException {
-  }
-
-  @Override
-  public void stop() {
-  }
-
-  @Override
-  public void close() {
-  }
-
-  @Override
-  public void put(String key, Serializable value) {
-  }
-
-  @Override
-  public void put(String key, Object value) {
-  }
+  public void put(String key, Object value) {}
 
   @Override
   public Object get(String key) {
@@ -64,8 +44,7 @@ public class NullCacheImplementation implements Cache {
   }
 
   @Override
-  public void remove(String key) {
-  }
+  public void remove(String key) {}
 
   @Override
   public List<String> getKeys() {
@@ -73,11 +52,16 @@ public class NullCacheImplementation implements Cache {
   }
 
   @Override
-  public void clear() {
-  }
+  public void clear() {}
 
   @Override
   public int size() {
     return 0;
   }
+
+  @Override
+  public void put(String key, Serializable value, long ttl) {}
+
+  @Override
+  public void put(String key, Object value, long ttl) {}
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
@@ -55,10 +55,10 @@ public class AddValueToCache extends SingleKeyValueCacheImpl {
       // should be hasExpiry.ifPresentOrElse() once we goto J11...
       if (hasExpiry.isPresent()) {
         TimeInterval expiryInterval = hasExpiry.get().asInterval();
-        log.trace("Expiry for [{}], in [{}]", cacheKey, expiryInterval);
+        log.trace("[{}] will expire in {}", cacheKey, expiryInterval);
         cache.put(cacheKey, getValueTranslator().getValueFromMessage(msg), hasExpiry.get().asInterval());
       } else {
-        log.trace("Expiry for [{}], taken from cache settings", cacheKey);
+        log.trace("Expiry for [{}] taken from cache settings", cacheKey);
         cache.put(cacheKey, getValueTranslator().getValueFromMessage(msg));
       }
     } catch (Exception e) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
@@ -11,6 +11,7 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.UnresolvedMetadataException;
 import com.adaptris.core.cache.Cache;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.util.TimeInterval;
@@ -67,10 +68,13 @@ public class AddValueToCache extends SingleKeyValueCacheImpl {
   }
 
   private Optional<ExpiryWrapper> buildExpiry(AdaptrisMessage msg) {
-    final String value = msg.resolve(getExpiry());
-    Optional<ExpiryWrapper> result =
-        EXPIRY_PARSERS.stream().map((p) -> p.parse(value)).filter((o) -> o.isPresent()).findFirst().orElse(Optional.empty());
-    return result;
+    try {
+      final String value = msg.resolve(getExpiry());
+      return
+          EXPIRY_PARSERS.stream().map((p) -> p.parse(value)).filter((o) -> o.isPresent()).findFirst().orElse(Optional.empty());
+    } catch (UnresolvedMetadataException e) {
+      return Optional.empty();
+    }
   }
 
   public <T extends AddValueToCache> T withExpiry(String s) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
@@ -99,9 +99,10 @@ public class AddValueToCache extends SingleKeyValueCacheImpl {
    * The rules once the value has been resolved are :
    * </p>
    * <ul>
-   * <li>If the value is numeric and less than {@link System#currentTimeMillis()} then it is treated as relative to
-   * {@code now()}</li>
-   * <li>If the value is numberic and greater than {@link System#currentTimeMillis()} then it is treated as absolute</li>
+   * <li>If the value is numeric and less than {@link System#currentTimeMillis()} then it is treated as relative to {@code now()};
+   * expiry is in milliseconds</li>
+   * <li>If the value is numberic and greater than {@link System#currentTimeMillis()} then it is treated as absolute; expiry is in
+   * milliseconds</li>
    * <li>If the value is a recognised value from {@link DateFormatUtil#parse(String)} then it is treated as absolute</li>
    * <li>If it can't be resolved by any of those means, then it is ignored (i.e. treated as though there is no expiry).
    * </ul>

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/AddValueToCache.java
@@ -1,10 +1,21 @@
 package com.adaptris.core.services.cache;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.math.NumberUtils;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.cache.Cache;
 import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.util.TimeInterval;
+import com.adaptris.util.text.DateFormatUtil;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -23,15 +34,107 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("add-single-value-to-cache")
 @ComponentProfile(summary = "Add a single key/value to the configured cache cache", since = "3.9.2", tag = "service,cache",
     recommended = {CacheConnection.class})
+@DisplayOrder(order = {"connection", "key", "valueTranslator", "expiry"})
 public class AddValueToCache extends SingleKeyValueCacheImpl {
+
+  private static final List<ExpiryParser> EXPIRY_PARSERS =
+      Collections.unmodifiableList(
+          Arrays.asList(new ExpiryParser[] {
+          (val) -> build(DateFormatUtil.parse(val, null)),
+          (val) -> build(val)
+      }));
+
+  @InputFieldHint(expression = true)
+  private String expiry;
 
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     try {
       Cache cache = retrieveCache();
-      cache.put(msg.resolve(getKey()), getValueTranslator().getValueFromMessage(msg));
+      Optional<ExpiryWrapper> hasExpiry = buildExpiry(msg);
+      // should be hasExpiry.ifPresentOrElse() once we goto J11...
+      if (hasExpiry.isPresent()) {
+        cache.put(msg.resolve(getKey()), getValueTranslator().getValueFromMessage(msg), hasExpiry.get().asInterval());
+      } else {
+        cache.put(msg.resolve(getKey()), getValueTranslator().getValueFromMessage(msg));
+      }
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
     }
+  }
+
+  private Optional<ExpiryWrapper> buildExpiry(AdaptrisMessage msg) {
+    final String value = msg.resolve(getExpiry());
+    Optional<ExpiryWrapper> result =
+        EXPIRY_PARSERS.stream().map((p) -> p.parse(value)).filter((o) -> o.isPresent()).findFirst().orElse(Optional.empty());
+    return result;
+  }
+
+  public <T extends AddValueToCache> T withExpiry(String s) {
+    setExpiry(s);
+    return (T) this;
+  }
+
+  public String getExpiry() {
+    return expiry;
+  }
+
+  private static Optional<ExpiryWrapper> build(final Date date) {
+    return Optional.ofNullable(date).map(d -> Optional.of(new ExpiryWrapper(d))).orElse(Optional.empty());
+  }
+
+  private static Optional<ExpiryWrapper> build(final String millis) {
+    return Optional.ofNullable(millis).filter(t -> NumberUtils.isCreatable(t))
+        .map(t -> Optional.of(new ExpiryWrapper(NumberUtils.toLong(t)))).orElse(Optional.empty());
+  }
+
+  /**
+   * Set the cache expiry for any value added to the cache (if any).
+   * 
+   * <p>
+   * The rules once the value has been resolved are :
+   * </p>
+   * <ul>
+   * <li>If the value is a recognised value from {@link DateFormatUtil#parse(String)} then it is treated as absolute</li>
+   * <li>If the value is numeric and less than {@link System#currentTimeMillis()} then it is treated as relative to
+   * {@code now()}</li>
+   * <li>If the value is numberic and greater than {@link System#currentTimeMillis()} then it is treated as absolute</li>
+   * <li>If it can't be resolved by any of those means, then it is ignored (i.e. treated as though there is no expiry).
+   * </ul>
+   * 
+   * @param s the expiry, which supports the {@code %message{}} syntax to resolve metadata.
+   */
+  public void setExpiry(String s) {
+    this.expiry = s;
+  }
+
+  // Can't do an array of generic functions so new Function<String,Optional<ExpiryWrapper>>[] isn't loved by the
+  // compiler. This is basically a Function though.
+  @FunctionalInterface
+  private static interface ExpiryParser {
+    Optional<ExpiryWrapper> parse(String s);
+  }
+
+  private static class ExpiryWrapper {
+    private long expiryValue;
+
+    public ExpiryWrapper(long absoluteOrRelativeMs) {
+      if (absoluteOrRelativeMs < System.currentTimeMillis()) {
+        expiryValue = absoluteOrRelativeMs;
+      } else {
+        expiryValue = absoluteOrRelativeMs - System.currentTimeMillis();
+      }
+    }
+
+    public ExpiryWrapper(Date futureDate) {
+      Date now = new Date();
+      expiryValue = futureDate.getTime() - now.getTime();
+    }
+
+    public TimeInterval asInterval() {
+      return new TimeInterval(expiryValue, TimeUnit.MILLISECONDS);
+    }
+
+
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/GetValueFromCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/GetValueFromCache.java
@@ -2,6 +2,7 @@ package com.adaptris.core.services.cache;
 
 import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
@@ -24,6 +25,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("get-single-value-from-cache")
 @ComponentProfile(summary = "Retrieve a value from the configured cache", since = "3.9.2", tag = "service,cache",
     recommended = {CacheConnection.class})
+@DisplayOrder(order = {"connection", "key", "valueTranslator", "exceptionIfNotFound"})
 public class GetValueFromCache extends SingleKeyValueCacheImpl {
 
   @InputFieldDefault(value = "true")

--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/RemoveKeyFromCache.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/RemoveKeyFromCache.java
@@ -1,6 +1,7 @@
 package com.adaptris.core.services.cache;
 
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.cache.Cache;
@@ -17,6 +18,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("remove-key-from-cache")
 @ComponentProfile(summary = "Remove a key from the configured cache", since = "3.9.2", tag = "service,cache",
     recommended = {CacheConnection.class})
+@DisplayOrder(order = {"connection", "key"})
 public class RemoveKeyFromCache extends SingleKeyCacheService {
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/util/TimeInterval.java
+++ b/interlok-core/src/main/java/com/adaptris/util/TimeInterval.java
@@ -16,9 +16,13 @@
 
 package com.adaptris.util;
 
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
+import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -32,14 +36,23 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("time-interval")
 @DisplayOrder(order = {"interval", "unit"})
 public class TimeInterval {
-
+  @InputFieldDefault(value = "SECONDS")
   private TimeUnit unit;
+  @InputFieldDefault(value = "10")
   private Long interval;
 
   private static final long DEFAULT_INTERVAL = 10L;
   private static final TimeUnit DEFAULT_UNIT = TimeUnit.SECONDS;
 
   public TimeInterval() {
+  }
+
+  /**
+   * Create a time interval from a duration.
+   * 
+   */
+  public TimeInterval(Duration d) {
+    this(d.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   public TimeInterval(Long interval, String unit) {
@@ -52,19 +65,13 @@ public class TimeInterval {
   }
 
   public long toMilliseconds() {
-    TimeUnit unit = getUnit() != null ? getUnit() : DEFAULT_UNIT;
-    return unit.toMillis(getInterval() != null ? getInterval().longValue() : DEFAULT_INTERVAL);
+    return ObjectUtils.defaultIfNull(getUnit(), DEFAULT_UNIT)
+        .toMillis(NumberUtils.toLongDefaultIfNull(getInterval(), DEFAULT_INTERVAL));
   }
 
   private static TimeUnit parse(String s) {
-    TimeUnit result = TimeUnit.SECONDS;
-    for (TimeUnit tu : TimeUnit.values()) {
-      if (tu.name().equalsIgnoreCase(s)) {
-        result = tu;
-        break;
-      }
-    }
-    return result;
+    Optional<TimeUnit> parsed = Arrays.stream(TimeUnit.values()).filter((t) -> t.name().equalsIgnoreCase(s)).findFirst();
+    return parsed.orElse(TimeUnit.SECONDS);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/util/TimeInterval.java
+++ b/interlok-core/src/main/java/com/adaptris/util/TimeInterval.java
@@ -16,7 +16,6 @@
 
 package com.adaptris.util;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -45,14 +44,6 @@ public class TimeInterval {
   private static final TimeUnit DEFAULT_UNIT = TimeUnit.SECONDS;
 
   public TimeInterval() {
-  }
-
-  /**
-   * Create a time interval from a duration.
-   * 
-   */
-  public TimeInterval(Duration d) {
-    this(d.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   public TimeInterval(Long interval, String unit) {

--- a/interlok-core/src/main/java/com/adaptris/util/text/DateFormatUtil.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/DateFormatUtil.java
@@ -23,6 +23,8 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Optional;
+import org.apache.commons.lang3.ObjectUtils;
 
 /**
  * Contains convenience method to format date strings into Date objects. <br>
@@ -142,16 +144,25 @@ public final class DateFormatUtil {
    * @return the date
    */
   public static Date parse(String s) {
-    if (s == null) {
-      return new Date();
-    }
+    return parse(s, new Date());
+  }
+
+  /**
+   * Return a date object from a given string returning a default if it could not.
+   *
+   * @param s the date in string format
+   * @param defaultDate the default Date (which could be null)
+   * @return the date
+   */
+  public static Date parse(String s, Date defaultDate) {
     Date date = useDefaultFormatter(s);
     int i = 0;
     while (date == null && i < DATE_FORMATS.length) {
       date = getDate(s, DATE_FORMATS[i++]);
     }
-    return date == null ? new Date() : date;
+    return ObjectUtils.defaultIfNull(date, defaultDate);
   }
+
 
   /**
    * Return the default formatted String for a given date.
@@ -189,20 +200,17 @@ public final class DateFormatUtil {
   }
 
 
-  private static Date useDefaultFormatter(String s) {
-
-    DateFormat df = DateFormat.getDateTimeInstance();
-    return df.parse(s, new ParsePosition(0));
+  private static Date useDefaultFormatter(String str) {
+    return Optional.ofNullable(str).map((s) -> DateFormat.getDateTimeInstance().parse(s, new ParsePosition(0))).orElse(null);
   }
 
   private static Date getDate(String s, String format) {
     Date d = null;
-
     SimpleDateFormat sdf = new SimpleDateFormat(format);
     try {
       d = sdf.parse(s);
     }
-    catch (ParseException e) {
+    catch (ParseException | NullPointerException e) {
       d = null;
     }
     return d;

--- a/interlok-core/src/test/java/com/adaptris/core/cache/CacheDefaultMethodsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/cache/CacheDefaultMethodsTest.java
@@ -1,11 +1,11 @@
 package com.adaptris.core.cache;
 
 import java.io.Serializable;
-
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
-
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.TimeInterval;
 
 public class CacheDefaultMethodsTest implements Cache {
 
@@ -19,7 +19,6 @@ public class CacheDefaultMethodsTest implements Cache {
       LifecycleHelper.stopAndClose(this);
     }
   }
-
 
   @Test(expected = UnsupportedOperationException.class)
   public void testDefaultGetKeys() throws Exception {
@@ -50,6 +49,29 @@ public class CacheDefaultMethodsTest implements Cache {
       LifecycleHelper.stopAndClose(this);
     }
   }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testDefaultPutSerializable_WithExpiration() throws Exception {
+    TimeInterval expiry = new TimeInterval(250L, TimeUnit.MILLISECONDS);
+    try {
+      LifecycleHelper.initAndStart(this);
+      put("hello", "", expiry);
+    } finally {
+      LifecycleHelper.stopAndClose(this);
+    }
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testDefaultPutObject_WithExpiration() throws Exception {
+    TimeInterval expiry = new TimeInterval(250L, TimeUnit.MILLISECONDS);
+    try {
+      LifecycleHelper.initAndStart(this);
+      put("hello", new Object(), expiry);
+    } finally {
+      LifecycleHelper.stopAndClose(this);
+    }
+  }
+
 
   @Override
   public void put(String key, Serializable value) throws CoreException {

--- a/interlok-core/src/test/java/com/adaptris/core/cache/CacheEventLoggerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/cache/CacheEventLoggerTest.java
@@ -1,0 +1,37 @@
+package com.adaptris.core.cache;
+
+import org.junit.Test;
+
+public class CacheEventLoggerTest {
+
+  @Test
+  public void testItemEvicted() {
+    CacheEventLogger logger = new CacheEventLogger();
+    logger.itemEvicted("key", new Object());
+  }
+
+  @Test
+  public void testItemExpired() {
+    CacheEventLogger logger = new CacheEventLogger();
+    logger.itemExpired("key", new Object());
+  }
+
+  @Test
+  public void testItemPut() {
+    CacheEventLogger logger = new CacheEventLogger();
+    logger.itemPut("key", new Object());
+  }
+
+  @Test
+  public void testItemRemoved() {
+    CacheEventLogger logger = new CacheEventLogger();
+    logger.itemRemoved("key", new Object());
+  }
+
+  @Test
+  public void testItemUpdated() {
+    CacheEventLogger logger = new CacheEventLogger();
+    logger.itemUpdated("key", new Object());
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/cache/MyCacheEventListener.java
+++ b/interlok-core/src/test/java/com/adaptris/core/cache/MyCacheEventListener.java
@@ -15,35 +15,57 @@
 */
 package com.adaptris.core.cache;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class MyCacheEventListener implements CacheEventListener {
-  public int evictedItems = 0;
-  public int expiredItems = 0;
-  public int putItems = 0;
-  public int removedItems = 0;
-  public int updatedItems = 0;
+  private AtomicInteger evictedItems = new AtomicInteger(0);
+  private AtomicInteger expiredItems = new AtomicInteger(0);;
+  private AtomicInteger putItems = new AtomicInteger(0);;
+  private AtomicInteger removedItems = new AtomicInteger(0);;
+  private AtomicInteger updatedItems = new AtomicInteger(0);;
 
   @Override
   public void itemEvicted(String key, Object value) {
-    evictedItems++;
+    evictedItems.incrementAndGet();
   }
 
   @Override
   public void itemExpired(String key, Object value) {
-    expiredItems++;
+    expiredItems.incrementAndGet();
   }
 
   @Override
   public void itemPut(String key, Object value) {
-    putItems++;
+    putItems.incrementAndGet();
   }
 
   @Override
   public void itemRemoved(String key, Object value) {
-    removedItems++;
+    removedItems.incrementAndGet();
   }
 
   @Override
   public void itemUpdated(String key, Object value) {
-    updatedItems++;
+    updatedItems.incrementAndGet();
+  }
+
+  public int evictCount() {
+    return evictedItems.get();
+  }
+
+  public int expiredCount() {
+    return expiredItems.get();
+  }
+
+  public int putCount() {
+    return putItems.get();
+  }
+
+  public int removedCount() {
+    return removedItems.get();
+  }
+
+  public int updatedCount() {
+    return updatedItems.get();
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/cache/NullCacheImplementationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/cache/NullCacheImplementationTest.java
@@ -20,12 +20,12 @@ import static com.adaptris.core.util.LifecycleHelper.stopAndClose;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-
 import java.util.List;
-
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import com.adaptris.util.TimeInterval;
 
 public class NullCacheImplementationTest {
 
@@ -111,6 +111,22 @@ public class NullCacheImplementationTest {
       assertFalse(x == y);
     }
     finally {
+      stopAndClose(cache);
+    }
+  }
+
+
+  @Test
+  public void testPut_WithExpiration() throws Exception {
+    NullCacheImplementation cache = new NullCacheImplementation();
+    TimeInterval expiry = new TimeInterval(250L, TimeUnit.MILLISECONDS);
+    initAndStart(cache);
+    try {
+      cache.put("one", "1", expiry);
+      cache.put("object", new Object(), expiry);
+      assertEquals(0, cache.size());
+      assertEquals(0, cache.getKeys().size());
+    } finally {
       stopAndClose(cache);
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/AddValueToCacheTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/AddValueToCacheTest.java
@@ -1,16 +1,26 @@
 package com.adaptris.core.services.cache;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import java.time.Duration;
+import java.util.Date;
 import java.util.EnumSet;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.cache.Cache;
+import com.adaptris.core.cache.ExpiringMapCache;
+import com.adaptris.core.cache.MyCacheEventListener;
 import com.adaptris.core.services.cache.translators.StringPayloadCacheTranslator;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
+import com.adaptris.util.TimeInterval;
+import com.adaptris.util.text.DateFormatUtil;
 
 public class AddValueToCacheTest extends SingleKeyCacheCase {
   @Override
@@ -54,6 +64,124 @@ public class AddValueToCacheTest extends SingleKeyCacheCase {
     }
   }
 
+
+  @Test
+  public void testDoService_NoExpiry() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    ExpiringMapCache cache = createCacheInstanceForTests().withExpiration(new TimeInterval(1L, TimeUnit.SECONDS));
+    MyCacheEventListener listener = new MyCacheEventListener();    
+    cache.getEventListener().addEventListener(listener);
+    AddValueToCache service =
+        new AddValueToCache().withExpiry("%message{expiry}").withValueTranslator(new StringPayloadCacheTranslator())
+        .withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      msg.addMetadata("expiry", "a"); // empty expiry should not expire.
+      service.doService(msg);
+      Object value = cache.get(msg.getUniqueId());
+      assertEquals("Hello World", value);
+      // Default expiration is > 5 seconds.
+      await()
+          .atMost(Duration.ofSeconds(5))
+          .with()
+          .pollInterval(Duration.ofMillis(100))
+          .until(listener::expiredCount, greaterThanOrEqualTo(1));
+      assertEquals(0, cache.size());      
+    } finally {
+      stop(service);
+    }
+  }
+  
+  @Test
+  public void testDoService_RelativeExpiry() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    ExpiringMapCache cache = createCacheInstanceForTests();
+    MyCacheEventListener listener = new MyCacheEventListener();    
+    cache.getEventListener().addEventListener(listener);
+    AddValueToCache service =
+        new AddValueToCache().withExpiry("%message{expiry}").withValueTranslator(new StringPayloadCacheTranslator())
+        .withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      msg.addMetadata("expiry", "500"); // relative expiry, 500ms
+      service.doService(msg);
+      Object value = cache.get(msg.getUniqueId());
+      assertEquals("Hello World", value);
+      
+      // Default expiration is > 5 seconds.
+      await()
+          .atMost(Duration.ofSeconds(5))
+          .with()
+          .pollInterval(Duration.ofMillis(100))
+          .until(listener::expiredCount, greaterThanOrEqualTo(1));
+      assertEquals(0, cache.size());      
+    } finally {
+      stop(service);
+    }
+  }
+
+  @Test
+  public void testDoService_AbsoluteExpiry_Millis() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    ExpiringMapCache cache = createCacheInstanceForTests();
+    MyCacheEventListener listener = new MyCacheEventListener();    
+    cache.getEventListener().addEventListener(listener);
+    AddValueToCache service =
+        new AddValueToCache().withExpiry("%message{expiry}").withValueTranslator(new StringPayloadCacheTranslator())
+        .withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      // Expire in 2 seconds or so.
+      long expiry = System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000) + 1000;
+      msg.addMetadata("expiry", String.valueOf(expiry));
+      System.err.println(getName() + ":" + msg.getMetadataValue("expiry"));
+      service.doService(msg);
+      Object value = cache.get(msg.getUniqueId());
+      assertEquals("Hello World", value);
+      
+      // Default expiration is > 5 seconds.
+      await()
+          .atMost(Duration.ofSeconds(5))
+          .with()
+          .pollInterval(Duration.ofMillis(100))
+          .until(listener::expiredCount, greaterThanOrEqualTo(1));
+      assertEquals(0, cache.size());      
+    } finally {
+      stop(service);
+    }
+  }
+
+  
+  @Test
+  public void testDoService_AbsoluteExpiry_Date() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    ExpiringMapCache cache = createCacheInstanceForTests();
+    MyCacheEventListener listener = new MyCacheEventListener();    
+    cache.getEventListener().addEventListener(listener);
+    AddValueToCache service =
+        new AddValueToCache().withExpiry("%message{expiry}").withValueTranslator(new StringPayloadCacheTranslator())
+        .withKey("%message{%uniqueId}").withConnection(new CacheConnection().withCacheInstance(cache));
+    try {
+      start(service);
+      // Expire in 2 seconds or so.
+      Date expiry = new Date(System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000) + 1000);
+      msg.addMetadata("expiry", DateFormatUtil.format(expiry));
+      service.doService(msg);
+      Object value = cache.get(msg.getUniqueId());
+      assertEquals("Hello World", value);
+      
+      // Default expiration is > 5 seconds.
+      await()
+          .atMost(Duration.ofSeconds(5))
+          .with()
+          .pollInterval(Duration.ofMillis(100))
+          .until(listener::expiredCount, greaterThanOrEqualTo(1));
+      assertEquals(0, cache.size());      
+    } finally {
+      stop(service);
+    }
+  }
+  
   @Override
   protected AddValueToCache retrieveObjectForSampleConfig() {
     return new AddValueToCache().withValueTranslator(new StringPayloadCacheTranslator()).withKey("%message{%uniqueId}")


### PR DESCRIPTION
## Motivation

If you are using OAUTH; then often you get `expires_in` which tells you when the token expires. This could differ from provider to provider; but you want to store all the tokens in the same cache. At the moment you need to set the cache to expire for the "shortest" provider; rather than having a per-item expiry, with the cache lifetime set to something longer.

Note that JSR107 cache implementions don't appear to allow for per-item expiry; so this probably doesn't work for anything other than the expiring-map-cache implementation that's bundled with interlok core.

## Modification

Added new methods to the `Cache` interface; the default is to throw UnsupportedOperationExceptions which means no changes required to the things in interlok-cache 

Retrofit expiry into add-single-value-to-cache so that this supports expiry, based on either a relative millisecond value, or an absolute date/millisecond value.

## Result

add-single-value-to-cache will allow you store things in the cache with a per-item expiry if you are using expiring-map-cache. 
If expiry is never configured (or unparseable), then it will just use the cache's settings.

## Testing

* Setup a add-single-value-to-cache service with an expiring map cache that expires in 1 day with a cache event logger, basically we're storing the payload in the cache against the message unique-id.
  * We're using the cache-event-logger just to log @ TRACE level when something expires.

```
<add-single-value-to-cache>
  <connection class="cache-connection">
    <cache-instance class="expiring-map-cache">
      <expiration>
        <unit>DAYS</unit>
        <interval>1</interval>
      </expiration>
      <expiration-policy>ACCESSED</expiration-policy>
      <event-listener>
        <cache-event-logger/>
      </event-listener>
    </cache-instance>
  </connection>
  <key>%message{%uniqueId}</key>
  <value-translator class="string-payload-cache-translator"/>
  <expiry>%message{expires}</expiry>
</add-single-value-to-cache>
```
* Add metadata that sets the expiry; it will be easiest to do this with a relative expiry (rather than an absolute expiry; you can if you want to using one of the formats supported by DateFormatUtil (e.g. `2020-04-09 08:31:00`)

```
<add-metadata-service>
  <metadata-element>
    <key>expires</key>
    <value>30000</value>
  </metadata-element>
</add-metadata-service>
```
* Trigger your workflow, and look at the logging : 

```
TRACE Expiry for [29c7b0a0-a0de-4394-bec2-7615628d8bc7], in [30 Seconds]
...
TRACE Key [29c7b0a0-a0de-4394-bec2-7615628d8bc7] expired
```
