### PR TITLE
INTERLOK-3342 Change default set to be LinkedHashSet

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdapterXStreamMarshallerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdapterXStreamMarshallerFactory.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -234,6 +236,8 @@ public class AdapterXStreamMarshallerFactory extends AdapterMarshallerFactory {
     }
 
     xstream.addDefaultImplementation(ArrayList.class, Collection.class);
+    xstream.addDefaultImplementation(LinkedHashSet.class, Set.class);
+
     return xstream;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddMetadataService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.validation.Valid;
@@ -52,10 +53,10 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * <li>$MSG_SIZE$ - add the messages current size as metadata</li>
  * </ul>
  * </p>
- * 
+ *
  * @config add-metadata-service
- * 
- * 
+ *
+ *
  */
 @XStreamAlias("add-metadata-service")
 @AdapterComponent
@@ -119,16 +120,16 @@ public class AddMetadataService extends MetadataServiceImpl {
    */
   public AddMetadataService() {
     super();
-    setMetadataElements(new HashSet<MetadataElement>());
+    setMetadataElements(new LinkedHashSet<MetadataElement>());
   }
 
   public AddMetadataService(Collection<MetadataElement> elements) {
     this();
-    setMetadataElements(new HashSet<MetadataElement>(elements));
+    setMetadataElements(new LinkedHashSet<MetadataElement>(elements));
   }
 
   public AddMetadataService(MetadataElement... elements) {
-    this(new HashSet<MetadataElement>(Arrays.asList(elements)));
+    this(new LinkedHashSet<MetadataElement>(Arrays.asList(elements)));
   }
 
   /**
@@ -206,11 +207,11 @@ public class AddMetadataService extends MetadataServiceImpl {
 
   /**
    * Whether or not to always overwrite metadata with the values configured.
-   * 
+   *
    * @param b the overwrite to set, default is true.
    */
   public void setOverwrite(Boolean b) {
-    this.overwrite = b;
+    overwrite = b;
   }
 
   private boolean overwrite() {

--- a/interlok-core/src/test/java/com/adaptris/core/BaseCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/BaseCase.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 package com.adaptris.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -174,7 +175,7 @@ public abstract class BaseCase implements UpgradedToJunit4 {
     }
     slf4jLogger.trace("Input = " + input);
     slf4jLogger.trace("Output = " + output);
-    assertEquals(input.getClass(), output.getClass());
+    lenientClassAssertion(input, output);
     try {
       String[] toCall = ObjectUtils.filterGetterWithNoSetter(input.getClass(), ObjectUtils.getPrimitiveGetters(input.getClass()));
       for (int i = 0; i < toCall.length; i++) {
@@ -214,6 +215,24 @@ public abstract class BaseCase implements UpgradedToJunit4 {
       slf4jLogger.error(e.getMessage(), e);
       throw e;
     }
+  }
+
+  // Make sure that lists are in fact lists (but we might be doing ArrayList vs LinkedList, or
+  // because of INTERLOK-3342 HashSet vs LinkedHashSet
+  public static void lenientClassAssertion(Object input, Object output) {
+    if (input instanceof Set) {
+      assertTrue(output instanceof Set);
+      return;
+    }
+    if (input instanceof List) {
+      assertTrue(output instanceof List);
+      return;
+    }
+    if (input instanceof Collection) {
+      assertTrue(output instanceof Collection);
+      return;
+    }
+    assertEquals(input.getClass(), output.getClass());
   }
 
   public static void assertRoundtripEquality(Object input, Object output) throws Exception {


### PR DESCRIPTION
## Motivation

To preserve "insertion order"; Set needs to be LinkedHashSet since XStream doesn't use the getters/setters and just uses its default implementation  when confronted with just a Set<> to unmarshal. Since we default to HashSet, we can't be sure that what's in the XML is what happens when we round trip since ordering minght change.

## Modification

- Force the default implementation for Set to be LinkedHashSet when creating the XStream instance
- Change default set to be LinkedHashSet in AddMetadataService but not the method signature, so it's still Set<> for the getters and setters (this should have no real effect because of the first change).
- Modify roundtripEquality to be less strict when asserting equality

Done it this fashion (making roundtripEquality less strict) because there will be lots of services in optional components  that use Set<> and we don't want to break all their tests...

## Result

Predictable order when creating an AddMetadataService from XML... No other behavioural change.

## Testing

Use this XML snippet when creating a new service in the UI.

```
               <add-metadata-service>
                        <unique-id>add-defaults</unique-id>
                        <metadata-element>
                          <key>message_id</key>
                          <value>$UNIQUE_ID$</value>
                        </metadata-element>
                        <metadata-element>
                          <key>include_header</key>
                          <value>true</value>
                        </metadata-element>
                        <metadata-element>
                          <key>total_row_count</key>
                          <value>0</value>
                        </metadata-element>
                        <metadata-element>
                          <key>page_size</key>
                          <value>100</value>
                        </metadata-element>
                        <metadata-element>
                          <key>page_number</key>
                          <value>1</value>
                        </metadata-element>
                        <metadata-element>
                          <key>sort</key>
                          <value>-updated_at</value>
                        </metadata-element>
                        <metadata-element>
                          <key>s3bucket</key>
                          <value>${s3bucket}</value>
                        </metadata-element>
                        <metadata-element>
                          <key>s3folder</key>
                          <value>${s3folder}</value>
                        </metadata-element>
                      </add-metadata-service>
```

* _If you're not on the PR branch_, then viewing it in the form should say "page_number" as the first element (rather than message_id) proving that the ordering has changed
* _If you're on the PR branch_ message_id should be first.