### PR TITLE
Added Serialization to the ManagementComponentInfo bean

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentInfo.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentInfo.java
@@ -1,18 +1,21 @@
 package com.adaptris.core.management;
 
-import com.adaptris.core.ComponentState;
 import java.io.Serializable;
 
+import com.adaptris.core.ComponentState;
+
 public class ManagementComponentInfo implements Serializable {
-  
+
+  private static final long serialVersionUID = 2020072701L;
+
   private String name;
-    
+
   private String className;
-  
+
   private ComponentState state;
-  
+
   private transient ManagementComponent instance;
-  
+
   public ManagementComponentInfo() {
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentInfo.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentInfo.java
@@ -1,8 +1,9 @@
 package com.adaptris.core.management;
 
 import com.adaptris.core.ComponentState;
+import java.io.Serializable;
 
-public class ManagementComponentInfo {
+public class ManagementComponentInfo implements Serializable {
   
   private String name;
     
@@ -10,7 +11,7 @@ public class ManagementComponentInfo {
   
   private ComponentState state;
   
-  private ManagementComponent instance;
+  private transient ManagementComponent instance;
   
   public ManagementComponentInfo() {
   }


### PR DESCRIPTION
## Motivation

The bean required serialization so we could use it on a ui feature : 
  INTERLOK-3251 - 'UI Dashboard - Add Adapter Management Info to the Information modal'

## Modification

Added Serializable to the ManagementComponentInfo class, and made member 'instance' transient, as there's no point (i think) of this being part of the serialized object.

## Result

people can use the AdapterRegistryMBean.getManagementComponentInfo method (either jconsole or ui)

## Testing

I tested using the UI dashboard information modal, from the branch:
interlok-ui (feature/INTERLOK-3251_Dashboard_Management_Information)

screenshot:
![screenshot-localhost_8080-2020 07 22-12_40_35](https://user-images.githubusercontent.com/15126529/88173143-0139c280-cc1a-11ea-8084-3d9cc45126a4.png)


