### PR TITLE
INTERLOK-3225 auto cache oauth token

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/cache/CacheExpiry.java
+++ b/interlok-core/src/main/java/com/adaptris/core/cache/CacheExpiry.java
@@ -1,0 +1,86 @@
+package com.adaptris.core.cache;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import com.adaptris.util.TimeInterval;
+import com.adaptris.util.text.DateFormatUtil;
+
+public class CacheExpiry {
+  
+  private static final List<ExpiryParser> EXPIRY_PARSERS =
+      Collections.unmodifiableList(
+          Arrays.asList(new ExpiryParser[] {
+          (val) -> build(val),
+          (val) -> build(DateFormatUtil.parse(val, null))
+      }));
+  
+
+  private static Optional<Expiry> build(final Date date) {
+    return Optional.ofNullable(date).map(d -> Optional.of(new Expiry(d))).orElse(Optional.empty());
+  }
+
+  private static Optional<Expiry> build(final String millis) {
+    // don't use NumberUtils since we don't want to support a - number...
+    return Optional.ofNullable(millis).filter(t -> t.chars().allMatch(c -> c >= '0' && c <= '9'))
+        .map(t -> Optional.of(new Expiry(Long.parseLong(t)))).orElse(Optional.empty());
+  }
+
+  /**
+   * Build an expiry from the provided value.
+   * 
+   * <p>
+   * If the value is null or unparseable then {@link Optional#empty()} is returned otherwise the behaviour is :
+   * </p>
+   * <ul>
+   * <li>If the value is numeric and less than {@link System#currentTimeMillis()} then it is treated as relative to {@code now()};
+   * expiry is in milliseconds</li>
+   * <li>If the value is numberic and greater than {@link System#currentTimeMillis()} then it is treated as absolute; expiry is in
+   * milliseconds</li>
+   * <li>If the value is a recognised value from {@link DateFormatUtil#parse(String)} then it is treated as absolute</li>
+   * <li>If it can't be resolved by any of those means, then it is ignored (i.e. treated as though there is no expiry).
+   * </ul>
+   * </p>
+   * 
+   * @param value the value.
+   * @return an Optional containing the expiry.
+   */
+  public static Optional<Expiry> buildExpiry(String value) {
+    return EXPIRY_PARSERS.stream().map((p) -> p.parse(value)).filter((o) -> o.isPresent()).findFirst().orElse(Optional.empty());
+  }
+  
+  public static class Expiry {
+    private transient TimeInterval expiry;
+
+    private Expiry(long absoluteOrRelativeMs) {
+      long now = System.currentTimeMillis();
+      if (absoluteOrRelativeMs < now) {
+        expiry = new TimeInterval(absoluteOrRelativeMs, TimeUnit.MILLISECONDS);
+      } else {
+        expiry = new TimeInterval(absoluteOrRelativeMs - now, TimeUnit.MILLISECONDS);
+      }
+    }
+
+    private Expiry(Date futureDate) {
+      Date now = new Date();
+      expiry = new TimeInterval(futureDate.getTime() - now.getTime(), TimeUnit.MILLISECONDS);
+    }
+
+    public TimeInterval expiresIn() {
+      return expiry;
+    }
+  }
+
+
+  // Can't do an array of generic functions so new Function<String,Optional<ExpiryWrapper>>[] isn't loved by the
+  // compiler. This is basically a Function though.
+  @FunctionalInterface
+  private static interface ExpiryParser {
+    Optional<Expiry> parse(String s);
+  }
+
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessToken.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessToken.java
@@ -1,5 +1,6 @@
 package com.adaptris.core.http.oauth;
 
+import java.io.Serializable;
 import java.util.Date;
 import com.adaptris.util.text.DateFormatUtil;
 
@@ -7,9 +8,11 @@ import com.adaptris.util.text.DateFormatUtil;
  * Wrapper around an OAUTH token.
  *
  */
-public class AccessToken {
+public class AccessToken implements Serializable {
 
+  private static final long serialVersionUID = 2020042101L;
   private static final String DEFAULT_TOKEN_TYPE = "Bearer";
+
   private String type;
   private String token;
   private String expiry;
@@ -17,7 +20,10 @@ public class AccessToken {
 
   /**
    * Calls {@link #AccessToken(String, String, long)} with {@code Bearer} as the type.
+   * 
+   * @deprecated since 3.10.1 with no replacement (use {@link #withExpiry(String)}) instead.
    */
+  @Deprecated
   public AccessToken(String token, long expiry) {
     this(DEFAULT_TOKEN_TYPE, token, expiry);
   }
@@ -32,6 +38,7 @@ public class AccessToken {
   /**
    * Calls {@link #AccessToken(String, String, long)} with {@code -1} as the expiry
    */
+  @SuppressWarnings("deprecation")
   public AccessToken(String type, String token) {
     this(type, token, -1);
   }
@@ -41,8 +48,10 @@ public class AccessToken {
    * 
    * @param type the token type (usually {@code 'Bearer'})
    * @param token the token itself.
-   * @param expiry the expiry; if there is no expiry, then use -1
+   * @param expiry the expiry; if there is no expiry in milliseconds (absolute), then use -1
+   * @deprecated since 3.10.1 with no replacement (use {@link #withExpiry(String)}) instead.
    */
+  @Deprecated
   public AccessToken(String type, String token, long expiry) {
     setType(type);
     setToken(token);
@@ -83,6 +92,11 @@ public class AccessToken {
 
   public void setExpiry(String expiry) {
     this.expiry = expiry;
+  }
+
+  public AccessToken withExpiry(String s) {
+    setExpiry(s);
+    return this;
   }
 
   public String getRefreshToken() {

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessToken.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessToken.java
@@ -99,6 +99,11 @@ public class AccessToken implements Serializable {
     return this;
   }
 
+  public AccessToken withExpiry(Date d) {
+    return withExpiry(DateFormatUtil.format(d));
+  }
+
+
   public String getRefreshToken() {
     return refreshToken;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessTokenBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessTokenBuilder.java
@@ -1,11 +1,11 @@
 package com.adaptris.core.http.oauth;
 
 import java.io.IOException;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ComponentLifecycle;
 import com.adaptris.core.CoreException;
 
+@FunctionalInterface
 public interface AccessTokenBuilder extends ComponentLifecycle {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessTokenWriter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessTokenWriter.java
@@ -1,0 +1,14 @@
+package com.adaptris.core.http.oauth;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ComponentLifecycle;
+
+@FunctionalInterface
+public interface AccessTokenWriter extends ComponentLifecycle {
+
+  /**
+   * Apply the token to the message.
+   * 
+   */
+  void apply(AccessToken token, AdaptrisMessage msg);
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/GetAndCacheOauthToken.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/GetAndCacheOauthToken.java
@@ -1,0 +1,172 @@
+package com.adaptris.core.http.oauth;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ConnectedService;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.cache.CacheExpiry;
+import com.adaptris.core.cache.CacheExpiry.Expiry;
+import com.adaptris.core.cache.CacheProvider;
+import com.adaptris.core.cache.ExpiringMapCache;
+import com.adaptris.core.services.cache.CacheConnection;
+import com.adaptris.core.services.cache.CheckCacheService;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.TimeInterval;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import net.jodah.expiringmap.ExpirationPolicy;
+
+/**
+ * Variation of {@link GetOauthToken} that automatically caches the {@link AccessToken} in the cache of your choosing.
+ * 
+ * <p>
+ * If the 'key' exists in the cache, then that is retrieved, and used. If it does not, then the configured
+ * {@link AccessTokenBuilder} is used to generate the access token; which is cached against the specified key. If an expiry is
+ * available, then that's used to as the expiry for the token within the cache. Bear in mind that not all caches support a
+ * per-item-expiry; {@link ExpiringMapCache} does and by default a {@link CacheConnection} with this configured will be used.
+ * </p>
+ * <p>
+ * Note that previously you would have composed a chain of services to achieve the same thing (probably involving
+ * {@link CheckCacheService} or similar); this just simplifies that chain into a single step since you almost certainly want to
+ * cache the access token.
+ * </p>
+ * 
+ * @config get-and-cache-oauth-token
+ * 
+ */
+@XStreamAlias("get-and-cache-oauth-token")
+@ComponentProfile(summary = "Get a cached OAUTH token or get a token and cache it", since = "3.10.1",
+    tag = "service,http,https,oauth",
+    recommended = {CacheConnection.class})
+@DisplayOrder(order = {"cacheKey", "connection", "accessTokenBuilder", "accessTokenWriter"})
+public class GetAndCacheOauthToken extends OauthTokenGetter implements ConnectedService {
+
+
+  @NotBlank
+  @InputFieldHint(expression = true)
+  private String cacheKey;
+
+  @NotNull
+  @Valid
+  private AdaptrisConnection connection;
+
+  public GetAndCacheOauthToken() {
+    setConnection(new CacheConnection(new ExpiringMapCache().withExpiration(new TimeInterval(1L, TimeUnit.HOURS))
+        .withExpirationPolicy(ExpirationPolicy.ACCESSED)));
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+    super.prepare();
+    Args.notNull(getConnection(), "connection");
+    Args.notBlank(getCacheKey(), "cache-key");
+    LifecycleHelper.prepare(getConnection());
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+    super.initService();
+    LifecycleHelper.init(getConnection());
+  }
+
+  @Override
+  public void start() throws CoreException {
+    super.start();
+    LifecycleHelper.start(getConnection());
+  }
+
+  @Override
+  public void stop() {
+    LifecycleHelper.stop(getConnection());
+    super.stop();
+  }
+
+  @Override
+  protected void closeService() {
+    LifecycleHelper.close(getConnection());
+    super.closeService();
+  }
+
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      Cache cache = getConnection().retrieveConnection(CacheProvider.class).retrieveCache();
+      String key = msg.resolve(getCacheKey());
+      AccessToken token = (AccessToken) cache.get(key);
+      if (token == null) {
+        token = getAccessTokenBuilder().build(msg);
+        addToCache(cache, key, token);
+      }
+      tokenWriterToUse().apply(token, msg);
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+
+  private void addToCache(Cache cache, String key, AccessToken token) throws Exception {
+    Optional<Expiry> hasExpiry = CacheExpiry.buildExpiry(token.getExpiry());
+    // should be hasExpiry.ifPresentOrElse() once we goto J11...
+    if (hasExpiry.isPresent()) {
+      TimeInterval expiryInterval = hasExpiry.get().expiresIn();
+      log.trace("[{}] will expire in {}", key, expiryInterval);
+      cache.put(key, token, hasExpiry.get().expiresIn());
+    } else {
+      log.trace("Expiry for [{}] taken from cache settings", key);
+      cache.put(key, token);
+    }
+  }
+
+
+  /**
+   * The connection to the cache where tokens will be stored.
+   * <p>
+   * If not expilicitly configured, will be defaulted to {@link ExpiringMapCache}; 1 Hour + ExpirationPolicy.ACCESSED.
+   * </p>
+   */
+  @Override
+  public void setConnection(AdaptrisConnection c) {
+    connection = Args.notNull(c, "connection");
+  }
+
+  @Override
+  public AdaptrisConnection getConnection() {
+    return connection;
+  }
+
+  public GetAndCacheOauthToken withConnection(AdaptrisConnection c) {
+    setConnection(c);
+    return this;
+  }
+
+  public String getCacheKey() {
+    return cacheKey;
+  }
+
+  /**
+   * Set the key to the cache.
+   * 
+   * @param cacheKey the key to the cache.
+   */
+  public void setCacheKey(String cacheKey) {
+    this.cacheKey = Args.notBlank(cacheKey, "cacheKey");
+  }
+
+  public GetAndCacheOauthToken withCacheKey(String s) {
+    setCacheKey(s);
+    return this;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/GetAndCacheOauthToken.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/GetAndCacheOauthToken.java
@@ -106,8 +106,11 @@ public class GetAndCacheOauthToken extends OauthTokenGetter implements Connected
       String key = msg.resolve(getCacheKey());
       AccessToken token = (AccessToken) cache.get(key);
       if (token == null) {
+        log.trace("[{}] not found in cache; requesting new token", key);
         token = getAccessTokenBuilder().build(msg);
         addToCache(cache, key, token);
+      } else {
+        log.trace("[{}] found in cache", key);
       }
       tokenWriterToUse().apply(token, msg);
     } catch (Exception e) {

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/MetadataAccessTokenWriter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/MetadataAccessTokenWriter.java
@@ -1,0 +1,115 @@
+package com.adaptris.core.http.oauth;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import javax.validation.constraints.NotBlank;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AffectsMetadata;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.util.Args;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Write the token to metadata.
+ * 
+ * @config oauth-access-token-to-metadata
+ */
+@XStreamAlias("oauth-access-token-to-metadata")
+@ComponentProfile(summary = "Write the OAUTH token to metadata", since = "3.10.1")
+@DisplayOrder(order = {"tokenKey", "tokenExpiryKey", "refreshTokenKey"})
+public class MetadataAccessTokenWriter implements AccessTokenWriter {
+
+  @NotBlank
+  @AffectsMetadata
+  @InputFieldDefault(value = "Authorization")
+  private String tokenKey;
+  @AffectsMetadata
+  @AdvancedConfig
+  private String tokenExpiryKey;
+  @AffectsMetadata
+  @AdvancedConfig
+  private String refreshTokenKey;
+
+
+  public MetadataAccessTokenWriter() {
+    setTokenKey("Authorization");
+  }
+
+  @Override
+  public void apply(AccessToken token, AdaptrisMessage msg) {
+    String tokenMetadataValue = String.format("%s %s", token.getType(), token.getToken());
+    msg.addMessageHeader(getTokenKey(), tokenMetadataValue);
+    if (!isBlank(getTokenExpiryKey()) && !isBlank(token.getExpiry())) {
+      msg.addMessageHeader(getTokenExpiryKey(), token.getExpiry());
+    }
+    if (!isBlank(getRefreshTokenKey()) && !isBlank(token.getRefreshToken())) {
+      msg.addMessageHeader(getRefreshTokenKey(), token.getRefreshToken());
+    }
+  }
+
+  public MetadataAccessTokenWriter withTokenKey(String b) {
+    setTokenKey(b);
+    return this;
+  }
+
+
+  public String getTokenKey() {
+    return tokenKey;
+  }
+
+  /**
+   * Set the metadata to store the token against.
+   * 
+   * @param key the key.
+   */
+  public void setTokenKey(String key) {
+    this.tokenKey = Args.notBlank(key, "tokenMetadataKey");
+  }
+
+  public MetadataAccessTokenWriter withTokenExpiryKey(String b) {
+    setTokenExpiryKey(b);
+    return this;
+  }
+
+  public String getTokenExpiryKey() {
+    return tokenExpiryKey;
+  }
+
+  /**
+   * Set the metadata key for storing the expiry.
+   * <p>
+   * In some cases, there is no expiry date for a token, in which case, the metadata key will never be set even if configured.
+   * Depending on how you have configured your expiry token, this might be an absolute ISO8601 date, or relative time in seconds.
+   * </p>
+   * 
+   * @param key key.
+   */
+  public void setTokenExpiryKey(String key) {
+    this.tokenExpiryKey = key;
+  }
+
+  public MetadataAccessTokenWriter withRefreshTokenKey(String refreshMetadataKey) {
+    setRefreshTokenKey(refreshMetadataKey);
+    return this;
+  }
+
+  public String getRefreshTokenKey() {
+    return refreshTokenKey;
+  }
+
+  /**
+   * Set the metadata key for storing the refresh token.
+   * <p>
+   * In some cases, there is no refresh token, in which case, the metadata key will never be set even if configured.
+   * </p>
+   * 
+   * @param key key.
+   */
+  public void setRefreshTokenKey(String key) {
+    this.refreshTokenKey = key;
+  }
+
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/OauthTokenGetter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/OauthTokenGetter.java
@@ -1,0 +1,111 @@
+package com.adaptris.core.http.oauth;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.LifecycleHelper;
+
+public abstract class OauthTokenGetter extends ServiceImp {
+  @InputFieldDefault(value = "oauth-access-token-to-metadata")
+  @Valid
+  private AccessTokenWriter accessTokenWriter;
+
+  @NotNull
+  @Valid
+  private AccessTokenBuilder accessTokenBuilder;
+
+  private transient AccessTokenWriter tokenWriterToUse;
+
+  public OauthTokenGetter() {
+
+  }
+
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notNull(getAccessTokenBuilder(), "accessTokenBuilder");
+    LifecycleHelper.prepare(getAccessTokenBuilder());
+    tokenWriterToUse = tokenWriterIfNull();
+    LifecycleHelper.prepare(tokenWriterToUse);
+  }
+
+  protected AccessTokenWriter tokenWriterIfNull() {
+    return ObjectUtils.defaultIfNull(getAccessTokenWriter(), new MetadataAccessTokenWriter());
+  }
+
+  protected AccessTokenWriter tokenWriterToUse() {
+    return tokenWriterToUse;
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+    LifecycleHelper.init(getAccessTokenBuilder());
+    LifecycleHelper.init(tokenWriterToUse);
+  }
+
+  @Override
+  public void start() throws CoreException {
+    super.start();
+    LifecycleHelper.start(getAccessTokenBuilder());
+    LifecycleHelper.start(tokenWriterToUse);
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+    LifecycleHelper.stop(getAccessTokenBuilder());
+    LifecycleHelper.stop(tokenWriterToUse);
+  }
+
+  @Override
+  protected void closeService() {
+    LifecycleHelper.close(getAccessTokenBuilder());
+    LifecycleHelper.close(tokenWriterToUse);
+  }
+
+
+  public <T extends OauthTokenGetter> T withAccessTokenBuilder(AccessTokenBuilder b) {
+    setAccessTokenBuilder(b);
+    return (T) this;
+  }
+
+  public AccessTokenBuilder getAccessTokenBuilder() {
+    return accessTokenBuilder;
+  }
+
+
+  /**
+   * Set the access token builder.
+   * 
+   * @param b the builder.
+   */
+  public void setAccessTokenBuilder(AccessTokenBuilder b) {
+    this.accessTokenBuilder = Args.notNull(b, "accessTokenBuilder");
+  }
+
+
+  public <T extends OauthTokenGetter> T withAccessTokenWriter(AccessTokenWriter b) {
+    setAccessTokenWriter(b);
+    return (T) this;
+  }
+
+  public AccessTokenWriter getAccessTokenWriter() {
+    return accessTokenWriter;
+  }
+
+
+  /**
+   * Specify how to write the access token once it is retrieved.
+   * 
+   * @param b the writer.
+   */
+  public void setAccessTokenWriter(AccessTokenWriter b) {
+    this.accessTokenWriter = b;
+  }
+
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/cache/CacheExpiryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/cache/CacheExpiryTest.java
@@ -1,0 +1,36 @@
+package com.adaptris.core.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import com.adaptris.util.text.DateFormatUtil;
+
+public class CacheExpiryTest extends CacheExpiry {
+
+  @Before
+  public void setUp() throws Exception {}
+
+  @After
+  public void tearDown() throws Exception {}
+
+  @Test
+  public void testBuildExpiry() {
+    assertEquals(Optional.empty(), CacheExpiry.buildExpiry(null));
+    // Should be relative
+    Optional<Expiry> o1 = CacheExpiry.buildExpiry("2000");
+    assertTrue(o1.isPresent());
+    assertTrue(o1.get().expiresIn().toMilliseconds() > 500);
+    Optional<Expiry> o2 = CacheExpiry.buildExpiry(System.currentTimeMillis() + "2000");
+    assertTrue(o2.isPresent());
+    assertTrue(o2.get().expiresIn().toMilliseconds() > 500);
+    Optional<Expiry> o3 = CacheExpiry.buildExpiry(DateFormatUtil.format(new Date(System.currentTimeMillis() + 2000)));
+    assertTrue(o3.isPresent());
+    System.err.println(o3.get().expiresIn());
+    assertTrue(o3.get().expiresIn().toMilliseconds() > 500);
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/oauth/GetAndCacheOauthTokenTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/oauth/GetAndCacheOauthTokenTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.http.oauth;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.ExpiringMapCache;
+import com.adaptris.core.http.HttpServiceExample;
+import com.adaptris.core.services.cache.CacheConnection;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.TimeInterval;
+
+public class GetAndCacheOauthTokenTest extends HttpServiceExample {
+  private static final String TEXT = "ABCDEFG";
+
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
+
+  @Test
+  public void testService_Lifecycle() throws Exception {
+    GetAndCacheOauthToken service = new GetAndCacheOauthToken();
+    try {
+      LifecycleHelper.prepare(service);
+      LifecycleHelper.init(service);
+      fail();
+    }
+    catch (Exception expected) {
+
+    }
+    service.setAccessTokenBuilder(new DummyAccessTokenBuilder());
+    service.setCacheKey("cacheKey");
+    LifecycleHelper.stopAndClose(LifecycleHelper.initAndStart(service));
+  }
+
+  @Test
+  public void testService() throws Exception {
+    ExpiringMapCache cache = new ExpiringMapCache().withExpiration(new TimeInterval(5L, TimeUnit.SECONDS));
+    AccessToken t = new AccessToken(getName());
+    GetAndCacheOauthToken service =
+        new GetAndCacheOauthToken().withCacheKey("OauthToken")
+            .withConnection(new CacheConnection(cache)).withAccessTokenBuilder(new DummyAccessTokenBuilder(t));
+    try {
+      AdaptrisMessage m1 = new DefaultMessageFactory().newMessage(TEXT);
+      LifecycleHelper.initAndStart(service);
+      service.doService(m1);
+      assertTrue(m1.headersContainsKey("Authorization"));
+      assertEquals("Bearer " + getName(), m1.getMetadataValue("Authorization"));
+      AccessToken t1 = (AccessToken) cache.get("OauthToken");
+      assertNotNull(t1);
+      AdaptrisMessage m2 = new DefaultMessageFactory().newMessage(TEXT);
+      service.doService(m2);
+      assertTrue(m2.headersContainsKey("Authorization"));
+      assertEquals("Bearer " + getName(), m1.getMetadataValue("Authorization"));
+      AccessToken t2 = (AccessToken) cache.get("OauthToken");
+      assertNotNull(t2);
+      assertSame(t1, t2);
+    }
+    finally {
+      LifecycleHelper.stopAndClose(service);
+
+    }
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testService_WithError() throws Exception {
+    ExpiringMapCache cache = new ExpiringMapCache().withExpiration(new TimeInterval(5L, TimeUnit.SECONDS));
+    AccessToken t = new AccessToken(getName());
+    GetAndCacheOauthToken service = new GetAndCacheOauthToken().withCacheKey("OauthToken")
+        .withConnection(new CacheConnection(cache)).withAccessTokenBuilder(new DummyAccessTokenBuilder(t, true));
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage(TEXT);
+    execute(service, msg);
+  }
+
+  @Test
+  public void testService_Expiry() throws Exception {
+    ExpiringMapCache cache = new ExpiringMapCache().withExpiration(new TimeInterval(5L, TimeUnit.SECONDS));
+    AccessToken t = new AccessToken(getName());
+    GetAndCacheOauthToken service = new GetAndCacheOauthToken().withCacheKey("OauthToken")
+        .withConnection(new CacheConnection(cache)).withAccessTokenBuilder(new ExpiringAccessToken(t, 1000));
+    try {
+      AdaptrisMessage m1 = new DefaultMessageFactory().newMessage(TEXT);
+      LifecycleHelper.initAndStart(service);
+      service.doService(m1);
+      AccessToken t1 = (AccessToken) cache.get("OauthToken");
+      assertNotNull(t1);
+      await()
+          .atMost(Duration.ofSeconds(3))
+          .with()
+          .pollInterval(Duration.ofMillis(100))
+          .until(() -> cache.size() == 0);
+      AdaptrisMessage m2 = new DefaultMessageFactory().newMessage(TEXT);
+      service.doService(m2);
+      AccessToken t2 = (AccessToken) cache.get("OauthToken");
+      assertNotNull(t2);
+      assertNotSame(t1, t2);
+    } finally {
+      LifecycleHelper.stopAndClose(service);
+    }
+  }
+
+  @Override
+  protected GetAndCacheOauthToken retrieveObjectForSampleConfig() {
+    return new GetAndCacheOauthToken()
+        .withCacheKey("%message{cachekey}")
+        .withAccessTokenWriter(new MetadataAccessTokenWriter())
+        .withAccessTokenBuilder(new DummyAccessTokenBuilder());
+  }
+
+  private class ExpiringAccessToken implements AccessTokenBuilder {
+
+    private transient long expiresIn;
+    private transient AccessToken baseToken;
+
+    private ExpiringAccessToken(AccessToken base, long expiryMs) {
+      baseToken = base;
+      expiresIn = expiryMs;
+    }
+
+    @Override
+    public AccessToken build(AdaptrisMessage msg) throws IOException, CoreException {
+      return rebuild();
+    }
+
+    private AccessToken rebuild() {
+      AccessToken t = new AccessToken(baseToken.getType(), baseToken.getToken()).withRefreshToken(baseToken.getRefreshToken());
+      t.setExpiry("" + expiresIn);
+      return t;
+    }
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/oauth/GetAndCacheOauthTokenTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/oauth/GetAndCacheOauthTokenTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
@@ -151,8 +152,8 @@ public class GetAndCacheOauthTokenTest extends HttpServiceExample {
     }
 
     private AccessToken rebuild() {
-      AccessToken t = new AccessToken(baseToken.getType(), baseToken.getToken()).withRefreshToken(baseToken.getRefreshToken());
-      t.setExpiry("" + expiresIn);
+      AccessToken t = new AccessToken(baseToken.getType(), baseToken.getToken()).withRefreshToken(baseToken.getRefreshToken())
+          .withExpiry(new Date(System.currentTimeMillis() + expiresIn));
       return t;
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/http/oauth/MetadataTokenWriterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/oauth/MetadataTokenWriterTest.java
@@ -1,0 +1,78 @@
+package com.adaptris.core.http.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.Date;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.text.DateFormatUtil;
+
+public class MetadataTokenWriterTest {
+
+  @Before
+  public void setUp() throws Exception {}
+
+  @After
+  public void tearDown() throws Exception {}
+
+  @Test
+  public void testApply() throws Exception {
+    AccessToken token = new AccessToken("Bearer", "token").withRefreshToken("refresh")
+        .withExpiry(DateFormatUtil.format(new Date(System.currentTimeMillis() + 2000)));
+    MetadataAccessTokenWriter writer = new MetadataAccessTokenWriter().withTokenKey("access_token")
+        .withTokenExpiryKey("expiry_token")
+        .withRefreshTokenKey("refresh_token");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try {
+      LifecycleHelper.initAndStart(writer);
+      writer.apply(token, msg);
+      assertTrue(msg.headersContainsKey("access_token"));
+      assertEquals("Bearer token", msg.getMetadataValue("access_token"));
+      assertTrue(msg.headersContainsKey("expiry_token"));
+      assertTrue(msg.headersContainsKey("refresh_token"));
+    } finally {
+      LifecycleHelper.stopAndClose(writer);
+    }
+  }
+
+  @Test
+  public void testApply_NoAdditionalKeys() throws Exception {
+    AccessToken token = new AccessToken("Bearer", "token").withRefreshToken("refresh")
+        .withExpiry(DateFormatUtil.format(new Date(System.currentTimeMillis() + 2000)));
+    MetadataAccessTokenWriter writer = new MetadataAccessTokenWriter().withTokenKey("access_token");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try {
+      LifecycleHelper.initAndStart(writer);
+      writer.apply(token, msg);
+      assertTrue(msg.headersContainsKey("access_token"));
+      assertEquals("Bearer token", msg.getMetadataValue("access_token"));
+      assertFalse(msg.headersContainsKey("expiry_token"));
+      assertFalse(msg.headersContainsKey("refresh_token"));
+    } finally {
+      LifecycleHelper.stopAndClose(writer);
+    }
+  }
+
+  @Test
+  public void testApply_NoAdditionalData() throws Exception {
+    AccessToken token = new AccessToken("Bearer", "token");
+    MetadataAccessTokenWriter writer = new MetadataAccessTokenWriter().withTokenKey("access_token")
+        .withTokenExpiryKey("expiry_token").withRefreshTokenKey("refresh_token");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try {
+      LifecycleHelper.initAndStart(writer);
+      writer.apply(token, msg);
+      assertTrue(msg.headersContainsKey("access_token"));
+      assertEquals("Bearer token", msg.getMetadataValue("access_token"));
+      assertFalse(msg.headersContainsKey("expiry_token"));
+      assertFalse(msg.headersContainsKey("refresh_token"));
+    } finally {
+      LifecycleHelper.stopAndClose(writer);
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

In almost all cases people want to get an OAUTH Access Token and re-use it repeatedly which means that they invariable have something like this as a shared-service (or any variation thereof).

```
<if>
  <exists-in-cache/>
  <then>
    <get-single-value-from-cache/>
  </then>
  <otherwise>
    <get-oauth-token/>
    <add-single-value-to-cache/>
 </otherwise>
</if>
```

Since this is a often used pattern (and in fact probably only use-case) then we should shorten the chain so it's not so unwieldy.

## Modification

* Refactor the existing add-single-value-to-cache so that the cache-expiry logic is exposed via a helper method in c.a.c.c
* Refactor get-oauth-token so that we now encapsulate what we do with the tokean via a `access-token-writer` interface (the only impl is `oauth-access-token-to-metadata`).
* Add a get-and-cache-oauth-token service that does everything...

## Result

A new service which can be configured, that allows you specify the underlying cache. Note that if an expiry exists then it will be used, so the underlying cache instance needs to support per-item-expiry otherwise an UnsupportedOperationException will be thrown (ExpiringMapCache is fine).

```
  <get-and-cache-oauth-token>
   <access-token-writer class="oauth-access-token-to-metadata">
    <token-key>Authorization</token-key>
   </access-token-writer>
   <access-token-builder class="com.adaptris.core.http.oauth.DummyAccessTokenBuilder"/>
   <cache-key>%message{cachekey}</cache-key>
   <connection class="cache-connection">
    // Defaults to expiry-map-cache with sensible defaults.
   </connection>
  </get-and-cache-oauth-token>
```

## Testing

You'll need something that requires OAUTH (microsoft graph ??); use get-and-cache-oauth-token where you would have used get-oauth-token. Do the operation > 1 time, and you should see logging about it being "cached".

```
            <services>
              <get-and-cache-oauth-token>
                <unique-id>get-oauth-token</unique-id>
                <access-token-writer class="oauth-access-token-to-metadata">
                  <token-key>Authorization</token-key>
                </access-token-writer>
                <access-token-builder class="azure-username-password-access-token">
                  <client-id>${azure.clientid}</client-id>
                  <resource>${azure.resource}</resource>
                  <authority-url>${azure.authority.url}</authority-url>
                  <username>${azure.username}</username>
                  <password>${azure.password}</password>
                </access-token-builder>
                <cache-key>authCache</cache-key>
                <connection class="shared-connection">
                  <lookup-name>oauth-cache</lookup-name>
                </connection>
              </get-and-cache-oauth-token>
              <apache-http-request-service>
                <unique-id>MS-graph-ME</unique-id>
                <url>https://graph.microsoft.com/v1.0/me/</url>
                <content-type>text/plain</content-type>
                <method>GET</method>
                <response-header-handler class="apache-http-response-headers-as-metadata"/>
                <request-header-provider class="apache-http-no-request-headers"/>
                <authenticator class="apache-http-configured-authorization-header">
                  <header-value>%message{Authorization}</header-value>
                </authenticator>
              </apache-http-request-service>
              <jetty-response-service>
                <http-status>%message{adphttpresponse}</http-status>
                <content-type>%message{Content-Type}</content-type>
                <response-header-provider class="jetty-no-response-headers"/>
              </jetty-response-service>
            </services>
```