### PR TITLE
INTERLOK-3315 Remove soLingerTime

### DIFF
--- a/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-failsafe.xml
+++ b/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-failsafe.xml
@@ -126,7 +126,6 @@
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port" default="8080" /></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.http.soLingerTime" deprecated="http.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
       </New>

--- a/interlok-core/src/main/resources/META-INF/templates/template-jetty.xml
+++ b/interlok-core/src/main/resources/META-INF/templates/template-jetty.xml
@@ -126,7 +126,6 @@
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port" default="8080" /></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.http.soLingerTime" deprecated="http.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
       </New>

--- a/interlok-core/src/test/resources/jetty/jetty.xml
+++ b/interlok-core/src/test/resources/jetty/jetty.xml
@@ -63,7 +63,6 @@
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port" default="8080" /></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.http.soLingerTime" deprecated="http.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
       </New>


### PR DESCRIPTION
## Motivation

The default jetty-failsafe (and jetty.xml files that we distribute) contain a deprecated setting which causes a warning on startup.

```
[o.e.j.s.AbstractConnector] Ignoring deprecated socket close linger time
```

## Modification

Remove the references to soLingerTime from the template jetty and jetty-failsafe

## Result

The warning should no longer be logged.

## Testing

### Runtime

* Make sure you end up using the failsafe-jetty.xml; i.e. by `managementComponents=jmx:jetty` but no `webServerConfigUrl`
* Start it up
* Eyeball the logging (easiest if you are using log4j colourization); should be no warnings from jetty.

### UI Additional Files

* Connect using the UI
* Create a new project
* Save it, opting to include all the "additional files"
* the jetty.xml that is saved should not have any soLingerTime