### PR TITLE
INTERLOK-3286 javax validation config checker

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,8 @@ package com.adaptris.core.management;
 
 import static com.adaptris.core.management.Constants.BOOTSTRAP_PROPERTIES_RESOURCE_KEY;
 import static com.adaptris.core.management.Constants.CFG_KEY_CONFIG_MANAGER;
-import static com.adaptris.core.management.Constants.CFG_KEY_CONFIG_RESOURCE;
 import static com.adaptris.core.management.Constants.CFG_KEY_CONFIG_URL;
 import static com.adaptris.core.management.Constants.CFG_KEY_JMX_SERVICE_URL_KEY;
-import static com.adaptris.core.management.Constants.CFG_KEY_LOG4J12_URL;
 import static com.adaptris.core.management.Constants.CFG_KEY_LOGGING_RECONFIGURE;
 import static com.adaptris.core.management.Constants.CFG_KEY_LOGGING_URL;
 import static com.adaptris.core.management.Constants.CFG_KEY_MANAGEMENT_COMPONENT;
@@ -29,6 +27,8 @@ import static com.adaptris.core.management.Constants.DBG;
 import static com.adaptris.core.management.Constants.DEFAULT_CONFIG_MANAGER;
 import static com.adaptris.core.management.Constants.DEFAULT_PROPS_RESOURCE;
 import static com.adaptris.core.management.Constants.PROTOCOL_FILE;
