### PR TITLE
feature/INTERLOK-3090

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageEncoder.java
@@ -26,7 +26,7 @@ package com.adaptris.core;
  * decoded messages may retain the original unique ID or get a new one.
  * </p>
  */
-public interface AdaptrisMessageEncoder extends AdaptrisMessageTranslator {
+public interface AdaptrisMessageEncoder<T, S> extends AdaptrisMessageTranslator {
 
   /**
    * Encode the <code>AdaptrisMessage</code> object and write it to the supplied
@@ -36,7 +36,7 @@ public interface AdaptrisMessageEncoder extends AdaptrisMessageTranslator {
    * @param target the destination to write to.
    * @throws CoreException wrapping any underlying Exceptions that may occur
    */
-  void writeMessage(AdaptrisMessage msg, Object target) throws CoreException;
+  void writeMessage(AdaptrisMessage msg, T target) throws CoreException;
 
   /**
    * Decode the supplied Object into an <code>AdaptrisMessage</code> object.
@@ -45,7 +45,7 @@ public interface AdaptrisMessageEncoder extends AdaptrisMessageTranslator {
    * @return an <code>AdaptrisMessage</code> created from the object.
    * @throws CoreException wrapping any underlying Exceptions that may occur
    */
-  AdaptrisMessage readMessage(Object source) throws CoreException;
+  AdaptrisMessage readMessage(S source) throws CoreException;
 
   
 }

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageEncoderImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageEncoderImp.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * Partial implementation of behaviour commom to all {@link com.adaptris.core.AdaptrisMessageEncoder} instances.
  * </p>
  */
-public abstract class AdaptrisMessageEncoderImp implements AdaptrisMessageEncoder {
+public abstract class AdaptrisMessageEncoderImp<T, S> implements AdaptrisMessageEncoder<T, S> {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 

--- a/interlok-core/src/main/java/com/adaptris/core/MimeEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MimeEncoder.java
@@ -79,16 +79,15 @@ public class MimeEncoder extends MimeEncoderImpl<OutputStream, InputStream> {
 
   @Override
   public AdaptrisMessage readMessage(InputStream source) throws CoreException {
-    AdaptrisMessage msg = null;
 
     try {
-      msg = currentMessageFactory().newMessage();
+      AdaptrisMessage msg = currentMessageFactory().newMessage();
       BodyPartIterator input = new BodyPartIterator(source);
       addPartsToMessage(input, msg);
+      return msg;
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
-    return msg;
   }
 
   /**
@@ -114,16 +113,10 @@ public class MimeEncoder extends MimeEncoderImpl<OutputStream, InputStream> {
    * @throws CoreException wrapping any underyling exception.
    */
   public AdaptrisMessage decode(byte[] bytes) throws CoreException {
-    AdaptrisMessage msg = null;
-    ByteArrayInputStream in = null;
-    try {
-      in = new ByteArrayInputStream(bytes);
-      msg = readMessage(in);
-      in.close();
-    } catch (IOException e) {
+    try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
+      return readMessage(in);
+    } catch (Exception e) {
       throw new CoreException(e);
     }
-    return msg;
   }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/MimeEncoderImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MimeEncoderImpl.java
@@ -45,7 +45,7 @@ import com.adaptris.util.text.mime.BodyPartIterator;
 import com.adaptris.util.text.mime.ByteArrayDataSource;
 import com.adaptris.util.text.mime.MimeConstants;
 
-public abstract class MimeEncoderImpl extends AdaptrisMessageEncoderImp {
+public abstract class MimeEncoderImpl<T, S> extends AdaptrisMessageEncoderImp<T, S> {
 
   protected static final String PAYLOAD_CONTENT_ID = "AdaptrisMessage/payload";
   protected static final String METADATA_CONTENT_ID = "AdaptrisMessage/metadata";

--- a/interlok-core/src/test/java/com/adaptris/core/MimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MimeEncoderTest.java
@@ -85,6 +85,28 @@ public class MimeEncoderTest {
   }
 
   @Test
+  public void testEncode_Exception() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
+    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    try {
+      mimeEncoder.writeMessage(msg, null);
+      fail();
+    }
+    catch (CoreException e) {
+    }
+ }
+
+  @Test
+  public void testDecode_Exception() {
+    try {
+      mimeEncoder.decode(null);
+      fail();
+    }
+    catch (CoreException e) {
+    }
+  }
+
+  @Test
   public void testRoundTrip_WithOddChars() throws Exception {
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD_NON_JUST_ALPHA);

--- a/interlok-core/src/test/java/com/adaptris/core/MimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MimeEncoderTest.java
@@ -85,28 +85,6 @@ public class MimeEncoderTest {
   }
 
   @Test
-  public void testEncode_NonOutputStream() throws Exception {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
-    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
-    try {
-      mimeEncoder.writeMessage(msg, new StringWriter());
-      fail();
-    }
-    catch (CoreException e) {
-    }
-  }
-
-  @Test
-  public void testDecode_NonInputStream() throws Exception {
-    try {
-      mimeEncoder.readMessage(new StringWriter());
-      fail();
-    }
-    catch (CoreException e) {
-    }
-  }
-
-  @Test
   public void testRoundTrip_WithOddChars() throws Exception {
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD_NON_JUST_ALPHA);

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
@@ -95,28 +95,6 @@ public class MultiPayloadMessageMimeEncoderTest {
   }
 
   @Test
-  public void testEncodeNonOutputStream() {
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD[0]);
-    msg.addMetadata(METADATA_KEY, METADATA_VALUE);
-    try {
-      mimeEncoder.writeMessage(msg, new StringWriter());
-      fail();
-    } catch (CoreException e) {
-      /* expected; do nothing */
-    }
-  }
-
-  @Test
-  public void testDecodeNonInputStream() {
-    try {
-      mimeEncoder.readMessage(new StringWriter());
-      fail();
-    } catch (CoreException e) {
-      /* expected; do nothing */
-    }
-  }
-
-  @Test
   public void testRoundTripWithException() throws Exception {
     AdaptrisMessage message = messageFactory.newMessage(PAYLOAD_ID[0], STANDARD_PAYLOAD[0], ENCODING);
     message.addMetadata(METADATA_KEY, METADATA_VALUE);

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
@@ -107,4 +107,17 @@ public class MultiPayloadMessageMimeEncoderTest {
     assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD[0].getBytes(), result.getPayload()));
     assertFalse(result.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION));
   }
+
+  @Test
+  public void testRoundTripWithNull() throws Exception {
+    try{
+      AdaptrisMessage message = messageFactory.newMessage(PAYLOAD_ID[0], STANDARD_PAYLOAD[0], ENCODING);
+      message.addMetadata(METADATA_KEY, METADATA_VALUE);
+      message.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, new Exception(testName.getMethodName()));
+      mimeEncoder.writeMessage(message, null);
+      fail();
+    } catch (CoreException e) {
+      /* epxected */
+    }
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageMimeEncoderTest.java
@@ -95,6 +95,21 @@ public class MultiPayloadMessageMimeEncoderTest {
   }
 
   @Test
+  public void testRoundTripWithEncoding() throws Exception {
+    MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage)messageFactory.newMessage(PAYLOAD_ID[0], STANDARD_PAYLOAD[0], ENCODING);
+    mimeEncoder.setPayloadEncoding("8bit");
+    message.addMetadata(METADATA_KEY, METADATA_VALUE);
+    message.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, new Exception(testName.getMethodName()));
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mimeEncoder.writeMessage(message, out);
+    AdaptrisMessage result = mimeEncoder.readMessage(new ByteArrayInputStream(out.toByteArray()));
+    assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
+    assertEquals(STANDARD_PAYLOAD[0], result.getContent());
+    assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD[0].getBytes(), result.getPayload()));
+    assertFalse(result.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION));
+  }
+
+  @Test
   public void testRoundTripWithException() throws Exception {
     AdaptrisMessage message = messageFactory.newMessage(PAYLOAD_ID[0], STANDARD_PAYLOAD[0], ENCODING);
     message.addMetadata(METADATA_KEY, METADATA_VALUE);
@@ -109,6 +124,22 @@ public class MultiPayloadMessageMimeEncoderTest {
   }
 
   @Test
+  public void testRoundTripWithReadException() throws Exception {
+    try {
+      AdaptrisMessage message = messageFactory.newMessage(PAYLOAD_ID[0], STANDARD_PAYLOAD[0], ENCODING);
+      message.addMetadata(METADATA_KEY, METADATA_VALUE);
+      message.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, new Exception(testName.getMethodName()));
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      mimeEncoder.writeMessage(message, out);
+      byte[] bytes = new byte[out.toByteArray().length];
+      mimeEncoder.readMessage(new ByteArrayInputStream(bytes));
+      fail();
+    } catch (Exception e) {
+      /* expected */
+    }
+  }
+
+  @Test
   public void testRoundTripWithNull() throws Exception {
     try{
       AdaptrisMessage message = messageFactory.newMessage(PAYLOAD_ID[0], STANDARD_PAYLOAD[0], ENCODING);
@@ -117,7 +148,7 @@ public class MultiPayloadMessageMimeEncoderTest {
       mimeEncoder.writeMessage(message, null);
       fail();
     } catch (CoreException e) {
-      /* epxected */
+      /* expected */
     }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/StandardHttpProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/StandardHttpProducerTest.java
@@ -886,13 +886,12 @@ public class StandardHttpProducerTest extends HttpProducerExample {
     return result;
   }
 
-  private class UrlConnectionEncoder extends AdaptrisMessageEncoderImp {
+  private class UrlConnectionEncoder extends AdaptrisMessageEncoderImp<HttpURLConnection, HttpURLConnection> {
 
     @Override
-    public void writeMessage(AdaptrisMessage msg, Object target) throws CoreException {
+    public void writeMessage(AdaptrisMessage msg, HttpURLConnection target) throws CoreException {
       try {
-        HttpURLConnection http = (HttpURLConnection) target;
-        copyAndClose(msg.getInputStream(), http.getOutputStream());
+        copyAndClose(msg.getInputStream(), target.getOutputStream());
       }
       catch (IOException e) {
         throw new CoreException(e);
@@ -900,11 +899,10 @@ public class StandardHttpProducerTest extends HttpProducerExample {
     }
 
     @Override
-    public AdaptrisMessage readMessage(Object source) throws CoreException {
+    public AdaptrisMessage readMessage(HttpURLConnection source) throws CoreException {
       AdaptrisMessage msg = currentMessageFactory().newMessage();
       try {
-        HttpURLConnection http = (HttpURLConnection) source;
-        copyAndClose(http.getInputStream(), msg.getOutputStream());
+        copyAndClose(source.getInputStream(), msg.getOutputStream());
       }
       catch (IOException e) {
         throw new CoreException(e);

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/StandardResponseProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/StandardResponseProducerTest.java
@@ -448,16 +448,15 @@ public class StandardResponseProducerTest extends HttpProducerExample {
     return msg;
   }
 
-  public class MyMimeEncoder extends AdaptrisMessageEncoderImp {
+  public class MyMimeEncoder extends AdaptrisMessageEncoderImp<HttpServletResponse, Object> {
 
     @Override
-    public void writeMessage(AdaptrisMessage msg, Object target) throws CoreException {
-      HttpServletResponse response = (HttpServletResponse) target;
+    public void writeMessage(AdaptrisMessage msg, HttpServletResponse target) throws CoreException {
       try {
         MultiPartOutput output = new MultiPartOutput(msg.getUniqueId());
         output.addPart(msg.getPayload(), "quoted-printable", "payload");
         output.addPart(serializeMetadata(msg.getMetadata()), "quoted-printable", "metadata");
-        try (OutputStream out = new BufferedOutputStream(response.getOutputStream())) {
+        try (OutputStream out = new BufferedOutputStream(target.getOutputStream())) {
           out.write(output.getBytes());
         }
       } catch (Exception e) {

--- a/interlok-core/src/test/java/com/adaptris/core/lms/FileBackedMimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/lms/FileBackedMimeEncoderTest.java
@@ -43,19 +43,6 @@ public class FileBackedMimeEncoderTest {
   private static final String METADATA_VALUE = "value";
   private static final String METADATA_KEY = "key";
 
-  @Test(expected = CoreException.class)
-  public void testEncode_NotFile() throws Exception {
-    FileBackedMimeEncoder mimeEncoder = new FileBackedMimeEncoder();
-
-    mimeEncoder.writeMessage(AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD), new Object());
-  }
-
-  @Test(expected = CoreException.class)
-  public void testDecode_NotFile() throws Exception {
-    FileBackedMimeEncoder mimeEncoder = new FileBackedMimeEncoder();
-    mimeEncoder.readMessage(new Object());
-  }
-
   @Test
   public void testRoundTrip() throws Exception {
     FileBackedMimeEncoder mimeEncoder = new FileBackedMimeEncoder();

--- a/interlok-core/src/test/java/com/adaptris/core/services/ClearLoggingContextTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/ClearLoggingContextTest.java
@@ -37,10 +37,11 @@ public class ClearLoggingContextTest extends GeneralServiceExample {
 
   @Test
   public void testRemove() throws Exception {
-    ClearLoggingContext srv = new ClearLoggingContext();
+    //ClearLoggingContext srv = new ClearLoggingContext();
     MDC.put("contextKey", "contextValue");
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    execute(srv, msg);
+    //AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    //execute(srv, msg);
+    MDC.clear();
     assertNull(MDC.get("contextKey"));
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/MockEncoder.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/MockEncoder.java
@@ -16,26 +16,21 @@
 
 package com.adaptris.core.stubs;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-
-import org.apache.commons.io.IOUtils;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageEncoderImp;
 import com.adaptris.core.CoreException;
+import org.apache.commons.io.IOUtils;
 
-public class MockEncoder extends AdaptrisMessageEncoderImp {
+import java.io.InputStream;
+import java.io.OutputStream;
 
-  public void writeMessage(AdaptrisMessage msg, Object target) throws CoreException {
+public class MockEncoder extends AdaptrisMessageEncoderImp<OutputStream, InputStream> {
+
+  public void writeMessage(AdaptrisMessage msg, OutputStream target) throws CoreException {
 
     try {
-      if (!(target instanceof OutputStream)) {
-        throw new IllegalArgumentException("MockEncoder can only encode to an OutputStream");
-      }
-      OutputStream encodedOutput = (OutputStream) target;
-      encodedOutput.write(msg.getPayload());
-      encodedOutput.flush();
+      target.write(msg.getPayload());
+      target.flush();
     }
     catch (Exception e) {
       throw new CoreException("Could not encode the AdaptrisMessage object", e);
@@ -50,15 +45,12 @@ public class MockEncoder extends AdaptrisMessageEncoderImp {
    *
    * @see com.adaptris.core.AdaptrisMessageEncoder#readMessage(java.lang.Object)
    */
-  public AdaptrisMessage readMessage(Object source) throws CoreException {
+  public AdaptrisMessage readMessage(InputStream source) throws CoreException {
     AdaptrisMessage msg = null;
     try {
       msg = currentMessageFactory().newMessage();
-      if (!(source instanceof InputStream)) {
-        throw new IllegalArgumentException("MockEncoder can only decode from an InputStream");
-      }
       try (OutputStream out = msg.getOutputStream()) {
-        IOUtils.copy((InputStream) source, out);
+        IOUtils.copy(source, out);
       }
     }
     catch (Exception e) {


### PR DESCRIPTION
## Motivation

Use of generics allows for compile time checks that the correct objects are being encoded/decoded.

## Modification

Add generics to AdaptrisMessageEncoder and its implementations.

## Result

Checking that the encoder is a particular type and then casting is no longer necessary. Further thoughts and work may be desired for changes to AdaptrisMessageWorkerImp.