### PR TITLE
INTERLOK-3283

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/HeartbeatEvent.java
+++ b/interlok-core/src/main/java/com/adaptris/core/HeartbeatEvent.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core;
 
+import org.slf4j.Logger;
+
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -29,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * </p>
  */
 @XStreamAlias("heartbeat-event")
-public class HeartbeatEvent extends AdapterLifecycleEvent {
+public class HeartbeatEvent extends AdapterLifecycleEvent implements LoggableEvent {
   private static final long serialVersionUID = 2014012301L;
 
   private long heartbeatTime;
@@ -93,6 +95,11 @@ public class HeartbeatEvent extends AdapterLifecycleEvent {
    */
   public void setAdapterStateSummary(AdapterStateSummary a) {
     this.adapterStateSummary = a;
+  }
+
+  @Override
+  public void logEvent(Logger logger) {
+    logger.trace("Heartbeat created=class {}", this.getClass().getSimpleName());
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/HeartbeatTimerTask.java
+++ b/interlok-core/src/main/java/com/adaptris/core/HeartbeatTimerTask.java
@@ -46,7 +46,7 @@ class HeartbeatTimerTask extends TimerTask {
       HeartbeatEvent heartbeat = EventFactory.create(heartbeatEventImp);
       heartbeat.setHeartbeatTime(System.currentTimeMillis());
       heartbeat.extractState(adapter);
-      log.trace("Heartbeat created=" + heartbeatEventImp);
+      heartbeat.logEvent(log);
       adapter.getEventHandler().send(heartbeat);
     }
     catch (Exception e) {

--- a/interlok-core/src/main/java/com/adaptris/core/LoggableEvent.java
+++ b/interlok-core/src/main/java/com/adaptris/core/LoggableEvent.java
@@ -1,0 +1,9 @@
+package com.adaptris.core;
+
+import org.slf4j.Logger;
+
+public interface LoggableEvent {
+
+  public void logEvent(Logger logger);
+  
+}

--- a/interlok-core/src/test/java/com/adaptris/core/HeartbeatEventTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/HeartbeatEventTest.java
@@ -1,0 +1,56 @@
+package com.adaptris.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+
+import java.util.Date;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+
+public class HeartbeatEventTest {
+
+  private HeartbeatEvent event;
+  
+  @Mock private Logger mockLogger;
+  
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    
+    event = new HeartbeatEvent();
+    event.setAdapterStateSummary(null);
+    event.setHeartbeatTime(new Date().getTime());
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    
+  }
+  
+  @Test
+  public void testExtractState() throws Exception {
+    Adapter adapter = new Adapter();
+    adapter.setUniqueId("MyAdapter");
+    Channel channel = new Channel();
+    channel.setUniqueId("MyChannel");
+    adapter.getChannelList().add(channel);
+    
+    event.extractState(adapter);
+    
+    assertEquals("MyAdapter", event.getAdapterStateSummary().getAdapterState().getKey());
+  }
+  
+  @Test
+  public void testLogEvent() throws Exception {
+    event.logEvent(mockLogger);
+    
+    verify(mockLogger).trace(anyString(), anyString());
+  }
+  
+}

--- a/interlok-core/src/test/java/com/adaptris/core/HeartbeatTimerTaskTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/HeartbeatTimerTaskTest.java
@@ -1,0 +1,63 @@
+package com.adaptris.core;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.adaptris.core.stubs.StubEventHandler;
+
+public class HeartbeatTimerTaskTest {
+  
+  private HeartbeatTimerTask timerTask; 
+  
+  private Adapter mockAdapter;
+  
+  private MockEventHandler mockEventHandler;
+  
+  @Before
+  public void setUp() throws Exception {    
+    mockEventHandler = new MockEventHandler();
+    
+    mockAdapter = new Adapter();
+    mockAdapter.setEventHandler(mockEventHandler);
+    
+    timerTask = new HeartbeatTimerTask(HeartbeatEvent.class, mockAdapter);
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    
+  }
+
+  @Test
+  public void testRunEventLogger() throws Exception {
+    timerTask.run();
+    
+    await()
+    .atMost(Duration.ofSeconds(1))
+  .with()
+    .pollInterval(Duration.ofMillis(100))
+    .until(mockEventHandler::getEventCount, greaterThanOrEqualTo(1));
+    
+    assertEquals(1, mockEventHandler.getEventCount());
+  }
+  
+  class MockEventHandler extends StubEventHandler {
+    int eventCount;
+    
+    @Override
+    public void send(Event evt) throws CoreException {
+      eventCount ++;
+    }
+    
+    int getEventCount() {
+      return eventCount;
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

We will need other implementations of the heartbeat event that can log their own messages.  Specifically a LicenseExpiryWarningEvent.

## Modification

The timer task used to have a static message it would print for the heartbeat event, but now it will delegate to the heartbeat event to log as it sees fit, including log level.  To do this I have added another interface LoggableEvent that defines a single method logEvent(logger).

This change has no effect on the current behaviour.  The current HeartbeatEvents logEvent method has been added to reflect previous behaviour.

## Result

End users will eventually be able to configure different heartbeat event implementations who will be responsible for the log level and message they want to spit out.

## Testing

Nothing has changed here if you still use the default HeartbeatEvent.  