### PR TITLE
INTERLOK-2895: Random Interval Poller TimeStamp

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
@@ -51,7 +51,15 @@ public class RandomIntervalPoller extends FixedIntervalPoller {
     if (executor != null && !executor.isShutdown()) {
       long delay = ThreadLocalRandom.current().nextLong(pollInterval());
       pollerTask = executor.schedule(new MyPollerTask(), delay, TimeUnit.MILLISECONDS);
-      log.trace("Next Execution scheduled in {}", DurationFormatUtils.formatDuration(delay, "HH'h' mm'm' ss's' SSS'ms'"));
+      if(delay >= 3600000L) {
+        log.trace("Next Execution scheduled in {}", DurationFormatUtils.formatDuration(delay, "HH'h' mm'm' ss's' SSS'ms'"));
+      }
+      else if(delay < 60000L){
+        log.trace("Next Execution scheduled in {}", DurationFormatUtils.formatDuration(delay, "ss's' SSS'ms'"));
+      }
+      else {
+        log.trace("Next Execution scheduled in {}", DurationFormatUtils.formatDuration(delay, "mm'm' ss's' SSS'ms'"));
+      }
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
@@ -48,8 +48,23 @@ public class RandomIntervalPoller extends FixedIntervalPoller {
   protected void scheduleTask() {
     if (executor != null && !executor.isShutdown()) {
       long delay = ThreadLocalRandom.current().nextLong(pollInterval());
-      pollerTask = executor.schedule(new MyPollerTask(), delay, TimeUnit.MILLISECONDS);
-      log.trace("Next Execution scheduled in {}ms", delay);
+      
+      if(delay < 5000L) {
+        pollerTask = executor.schedule(new MyPollerTask(), TimeUnit.MILLISECONDS.toMillis(delay), TimeUnit.MILLISECONDS);
+        log.trace("Next Execution scheduled in {}ms", TimeUnit.MILLISECONDS.toMillis(delay));
+      }
+      else if((delay >= 5000L) && (delay <= 120000L)) {
+        pollerTask = executor.schedule(new MyPollerTask(), TimeUnit.MILLISECONDS.toSeconds(delay), TimeUnit.SECONDS);
+        log.trace("Next Execution scheduled in {}s",TimeUnit.MILLISECONDS.toSeconds(delay));
+      }
+      else if ((delay > 120000L) && (delay <= 7200000L)) {
+        pollerTask = executor.schedule(new MyPollerTask(), TimeUnit.MILLISECONDS.toMinutes(delay), TimeUnit.MINUTES);
+        log.trace("Next Execution scheduled in {}m",TimeUnit.MILLISECONDS.toMinutes(delay));
+      }
+      else {
+        pollerTask = executor.schedule(new MyPollerTask(), TimeUnit.MILLISECONDS.toHours(delay), TimeUnit.HOURS);
+        log.trace("Next Execution scheduled in {}h", TimeUnit.MILLISECONDS.toHours(delay));
+      }
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
@@ -43,23 +43,23 @@ public class RandomIntervalPoller extends FixedIntervalPoller {
   public RandomIntervalPoller(TimeInterval interval) {
     super(interval);
   }
-  
+
   private long millToMill(long milliseconds) {
     return TimeUnit.MILLISECONDS.toMillis(milliseconds);
   }
-  
+
   private long millToSec(long milliseconds) {
     return TimeUnit.MILLISECONDS.toSeconds(milliseconds);
   }
-  
+
   private long millToMin(long milliseconds) {
     return TimeUnit.MILLISECONDS.toMinutes(milliseconds);
   }
-  
+
   private long millToHour(long milliseconds) {
     return TimeUnit.MILLISECONDS.toHours(milliseconds);
   }
-  
+
   private long residualTime(String measure, long millis) {
     if(measure == "minutes") {
       return millToMin(millis) - (millToHour(millis) * 60);
@@ -77,12 +77,12 @@ public class RandomIntervalPoller extends FixedIntervalPoller {
     if (executor != null && !executor.isShutdown()) {
       long delay = ThreadLocalRandom.current().nextLong(pollInterval());
       pollerTask = executor.schedule(new MyPollerTask(), delay, TimeUnit.MILLISECONDS);
-      
+
       if(delay < 5000L) {
         log.trace("Next Execution scheduled in {}ms", millToMill(delay));
       }
       else if((delay >= 5000L) && (delay <= 120000L)) {
-        log.trace("Next Execution scheduled in {}s", millToSec(delay));
+        log.trace("Next Execution scheduled in: {}s {}ms", millToSec(delay), residualTime("milliseconds", delay));
       }
       else if ((delay > 120000L) && (delay <= 7200000L)) {
         log.trace("Next Execution scheduled in: {}m {}s",millToMin(delay), residualTime("seconds", delay));

--- a/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core;
 
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -51,15 +53,10 @@ public class RandomIntervalPoller extends FixedIntervalPoller {
     if (executor != null && !executor.isShutdown()) {
       long delay = ThreadLocalRandom.current().nextLong(pollInterval());
       pollerTask = executor.schedule(new MyPollerTask(), delay, TimeUnit.MILLISECONDS);
-      if(delay >= 3600000L) {
-        log.trace("Next Execution scheduled in {}", DurationFormatUtils.formatDuration(delay, "HH'h' mm'm' ss's' SSS'ms'"));
-      }
-      else if(delay < 60000L){
-        log.trace("Next Execution scheduled in {}", DurationFormatUtils.formatDuration(delay, "ss's' SSS'ms'"));
-      }
-      else {
-        log.trace("Next Execution scheduled in {}", DurationFormatUtils.formatDuration(delay, "mm'm' ss's' SSS'ms'"));
-      }
+      Calendar currentTime = Calendar.getInstance();
+      currentTime.add(Calendar.MILLISECOND, (int)delay);
+      SimpleDateFormat approxFormat = new SimpleDateFormat("HH:mm");
+      log.trace("Next Execution scheduled in {} approx {}", DurationFormatUtils.formatDurationWords(delay, true, true), approxFormat.format(currentTime.getTime()));
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
@@ -24,7 +24,6 @@ import com.adaptris.util.TimeInterval;
 
 public class RandomIntervalPollerTest extends BaseCase {
 
-
   @Override
   public boolean isAnnotatedForJunit4() {
     return true;
@@ -34,7 +33,6 @@ public class RandomIntervalPollerTest extends BaseCase {
   public void testSetConstructors() throws Exception {
     RandomIntervalPoller p = new RandomIntervalPoller();
     p = new RandomIntervalPoller(new TimeInterval(10L, TimeUnit.SECONDS));
-    
   }
 
   @Test
@@ -69,7 +67,7 @@ public class RandomIntervalPollerTest extends BaseCase {
       channel.requestClose();
     }
   }
-  
+
   @Test
   public void testAlternativeTimeIntervals() throws Exception {
     PollingTrigger consumer = new PollingTrigger();
@@ -82,44 +80,34 @@ public class RandomIntervalPollerTest extends BaseCase {
     workflow.setProducer(producer);
     channel.getWorkflowList().add(workflow);
     try {
-      
       channel.requestStop();
       consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72001L, TimeUnit.MILLISECONDS)));
       channel.requestStart();
       waitForMessages(producer, 1);
-      
 
       channel.requestStop();
       producer.getMessages().clear();
-      
-      channel.requestClose();
       channel.requestStart();
       waitForMessages(producer, 1);
-      
-      
 
       channel.requestStop();
       producer.getMessages().clear();
-      
       consumer.setPoller(new RandomIntervalPoller(new TimeInterval(7200000L, TimeUnit.MILLISECONDS)));
 
       channel.requestStart();
       waitForMessages(producer, 1);
 
-      channel.requestClose();
+      channel.requestStop();
       producer.getMessages().clear();
       consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72000001L, TimeUnit.MILLISECONDS)));
 
       channel.requestStart();
       waitForMessages(producer, 1);
-      
+
     }
     finally {
       channel.requestClose();
     }
   }
- 
-  
-  
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
@@ -68,39 +68,4 @@ public class RandomIntervalPollerTest extends BaseCase {
     }
   }
 
-  @Test
-  public void testAlternativeTimeIntervals() throws Exception {
-    PollingTrigger consumer = new PollingTrigger();
-    consumer.setPoller(new RandomIntervalPoller(new TimeInterval(9000L, TimeUnit.MILLISECONDS)));
-    MockMessageProducer producer = new MockMessageProducer();
-
-    MockChannel channel = new MockChannel();
-    StandardWorkflow workflow = new StandardWorkflow();
-    workflow.setConsumer(consumer);
-    workflow.setProducer(producer);
-    channel.getWorkflowList().add(workflow);
-    try {
-      channel.requestStop();
-      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72001L, TimeUnit.MILLISECONDS)));
-      channel.requestStart();
-      waitForMessages(producer, 1);
-
-      channel.requestStop();
-      producer.getMessages().clear();
-      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(7200000L, TimeUnit.MILLISECONDS)));
-      channel.requestStart();
-      waitForMessages(producer, 1);
-
-      channel.requestStop();
-      producer.getMessages().clear();
-      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72000001L, TimeUnit.MILLISECONDS)));
-      channel.requestStart();
-      waitForMessages(producer, 1);
-
-    }
-    finally {
-      channel.requestClose();
-    }
-  }
-
 }

