### PR TITLE
Interlok 2594 config test

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
@@ -52,6 +52,7 @@ import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.management.logging.LoggingConfigurator;
 import com.adaptris.core.util.PropertyHelper;
+import com.adaptris.util.URLHelper;
 import com.adaptris.util.URLString;
 
 /**
@@ -181,10 +182,13 @@ public class BootstrapProperties extends Properties {
   public synchronized Adapter createAdapter() throws Exception {
     // First of all make sure the the config manager has made the default marshaller correct.
     getConfigManager();
-    Adapter result = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(new URLString(findAdapterResource()));
+    Adapter result = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(this.getConfigurationStream());
     log.info("Adapter created");
     return result;
-
+  }
+  
+  public InputStream getConfigurationStream() throws Exception {
+    return URLHelper.connect(new URLString(this.findAdapterResource()));
   }
 
   public String[] getConfigurationUrls() {

--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -17,16 +17,15 @@
 package com.adaptris.core.management;
 
 import static com.adaptris.core.management.Constants.CFG_KEY_START_QUIETLY;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Map;
-import com.adaptris.core.Adapter;
-import com.adaptris.core.DefaultMarshaller;
+
 import com.adaptris.core.management.config.ConfigurationCheckRunner;
 import com.adaptris.core.management.logging.LoggingConfigurator;
-import com.adaptris.core.runtime.AdapterManagerMBean;
-import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.ManagedThreadFactory;
+
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.Resource;
 import io.github.classgraph.ResourceList;
@@ -111,7 +110,11 @@ abstract class CmdLineBootstrap {
       launchAdapter(bootstrap, startQuietly);
     }
     else {
-      new ConfigurationCheckRunner().runChecks(bootProperties, bootstrap);
+      new ConfigurationCheckRunner().runChecks(bootProperties, bootstrap).forEach(report -> {
+        System.err.println("\n********************");
+        System.err.println(report.toString());
+        System.err.println("\n");
+      });
       
    // INTERLOK-1455 Shutdown the logging subsystem if we're only just doing a config check.
       LoggingConfigurator.newConfigurator().requestShutdown();

--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -22,16 +22,10 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import com.adaptris.core.management.config.ConfigurationCheckRunner;
 import com.adaptris.core.management.logging.LoggingConfigurator;
 import com.adaptris.core.util.ManagedThreadFactory;
-
-import io.github.classgraph.ClassGraph;
-import io.github.classgraph.Resource;
-import io.github.classgraph.ResourceList;
-import io.github.classgraph.ScanResult;
 
 /**
  * Abstract boostrap that contains standard commandline parsing.
@@ -115,8 +109,8 @@ abstract class CmdLineBootstrap {
       final List<Exception> fatals = new ArrayList<>();
       new ConfigurationCheckRunner().runChecks(bootProperties, bootstrap).forEach(report -> {
         System.err.println("\n" + report.toString());
-        if(report.getFailureException() != null)
-          fatals.add(report.getFailureException());
+        if(report.getFailureExceptions().size() > 0)
+          fatals.addAll(report.getFailureExceptions());
       });
       
    // INTERLOK-1455 Shutdown the logging subsystem if we're only just doing a config check.

--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -22,6 +22,7 @@ import java.io.StringWriter;
 import java.util.Map;
 import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.management.config.ConfigurationCheckRunner;
 import com.adaptris.core.management.logging.LoggingConfigurator;
 import com.adaptris.core.runtime.AdapterManagerMBean;
 import com.adaptris.core.util.LifecycleHelper;
@@ -110,16 +111,12 @@ abstract class CmdLineBootstrap {
       launchAdapter(bootstrap, startQuietly);
     }
     else {
-      // This seems a bit cheaty, but we're going to exit anyway, so
-      // calling prepare probably makes no difference.
-      Adapter clonedAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(bootstrap.createAdapter().getConfiguration());
-      LifecycleHelper.prepare(clonedAdapter);
-
-      // INTERLOK-1455 Shutdown the logging subsystem if we're only just doing a config check.
+      new ConfigurationCheckRunner().runChecks(bootProperties, bootstrap);
+      
+   // INTERLOK-1455 Shutdown the logging subsystem if we're only just doing a config check.
       LoggingConfigurator.newConfigurator().requestShutdown();
-      // No starting an adapter, so just terminate.
-      logClasspathIssues();
-      System.err.println("Config check only; terminating");
+      
+      System.err.println("\nConfig check only; terminating");
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ClasspathDupConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ClasspathDupConfigurationChecker.java
@@ -1,0 +1,51 @@
+package com.adaptris.core.management.config;
+
+import java.util.Map;
+
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.Constants;
+import com.adaptris.core.management.UnifiedBootstrap;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.Resource;
+import io.github.classgraph.ResourceList;
+import io.github.classgraph.ScanResult;
+
+public class ClasspathDupConfigurationChecker implements ConfigurationChecker {
+  
+  private static final String FRIENDLY_NAME = "Classpath duplication check.";
+  
+  private static final String DESCRIPTION = "This test will scan your libraries checking and reporting on any duplicates found.";
+
+  @SuppressWarnings("resource")
+  @Override
+  public void performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrapProperties) throws ConfigurationException {
+    if (Constants.DBG) {
+      boolean passed = true;
+      try (ScanResult result = new ClassGraph().scan()) {
+        for (Map.Entry<String, ResourceList> dup : result.getAllResources().classFilesOnly().findDuplicatePaths()) {
+          if (dup.getKey().equalsIgnoreCase("module-info.class")) {
+            continue;
+          }
+          passed = false;
+          System.err.println(String.format("%s has possible duplicates", dup.getKey()));
+          for (Resource res : dup.getValue()) {
+            System.err.println(String.format(" -> Found in %s", res.getURI()));
+          }
+        }
+      }
+      if(!passed)  throw new ConfigurationException("Possible duplicates found.");
+    }
+  }
+  
+  @Override
+  public String getFriendlyName() {
+    return FRIENDLY_NAME;
+  }
+
+  @Override
+  public String getDescription() {
+    return DESCRIPTION;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckReport.java
@@ -9,10 +9,11 @@ public class ConfigurationCheckReport {
     
   private List<String> warnings;
   
-  private Exception failureException;
+  private List<Exception> failureExceptions;
   
   public ConfigurationCheckReport() {
     this.setWarnings(new ArrayList<>());
+    this.setFailureExceptions(new ArrayList<>());
   }
 
   public String getCheckName() {
@@ -24,15 +25,15 @@ public class ConfigurationCheckReport {
   }
 
   public boolean isCheckPassed() {
-    return this.getWarnings().size() == 0 && this.getFailureException() == null;
+    return this.getWarnings().size() == 0 && this.getFailureExceptions().size() == 0;
   }
 
-  public Exception getFailureException() {
-    return failureException;
+  public List<Exception> getFailureExceptions() {
+    return failureExceptions;
   }
 
-  public void setFailureException(Exception failureException) {
-    this.failureException = failureException;
+  public void setFailureExceptions(List<Exception> failureExceptions) {
+    this.failureExceptions = failureExceptions;
   }
   
   public List<String> getWarnings() {
@@ -50,9 +51,11 @@ public class ConfigurationCheckReport {
     buffer.append(": ");
     if(this.isCheckPassed())
       buffer.append("\nPassed.");
-    if(this.getFailureException() != null) {
-      buffer.append("\nFailed with exception: ");
-      buffer.append(this.getFailureException().getMessage());
+    if(this.getFailureExceptions().size() > 0) {
+      buffer.append("\nFailed with exceptions: ");
+      this.getFailureExceptions().forEach(exception -> {
+        buffer.append("\n" + exception.getMessage());
+      });
     }
     if(this.getWarnings().size() > 0) {
       buffer.append("\nWarnings found;");

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckReport.java
@@ -1,0 +1,54 @@
+package com.adaptris.core.management.config;
+
+public class ConfigurationCheckReport {
+
+  private String checkName;
+  
+  private boolean checkPassed;
+  
+  private Exception failureException;
+  
+  public ConfigurationCheckReport() {
+    
+  }
+
+  public String getCheckName() {
+    return checkName;
+  }
+
+  public void setCheckName(String checkName) {
+    this.checkName = checkName;
+  }
+
+  public boolean isCheckPassed() {
+    return checkPassed;
+  }
+
+  public void setCheckPassed(boolean checkPassed) {
+    this.checkPassed = checkPassed;
+  }
+
+  public Exception getFailureException() {
+    return failureException;
+  }
+
+  public void setFailureException(Exception failureException) {
+    this.failureException = failureException;
+  }
+  
+  public String toString() {
+    StringBuffer buffer = new StringBuffer();
+    
+    buffer.append(this.getCheckName());
+    buffer.append(": ");
+    buffer.append(this.isCheckPassed() ? "Passed." : "Failed.");
+    
+    if(this.getFailureException() != null) {
+      buffer.append("  With Exception: ");
+      buffer.append(this.getFailureException().getMessage());
+    }
+    
+    return buffer.toString();
+  }
+  
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckReport.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckReport.java
@@ -1,15 +1,18 @@
 package com.adaptris.core.management.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ConfigurationCheckReport {
 
   private String checkName;
-  
-  private boolean checkPassed;
+    
+  private List<String> warnings;
   
   private Exception failureException;
   
   public ConfigurationCheckReport() {
-    
+    this.setWarnings(new ArrayList<>());
   }
 
   public String getCheckName() {
@@ -21,11 +24,7 @@ public class ConfigurationCheckReport {
   }
 
   public boolean isCheckPassed() {
-    return checkPassed;
-  }
-
-  public void setCheckPassed(boolean checkPassed) {
-    this.checkPassed = checkPassed;
+    return this.getWarnings().size() == 0 && this.getFailureException() == null;
   }
 
   public Exception getFailureException() {
@@ -36,16 +35,30 @@ public class ConfigurationCheckReport {
     this.failureException = failureException;
   }
   
+  public List<String> getWarnings() {
+    return warnings;
+  }
+
+  public void setWarnings(List<String> warnings) {
+    this.warnings = warnings;
+  }
+
   public String toString() {
     StringBuffer buffer = new StringBuffer();
     
     buffer.append(this.getCheckName());
     buffer.append(": ");
-    buffer.append(this.isCheckPassed() ? "Passed." : "Failed.");
-    
+    if(this.isCheckPassed())
+      buffer.append("\nPassed.");
     if(this.getFailureException() != null) {
-      buffer.append("  With Exception: ");
+      buffer.append("\nFailed with exception: ");
       buffer.append(this.getFailureException().getMessage());
+    }
+    if(this.getWarnings().size() > 0) {
+      buffer.append("\nWarnings found;");
+      this.getWarnings().forEach(warningText -> {
+        buffer.append("\n" + warningText);
+      });
     }
     
     return buffer.toString();

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
@@ -1,0 +1,30 @@
+package com.adaptris.core.management.config;
+
+import java.util.Arrays;
+
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.UnifiedBootstrap;
+
+public class ConfigurationCheckRunner {
+
+  public void runChecks(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
+    Arrays.asList(ConfigurationCheckersEnum.values()).forEach( checker -> runCheck(checker, bootProperties, bootstrap) );
+  }
+
+  private void runCheck(ConfigurationCheckersEnum configCheck, BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
+    System.err.println("\n\n**************************************************");
+    System.err.println("Performing configuration check: " + configCheck.getChecker().getFriendlyName());
+    System.err.println(configCheck.getChecker().getDescription() + "\n");
+    
+    try {
+      configCheck.performCheck(bootProperties, bootstrap);
+      
+      System.err.println(configCheck.getChecker().getFriendlyName() + " Passed.");
+    } catch (ConfigurationException exception) {
+      System.err.println(configCheck.getChecker().getFriendlyName() + " Failed with exception(s):");
+      System.err.println(exception.getMessage());
+    }
+    
+  }
+  
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
@@ -1,30 +1,29 @@
 package com.adaptris.core.management.config;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.adaptris.core.management.BootstrapProperties;
 import com.adaptris.core.management.UnifiedBootstrap;
 
 public class ConfigurationCheckRunner {
 
-  public void runChecks(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
-    Arrays.asList(ConfigurationCheckersEnum.values()).forEach( checker -> runCheck(checker, bootProperties, bootstrap) );
+  public List<ConfigurationCheckReport> runChecks(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
+    List<ConfigurationCheckReport> reports = new ArrayList<>();
+    Arrays.asList(ConfigurationCheckersEnum.values()).forEach( checker -> {
+      reports.add(runCheck(checker, bootProperties, bootstrap)); 
+    });
+    
+    return reports;
   }
 
-  private void runCheck(ConfigurationCheckersEnum configCheck, BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
+  private ConfigurationCheckReport runCheck(ConfigurationCheckersEnum configCheck, BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
     System.err.println("\n\n**************************************************");
     System.err.println("Performing configuration check: " + configCheck.getChecker().getFriendlyName());
     System.err.println(configCheck.getChecker().getDescription() + "\n");
     
-    try {
-      configCheck.performCheck(bootProperties, bootstrap);
-      
-      System.err.println(configCheck.getChecker().getFriendlyName() + " Passed.");
-    } catch (ConfigurationException exception) {
-      System.err.println(configCheck.getChecker().getFriendlyName() + " Failed with exception(s):");
-      System.err.println(exception.getMessage());
-    }
-    
+    return configCheck.performCheck(bootProperties, bootstrap);    
   }
   
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
@@ -12,18 +12,10 @@ public class ConfigurationCheckRunner {
   public List<ConfigurationCheckReport> runChecks(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
     List<ConfigurationCheckReport> reports = new ArrayList<>();
     Arrays.asList(ConfigurationCheckersEnum.values()).forEach( checker -> {
-      reports.add(runCheck(checker, bootProperties, bootstrap)); 
+      reports.add(checker.performCheck(bootProperties, bootstrap)); 
     });
     
     return reports;
-  }
-
-  private ConfigurationCheckReport runCheck(ConfigurationCheckersEnum configCheck, BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
-    System.err.println("\n\n**************************************************");
-    System.err.println("Performing configuration check: " + configCheck.getChecker().getFriendlyName());
-    System.err.println(configCheck.getChecker().getDescription() + "\n");
-    
-    return configCheck.performCheck(bootProperties, bootstrap);    
   }
   
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationChecker.java
@@ -1,0 +1,14 @@
+package com.adaptris.core.management.config;
+
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.UnifiedBootstrap;
+
+public interface ConfigurationChecker {
+
+  public String getFriendlyName();
+  
+  public String getDescription();
+  
+  public void performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrapProperties) throws ConfigurationException;
+  
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationChecker.java
@@ -9,6 +9,6 @@ public interface ConfigurationChecker {
   
   public String getDescription();
   
-  public void performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrapProperties) throws ConfigurationException;
+  public ConfigurationCheckReport performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrapProperties);
   
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationChecker.java
@@ -6,9 +6,7 @@ import com.adaptris.core.management.UnifiedBootstrap;
 public interface ConfigurationChecker {
 
   public String getFriendlyName();
-  
-  public String getDescription();
-  
+    
   public ConfigurationCheckReport performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrapProperties);
   
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckersEnum.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckersEnum.java
@@ -1,0 +1,36 @@
+package com.adaptris.core.management.config;
+
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.UnifiedBootstrap;
+
+public enum ConfigurationCheckersEnum {
+  
+  // **************
+  // Available checkers
+
+  DESERIALIZATION (new DeserializationConfigurationChecker()),
+  
+  CLASSPATH_DUPLICATION (new ClasspathDupConfigurationChecker()),
+  
+  SHARED_CONNECTION_USAGE (new SharedConnectionConfigurationChecker());
+  
+//**************
+  
+  private ConfigurationChecker checker;
+  
+  ConfigurationCheckersEnum(ConfigurationChecker configurationChecker) {
+    this.setChecker(configurationChecker);
+  }
+  
+  public void performCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) throws ConfigurationException {
+    this.getChecker().performConfigCheck(bootProperties, bootstrap);
+  };
+
+  public ConfigurationChecker getChecker() {
+    return checker;
+  }
+
+  public void setChecker(ConfigurationChecker checker) {
+    this.checker = checker;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckersEnum.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckersEnum.java
@@ -22,8 +22,8 @@ public enum ConfigurationCheckersEnum {
     this.setChecker(configurationChecker);
   }
   
-  public void performCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) throws ConfigurationException {
-    this.getChecker().performConfigCheck(bootProperties, bootstrap);
+  public ConfigurationCheckReport performCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
+    return this.getChecker().performConfigCheck(bootProperties, bootstrap);
   };
 
   public ConfigurationChecker getChecker() {

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationException.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationException.java
@@ -1,0 +1,30 @@
+package com.adaptris.core.management.config;
+
+import com.adaptris.core.CoreException;
+
+public class ConfigurationException extends CoreException {
+
+  private static final long serialVersionUID = -6768566897581637451L;
+  
+  /**
+   * <p>
+   * Creates a new instance with a reference to a previous 
+   * <code>Exception</code>.
+   * </p>
+   * @param cause a previous, causal <code>Exception</code>
+   */
+  public ConfigurationException(Throwable cause) {
+    super(cause);
+  }
+  
+  /**
+   * <p>
+   * Creates a new instance with a description of the <code>Exception</code>.
+   * </p>
+   * @param description description of the <code>Exception</code>
+   */
+  public ConfigurationException(String description) {
+    super(description);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationException.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationException.java
@@ -4,19 +4,7 @@ import com.adaptris.core.CoreException;
 
 public class ConfigurationException extends CoreException {
 
-  private static final long serialVersionUID = -6768566897581637451L;
-  
-  /**
-   * <p>
-   * Creates a new instance with a reference to a previous 
-   * <code>Exception</code>.
-   * </p>
-   * @param cause a previous, causal <code>Exception</code>
-   */
-  public ConfigurationException(Throwable cause) {
-    super(cause);
-  }
-  
+  private static final long serialVersionUID = -6768566897581637451L;  
   /**
    * <p>
    * Creates a new instance with a description of the <code>Exception</code>.

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
@@ -13,15 +13,22 @@ public class DeserializationConfigurationChecker implements ConfigurationChecker
   private static final String DESCRIPTION = "This test will attempt to create an Interlok adapter from your configuration files and then pre-initialize each component.";
 
   @Override
-  public void performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) throws ConfigurationException {
+  public ConfigurationCheckReport performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(this.getFriendlyName());
+    
     // This seems a bit cheaty, but we're going to exit anyway, so
     // calling prepare probably makes no difference.
     try {
       Adapter clonedAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(bootstrap.createAdapter().getConfiguration());
       LifecycleHelper.prepare(clonedAdapter);
+      
+      report.setCheckPassed(true);
     } catch (Exception ex) {
-      throw new ConfigurationException(ex);
+      report.setCheckPassed(false);
+      report.setFailureException(ex);
     }
+    return report;
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
@@ -10,8 +10,6 @@ public class DeserializationConfigurationChecker implements ConfigurationChecker
   
   private static final String FRIENDLY_NAME = "Configuration loading test";
   
-  private static final String DESCRIPTION = "This test will attempt to create an Interlok adapter from your configuration files and then pre-initialize each component.";
-
   @Override
   public ConfigurationCheckReport performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
     ConfigurationCheckReport report = new ConfigurationCheckReport();
@@ -23,9 +21,7 @@ public class DeserializationConfigurationChecker implements ConfigurationChecker
       Adapter clonedAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(bootstrap.createAdapter().getConfiguration());
       LifecycleHelper.prepare(clonedAdapter);
       
-      report.setCheckPassed(true);
     } catch (Exception ex) {
-      report.setCheckPassed(false);
       report.setFailureException(ex);
     }
     return report;
@@ -34,11 +30,6 @@ public class DeserializationConfigurationChecker implements ConfigurationChecker
   @Override
   public String getFriendlyName() {
     return FRIENDLY_NAME;
-  }
-
-  @Override
-  public String getDescription() {
-    return DESCRIPTION;
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
@@ -22,7 +22,7 @@ public class DeserializationConfigurationChecker implements ConfigurationChecker
       LifecycleHelper.prepare(clonedAdapter);
       
     } catch (Exception ex) {
-      report.setFailureException(ex);
+      report.getFailureExceptions().add(ex);
     }
     return report;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
@@ -1,0 +1,37 @@
+package com.adaptris.core.management.config;
+
+import com.adaptris.core.Adapter;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.UnifiedBootstrap;
+import com.adaptris.core.util.LifecycleHelper;
+
+public class DeserializationConfigurationChecker implements ConfigurationChecker {
+  
+  private static final String FRIENDLY_NAME = "Configuration loading test";
+  
+  private static final String DESCRIPTION = "This test will attempt to create an Interlok adapter from your configuration files and then pre-initialize each component.";
+
+  @Override
+  public void performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) throws ConfigurationException {
+    // This seems a bit cheaty, but we're going to exit anyway, so
+    // calling prepare probably makes no difference.
+    try {
+      Adapter clonedAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(bootstrap.createAdapter().getConfiguration());
+      LifecycleHelper.prepare(clonedAdapter);
+    } catch (Exception ex) {
+      throw new ConfigurationException(ex);
+    }
+  }
+
+  @Override
+  public String getFriendlyName() {
+    return FRIENDLY_NAME;
+  }
+
+  @Override
+  public String getDescription() {
+    return DESCRIPTION;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/SharedConnectionConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/SharedConnectionConfigurationChecker.java
@@ -101,6 +101,7 @@ public class SharedConnectionConfigurationChecker implements ConfigurationChecke
     InputStream configuration = bootProperties.getConfigurationStream();
     
     DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+    builderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
     DocumentBuilder builder = builderFactory.newDocumentBuilder();
     Document xmlDocument = builder.parse(configuration);
     return xmlDocument;

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/SharedConnectionConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/SharedConnectionConfigurationChecker.java
@@ -1,0 +1,126 @@
+package com.adaptris.core.management.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.UnifiedBootstrap;
+import com.adaptris.util.URLHelper;
+import com.adaptris.util.URLString;
+
+public class SharedConnectionConfigurationChecker implements ConfigurationChecker {
+  
+  private static final String FRIENDLY_NAME = "Shared connection check.";
+  
+  private static final String DESCRIPTION = "This test will scan your configuration for shared connections, making sure each is used and referenced correctly.";
+  
+  private static final String XPATH_AVAILABLE_CONNECTIONS = "/adapter/shared-components/connections/*/unique-id";
+  
+  private static final String XPATH_REFERENCED_CONSUME_CONNECTIONS = "//consume-connection/lookup-name";
+
+  private static final String XPATH_REFERENCED_PRODUCE_CONNECTIONS = "//produce-connection/lookup-name";
+
+  @Override
+  public void performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) throws ConfigurationException {
+    try {      
+      Document xmlDocument = buildXmlDocument(bootProperties);
+      
+      NodeList availableConnections = scanForConnections(xmlDocument, XPATH_AVAILABLE_CONNECTIONS);
+      System.err.println("Found " + availableConnections.getLength() + " available connection(s).");
+      
+      NodeList referencedConsumeConnections = scanForConnections(xmlDocument, XPATH_REFERENCED_CONSUME_CONNECTIONS);
+      System.err.println("Found " + referencedConsumeConnections.getLength() + " referenced consume connection(s).");
+      
+      NodeList referencedProduceConnections = scanForConnections(xmlDocument, XPATH_REFERENCED_PRODUCE_CONNECTIONS);
+      System.err.println("Found " + referencedProduceConnections.getLength() + " referenced produce connection(s).");
+      
+      boolean warningsFound = false;
+      StringBuilder warningText = new StringBuilder();
+      
+      // **********************************
+      // Check all shared connections are used.
+      for(int counter = 0; counter < availableConnections.getLength(); counter ++) {
+        if(!this.testReferenceExistsInNodeSets(availableConnections.item(counter).getTextContent(), referencedConsumeConnections)) {
+          warningsFound = true;
+          warningText.append("\nShared connection unused: " + availableConnections.item(counter).getTextContent());
+        }
+      }
+      
+      // **********************************
+      // Check all consume shared connections exist.
+      for(int counter = 0; counter < referencedConsumeConnections.getLength(); counter ++) {
+        if(!this.testReferenceExistsInNodeSets(referencedConsumeConnections.item(counter).getTextContent(), availableConnections)) {
+          warningsFound = true;
+          warningText.append("\nConsume shared connection does not exist in shared connections: " + referencedConsumeConnections.item(counter).getTextContent());
+        }
+      }
+      
+      // **********************************
+      // Check all produce shared connections exist.
+      for(int counter = 0; counter < referencedProduceConnections.getLength(); counter ++) {
+        if(!this.testReferenceExistsInNodeSets(referencedProduceConnections.item(counter).getTextContent(), availableConnections)) {
+          warningsFound = true;
+          warningText.append("\nProduce shared connection does not exist in shared connections: " + referencedProduceConnections.item(counter).getTextContent());
+        }
+      }
+      
+      if(warningsFound)
+        throw new ConfigurationException(warningText.toString());
+      
+    } catch (ConfigurationException configurationException) {
+      throw configurationException;
+    } catch (Exception ex) {
+      throw new ConfigurationException(ex);
+    }
+  }
+  
+  private boolean testReferenceExistsInNodeSets(String searchValue, NodeList listOfNodes) {
+    boolean result = false;
+    for(int counter = 0; counter < listOfNodes.getLength(); counter ++) {
+      if(searchValue.equals(listOfNodes.item(counter).getTextContent())) {
+        result = true;
+        break;
+      }
+    }
+    
+    return result;
+  }
+
+  private Document buildXmlDocument(BootstrapProperties bootProperties)
+      throws IOException, ParserConfigurationException, SAXException {
+    InputStream configuration = URLHelper.connect(new URLString(bootProperties.findAdapterResource()));
+    
+    DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = builderFactory.newDocumentBuilder();
+    Document xmlDocument = builder.parse(configuration);
+    return xmlDocument;
+  }
+  
+  private NodeList scanForConnections(Document xmlDocument, String xpath) throws XPathExpressionException {
+    XPath xPathAvailableConnections = XPathFactory.newInstance().newXPath();
+    return (NodeList) xPathAvailableConnections.compile(xpath).evaluate(xmlDocument, XPathConstants.NODESET);
+  }
+  
+  @Override
+  public String getFriendlyName() {
+    return FRIENDLY_NAME;
+  }
+
+  @Override
+  public String getDescription() {
+    return DESCRIPTION;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/ClasspathDupConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/ClasspathDupConfigurationCheckerTest.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClasspathDupConfigurationCheckerTest {
+
+  private ClasspathDupConfigurationChecker checker;
+  
+  @Before
+  public void setUp() throws Exception {
+    checker = new ClasspathDupConfigurationChecker();
+    
+    System.setProperty("interlok.bootstrap.debug", "true");
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    
+  }
+  
+  @Test
+  public void testDeDup() throws Exception {
+    // this one may actually fail occassionally.
+    ConfigurationCheckReport report = checker.performConfigCheck(null, null);
+    if(!report.isCheckPassed()) {
+      assertNotNull(report.getFailureException());
+    }
+    assertNotNull(report.toString());
+  }
+  
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/ClasspathDupConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/ClasspathDupConfigurationCheckerTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.core.management.config;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
@@ -14,7 +15,7 @@ public class ClasspathDupConfigurationCheckerTest {
   public void setUp() throws Exception {
     checker = new ClasspathDupConfigurationChecker();
     
-    System.setProperty("interlok.bootstrap.debug", "true");
+    checker.setDebug(true);
   }
   
   @After
@@ -27,7 +28,18 @@ public class ClasspathDupConfigurationCheckerTest {
     // this one may actually fail occassionally.
     ConfigurationCheckReport report = checker.performConfigCheck(null, null);
     if(!report.isCheckPassed()) {
-      assertNotNull(report.getFailureException());
+      assertTrue(report.getWarnings().size() > 0);
+    }
+    assertNotNull(report.toString());
+  }
+  
+  @Test
+  public void testDeDupWithNoLogging() throws Exception {
+    // this one may actually fail occassionally.
+    checker.setDebug(false);
+    ConfigurationCheckReport report = checker.performConfigCheck(null, null);
+    if(!report.isCheckPassed()) {
+      assertTrue(report.getWarnings().size() > 0);
     }
     assertNotNull(report.toString());
   }

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/ConfigurationCheckRunnerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/ConfigurationCheckRunnerTest.java
@@ -1,8 +1,8 @@
 package com.adaptris.core.management.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -69,7 +69,7 @@ public class ConfigurationCheckRunnerTest {
       // The de-dup test might actually fail, so lets test the shared connection test.
       if(report.getCheckName().equals(SHARED_CONN_TEST_FRIENDLY_NAME)) {
         assertTrue(report.isCheckPassed());
-        assertNull(report.getFailureException());
+        assertEquals(0, report.getFailureExceptions().size());
       }
     });
   }

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/ConfigurationCheckRunnerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/ConfigurationCheckRunnerTest.java
@@ -1,0 +1,114 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+
+import org.fusesource.hawtbuf.ByteArrayInputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.Adapter;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.Channel;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.NullConnection;
+import com.adaptris.core.SharedConnection;
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.UnifiedBootstrap;
+import com.adaptris.core.runtime.AdapterManagerMBean;
+
+public class ConfigurationCheckRunnerTest {
+  
+  private static final String SHARED_CONN_TEST_FRIENDLY_NAME = "Shared connection check.";
+
+  private ConfigurationCheckRunner checkRunner;
+  
+  private InputStream configurationStream;
+  
+  @Mock private BootstrapProperties mockBootProperties;
+  
+  @Mock private AdapterManagerMBean mockAdapterMBean;
+  
+  @Mock private UnifiedBootstrap mockUnifiedBootstrap;
+  
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    checkRunner = new ConfigurationCheckRunner();
+    
+    when(mockUnifiedBootstrap.createAdapter())
+        .thenReturn(mockAdapterMBean);
+
+    when(mockAdapterMBean.getConfiguration())
+        .thenReturn(createAdapterConfig());
+    
+    System.setProperty("interlok.bootstrap.debug", "true");
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    
+  }
+  
+  @Test
+  public void testSuccessRunner() throws Exception {
+    configurationStream = this.createAdapterConfig(new NullConnection("SharedNullConnection"), new SharedConnection("SharedNullConnection"), new SharedConnection("SharedNullConnection"));
+    
+    when(mockBootProperties.getConfigurationStream())
+        .thenReturn(configurationStream);
+    
+    checkRunner.runChecks(mockBootProperties, mockUnifiedBootstrap).forEach(report -> {
+      // The de-dup test might actually fail, so lets test the shared connection test.
+      if(report.getCheckName().equals(SHARED_CONN_TEST_FRIENDLY_NAME)) {
+        assertTrue(report.isCheckPassed());
+        assertNull(report.getFailureException());
+      }
+    });
+  }
+  
+  @Test
+  public void testFailureRunner() throws Exception {
+    configurationStream = this.createAdapterConfig(new NullConnection("SharedNullConnection"), null, null);
+    
+    when(mockBootProperties.getConfigurationStream())
+        .thenReturn(configurationStream);
+    
+    checkRunner.runChecks(mockBootProperties, mockUnifiedBootstrap).forEach(report -> {
+      if(report.getCheckName().equals(SHARED_CONN_TEST_FRIENDLY_NAME)) {
+        assertFalse(report.isCheckPassed());
+        assertNotNull(report.getFailureException());
+        assertNotNull(report.toString());
+      }
+    });
+  }
+  
+  private InputStream createAdapterConfig(AdaptrisConnection sharedComponent, AdaptrisConnection consumeConnection, AdaptrisConnection produceConnection) throws Exception {
+    Adapter adapter = new Adapter();
+    if(sharedComponent != null)
+      adapter.getSharedComponents().addConnection(sharedComponent);
+    
+    Channel channel = new Channel();
+    if(consumeConnection != null)
+      channel.setConsumeConnection(consumeConnection);
+    if(produceConnection != null)
+      channel.setProduceConnection(produceConnection);
+    
+    adapter.getChannelList().add(channel);
+    String marshalledConfig = DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
+    return new ByteArrayInputStream(marshalledConfig.getBytes());
+  }
+  
+  private String createAdapterConfig() throws Exception {
+    Adapter adapter = new Adapter();
+    adapter.setUniqueId("MyAdapter");
+    return DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/ConfigurationCheckRunnerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/ConfigurationCheckRunnerTest.java
@@ -84,7 +84,7 @@ public class ConfigurationCheckRunnerTest {
     checkRunner.runChecks(mockBootProperties, mockUnifiedBootstrap).forEach(report -> {
       if(report.getCheckName().equals(SHARED_CONN_TEST_FRIENDLY_NAME)) {
         assertFalse(report.isCheckPassed());
-        assertNotNull(report.getFailureException());
+        assertTrue(report.getWarnings().size() > 0);
         assertNotNull(report.toString());
       }
     });

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeserializationConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeserializationConfigurationCheckerTest.java
@@ -1,0 +1,68 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.Adapter;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.UnifiedBootstrap;
+import com.adaptris.core.runtime.AdapterManagerMBean;
+
+public class DeserializationConfigurationCheckerTest {
+  
+  private DeserializationConfigurationChecker checker;
+  
+  @Mock private BootstrapProperties mockBootProperties;
+  
+  @Mock private AdapterManagerMBean mockAdapterMBean;
+  
+  @Mock private UnifiedBootstrap mockUnifiedBootstrap;
+  
+  
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    
+    checker = new DeserializationConfigurationChecker();
+    
+    when(mockUnifiedBootstrap.createAdapter())
+        .thenReturn(mockAdapterMBean);
+    
+    when(mockAdapterMBean.getConfiguration())
+        .thenReturn(createAdapterConfig());
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    
+  }
+
+  @Test
+  public void testUnmarshallSuccess() throws Exception {
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, mockUnifiedBootstrap);
+    assertTrue(report.isCheckPassed());
+  }
+  
+  @Test
+  public void testUnmarshallFailureBadXml() throws Exception {
+    when(mockAdapterMBean.getConfiguration())
+        .thenReturn("xxx");
+    
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, mockUnifiedBootstrap);
+    assertFalse(report.isCheckPassed());
+  }
+  
+  private String createAdapterConfig() throws Exception {
+    Adapter adapter = new Adapter();
+    adapter.setUniqueId("MyAdapter");
+    return DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/SharedConnectionConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/SharedConnectionConfigurationCheckerTest.java
@@ -53,7 +53,7 @@ public class SharedConnectionConfigurationCheckerTest {
     
     ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
     assertFalse(report.isCheckPassed());
-    assertNotNull(report.getFailureException());
+    assertTrue(report.getFailureExceptions().size() > 0);
   }
   
   @Test
@@ -87,7 +87,7 @@ public class SharedConnectionConfigurationCheckerTest {
     
     ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
     assertFalse(report.isCheckPassed());
-    assertNotNull(report.getFailureException());
+    assertTrue(report.getFailureExceptions().size() > 0);
   }
   
   @Test
@@ -99,7 +99,7 @@ public class SharedConnectionConfigurationCheckerTest {
     
     ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
     assertFalse(report.isCheckPassed());
-    assertNotNull(report.getFailureException());
+    assertTrue(report.getFailureExceptions().size() > 0);
   }
   
   @Test
@@ -123,7 +123,7 @@ public class SharedConnectionConfigurationCheckerTest {
     
     ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
     assertFalse(report.isCheckPassed());
-    assertNotNull(report.getFailureException());
+    assertTrue(report.getFailureExceptions().size() > 0);
     assertNotNull(report.toString());
   }
   

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/SharedConnectionConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/SharedConnectionConfigurationCheckerTest.java
@@ -1,0 +1,116 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+
+import org.fusesource.hawtbuf.ByteArrayInputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.Adapter;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.Channel;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.NullConnection;
+import com.adaptris.core.SharedConnection;
+import com.adaptris.core.management.BootstrapProperties;
+
+public class SharedConnectionConfigurationCheckerTest {
+
+  private SharedConnectionConfigurationChecker checker;
+  
+  private InputStream configurationStream;
+  
+  @Mock private BootstrapProperties mockBootProperties;
+  
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    checker = new SharedConnectionConfigurationChecker();
+    
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+  }
+  
+  @Test
+  public void testNoConnections() throws Exception {
+    configurationStream = this.createAdapterConfig(null, null, null);
+    
+    when(mockBootProperties.getConfigurationStream())
+        .thenReturn(configurationStream);
+    
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    assertTrue(report.isCheckPassed());
+  }
+  
+  @Test
+  public void testSharedNotUsed() throws Exception {
+    configurationStream = this.createAdapterConfig(new NullConnection("SharedNullConnection"), null, null);
+    
+    when(mockBootProperties.getConfigurationStream())
+        .thenReturn(configurationStream);
+    
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    assertFalse(report.isCheckPassed());
+  }
+  
+  @Test
+  public void testConsumeConnectionNoShared() throws Exception {
+    configurationStream = this.createAdapterConfig(null, new SharedConnection("DoesNotExist"), null);
+    
+    when(mockBootProperties.getConfigurationStream())
+        .thenReturn(configurationStream);
+    
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    assertFalse(report.isCheckPassed());
+
+  }
+  
+  @Test
+  public void testProduceConnectionNoShared() throws Exception {
+    configurationStream = this.createAdapterConfig(null, null, new SharedConnection("DoesNotExist"));
+    
+    when(mockBootProperties.getConfigurationStream())
+        .thenReturn(configurationStream);
+    
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    assertFalse(report.isCheckPassed());
+  }
+  
+  @Test
+  public void testProduceAndConsumeConnectionsExist() throws Exception {
+    configurationStream = this.createAdapterConfig(new NullConnection("SharedNullConnection"), new SharedConnection("SharedNullConnection"), new SharedConnection("SharedNullConnection"));
+    
+    when(mockBootProperties.getConfigurationStream())
+        .thenReturn(configurationStream);
+    
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    assertTrue(report.isCheckPassed());
+  }
+  
+  
+  private InputStream createAdapterConfig(AdaptrisConnection sharedComponent, AdaptrisConnection consumeConnection, AdaptrisConnection produceConnection) throws Exception {
+    Adapter adapter = new Adapter();
+    if(sharedComponent != null)
+      adapter.getSharedComponents().addConnection(sharedComponent);
+    
+    Channel channel = new Channel();
+    if(consumeConnection != null)
+      channel.setConsumeConnection(consumeConnection);
+    if(produceConnection != null)
+      channel.setProduceConnection(produceConnection);
+    
+    adapter.getChannelList().add(channel);
+    String marshalledConfig = DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
+    return new ByteArrayInputStream(marshalledConfig.getBytes());
+  }
+  
+}


### PR DESCRIPTION
## Motivation

The initial request was to have a new configuration test when starting an instance with --configtest to make sure shared connections were all referenced and being used in your channels and to make sure that any channels shared connections referenced a shared connection component.

## Modification

We were already running 2 tests; classpath Dedup and an un-marshalling test.  I have abstracted these tests out into a new Interface ConfigurationChecker and impls.
I added a third implementation which will test the shared connections.
Currently these tests are a static list in a new enum; ConfigurationCheckersEnum.  So if you wanted to add a new configuration test, then you'd create a new implementation and add yours to the enum.
Each test returns a report object including any exception.
In the CmdBootstrap class we now simply call the config checker class to run all tests and then output the reports at the end.

## Result

We can now run multiple configuration tests in the CmdBootstrap.  Each test will generate a report.  Those reports will tell us if the test has passed, or give exception details if it has not.
Further we can add to this list as developers by creating a new implementation of ConfigurationChecker and adding a new entry into the ConfigurationCheckersEnum.

We may want to improve this later by having our checker runner scan the classpath for all implementations of the ConfigurationChecker interface, thereby making it easier to add tests. 

## Testing

Simply create an instance of Interlok that has duplicated classes in the classpath, or has shared connections that do not all match up correctly, or finally supply a configuration that will fail unmarshalling.

Then run your instance with any of the following switchs;
"-configtest", "-configcheck", "--configtest", "--configcheck"

After the tests have completed you'll see a report at the end that may look something like this;
```
********************
Configuration loading test: Failed.  With Exception: com.adaptris.core.CoreException: Failed to find adaptris component: [comp/env/solace] or [solace]



********************
Classpath duplication check.: Failed.  With Exception: Possible duplicates found.



********************
Shared connection check.: Failed.  With Exception:
Shared connection unused: http-embedded-connection
Consume shared connection does not exist in shared connections: wmq
Produce shared connection does not exist in shared connections: solace
```
