### PR TITLE
INTERLOK-3277

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
@@ -16,13 +16,18 @@
 
 package com.adaptris.core;
 
+import com.adaptris.annotation.Removal;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Implementation of {@link ProduceExceptionHandler} which attempts to restart the {@link Workflow} that had the failure.
  * 
  * @config restart-produce-exception-handler
+ * 
+ * @deprecated since 3.10.2
  */
+@Deprecated
+@Removal(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", version = "3.11.0")
 @XStreamAlias("restart-produce-exception-handler")
 public class RestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
@@ -27,7 +27,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @deprecated since 3.10.2
  */
 @Deprecated
-@Removal(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", version = "3.11.0")
+@Removal(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", version = "3.12.0")
 @XStreamAlias("restart-produce-exception-handler")
 public class RestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 


### PR DESCRIPTION
## Motivation

Restarting workflows on produce failures causes way more problems than it solves.  It shoujldn't be used.  So let's remove it.

## Modification

Simply deprecated this restart produce exception handler.  The channel-restart-produce-exception-handler can still be used and does work (well once a bug is fixed in it, in this sprint).

I've said 3.11.0 as removal... do we want to stick with that or go higher?
EDIT:  Now set to 3.12

## Result

We're telling people not to use this.

## Testing

Deprecation warnings should be thrown in the UI if you've configured this component.