--- a/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
@@ -68,33 +68,4 @@ public class RandomIntervalPollerTest extends BaseCase {
     }
   }
 
-  @Test
-  public void testAlternativeTimeIntervals() throws Exception {
-    PollingTrigger consumer = new PollingTrigger();
-    consumer.setPoller(new RandomIntervalPoller(new TimeInterval(6000L, TimeUnit.MILLISECONDS)));
-    MockMessageProducer producer = new MockMessageProducer();
-
-    MockChannel channel = new MockChannel();
-    StandardWorkflow workflow = new StandardWorkflow();
-    workflow.setConsumer(consumer);
-    workflow.setProducer(producer);
-    channel.getWorkflowList().add(workflow);
-    try {
-      channel.requestStop();
-      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72000000L, TimeUnit.MILLISECONDS)));
-      channel.requestStart();
-      waitForMessages(producer, 1);
-
-      channel.requestStop();
-      producer.getMessages().clear();
-      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(600000L, TimeUnit.MILLISECONDS)));
-      channel.requestStart();
-      waitForMessages(producer, 1);
-
-    }
-    finally {
-      channel.requestClose();
-    }
-  }
-
 }

--- a/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
@@ -22,7 +22,14 @@ import com.adaptris.core.stubs.MockChannel;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.util.TimeInterval;
 
