### PR TITLE
INTERLOK-3340 Add a ClearCacheService

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/cache/ClearCacheService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/cache/ClearCacheService.java
@@ -1,0 +1,74 @@
+package com.adaptris.core.services.cache;
+
+import org.apache.commons.lang3.BooleanUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Clear the contents of the specified cache.
+ *
+ * <p>
+ * You may wish to invalidate the contents of the cache from time to time outside of the standard
+ * expiry conditions. You can use this service to clear the contents of the cache. Since
+ * {@link Cache#clear()} defaults to throwing an {@code UnsupportedOperationException} you can opt
+ * for this service to silently ignore that exception if the underlying cache doesn't support it.
+ * </p>
+ *
+ * @config clear-cache-service
+ */
+@XStreamAlias("clear-cache-service")
+@ComponentProfile(summary = "Clear the contents of the configured cache", since = "3.10.2",
+    tag = "service,cache", recommended = {CacheConnection.class})
+@DisplayOrder(order = {"connection", "quietly"})
+public class ClearCacheService extends CacheServiceImpl {
+
+  @AdvancedConfig
+  @InputFieldDefault(value = "false")
+  private Boolean ignoreUnsupported;
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      retrieveCache().clear();
+    } catch (CoreException e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    } catch (UnsupportedOperationException e) {
+      if (!quietly()) {
+        throw ExceptionHelper.wrapServiceException(e);
+      }
+    }
+  }
+
+  public Boolean getIgnoreUnsupported() {
+    return ignoreUnsupported;
+  }
+
+  /**
+   * Whether or not to silently eat a possible {@code UnsupportedOperationException} that could be
+   * thrown by {@link Cache#clear()}.
+   *
+   * @param b true to ignore {@code UnsupportedOperationException}, default is false if not
+   *        specified.
+   */
+  public void setIgnoreUnsupported(Boolean b) {
+    ignoreUnsupported = b;
+  }
+
+  public ClearCacheService withIgnoreUnsupported(Boolean s) {
+    setIgnoreUnsupported(s);
+    return this;
+  }
+
+  private boolean quietly() {
+    return BooleanUtils.toBooleanDefaultIfNull(getIgnoreUnsupported(), false);
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/ClearCacheServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/ClearCacheServiceTest.java
@@ -1,0 +1,47 @@
+package com.adaptris.core.services.cache;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceCase;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.cache.Cache;
+
+public class ClearCacheServiceTest {
+
+  @Test
+  public void testDoService() throws Exception {
+    Cache mockCache = Mockito.mock(Cache.class);
+    CacheConnection cache = new CacheConnection(mockCache);
+    ClearCacheService service = new ClearCacheService().withConnection(cache);
+    ServiceCase.execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
+  }
+
+  @Test
+  public void testDoService_Quietly() throws Exception {
+    Cache mockCache = Mockito.mock(Cache.class);
+    Mockito.doThrow(new UnsupportedOperationException()).when(mockCache).clear();
+    CacheConnection cache = new CacheConnection(mockCache);
+    ClearCacheService service = new ClearCacheService().withIgnoreUnsupported(true).withConnection(cache);
+    ServiceCase.execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testDoService_NotQuietly() throws Exception {
+    Cache mockCache = Mockito.mock(Cache.class);
+    Mockito.doThrow(new UnsupportedOperationException()).when(mockCache).clear();
+    CacheConnection cache = new CacheConnection(mockCache);
+    ClearCacheService service = new ClearCacheService().withConnection(cache);
+    ServiceCase.execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testDoService_Exception() throws Exception {
+    Cache mockCache = Mockito.mock(Cache.class);
+    Mockito.doThrow(new CoreException()).when(mockCache).clear();
+    CacheConnection cache = new CacheConnection(mockCache);
+    ClearCacheService service = new ClearCacheService().withIgnoreUnsupported(true).withConnection(cache);
+    ServiceCase.execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
+  }
+}


### PR DESCRIPTION
## Motivation

Add a simple service that clears the cache upon demand.

## Modification

Added a ClearCacheService that invokes cache.clear() optionally ignoring the "UnsupportedOperationException" that's possible from the default cache.clear() method.

## Result

The ability to clear the contents of the cache outside of the normal expiry window.
Note that ehcache / jsr107 caching doesn't appear to support clear() (since it's not part of the JSR), so this really only works with the default expiring-map-cache implementation.

## Testing

You'll need 3 workflows that can be triggered on demand.

- First one adds something to the cache.
- Second one retrieves that something from the cache (or fails)
- Third one clears the cache.

Execute 1/2/3/2 the last invocation of the 2nd workflow should fail.
