### PR TITLE
INTERLOK-3284 add javax.websocket to owasp suppression

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -22,4 +22,18 @@
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.orbit/javax\.security\.auth\.message@.*$</packageUrl>
     <cpe>cpe:/a:apache:geronimo</cpe>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+    javax.websocket-api != Java-WebSocket (INTERLOK-3284)
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/javax\.websocket/javax\.websocket\-api@.*$</packageUrl>
+    <cve>CVE-2020-11050</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    javax.websocket-client-api != Java-WebSocket (INTERLOK-3284)
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/javax\.websocket/javax\.websocket\-client\-api@.*$</packageUrl>
+    <cve>CVE-2020-11050</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
## Motivation

Depedency check is currently reporting a false positive for `javax.websocket` jars.

```
javax.websocket-api-1.0.jar (pkg:maven/javax.websocket/javax.websocket-api@1.0, cpe:2.3:a:java-websocket_project:java-websocket:1.0:*:*:*:*:*:*:*) : CVE-2020-11050
javax.websocket-client-api-1.0.jar (pkg:maven/javax.websocket/javax.websocket-client-api@1.0, cpe:2.3:a:java-websocket_project:java-websocket:1.0:*:*:*:*:*:*:*) : CVE-2020-11050
```

## Modification

Added suppression generated by dependency check to owasp exclude.

## Result

Report no longer reports the above as violations.

## Testing

Update a project using the parent with the following config:

```
dependencyCheck  {
  suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/feature/INTERLOK-3284_owasp_javax_websocket/gradle/owasp-exclude.xml" ]
}
```
Run dependency check :
```
./gradlew dependencyCheckAnalyze
```
