### PR TITLE
INTERLOK-3230 Channel Restart Produce Exception Handler

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/Channel.java
+++ b/interlok-core/src/main/java/com/adaptris/core/Channel.java
@@ -167,6 +167,7 @@ public class Channel implements ComponentLifecycleExtension, StateManagedCompone
       LifecycleHelper.start(produceConnection);
       LifecycleHelper.start(workflowList);
       LifecycleHelper.start(consumeConnection);
+      toggleAvailability(true);
     }
     startTime = new Date();
   }

--- a/interlok-core/src/test/java/com/adaptris/core/ChannelTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ChannelTest.java
@@ -103,7 +103,17 @@ public class ChannelTest extends ExampleChannelCase {
     c.requestClose();
     assertEquals(ClosedState.getInstance(), c.retrieveComponentState());
   }
-
+  
+  @Test
+  public void channelAvailability_toggleTest() throws Exception {
+  Channel c = new Channel();
+  c.toggleAvailability(false);
+  assertEquals(false, c.isAvailable());
+  c.requestStart();
+  assertEquals(true, c.isAvailable());
+  
+  }
+  
   @Test
   public void testChannel_StateManagedComponentContainerInit() throws Exception {
     Channel channel = new Channel();


### PR DESCRIPTION
## Motivation

Why am I doing this

When the channel restarts after it's produce exception it still doesn't think it's back up and running, stopping any messages from being processed.

## Modification

What did I change

Set the availability to true when the Channel is started.

## Result

What's the end result for the user

The channel fully restarts upon the channel produce exception handler.

## Testing

How can I test this if I'm reviewing this.

Follow the instructions at Interlok-3230 to recreate, with the current change the channel will restart properly.
