### PR TITLE
INTERLOK-3337 addServlet is now synchronized

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/core/management/webserver/JettyServerManager.java
+++ b/interlok-common/src/main/java/com/adaptris/core/management/webserver/JettyServerManager.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,9 +47,9 @@ import org.slf4j.LoggerFactory;
  * This class only deals with a specific handler structure. The uppermost handler must be a HandlerCollection and we add the
  * deployment to all of it's appropriate childhandlers.
  * </p>
- * 
+ *
  * @author gcsiki
- * 
+ *
  */
 public class JettyServerManager implements ServerManager {
 
@@ -73,10 +73,12 @@ public class JettyServerManager implements ServerManager {
   public static final String SECURITY_CONSTRAINTS = "securityConstraints";
 
   /**
-   * Enable additional debug logging by specifying the system property {@code adp.jetty.debug} to true.
-   * 
+   * Enable additional debug logging by specifying the system property {@code interlok.jetty.debug}
+   * to true.
+   *
    */
-  public static final boolean JETTY_DEBUG = Boolean.getBoolean("adp.jetty.debug");
+  public static final boolean JETTY_DEBUG =
+      Boolean.getBoolean("adp.jetty.debug") || Boolean.getBoolean("interlok.jetty.debug");
   private Logger log = LoggerFactory.getLogger(this.getClass());
 
   /**
@@ -120,7 +122,8 @@ public class JettyServerManager implements ServerManager {
     addServlet(new ServletHolder(servlet), additionalProperties);
   }
 
-  public void addServlet(ServletHolder servlet, HashMap<String, Object> additionalProperties) throws Exception {
+  public synchronized void addServlet(ServletHolder servlet,
+      HashMap<String, Object> additionalProperties) throws Exception {
     boolean addedAtLeastOnce = false;
     for (Server server : servers) {
       WebAppContext rootWar = findRootContext(server, true);
@@ -154,7 +157,8 @@ public class JettyServerManager implements ServerManager {
     rootWar.start();
   }
 
-  private WebAppContext findRootContext(Server server, boolean create) throws Exception {
+  private WebAppContext findRootContext(Server server, boolean create)
+      throws Exception {
     WebAppContext root = rootContextFromHandler(server.getHandler());
     if (root == null && create) {
       log.trace("No ROOT WebAppContext, creating one");

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/EmbeddedConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/EmbeddedConnection.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 package com.adaptris.core.http.jetty;
 
 import java.util.HashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import javax.validation.Valid;
 import org.eclipse.jetty.security.SecurityHandler;
@@ -48,9 +49,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * get HTTP 404 errors, then enable logging for the {@code org.eclipse.jetty} category and check how the request is routed by the
  * Jetty engine.
  * </p>
- * 
+ *
  * @config jetty-embedded-connection
- * 
+ *
  */
 @XStreamAlias("jetty-embedded-connection")
 @AdapterComponent
@@ -141,8 +142,9 @@ public class EmbeddedConnection extends AdaptrisConnectionImp implements JettySe
     long totalWaitTime = 0;
     try {
       while (!sm.isStarted() && totalWaitTime < maxWaitTime) {
-        Thread.sleep(DEFAULT_WAIT_INTERVAL_MS);
-        totalWaitTime += DEFAULT_WAIT_INTERVAL_MS;
+        long randomizedWait = ThreadLocalRandom.current().nextInt(DEFAULT_WAIT_INTERVAL_MS) + 1;
+        Thread.sleep(randomizedWait);
+        totalWaitTime += randomizedWait;
       }
       if (!sm.isStarted()) {
         throw new CoreException("Max Wait time exceeded : " + maxWaitTime + "ms");
@@ -168,7 +170,7 @@ public class EmbeddedConnection extends AdaptrisConnectionImp implements JettySe
    * of servlets and also ready for incoming HTTP requests. This value controls how long we wait for the server to start up before
    * throwing an exception.
    * </p>
-   * 
+   *
    * @param t the maxStartupWait to set, default if not specified is 10 minutes.
    */
   public void setMaxStartupWait(TimeInterval t) {
@@ -194,7 +196,7 @@ public class EmbeddedConnection extends AdaptrisConnectionImp implements JettySe
    * configured inside your adapter, then results may be undefined; you are advised to configure a single {@code EmbeddedConnection}
    * as a {@code shared-component} to avoid any issues.
    * </p>
-   * 
+   *
    * @param s the securityHandler wrapper implementation.
    */
   public void setSecurityHandler(SecurityHandlerWrapper s) {


### PR DESCRIPTION
## Motivation

In some situations down to timing, you can have multiple RootContexts being created, which means that some things are added to the wrong context and never become available.

## Modification

Make sure that addServlet is synchronized so that we don't have the chance to create multiple Root contexts.
Made the wait time in EmbeddedJettyConnection a bit more random...
Added `interlok.jetty.debug` in addition to `adp.jetty.debug` cos naming is important.

This is fine, since it's only executed in consumer#start

## Result

A marginally slower startup.

## Testing

Most easily seen with
* workflow-rest-services (health-check)
* adapter with a single jetty workflow that takes no time to start.
* No UI.

Depending on the order in which you run, 3.10-SNAPSHOT / 3.10.1-RELEASE will show you logging about add multiple Root webapps : 

```
2020-06-24T08:01:46,072 TRACE [Thread-4] [c.a.c.m.w.JettyServerManager] No ROOT WebAppContext, creating one
2020-06-24T08:01:46,115 TRACE [JMX-Request-0:jetty-stub.START] [c.a.c.m.w.JettyServerManager] No ROOT WebAppContext, creating one
2020-06-24T08:01:46,140 TRACE [Thread-4] [c.a.c.m.w.JettyServerManager] Adding servlet to existing ROOT WebAppContext against /workflow-health-check/*
2020-06-24T08:01:46,140 TRACE [JMX-Request-0:jetty-stub.START] [c.a.c.m.w.JettyServerManager] Adding servlet to existing ROOT WebAppContext against /api/stub/*
```

Depending on the order in which things fire, you can end up with one or other of the root contexts being unavailable.

This doesn't tend to happen if the UI is present; since the timing is all off based on the fact that the JettyServerComponent takes "time to start and initialise" the war file.