+
+
+
 public class RandomIntervalPollerTest extends BaseCase {
+  
+  private long tenMillis = 10L;
+  private long hundredMillis = 100L;
+  private int listenerCount = 1;
 
   @Override
   public boolean isAnnotatedForJunit4() {
@@ -32,13 +39,13 @@ public class RandomIntervalPollerTest extends BaseCase {
   @Test
   public void testSetConstructors() throws Exception {
     RandomIntervalPoller p = new RandomIntervalPoller();
-    p = new RandomIntervalPoller(new TimeInterval(10L, TimeUnit.SECONDS));
+    p = new RandomIntervalPoller(new TimeInterval(tenMillis, TimeUnit.SECONDS));
   }
 
   @Test
   public void testLifecycle() throws Exception {
     PollingTrigger consumer = new PollingTrigger();
-    consumer.setPoller(new RandomIntervalPoller(new TimeInterval(100L, TimeUnit.MILLISECONDS)));
+    consumer.setPoller(new RandomIntervalPoller(new TimeInterval(hundredMillis, TimeUnit.MILLISECONDS)));
     MockMessageProducer producer = new MockMessageProducer();
 
     MockChannel channel = new MockChannel();
@@ -49,19 +56,19 @@ public class RandomIntervalPollerTest extends BaseCase {
     try {
       channel.requestClose();
       channel.requestStart();
-      waitForMessages(producer, 1);
+      waitForMessages(producer, listenerCount);
 
       channel.requestStop();
       producer.getMessages().clear();
 
       channel.requestStart();
-      waitForMessages(producer, 1);
+      waitForMessages(producer, listenerCount);
 
       channel.requestClose();
       producer.getMessages().clear();
 
       channel.requestStart();
-      waitForMessages(producer, 1);
+      waitForMessages(producer, listenerCount);
     }
     finally {
       channel.requestClose();

--- a/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
@@ -87,20 +87,13 @@ public class RandomIntervalPollerTest extends BaseCase {
 
       channel.requestStop();
       producer.getMessages().clear();
-      channel.requestStart();
-      waitForMessages(producer, 1);
-
-      channel.requestStop();
-      producer.getMessages().clear();
       consumer.setPoller(new RandomIntervalPoller(new TimeInterval(7200000L, TimeUnit.MILLISECONDS)));
-
       channel.requestStart();
       waitForMessages(producer, 1);
 
       channel.requestStop();
       producer.getMessages().clear();
       consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72000001L, TimeUnit.MILLISECONDS)));
-
       channel.requestStart();
       waitForMessages(producer, 1);
 

--- a/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Adaptris Ltd.
+ * Copyright 2020 Adaptris Ltd.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
@@ -34,6 +34,7 @@ public class RandomIntervalPollerTest extends BaseCase {
   public void testSetConstructors() throws Exception {
     RandomIntervalPoller p = new RandomIntervalPoller();
     p = new RandomIntervalPoller(new TimeInterval(10L, TimeUnit.SECONDS));
+    
   }
 
   @Test
@@ -68,4 +69,57 @@ public class RandomIntervalPollerTest extends BaseCase {
       channel.requestClose();
     }
   }
+  
+  @Test
+  public void testAlternativeTimeIntervals() throws Exception {
+    PollingTrigger consumer = new PollingTrigger();
+    consumer.setPoller(new RandomIntervalPoller(new TimeInterval(9000L, TimeUnit.MILLISECONDS)));
+    MockMessageProducer producer = new MockMessageProducer();
+
+    MockChannel channel = new MockChannel();
+    StandardWorkflow workflow = new StandardWorkflow();
+    workflow.setConsumer(consumer);
+    workflow.setProducer(producer);
+    channel.getWorkflowList().add(workflow);
+    try {
+      
+      channel.requestStop();
+      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72001L, TimeUnit.MILLISECONDS)));
+      channel.requestStart();
+      waitForMessages(producer, 1);
+      
+
+      channel.requestStop();
+      producer.getMessages().clear();
+      
+      channel.requestClose();
+      channel.requestStart();
+      waitForMessages(producer, 1);
+      
+      
+
+      channel.requestStop();
+      producer.getMessages().clear();
+      
+      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(7200000L, TimeUnit.MILLISECONDS)));
+
+      channel.requestStart();
+      waitForMessages(producer, 1);
+
+      channel.requestClose();
+      producer.getMessages().clear();
+      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72000001L, TimeUnit.MILLISECONDS)));
+
+      channel.requestStart();
+      waitForMessages(producer, 1);
+      
+    }
+    finally {
+      channel.requestClose();
+    }
+  }
+ 
+  
+  
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/RandomIntervalPollerTest.java
@@ -68,4 +68,33 @@ public class RandomIntervalPollerTest extends BaseCase {
     }
   }
 