+import static com.adaptris.core.util.PropertyHelper.getPropertyIgnoringCase;
+import static com.adaptris.core.util.PropertyHelper.getPropertySubset;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -94,8 +94,6 @@ public class BootstrapProperties extends Properties {
     HTTPENABLEPROXYAUTH(true),
     // Constants#CFG_KEY_USE_MANAGEMENT_FACTORY_FOR_JMX
     USEJAVALANGMANAGEMENTFACTORY(true),
-    // Constants#CFG_KEY_VALIDATE_CONFIG
-    VALIDATECONFIG(false),
     // CFG_KEY_LOGGING_RECONFIGURE
     LOGGINGRECONFIGURE(true),
     // Constants#CFG_KEY_START_QUIETLY
@@ -159,12 +157,12 @@ public class BootstrapProperties extends Properties {
 
   /**
    * Add overloaded method to get numerical values from bootstrap.properties.
-   * 
+   *
    * @param key
    *      The property key to get.
    * @param defaultValue
    *      The default numerical value if the key isn't found (or cannot be parsed as numercial).
-   * 
+   *
    * @return The numerical value for the given property key, or default if necessary.
    */
   public Long getProperty(String key, Long defaultValue) {
@@ -173,7 +171,7 @@ public class BootstrapProperties extends Properties {
 
   /**
    * Convenience method to create an adapter based on the existing bootstrap properties
-   * 
+   *
    * @return the adapter object.
    * @throws Exception if an exception occured.
    * @deprecated use {@link #getConfigManager()} to create an AdapterManagerMBean instead.
@@ -182,13 +180,13 @@ public class BootstrapProperties extends Properties {
   public synchronized Adapter createAdapter() throws Exception {
     // First of all make sure the the config manager has made the default marshaller correct.
     getConfigManager();
-    Adapter result = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(this.getConfigurationStream());
+    Adapter result = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(getConfigurationStream());
     log.info("Adapter created");
     return result;
   }
-  
+
   public InputStream getConfigurationStream() throws Exception {
-    return URLHelper.connect(new URLString(this.findAdapterResource()));
+    return URLHelper.connect(new URLString(findAdapterResource()));
   }
 
   public String[] getConfigurationUrls() {
@@ -233,10 +231,6 @@ public class BootstrapProperties extends Properties {
           break;
         }
       }
-    }
-    if (adapterXml == null) {
-      log.trace("Sourcing configuration from [{}] property", CFG_KEY_CONFIG_RESOURCE);
-      adapterXml = getProperty(CFG_KEY_CONFIG_RESOURCE);
     }
     return adapterXml;
   }
@@ -301,12 +295,9 @@ public class BootstrapProperties extends Properties {
     return configManager;
   }
 
-  @SuppressWarnings("deprecation")
   public void reconfigureLogging() {
     if (isEnabled(CFG_KEY_LOGGING_RECONFIGURE)) {
-      // Default to log4j12Url for backwards compat.
-      String legacy = getPropertyIgnoringCase(this, CFG_KEY_LOG4J12_URL, "");
-      String loggingUrl = getPropertyIgnoringCase(this, CFG_KEY_LOGGING_URL, legacy);
+      String loggingUrl = getPropertyIgnoringCase(this, CFG_KEY_LOGGING_URL, "");
       if (!StringUtils.isEmpty(loggingUrl)) {
         log.trace("Attempting Logging reconfiguration using {}", loggingUrl);
         LoggingConfigurator.newConfigurator().initialiseFrom(loggingUrl);
@@ -332,35 +323,4 @@ public class BootstrapProperties extends Properties {
     return BooleanUtils.toBooleanDefaultIfNull(BooleanUtils.toBooleanObject(val), enabledByDefault(key));
   }
 
-  /**
-   * @deprecated since 3.1.1 use {@link PropertyHelper#getPropertySubset(Properties, String)} instead.
-   */
-  @Deprecated
-  public static Properties getPropertySubset(Properties p, String prefix) {
-    return PropertyHelper.getPropertySubset(p, prefix, false);
-  }
-
-  /**
-   * @deprecated since 3.1.1 use {@link PropertyHelper#getPropertySubset(Properties, String, boolean)} instead.
-   */
-  @Deprecated
-  public static Properties getPropertySubset(Properties p, String prefix, boolean ignoreCase) {
-    return PropertyHelper.getPropertySubset(p, prefix, ignoreCase);
-  }
-
-  /**
-   * @deprecated since 3.1.1 use {@link PropertyHelper#getPropertyIgnoringCase(Properties, String, String)} instead.
-   */
-  @Deprecated
-  public static String getPropertyIgnoringCase(Properties p, String key, String defaultValue) {
-    return PropertyHelper.getPropertyIgnoringCase(p, key, defaultValue);
-  }
-
-  /**
-   * @deprecated since 3.1.1 use {@link PropertyHelper#getPropertyIgnoringCase(Properties, String)} instead.
-   */
-  @Deprecated
-  public static String getPropertyIgnoringCase(Properties p, String key) {
-    return PropertyHelper.getPropertyIgnoringCase(p, key, null);
-  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/Constants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/Constants.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,13 +35,7 @@ public final class Constants {
    * Bootstrap Property containing the the URL of the adapter config.
    */
   public static final String CFG_KEY_CONFIG_URL = "adapterConfigUrl";
-  /**
-   * Bootstrap Property containing the name of adapter config that is available on the classpath.
-   *
-   * @deprecated use {@link #CFG_KEY_CONFIG_URL} instead; will be removed w/o warning
-   */
-  @Deprecated
-  public static final String CFG_KEY_CONFIG_RESOURCE = "adapterResourceName";
+
   /**
    * Bootstrap Property containing the URL of the license file.
    */
@@ -54,21 +48,11 @@ public final class Constants {
   public static final String CFG_KEY_CONFIG_MANAGER = "configManager";
   /**
    * Bootstrap Property containing an enum value that defines the Data Binder output format to generate ie XML/JSON.
-   * 
+   *
    * @see com.adaptris.core.AdapterMarshallerFactory.MarshallingOutput for a list of valid values
    */
   public static final String CFG_KEY_MARSHALLER_OUTPUT_TYPE = "marshallerOutputType";
-  /**
-   * Bootstrap Property that configures XStream to generate Beautified XML output.
-   * <p>
-   * <strong>This was removed in 3.8.2</strong> for compliance with Java 11; beautification uses some {@code com.sun} classes which
-   * is now illegal. It was also causing some implied behaviour based on ordering, which led to undefined behaviour.
-   * </p>
-   * 
-   * @deprecated actually removed in 3.8.2 and has no meaning.
-   */
-  @Deprecated
-  public static final String CFG_XSTREAM_BEAUTIFIED_OUTPUT = "beautifyXStreamOutput";
+
   /**
    * Bootstrap property that enables default HTTP Proxy authentication via the user of standard java.net system properties.
    *
@@ -77,7 +61,7 @@ public final class Constants {
 
   /**
    * Bootstrap property containing a colon separated list of items that implement {@link ManagementComponent}
-   * 
+   *
    */
   public static final String CFG_KEY_MANAGEMENT_COMPONENT = "managementComponents";
 
@@ -142,10 +126,10 @@ public final class Constants {
    * Bootstrap Property specifying whether or not to enable the localJndiServer.
    */
   public static final String CFG_KEY_JNDI_SERVER = "enableLocalJndiServer";
-  
+
   /**
    * Bootstrap Property that specifies whether or not to start the adapter quietly
-   * 
+   *
    * <p>
    * The default value for this is true, if set to false, then any exceptions starting the adapter will be propagated back to the
    * caller (in most cases the <code>main</code> method); which may terminate the JVM depending on how the adapter has been started.
@@ -154,33 +138,16 @@ public final class Constants {
   public static final String CFG_KEY_START_QUIETLY = "startAdapterQuietly";
 
   /**
-   * Bootstrap Property specifying the log4j12 URL.
-   * 
-   * @since 3.0.2
-   * @deprecated since 3.1.0 use {@value #CFG_KEY_LOGGING_URL}
-   */
-  @Deprecated
-  public static final String CFG_KEY_LOG4J12_URL = "log4j12Url";
-
-  /**
    * Bootstrap Property specifying the logging configuration URL.
-   * 
+   *
    * @since 3.1.0
    */
   public static final String CFG_KEY_LOGGING_URL = "loggingConfigUrl";
 
 
   /**
-   * Bootstrap property that enables validation of the adapter object post unmarshalling.
-   * 
-   * @since 3.0.6
-   */
-  public static final String CFG_KEY_VALIDATE_CONFIG = "validateConfig";
-
-
-  /**
    * Bootstrap Property specifying whether or not reconfigure logging
-   * 
+   *
    * @since 3.7.0 defaults to true.
    */
   public static final String CFG_KEY_LOGGING_RECONFIGURE = "loggingReconfigure";

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/AdapterConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/AdapterConfigurationChecker.java
@@ -1,0 +1,47 @@
+package com.adaptris.core.management.config;
+
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import org.apache.commons.io.IOUtils;
+import com.adaptris.core.Adapter;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.config.ConfigPreProcessorLoader;
+import com.adaptris.core.config.DefaultPreProcessorLoader;
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.management.UnifiedBootstrap;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public abstract class AdapterConfigurationChecker implements ConfigurationChecker {
+
+  private transient ConfigPreProcessorLoader loader = new DefaultPreProcessorLoader();
+
+
+  @Override
+  public ConfigurationCheckReport performConfigCheck(BootstrapProperties config,
+      UnifiedBootstrap bootstrap) {
+
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(getFriendlyName());
+    try {
+      String xml = loader.load(config).process(readAdapterXml(config));
+      Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);
+      validate(adapter, report);
+    } catch (Exception ex) {
+      report.getFailureExceptions().add(ex);
+    }
+    return report;
+  }
+
+  private String readAdapterXml(BootstrapProperties config) throws Exception {
+    String result = "";
+    try (InputStream in = config.getConfigurationStream()) {
+      result = IOUtils.toString(in, Charset.defaultCharset());
+    }
+    return result;
+  }
+
+
+  protected abstract void validate(Adapter adapter, ConfigurationCheckReport report);
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ClasspathDupConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ClasspathDupConfigurationChecker.java
@@ -1,28 +1,27 @@
 package com.adaptris.core.management.config;
 
 import java.util.Map;
-
+import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.core.management.BootstrapProperties;
 import com.adaptris.core.management.Constants;
 import com.adaptris.core.management.UnifiedBootstrap;
-
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.Resource;
 import io.github.classgraph.ResourceList;
 import io.github.classgraph.ScanResult;
 
 public class ClasspathDupConfigurationChecker implements ConfigurationChecker {
-  
+
   private static final String FRIENDLY_NAME = "Classpath duplication check.";
 
   private boolean debug;
-  
+
   @SuppressWarnings("resource")
   @Override
   public ConfigurationCheckReport performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrapProperties) {
     ConfigurationCheckReport report = new ConfigurationCheckReport();
-    report.setCheckName(this.getFriendlyName());
-    
+    report.setCheckName(getFriendlyName());
+
     boolean passed = true;
     try (ScanResult result = new ClassGraph().scan()) {
       for (Map.Entry<String, ResourceList> dup : result.getAllResources().classFilesOnly().findDuplicatePaths()) {
@@ -30,7 +29,7 @@ public class ClasspathDupConfigurationChecker implements ConfigurationChecker {
           continue;
         }
         passed = false;
-        if(Constants.DBG || this.isDebug()) {
+        if (debugMode()) {
           System.err.println(String.format("%s has possible duplicates", dup.getKey()));
           for (Resource res : dup.getValue()) {
             System.err.println(String.format(" -> Found in %s", res.getURI()));
@@ -39,18 +38,22 @@ public class ClasspathDupConfigurationChecker implements ConfigurationChecker {
       }
     }
     if(!passed) {
-      if(Constants.DBG || this.isDebug())
+      if (debugMode())
         report.getWarnings().add("Possible duplicates found.  Details above.");
       else
         report.getWarnings().add("Possible duplicates found.  Re-run with '-Dinterlok.bootstrap.debug=true' for more details.");
     }
-    
+
     return report;
   }
-  
+
   @Override
   public String getFriendlyName() {
     return FRIENDLY_NAME;
+  }
+
+  private boolean debugMode() {
+    return BooleanUtils.or(new boolean[] {Constants.DBG, isDebug()});
   }
 
   public boolean isDebug() {

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckersEnum.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckersEnum.java
@@ -4,26 +4,28 @@ import com.adaptris.core.management.BootstrapProperties;
 import com.adaptris.core.management.UnifiedBootstrap;
 
 public enum ConfigurationCheckersEnum {
-  
+
   // **************
   // Available checkers
 
   DESERIALIZATION (new DeserializationConfigurationChecker()),
-  
+
   CLASSPATH_DUPLICATION (new ClasspathDupConfigurationChecker()),
-  
-  SHARED_CONNECTION_USAGE (new SharedConnectionConfigurationChecker());
-  
+
+  JAVAX_VALIDATION(new JavaxValidationChecker()),
+
+  SHARED_CONNECTION_USAGE(new SharedConnectionConfigurationChecker());
+
 //**************
-  
+
   private ConfigurationChecker checker;
-  
+
   ConfigurationCheckersEnum(ConfigurationChecker configurationChecker) {
-    this.setChecker(configurationChecker);
+    setChecker(configurationChecker);
   }
-  
+
   public ConfigurationCheckReport performCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
-    return this.getChecker().performConfigCheck(bootProperties, bootstrap);
+    return getChecker().performConfigCheck(bootProperties, bootstrap);
   };
 
   public ConfigurationChecker getChecker() {

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeserializationConfigurationChecker.java
@@ -1,35 +1,27 @@
 package com.adaptris.core.management.config;
 
 import com.adaptris.core.Adapter;
-import com.adaptris.core.DefaultMarshaller;
-import com.adaptris.core.management.BootstrapProperties;
-import com.adaptris.core.management.UnifiedBootstrap;
 import com.adaptris.core.util.LifecycleHelper;
+import lombok.NoArgsConstructor;
 
-public class DeserializationConfigurationChecker implements ConfigurationChecker {
-  
+@NoArgsConstructor
+public class DeserializationConfigurationChecker extends AdapterConfigurationChecker {
+
   private static final String FRIENDLY_NAME = "Configuration loading test";
-  
-  @Override
-  public ConfigurationCheckReport performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
-    ConfigurationCheckReport report = new ConfigurationCheckReport();
-    report.setCheckName(this.getFriendlyName());
-    
-    // This seems a bit cheaty, but we're going to exit anyway, so
-    // calling prepare probably makes no difference.
-    try {
-      Adapter clonedAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(bootstrap.createAdapter().getConfiguration());
-      LifecycleHelper.prepare(clonedAdapter);
-      
-    } catch (Exception ex) {
-      report.getFailureExceptions().add(ex);
-    }
-    return report;
-  }
 
   @Override
   public String getFriendlyName() {
     return FRIENDLY_NAME;
+  }
+
+  @Override
+  protected void validate(Adapter adapter, ConfigurationCheckReport report) {
+    try {
+      LifecycleHelper.prepare(adapter);
+
+    } catch (Exception ex) {
+      report.getFailureExceptions().add(ex);
+    }
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/JavaxValidationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/JavaxValidationChecker.java
@@ -1,0 +1,46 @@
+package com.adaptris.core.management.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import com.adaptris.core.Adapter;
+import com.adaptris.core.CoreException;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class JavaxValidationChecker extends AdapterConfigurationChecker {
+
+  private static final String FRIENDLY_NAME = "javax.validation Checks";
+  private static final ValidatorFactory JAVAX_VALIDATOR_FACTORY =
+      Validation.buildDefaultValidatorFactory();
+
+
+  @Override
+  protected void validate(Adapter adapter, ConfigurationCheckReport report) {
+    try {
+      Validator validator = JAVAX_VALIDATOR_FACTORY.getValidator();
+      // There are no warnings; everything is a hard failure.
+      report.setFailureExceptions((violationsToException(validator.validate(adapter))));
+    } catch (Exception ex) {
+      report.getFailureExceptions().add(ex);
+    }
+  }
+
+  @Override
+  public String getFriendlyName() {
+    return FRIENDLY_NAME;
+  }
+
+  private List<Exception> violationsToException(Set<ConstraintViolation<Adapter>> violations) {
+    List<Exception> result = new ArrayList<>();
+    for (ConstraintViolation v : violations) {
+      result.add(new CoreException(String.format("Interlok Validation Error: [%1$s]=[%2$s]",
+          v.getPropertyPath(), v.getMessage())));
+    }
+    return result;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/JavaxValidationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/JavaxValidationChecker.java
@@ -1,8 +1,8 @@
 package com.adaptris.core.management.config;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
@@ -35,12 +35,11 @@ public class JavaxValidationChecker extends AdapterConfigurationChecker {
     return FRIENDLY_NAME;
   }
 
+
   private List<Exception> violationsToException(Set<ConstraintViolation<Adapter>> violations) {
-    List<Exception> result = new ArrayList<>();
-    for (ConstraintViolation v : violations) {
-      result.add(new CoreException(String.format("Interlok Validation Error: [%1$s]=[%2$s]",
-          v.getPropertyPath(), v.getMessage())));
-    }
-    return result;
+    return violations.stream().map((v) -> new CoreException(String
+        .format("Interlok Validation Error: [%1$s]=[%2$s]", v.getPropertyPath(), v.getMessage())))
+        .collect(Collectors.toList());
   }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/XStreamConfigManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/XStreamConfigManager.java
@@ -16,7 +16,6 @@
 
 package com.adaptris.core.management.config;
 import static com.adaptris.core.util.PropertyHelper.getPropertyIgnoringCase;
-
 import com.adaptris.core.AdapterMarshallerFactory;
 import com.adaptris.core.AdapterXStreamMarshallerFactory;
 import com.adaptris.core.DefaultMarshaller;
@@ -46,11 +45,6 @@ public class XStreamConfigManager extends ReadWriteConfigManager {
     // Get the configured output type property (XML/JSON) and create the marshaller based on this
     final String marshallerOutputProperty = getPropertyIgnoringCase(bootstrapProperties, Constants.CFG_KEY_MARSHALLER_OUTPUT_TYPE);
 
-    // Get the xstream enable beautified output flag
-    final boolean enableBeautifiedOutputFlag = bootstrapProperties.isEnabled(Constants.CFG_XSTREAM_BEAUTIFIED_OUTPUT);
-    if (enableBeautifiedOutputFlag) {
-      log.warn("Beautification is no longer supported due to illegal module access in Java 11");
-    }
     // Now initialize the marshaller
     marshallerFactory = AdapterXStreamMarshallerFactory.getInstance();
     marshaller = marshallerFactory.createMarshaller(marshallerOutputProperty);

--- a/interlok-core/src/test/java/com/adaptris/core/management/BootstrapPropertiesTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/BootstrapPropertiesTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,25 +14,21 @@
  * limitations under the License.
 */
 package com.adaptris.core.management;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Properties;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
 import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.stubs.TempFileUtils;
@@ -56,7 +52,7 @@ public class BootstrapPropertiesTest {
     Object marker = new Object();
     File filename = TempFileUtils.createTrackedFile(testName.getMethodName(), null, marker);
     try (OutputStream o = new FileOutputStream(filename)) {
-      createTestSample().store(o, testName.getMethodName());     
+      createTestSample().store(o, testName.getMethodName());
     }
     BootstrapProperties boot = new BootstrapProperties(filename.getCanonicalPath());
     new BootstrapProperties();
@@ -117,11 +113,9 @@ public class BootstrapPropertiesTest {
   @Test
   public void testIsEnabled() {
     BootstrapProperties boot = new BootstrapProperties(createTestSample());
-    
-    assertFalse(boot.isEnabled(Constants.CFG_XSTREAM_BEAUTIFIED_OUTPUT));
+
     assertTrue(boot.isEnabled(Constants.CFG_KEY_PROXY_AUTHENTICATOR));
     assertTrue(boot.isEnabled(Constants.CFG_KEY_USE_MANAGEMENT_FACTORY_FOR_JMX));
-    assertFalse(boot.isEnabled(Constants.CFG_KEY_VALIDATE_CONFIG));
     assertTrue(boot.isEnabled(Constants.CFG_KEY_LOGGING_RECONFIGURE));
     assertTrue(boot.isEnabled(Constants.CFG_KEY_START_QUIETLY));
     assertFalse(boot.isEnabled(Constants.CFG_KEY_JNDI_SERVER));
@@ -129,31 +123,6 @@ public class BootstrapPropertiesTest {
     assertFalse(boot.isEnabled(Constants.CFG_KEY_LOGGING_RECONFIGURE));
     assertFalse(boot.isEnabled("blahblahblah"));
     assertTrue(BootstrapProperties.isEnabled(createTestSample(), Constants.CFG_KEY_USE_MANAGEMENT_FACTORY_FOR_JMX));
-  }
-
-  @Test
-  public void testGetPropertySubsetPropertiesString() {
-    Properties p = BootstrapProperties.getPropertySubset(createTestSample(), "a");
-    assertEquals(2, p.size());
-  }
-
-  @Test
-  public void testGetPropertySubsetPropertiesStringBoolean() {
-    Properties p = BootstrapProperties.getPropertySubset(createTestSample(), "A", true);
-    assertEquals(2, p.size());
-  }
-
-  @Test
-  public void testGetPropertyIgnoringCasePropertiesStringString() {
-    assertEquals("a.value", BootstrapProperties.getPropertyIgnoringCase(createTestSample(), "A.KEY", "defaultValue"));
-    assertEquals("defaultValue", BootstrapProperties.getPropertyIgnoringCase(createTestSample(), "BLAH", "defaultValue"));
-  }
-
-
-  @Test
-  public void testGetPropertyIgnoringCasePropertiesString() {
-    assertEquals("a.value", BootstrapProperties.getPropertyIgnoringCase(createTestSample(), "A.KEY"));
-    assertNull(BootstrapProperties.getPropertyIgnoringCase(createTestSample(), "BLAH"));
   }
 
   private Properties createTestSample() {

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeserializationConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeserializationConfigurationCheckerTest.java
@@ -19,8 +19,6 @@ public class DeserializationConfigurationCheckerTest {
 
   private DeserializationConfigurationChecker checker;
 
-  @Mock private BootstrapProperties mockBootProperties;
-
   @Mock private AdapterManagerMBean mockAdapterMBean;
 
   @Mock private UnifiedBootstrap mockUnifiedBootstrap;
@@ -32,12 +30,8 @@ public class DeserializationConfigurationCheckerTest {
     openMocks = MockitoAnnotations.openMocks(this);
 
     checker = new DeserializationConfigurationChecker();
-
-    when(mockUnifiedBootstrap.createAdapter())
-        .thenReturn(mockAdapterMBean);
-
-    when(mockAdapterMBean.getConfiguration())
-        .thenReturn(createAdapterConfig());
+    when(mockUnifiedBootstrap.createAdapter()).thenReturn(mockAdapterMBean);
+    when(mockAdapterMBean.getConfiguration()).thenReturn(createAdapterConfig());
   }
 
   @After
@@ -47,15 +41,14 @@ public class DeserializationConfigurationCheckerTest {
 
   @Test
   public void testUnmarshallSuccess() throws Exception {
+    BootstrapProperties mockBootProperties = new MockBootProperties(createAdapterConfig());
     ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, mockUnifiedBootstrap);
     assertTrue(report.isCheckPassed());
   }
 
   @Test
   public void testUnmarshallFailureBadXml() throws Exception {
-    when(mockAdapterMBean.getConfiguration())
-        .thenReturn("xxx");
-
+    BootstrapProperties mockBootProperties = new MockBootProperties("xxx");
     ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, mockUnifiedBootstrap);
     assertFalse(report.isCheckPassed());
   }

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/JavaxValidationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/JavaxValidationCheckerTest.java
@@ -1,0 +1,96 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.adaptris.core.Adapter;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.services.metadata.AddTimestampMetadataService;
+import com.adaptris.core.services.metadata.PayloadHashingService;
+
+public class JavaxValidationCheckerTest {
+
+  @Test
+  public void testPerformCheck_Valid() throws Exception {
+    JavaxValidationChecker checker = new JavaxValidationChecker();
+
+    BootstrapProperties mockBootProperties =
+        new MockBootProperties(toString(createAdapterConfig(true)));
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    assertTrue(report.isCheckPassed());
+  }
+
+  @Test
+  public void testValidate_Valid() throws Exception {
+    JavaxValidationChecker checker = new JavaxValidationChecker();
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(createAdapterConfig(true), report);
+    assertTrue(report.isCheckPassed());
+    assertEquals(0, report.getFailureExceptions().size());
+    assertEquals(0, report.getWarnings().size());
+  }
+
+  @Test
+  public void testValidate_Invalid() throws Exception {
+    JavaxValidationChecker checker = new JavaxValidationChecker();
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(createAdapterConfig(false), report);
+
+    assertFalse(report.isCheckPassed());
+    // Should be 4 exceptions, 1x adapter-unique-id, 3 from the shared-services
+    assertEquals(0, report.getWarnings().size());
+    assertEquals(4, report.getFailureExceptions().size());
+  }
+
+  @Test
+  public void testValidate_Null() throws Exception {
+    JavaxValidationChecker checker = new JavaxValidationChecker();
+
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(null, report);
+    assertFalse(report.isCheckPassed());
+    assertEquals(1, report.getFailureExceptions().size());
+  }
+
+  private String toString(Adapter adapter) throws Exception {
+    return DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
+  }
+
+  private Adapter createAdapterConfig(boolean validates) throws Exception {
+
+    Adapter adapter = new Adapter();
+    if (validates) {
+      // have a unique-id
+      adapter.setUniqueId("MyAdapter");
+      AddTimestampMetadataService ts = new AddTimestampMetadataService();
+      ts.setUniqueId("valid-add-timestamp-service");
+      PayloadHashingService ph = new PayloadHashingService();
+      ph.setUniqueId("valid-payload-hasher");
+      ph.setMetadataKey("payloadHash");
+      ph.setHashAlgorithm("SHA-256");
+
+      adapter.getSharedComponents().addService(ts);
+      adapter.getSharedComponents().addService(ph);
+    } else {
+      // no adapter unique-id
+      // explicitly set add timestamp to have an empty key, thankfully
+      // no checks on the setter...
+      AddTimestampMetadataService ts = new AddTimestampMetadataService();
+      ts.setUniqueId("invalid-add-timestamp-service");
+      ts.setMetadataKey("");
+
+      // don't specify the hash algo or the metadata-key
+      PayloadHashingService ph = new PayloadHashingService();
+      ph.setUniqueId("invalid-payload-hasher");
+
+      adapter.getSharedComponents().addService(ts);
+      adapter.getSharedComponents().addService(ph);
+    }
+    return adapter;
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/MockBootProperties.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/MockBootProperties.java
@@ -1,0 +1,24 @@
+package com.adaptris.core.management.config;
+
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.input.ReaderInputStream;
+import com.adaptris.core.management.BootstrapProperties;
+
+public class MockBootProperties extends BootstrapProperties {
+  private static final long serialVersionUID = 2020080401L;
+
+  private transient String xml;
+
+  public MockBootProperties(String config) {
+    super();
+    xml = config;
+  }
+
+  @Override
+  public InputStream getConfigurationStream() throws Exception {
+    return new ReaderInputStream(new StringReader(xml), StandardCharsets.UTF_8);
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterRegistryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterRegistryTest.java
@@ -59,7 +59,6 @@ import com.adaptris.core.config.DummyConfigurationPreProcessor;
 import com.adaptris.core.event.AdapterShutdownEvent;
 import com.adaptris.core.management.AdapterConfigManager;
 import com.adaptris.core.management.BootstrapProperties;
-import com.adaptris.core.management.Constants;
 import com.adaptris.core.management.vcs.RuntimeVersionControl;
 import com.adaptris.core.management.vcs.VcsException;
 import com.adaptris.core.management.vcs.VersionControlSystem;
@@ -923,26 +922,6 @@ public class AdapterRegistryTest extends ComponentManagerCase {
     AdapterBuilder builder = new ArrayList<AdapterBuilder>(myAdapterRegistry.builders()).get(0);
     builder.overrideRuntimeVCS(new MockRuntimeVersionControl());
     assertEquals("MOCK", myAdapterRegistry.getVersionControl());
-  }
-
-  @Test
-  public void testValidateAdapter() throws Exception {
-    Properties custom = new Properties();
-    custom.setProperty(Constants.CFG_KEY_VALIDATE_CONFIG, "true");
-    AdapterRegistry myAdapterRegistry = (AdapterRegistry) AdapterRegistry.findInstance(new JunitBootstrapProperties(custom));
-    Adapter adapter = new Adapter();
-    String xml = DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
-    try {
-      myAdapterRegistry.createAdapter(xml);
-      fail();
-    } catch (CoreException expected) {
-      assertTrue(expected.getMessage().contains("uniqueId"));
-    }
-    adapter = createAdapter(getName());
-    xml = DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
-    ObjectName objName = myAdapterRegistry.createAdapter(xml);
-    assertNotNull(objName);
-    myAdapterRegistry.destroyAdapter(objName);
   }
 
   @Test


### PR DESCRIPTION
## Motivation

At the moment `java -jar lib/interlok-boot.jar -configcheck` doesn't actually validate that the configuration is correct; and it should.

## Modification

- Add a JavaxValidationChecker that uses Validation.buildDefaultValidatorFactory()
- Add a shared hierarchy for DeserializationCheck + JavaxValidationCheck so that we have common behaviour to get to the Adapter object.
   - The config checkers no longer delegate to the AdapterRegistry but instead manage how to get to the "configuration" themselves. It would have been better to delegate it to AdapterBuilder but that's a weird rats nest.
- Changed the tests so that we don't mock BootstrapProperties since there is odd behaviour from mockito around returning null after multiple mock invocations; I suspect that it's because of the class member mocking but life is too short to go unpicking mocks, and since bootstrapProperties doesn't need to be mocked; we can just have a real class that extends it.

## Result

If you have this as your adapter config 
```
<adapter>
  <unique-id>MyInterlokInstance</unique-id>
  <shared-components>
    <connections>
    </connections>
    <services>
      <service-list>
        <unique-id>shared-service</unique-id>
        <services>
          <add-timestamp-metadata-service>
            <unique-id>timestamp with blank metadata key</unique-id>
            <metadata-key></metadata-key>
          </add-timestamp-metadata-service>
          <payload-hashing-service>
            <unique-id>payload-hash-with-no-algo</unique-id>
          </payload-hashing-service>
        </services>
      </service-list>
    </services>
  </shared-components>
</adapter>
```

then it should fail validation because payload-hashing-service requires an algorithm + metadata key. Similarly add-timestamp-metadata-service should have a metadata-key set but we have explicitly set it to be "blank".

Validation errors are always considered to be hard-failures (i.e. they're not warnings).

```
$ java -jar lib/interlok-boot.jar -configcheck
Bootstrap of Interlok 3.11-SNAPSHOT(2020-08-04:INTERLOK-3286-javax.validation-on-config-check) complete
TRACE [main] [c.a.c.m.BootstrapProperties] Properties resource is [bootstrap.properties]
.... some logging skipped

Configuration loading test:
Passed.

Classpath duplication check.:
Warnings found;
Possible duplicates found.  Re-run with '-Dinterlok.bootstrap.debug=true' for more details.

javax.validation Checks:
Failed with exceptions:
Interlok Validation Error: [sharedComponents.services[0].services[0].metadataKey]=[Must provide a metadata key]
Interlok Validation Error: [sharedComponents.services[0].services[1].metadataKey]=[must not be blank]
Interlok Validation Error: [sharedComponents.services[0].services[1].hashAlgorithm]=[must not be blank]

Shared connection check.:
Passed.

Config check only; terminating

chanl3@lhrm32445 ~/work/runtime/ant-nightly
$ echo $?
1

```

## Testing

see above.