+  @Test
+  public void testAlternativeTimeIntervals() throws Exception {
+    PollingTrigger consumer = new PollingTrigger();
+    consumer.setPoller(new RandomIntervalPoller(new TimeInterval(6000L, TimeUnit.MILLISECONDS)));
+    MockMessageProducer producer = new MockMessageProducer();
+
+    MockChannel channel = new MockChannel();
+    StandardWorkflow workflow = new StandardWorkflow();
+    workflow.setConsumer(consumer);
+    workflow.setProducer(producer);
+    channel.getWorkflowList().add(workflow);
+    try {
+      channel.requestStop();
+      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(72000000L, TimeUnit.MILLISECONDS)));
+      channel.requestStart();
+      waitForMessages(producer, 1);
+
+      channel.requestStop();
+      producer.getMessages().clear();
+      consumer.setPoller(new RandomIntervalPoller(new TimeInterval(600000L, TimeUnit.MILLISECONDS)));
+      channel.requestStart();
+      waitForMessages(producer, 1);
+
+    }
+    finally {
+      channel.requestClose();
+    }
+  }
+
 }


### PR DESCRIPTION
## Motivation

Why am I doing this

Clearer more human readable logging

## Modification

What did I change

Improved logging readability by dividing hours, minutes, seconds and milliseconds into more manageable quantities.

## Result

What's the end result for the user

The Random Interval Poller now logs more human readable time based on user input

## Testing

How can I test this if I'm reviewing this.

Run the tests, alternatively build and drop the Jar into an instance of Interlok and watch the logger (stop watch advisable).
