### PR TITLE
Interlok 3373

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageListener.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageListener.java
@@ -45,16 +45,25 @@ public interface AdaptrisMessageListener {
    * @implNote the default implementation just calls {@link #onAdaptrisMessage(AdaptrisMessage, Consumer)}.
    */
   default void onAdaptrisMessage(AdaptrisMessage msg) {
-    onAdaptrisMessage(msg, (s) -> {});
+    onAdaptrisMessage(msg, (s) -> {}, (f) -> {});
   }
 
   /**
-   * Handle a message with call back actions if a message is successful or failed.
+   * Handle a message with a call back action if a message is successful.
    * 
    * @param msg the message
    * @param success called on success
    */
   void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success);
+  
+  /**
+   * Handle a message with call back actions if a message is successful or failed.
+   * 
+   * @param msg the message
+   * @param success called on success
+   * @param failure called on failure
+   */
+  void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure);
 
   /**
    * Get the friendly name for this component.

--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -412,6 +412,21 @@ public abstract class CoreConstants {
    *
    * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer)
    */
+  public static final String OBJ_METADATA_MESSAGE_FAILED = "_messageFailed";
+  
+  /**
+   * Object metadata that stores the on success callback.
+   *
+   * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer)
+   */
   public static final String OBJ_METADATA_ON_SUCCESS_CALLBACK = "_onSuccessCallback";
+  
+  
+  /**
+   * Object metadata that stores the on failure callback.
+   *
+   * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer, java.util.function.Consumer)
+   */
+  public static final String OBJ_METADATA_ON_FAILURE_CALLBACK = "_onFailureCallback";
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
@@ -60,10 +60,15 @@ public abstract class FailedMessageRetrierImp implements FailedMessageRetrier {
 
   @Override
   public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
+    onAdaptrisMessage(msg, success, null);
+  }
+  
+  @Override
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
     try {
       Workflow workflow = getWorkflow(msg);
       updateRetryCountMetadata(msg);
-      workflow.onAdaptrisMessage(msg, success); // workflow.onAM is sync'd...
+      workflow.onAdaptrisMessage(msg, success, failure); // workflow.onAM is sync'd...
     }
     catch (Exception e) { // inc. runtime, exc. Workflow
       log.error("exception retrying message", e);

--- a/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
@@ -1,9 +1,9 @@
 package com.adaptris.core;
 
-import static com.adaptris.core.CoreConstants.OBJ_METADATA_MESSAGE_FAILED;
-import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK;
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 import java.util.function.Consumer;
 
 import org.slf4j.Logger;
@@ -26,18 +26,10 @@ public class ListenerCallbackHelper {
     return msg;
   }
 
-  public static AdaptrisMessage handleCallback(AdaptrisMessage msg) {
-    return defaultIfNull((Boolean) msg.getObjectHeaders().get(OBJ_METADATA_MESSAGE_FAILED), Boolean.FALSE)
-        ? handleFailureCallback(msg)
-        : handleSuccessCallback(msg);
-  }
-
   public static AdaptrisMessage handleSuccessCallback(AdaptrisMessage msg) {
     log.trace("Handling success callback for message [{}]", msg.getUniqueId());
     Consumer c = defaultIfNull((Consumer) msg.getObjectHeaders().get(OBJ_METADATA_ON_SUCCESS_CALLBACK), (o) -> {   });
     c.accept(msg);
-    // although we should never call success of failure more than once per message, we can be safe and just remove them.
-    removeCallbacks(msg);
     return msg;
   }
   
@@ -45,12 +37,6 @@ public class ListenerCallbackHelper {
     log.trace("Handling failure callback for message [{}]", msg.getUniqueId());
     Consumer c = defaultIfNull((Consumer) msg.getObjectHeaders().get(OBJ_METADATA_ON_FAILURE_CALLBACK), (o) -> {   });
     c.accept(msg);
-    removeCallbacks(msg);
     return msg;
-  }
-  
-  private static void removeCallbacks(AdaptrisMessage msg) {
-    msg.getObjectHeaders().remove(OBJ_METADATA_ON_SUCCESS_CALLBACK);
-    msg.getObjectHeaders().remove(OBJ_METADATA_ON_FAILURE_CALLBACK);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
@@ -14,7 +14,7 @@ public class ListenerCallbackHelper {
   protected static final Logger log = LoggerFactory.getLogger(ListenerCallbackHelper.class.getName());
   
   public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess) {
-    return prepare(msg, onSuccess, null);
+    return prepare(msg, onSuccess, (message) -> {});
   }
   
   public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess, Consumer<AdaptrisMessage> onFailure) {

--- a/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
@@ -1,22 +1,56 @@
 package com.adaptris.core;
 
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_MESSAGE_FAILED;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK;
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import java.util.function.Consumer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ListenerCallbackHelper {
   
+  protected static Logger log = LoggerFactory.getLogger(ListenerCallbackHelper.class.getName());
+  
   public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess) {
+    return prepare(msg, onSuccess, null);
+  }
+  
+  public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess, Consumer<AdaptrisMessage> onFailure) {
     // since msg.clone() copies object metadata, we're good doing this, since the consumer
     // object should be preserved across clones
     msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK, onSuccess);
+    if(onFailure != null)
+      msg.addObjectHeader(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK, onFailure);
     return msg;
   }
 
+  public static AdaptrisMessage handleCallback(AdaptrisMessage msg) {
+    return defaultIfNull((Boolean) msg.getObjectHeaders().get(OBJ_METADATA_MESSAGE_FAILED), Boolean.FALSE)
+        ? handleFailureCallback(msg)
+        : handleSuccessCallback(msg);
+  }
 
   public static AdaptrisMessage handleSuccessCallback(AdaptrisMessage msg) {
+    log.trace("Handling success callback for message [{}]", msg.getUniqueId());
     Consumer c = defaultIfNull((Consumer) msg.getObjectHeaders().get(OBJ_METADATA_ON_SUCCESS_CALLBACK), (o) -> {   });
     c.accept(msg);
+    // although we should never call success of failure more than once per message, we can be safe and just remove them.
+    removeCallbacks(msg);
     return msg;
+  }
+  
+  public static AdaptrisMessage handleFailureCallback(AdaptrisMessage msg) {
+    log.trace("Handling failure callback for message [{}]", msg.getUniqueId());
+    Consumer c = defaultIfNull((Consumer) msg.getObjectHeaders().get(OBJ_METADATA_ON_FAILURE_CALLBACK), (o) -> {   });
+    c.accept(msg);
+    removeCallbacks(msg);
+    return msg;
+  }
+  
+  private static void removeCallbacks(AdaptrisMessage msg) {
+    msg.getObjectHeaders().remove(OBJ_METADATA_ON_SUCCESS_CALLBACK);
+    msg.getObjectHeaders().remove(OBJ_METADATA_ON_FAILURE_CALLBACK);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ListenerCallbackHelper.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 public class ListenerCallbackHelper {
   
-  protected static Logger log = LoggerFactory.getLogger(ListenerCallbackHelper.class.getName());
+  protected static final Logger log = LoggerFactory.getLogger(ListenerCallbackHelper.class.getName());
   
   public static AdaptrisMessage prepare(AdaptrisMessage msg, Consumer<AdaptrisMessage> onSuccess) {
     return prepare(msg, onSuccess, null);

--- a/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
@@ -16,6 +16,9 @@
 
 package com.adaptris.core;
 
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_MESSAGE_FAILED;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -116,24 +119,33 @@ public class MultiProducerWorkflow extends StandardWorkflow {
       doProduce(wip);
       sendProcessedMessage(wip, msg); // only if produce succeeds
       logSuccess(msg, start);
+      ListenerCallbackHelper.handleSuccessCallback(wip);
     }
     catch (ServiceException e) {
       handleBadMessage("Exception from ServiceCollection", e, copyExceptionHeaders(wip, msg));
+      handleFailureCallback(msg);
     }
     catch (ProduceException e) {
       wip.addEvent(getProducer(), false); // generate event
       handleBadMessage("Exception producing msg", e, copyExceptionHeaders(wip, msg));
       handleProduceException();
+      handleFailureCallback(msg);
     }
     catch (Exception e) { // all other Exc. inc. runtime
       handleBadMessage("Exception processing message", e, copyExceptionHeaders(wip, msg));
+      handleFailureCallback(msg);
     }
     finally {
       sendMessageLifecycleEvent(wip);
-      
-      ListenerCallbackHelper.handleCallback(wip);
     }
     workflowEnd(msg, wip);
+  }
+  
+  private void handleFailureCallback(AdaptrisMessage msg) {
+    // Some message error handlers may not deem a message as failed immediately, like the retry handler.
+    if(defaultIfNull((Boolean) msg.getObjectHeaders().get(OBJ_METADATA_MESSAGE_FAILED), Boolean.FALSE)) {
+      ListenerCallbackHelper.handleFailureCallback(msg);
+    }    
   }
 
   private void sendProcessedMessage(AdaptrisMessage wip, AdaptrisMessage msg) {

--- a/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiProducerWorkflow.java
@@ -71,20 +71,6 @@ public class MultiProducerWorkflow extends StandardWorkflow {
     super();
     standaloneProducers = new ArrayList<StandaloneProducer>();
   }
-
-  /**
-   * @see AdaptrisMessageListener#onAdaptrisMessage(AdaptrisMessage)
-   */
-  @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
-    ListenerCallbackHelper.prepare(msg, success);
-    if (!obtainChannel().isAvailable()) {
-      handleChannelUnavailable(msg); // make pluggable?
-    }
-    else {
-      onMessage(msg);
-    }
-  }
   
   /**
    * @see AdaptrisMessageListener#onAdaptrisMessage(AdaptrisMessage)

--- a/interlok-core/src/main/java/com/adaptris/core/NoRetries.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NoRetries.java
@@ -63,6 +63,10 @@ public class NoRetries implements FailedMessageRetrier {
   @Override
   public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
   }
+  
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+  }
 
   @Override
   public void clearWorkflows() {

--- a/interlok-core/src/main/java/com/adaptris/core/NullProcessingExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NullProcessingExceptionHandler.java
@@ -38,6 +38,7 @@ public class NullProcessingExceptionHandler extends RootProcessingExceptionHandl
   }
 
   public void handleProcessingException(AdaptrisMessage msg) {
+    msg.getObjectHeaders().put(CoreConstants.OBJ_METADATA_MESSAGE_FAILED, true);
     notifyParent(msg);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -308,7 +308,12 @@ public class PoolingWorkflow extends WorkflowImp {
    */
   @Override
   public void onAdaptrisMessage(final AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
-    ListenerCallbackHelper.prepare(msg, success);
+    onAdaptrisMessage(msg, success, (f) -> {});
+  }
+
+  @Override
+  public void onAdaptrisMessage(final AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+    ListenerCallbackHelper.prepare(msg, success, failure);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg);
     }
@@ -316,7 +321,7 @@ public class PoolingWorkflow extends WorkflowImp {
       onMessage(msg);
     }
   }
-
+  
   /**
    *
    * @see WorkflowImp#resubmitMessage(com.adaptris.core.AdaptrisMessage)

--- a/interlok-core/src/main/java/com/adaptris/core/RetryMessageErrorHandlerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RetryMessageErrorHandlerImp.java
@@ -77,6 +77,8 @@ public abstract class RetryMessageErrorHandlerImp extends StandardProcessingExce
 
   @Override
   public synchronized void handleProcessingException(AdaptrisMessage msg) {
+    // we will only set this to true if our retries fail.
+    msg.getObjectHeaders().put(CoreConstants.OBJ_METADATA_MESSAGE_FAILED, false);
     if (shouldFail(msg) || failAll) {
       failMessage(msg);
     }
@@ -203,6 +205,7 @@ public abstract class RetryMessageErrorHandlerImp extends StandardProcessingExce
       log.error(e.getMessage(), e);
     }
     super.handleProcessingException(msg);
+    msg.getObjectHeaders().put(CoreConstants.OBJ_METADATA_MESSAGE_FAILED, true);
   }
 
   protected void scheduleNextRun(AdaptrisMessage msg) {

--- a/interlok-core/src/main/java/com/adaptris/core/StandardProcessingExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardProcessingExceptionHandler.java
@@ -73,6 +73,7 @@ public class StandardProcessingExceptionHandler extends RootProcessingExceptionH
    */
   @Override
   public synchronized void handleProcessingException(AdaptrisMessage msg) {
+    msg.getObjectHeaders().put(CoreConstants.OBJ_METADATA_MESSAGE_FAILED, true);
     try {
       if (getProcessingExceptionService() != null) {
         getProcessingExceptionService().doService(msg);

--- a/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardWorkflow.java
@@ -62,5 +62,10 @@ public class StandardWorkflow extends StandardWorkflowImpl {
   public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
     super.onAdaptrisMessage(msg, success);
   }
+  
+  @Override
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+    super.onAdaptrisMessage(msg, success, failure);
+  }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/StandardWorkflowImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandardWorkflowImpl.java
@@ -16,6 +16,9 @@
 
 package com.adaptris.core;
 
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_MESSAGE_FAILED;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 import java.util.function.Consumer;
 import com.adaptris.core.util.LifecycleHelper;
 
@@ -110,19 +113,28 @@ public abstract class StandardWorkflowImpl extends WorkflowImp {
       getServiceCollection().doService(wip);
       doProduce(wip);
       logSuccess(wip, start);
+      ListenerCallbackHelper.handleSuccessCallback(wip);
     } catch (ServiceException e) {
       handleBadMessage("Exception from ServiceCollection", e, copyExceptionHeaders(wip, msg));
+      handleFailureCallback(msg);
     } catch (ProduceException e) {
       wip.addEvent(getProducer(), false); // generate event
       handleBadMessage("Exception producing msg", e, copyExceptionHeaders(wip, msg));
       handleProduceException();
+      handleFailureCallback(msg);
     } catch (Exception e) { // all other Exc. inc. runtime
       handleBadMessage("Exception processing message", e, copyExceptionHeaders(wip, msg));
+      handleFailureCallback(msg);
     } finally {
       sendMessageLifecycleEvent(wip);
-   // handle success or failure callback here.
-      ListenerCallbackHelper.handleCallback(wip);
     }
     workflowEnd(msg, wip);
+  }
+
+  private void handleFailureCallback(AdaptrisMessage msg) {
+    // Some message error handlers may not deem a message as failed immediately, like the retry handler.
+    if(defaultIfNull((Boolean) msg.getObjectHeaders().get(OBJ_METADATA_MESSAGE_FAILED), Boolean.FALSE)) {
+      ListenerCallbackHelper.handleFailureCallback(msg);
+    }    
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -758,7 +758,6 @@ public abstract class WorkflowImp implements Workflow {
       log.error(logMsg, e);
     }
     msg.addObjectHeader(OBJ_METADATA_EXCEPTION, e);
-    msg.addObjectHeader(OBJ_METADATA_MESSAGE_FAILED, Boolean.TRUE);
     handleBadMessage(msg);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -17,25 +17,28 @@
 package com.adaptris.core;
 
 import static com.adaptris.core.CoreConstants.KEY_WORKFLOW_SKIP_PRODUCER;
-import static com.adaptris.core.CoreConstants.OBJ_METADATA_MESSAGE_FAILED;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION_CAUSE;
 import static com.adaptris.core.CoreConstants.UNIQUE_ID_JMX_PATTERN;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -17,6 +17,7 @@
 package com.adaptris.core;
 
 import static com.adaptris.core.CoreConstants.KEY_WORKFLOW_SKIP_PRODUCER;
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_MESSAGE_FAILED;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION_CAUSE;
 import static com.adaptris.core.CoreConstants.UNIQUE_ID_JMX_PATTERN;
@@ -757,6 +758,7 @@ public abstract class WorkflowImp implements Workflow {
       log.error(logMsg, e);
     }
     msg.addObjectHeader(OBJ_METADATA_EXCEPTION, e);
+    msg.addObjectHeader(OBJ_METADATA_MESSAGE_FAILED, e);
     handleBadMessage(msg);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -758,7 +758,7 @@ public abstract class WorkflowImp implements Workflow {
       log.error(logMsg, e);
     }
     msg.addObjectHeader(OBJ_METADATA_EXCEPTION, e);
-    msg.addObjectHeader(OBJ_METADATA_MESSAGE_FAILED, e);
+    msg.addObjectHeader(OBJ_METADATA_MESSAGE_FAILED, Boolean.TRUE);
     handleBadMessage(msg);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsTransactedWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsTransactedWorkflow.java
@@ -113,13 +113,14 @@ public final class JmsTransactedWorkflow extends StandardWorkflow {
     else {
       log.error(logMsg, e);
     }
-    if (!(retrieveActiveMsgErrorHandler() instanceof NullProcessingExceptionHandler)) {
-      msg.getObjectHeaders().put(CoreConstants.OBJ_METADATA_EXCEPTION, e);
-      handleBadMessage(msg);
-      if (!isStrict()) {
-        LAST_MSG_FAILED.set(Boolean.FALSE);
-      }
+    msg.getObjectHeaders().put(CoreConstants.OBJ_METADATA_EXCEPTION, e);
+    handleBadMessage(msg);
+    if (!isStrict()) {
+      LAST_MSG_FAILED.set(Boolean.FALSE);
+      // If we want the message to pass (even though the workflow thinks it's failed) then lets stick the success callback into the failure callback.
+      msg.getObjectHeaders().put(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK, msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK));
     }
+    
   }
 
   boolean lastMessageFailed() {

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsTransactedWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsTransactedWorkflow.java
@@ -17,7 +17,9 @@
 package com.adaptris.core.jms;
 
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -28,7 +30,6 @@ import com.adaptris.core.AdaptrisMessageConsumer;
 import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullMessageConsumer;
-import com.adaptris.core.NullProcessingExceptionHandler;
 import com.adaptris.core.NullProduceExceptionHandler;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ProduceExceptionHandler;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/OnMessageHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/OnMessageHandler.java
@@ -172,6 +172,7 @@ public class OnMessageHandler {
 
     Consumer<AdaptrisMessage> successCallback = message -> {
       try {
+        logR.trace("Commiting/Ack'ing message with id {}", msg.getJMSMessageID());
         acknowledge(msg);
       }
       catch (JMSException e) {
@@ -181,7 +182,13 @@ public class OnMessageHandler {
     };
     
     Consumer<AdaptrisMessage> failureCallback = message -> {
-      rollback(msg);
+      try {
+        logR.trace("Rolling back/not Ack'ing message with id {}", msg.getJMSMessageID());
+        rollback(msg);
+      } catch (JMSException e) {
+        logR.error("Exception rolling back JMS message", e);
+      }
+      
     };
     
     try {

--- a/interlok-core/src/main/java/com/adaptris/core/jms/OnMessageHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/OnMessageHandler.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core.jms;
 
+import java.util.function.Consumer;
+
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
@@ -168,8 +170,7 @@ public class OnMessageHandler {
       // this might throw an exception, if it does, we don't care.
     }
 
-    try {
-      msgListener.onAdaptrisMessage(adaptrisMessage);
+    Consumer<AdaptrisMessage> successCallback = message -> {
       try {
         acknowledge(msg);
       }
@@ -177,6 +178,14 @@ public class OnMessageHandler {
         logR.error("Exception acknowledging/committing JMS message", e);
         rollback(msg);
       }
+    };
+    
+    Consumer<AdaptrisMessage> failureCallback = message -> {
+      rollback(msg);
+    };
+    
+    try {
+      msgListener.onAdaptrisMessage(adaptrisMessage, successCallback, failureCallback);
     }
     catch (Throwable e) { // impossible if AML is StandardWorkflow
       logR.error("Unexpected Throwable from AdaptrisMessageListener", e);

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeMessageWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeMessageWorkflow.java
@@ -68,7 +68,7 @@ public class LargeMessageWorkflow extends StandardWorkflow {
   }
   
   @Override
-  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
     ListenerCallbackHelper.prepare(msg, success, failure);
     if (!obtainChannel().isAvailable()) {
       handleChannelUnavailable(msg); // make pluggable?

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeMessageWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeMessageWorkflow.java
@@ -66,6 +66,16 @@ public class LargeMessageWorkflow extends StandardWorkflow {
       handleMessage(msg, false);
     }
   }
+  
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+    ListenerCallbackHelper.prepare(msg, success, failure);
+    if (!obtainChannel().isAvailable()) {
+      handleChannelUnavailable(msg); // make pluggable?
+    } else {
+      handleMessage(msg, false);
+    }
+  }
 
   @Override
   protected void resubmitMessage(AdaptrisMessage msg) {

--- a/interlok-core/src/test/java/com/adaptris/core/StandardWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/StandardWorkflowTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -29,11 +31,12 @@ import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adaptris.core.services.AlwaysFailService;
 import com.adaptris.core.services.exception.ConfiguredException;
 import com.adaptris.core.services.exception.ThrowExceptionService;
 import com.adaptris.core.services.metadata.AddMetadataService;
@@ -640,6 +643,12 @@ public class StandardWorkflowTest extends ExampleWorkflowCase {
           (m) -> {
             onSuccess.set(false);
           });
+      
+      Awaitility.await()
+        .atMost(Duration.ofSeconds(2))
+      .with()
+        .pollInterval(Duration.ofMillis(100))
+        .until(onSuccess::get);
       
       assertTrue(onSuccess.get());
     } finally {

--- a/interlok-core/src/test/java/com/adaptris/core/StandardWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/StandardWorkflowTest.java
@@ -32,6 +32,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.adaptris.core.services.AlwaysFailService;
 import com.adaptris.core.services.exception.ConfiguredException;
 import com.adaptris.core.services.exception.ThrowExceptionService;
 import com.adaptris.core.services.metadata.AddMetadataService;
@@ -39,6 +41,7 @@ import com.adaptris.core.services.metadata.PayloadFromMetadataService;
 import com.adaptris.core.stubs.EventHandlerAwareConsumer;
 import com.adaptris.core.stubs.EventHandlerAwareProducer;
 import com.adaptris.core.stubs.EventHandlerAwareService;
+import com.adaptris.core.stubs.FailFirstMockMessageProducer;
 import com.adaptris.core.stubs.MockChannel;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.stubs.MockSkipProducerService;
@@ -548,6 +551,125 @@ public class StandardWorkflowTest extends ExampleWorkflowCase {
       stop(channel);
     }
 
+  }
+  
+  @Test
+  public void testOnMessage_ServiceFailsFailureCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new MockMessageProducer(), Arrays.asList(new Service[] {new ThrowExceptionService(new ConfiguredException("expected"))}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    StandardWorkflow workflow = (StandardWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg, 
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+      
+      assertFalse(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+  
+  @Test
+  public void testOnMessage_ServiceFailsWithRetryHandlerFailureCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new MockMessageProducer(), Arrays.asList(new Service[] {new ThrowExceptionService(new ConfiguredException("expected"))}));
+    
+    channel.setMessageErrorHandler(new RetryMessageErrorHandler(3, new TimeInterval(100l, TimeUnit.MILLISECONDS), new NullService()));
+    
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    StandardWorkflow workflow = (StandardWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg, 
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+      
+      assertFalse(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+  
+  @Test
+  public void testOnMessage_ProducerFailsFailureCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new FailFirstMockMessageProducer(1), Arrays.asList(new Service[] {new NullService()}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    StandardWorkflow workflow = (StandardWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg, 
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+      
+      assertFalse(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+  
+  @Test
+  public void testOnMessage_ProducerFailsWithRetryHandlerSuccessCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new FailFirstMockMessageProducer(1), Arrays.asList(new Service[] {new NullService()}));
+    
+    channel.setMessageErrorHandler(new RetryMessageErrorHandler(2, new TimeInterval(100l, TimeUnit.MILLISECONDS), new NullService()));
+    
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    StandardWorkflow workflow = (StandardWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg, 
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+      
+      assertTrue(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+  
+  @Test
+  public void testOnMessage_ProducerFailsWithRetryHandlerFailureCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new FailFirstMockMessageProducer(5), Arrays.asList(new Service[] {new NullService()}));
+    
+    channel.setMessageErrorHandler(new RetryMessageErrorHandler(4, new TimeInterval(100l, TimeUnit.MILLISECONDS), new NullService()));
+    
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    StandardWorkflow workflow = (StandardWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg, 
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+      
+      assertFalse(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerCase.java
@@ -70,7 +70,7 @@ public abstract class JmsProducerCase extends JmsProducerExample {
   }
 
   private DefinedJmsProducer createDummyProducer() {
-    DefinedJmsProducer p = new DummyProducer();
+    DefinedJmsProducer p = new MockProducer();
     p.setDeliveryMode(com.adaptris.core.jms.DeliveryMode.Mode.PERSISTENT.toString());
     p.setPriority(1);
     p.setTtl(0L);
@@ -168,51 +168,5 @@ public abstract class JmsProducerCase extends JmsProducerExample {
     mcs.setMetadataKey("MetadataKey_ForCorrelation");
     p.setCorrelationIdSource(mcs);
     return p;
-  }
-
-  private class DummyProducer extends DefinedJmsProducer {
-
-    @Override
-    protected Destination createDestination(String name) throws JMSException {
-      throw new JMSException("NO!");
-    }
-
-    @Override
-    protected void doProduce(AdaptrisMessage msg, Destination dest, Destination replyTo)
-        throws JMSException, CoreException {
-      throw new ProduceException();
-    }
-
-    @Override
-    public AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination dest, long timeout)
-        throws ProduceException {
-      throw new ProduceException();
-    }
-
-    @Override
-    protected Destination createTemporaryDestination() throws JMSException {
-      throw new JMSException("NO!");
-    }
-
-    @Override
-    public AdaptrisMessage request(AdaptrisMessage msg) throws ProduceException {
-      throw new ProduceException();
-    }
-
-    @Override
-    public void produce(AdaptrisMessage msg) throws ProduceException {
-      throw new ProduceException();
-    }
-
-    @Override
-    public String endpoint(AdaptrisMessage msg) throws ProduceException {
-      return null;
-    }
-
-    @Override
-    public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
-      throw new ProduceException();
-    }
-
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MockConsumer.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MockConsumer.java
@@ -1,0 +1,31 @@
+package com.adaptris.core.jms;
+
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+
+import com.adaptris.core.CoreException;
+
+public class MockConsumer extends JmsConsumerImpl {
+  
+  private Session currentSession;;
+
+  @Override
+  protected String configuredEndpoint() {
+    return null;
+  }
+
+  @Override
+  protected MessageConsumer createConsumer() throws JMSException, CoreException {
+    return null;
+  }
+
+  public void setCurrentSession(Session session) {
+    this.currentSession = session;
+  }
+  
+  public Session currentSession() {
+    return currentSession;
+  }
+  
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MockProducer.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MockProducer.java
@@ -1,0 +1,54 @@
+package com.adaptris.core.jms;
+
+import javax.jms.Destination;
+import javax.jms.JMSException;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ProduceDestination;
+import com.adaptris.core.ProduceException;
+
+public class MockProducer extends DefinedJmsProducer {
+
+  @Override
+  protected Destination createDestination(String name) throws JMSException {
+    throw new JMSException("NO!");
+  }
+
+  @Override
+  protected void doProduce(AdaptrisMessage msg, Destination dest, Destination replyTo)
+      throws JMSException, CoreException {
+    throw new ProduceException();
+  }
+
+  @Override
+  public AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination dest, long timeout)
+      throws ProduceException {
+    throw new ProduceException();
+  }
+
+  @Override
+  protected Destination createTemporaryDestination() throws JMSException {
+    throw new JMSException("NO!");
+  }
+
+  @Override
+  public AdaptrisMessage request(AdaptrisMessage msg) throws ProduceException {
+    throw new ProduceException();
+  }
+
+  @Override
+  public void produce(AdaptrisMessage msg) throws ProduceException {
+    throw new ProduceException();
+  }
+
+  @Override
+  public String endpoint(AdaptrisMessage msg) throws ProduceException {
+    return null;
+  }
+
+  @Override
+  public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
+    throw new ProduceException();
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jms/OnMessageHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/OnMessageHandlerTest.java
@@ -1,0 +1,275 @@
+package com.adaptris.core.jms;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Enumeration;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.AdaptrisMessageProducer;
+import com.adaptris.core.Channel;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.NullMessageConsumer;
+import com.adaptris.core.NullMessageProducer;
+import com.adaptris.core.ProduceException;
+import com.adaptris.core.stubs.MockMessageListener;
+
+public class OnMessageHandlerTest {
+  
+  private OnMessageHandler handler;
+  
+  private MockConsumer config;
+  
+  private CorrelationIdSource mockCorrelationSourceId;
+  
+  private MockMessageListener mockListener;
+  
+  private MessageTypeTranslator mockTranslator;
+  
+  private Enumeration<?> messageProperties;
+  
+  @Mock private Message jmsMessage;
+  
+  @Mock private Session mockSession;
+  
+  @Mock private Channel mockChannel;
+  
+  @Mock private AdaptrisConnection mockConnection;
+  
+  @Mock private AdaptrisMessageProducer mockProducer;
+  
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    
+    mockCorrelationSourceId = new MessageIdCorrelationIdSource();
+    mockListener = new MockMessageListener();
+    mockListener.setChannel(mockChannel);
+    mockTranslator = new TextMessageTranslator();
+    
+    config = new MockConsumer();
+    config.setCurrentSession(mockSession);
+    
+    messageProperties = Collections.emptyEnumeration();
+    
+    when(jmsMessage.getPropertyNames())
+        .thenReturn(messageProperties);
+    
+    when(jmsMessage.getJMSMessageID())
+        .thenReturn("id");
+    
+    when(mockSession.getTransacted())
+        .thenReturn(false);
+    
+    when(mockChannel.isAvailable())
+        .thenReturn(true);
+    
+    when(mockChannel.getConsumeConnection())
+        .thenReturn(mockConnection);
+    
+    when(mockChannel.getProduceConnection())
+        .thenReturn(mockConnection);
+
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    
+  }
+  
+  @Test
+  public void testMisConfig() {    
+    try {
+      new OnMessageHandler(config);
+      fail("JmsActorConfig ");
+    } catch (CoreException ex) {
+      // expected
+    }
+  }
+  
+  @Test
+  public void testOnMessageHandlerSuccessAck() throws Exception {
+    config.setCorrelationIdSource(mockCorrelationSourceId);
+    config.setMessageTranslator(mockTranslator);
+    config.registerAdaptrisMessageListener(mockListener);
+    
+    handler = new OnMessageHandler(config);
+    
+    handler.onMessage(jmsMessage);
+    
+    verify(jmsMessage).acknowledge();
+  }
+  
+  @Test
+  public void testOnMessageHandlerSuccessTransactedCommit() throws Exception {
+    when(mockSession.getTransacted())
+        .thenReturn(true);
+    
+    JmsTransactedWorkflow jmsTransactedWorkflow = new JmsTransactedWorkflow();
+    jmsTransactedWorkflow.setConsumer(new NullMessageConsumer());
+    jmsTransactedWorkflow.setProducer(new NullMessageProducer());
+    
+    jmsTransactedWorkflow.registerChannel(mockChannel);
+    
+    config.setCorrelationIdSource(mockCorrelationSourceId);
+    config.setMessageTranslator(mockTranslator);
+    config.registerAdaptrisMessageListener(jmsTransactedWorkflow);
+    
+    handler = new OnMessageHandler(config);
+    
+    handler.onMessage(jmsMessage);
+    
+    verify(mockSession).commit();
+  }
+  
+  @Test
+  public void testOnMessageHandlerSuccessTransactedRollback() throws Exception {
+    when(mockSession.getTransacted())
+        .thenReturn(true);
+    
+    doThrow(new ProduceException("Expected"))
+        .when(mockProducer).produce(any());
+    
+    when(mockProducer.createName())
+        .thenReturn("name");
+    
+    when(mockProducer.createQualifier())
+        .thenReturn("Qualifier");
+    
+    when(mockProducer.isTrackingEndpoint())
+        .thenReturn(false);
+    
+    JmsTransactedWorkflow jmsTransactedWorkflow = new JmsTransactedWorkflow();
+    jmsTransactedWorkflow.setConsumer(new NullMessageConsumer());
+    jmsTransactedWorkflow.setProducer(mockProducer);
+    
+    jmsTransactedWorkflow.registerChannel(mockChannel);
+    
+    config.setCorrelationIdSource(mockCorrelationSourceId);
+    config.setMessageTranslator(mockTranslator);
+    config.registerAdaptrisMessageListener(jmsTransactedWorkflow);
+    
+    handler = new OnMessageHandler(config);
+    
+    handler.onMessage(jmsMessage);
+    
+    verify(mockSession).rollback();
+  }
+  
+  @Test
+  public void testOnMessageHandlerTranslatorFailsRollback() throws Exception {
+    when(mockSession.getTransacted())
+        .thenReturn(true);
+    
+    doThrow(new JMSException("Expected"))
+        .when(jmsMessage).getPropertyNames();
+    
+    JmsTransactedWorkflow jmsTransactedWorkflow = new JmsTransactedWorkflow();
+    jmsTransactedWorkflow.setConsumer(new NullMessageConsumer());
+    jmsTransactedWorkflow.setProducer(new NullMessageProducer());
+    
+    jmsTransactedWorkflow.registerChannel(mockChannel);
+    
+    config.setCorrelationIdSource(mockCorrelationSourceId);
+    config.setMessageTranslator(mockTranslator);
+    config.registerAdaptrisMessageListener(jmsTransactedWorkflow);
+    
+    handler = new OnMessageHandler(config);
+    
+    handler.onMessage(jmsMessage);
+    
+    verify(mockSession).rollback();
+  }
+
+  @Test
+  public void testOnMessageHandlerCommitFailsThenRollback() throws Exception {
+    when(mockSession.getTransacted())
+        .thenReturn(true);
+    
+    doThrow(new JMSException("Expected"))
+        .when(mockSession).commit();
+    
+    JmsTransactedWorkflow jmsTransactedWorkflow = new JmsTransactedWorkflow();
+    jmsTransactedWorkflow.setConsumer(new NullMessageConsumer());
+    jmsTransactedWorkflow.setProducer(new NullMessageProducer());
+    
+    jmsTransactedWorkflow.registerChannel(mockChannel);
+    
+    config.setCorrelationIdSource(mockCorrelationSourceId);
+    config.setMessageTranslator(mockTranslator);
+    config.registerAdaptrisMessageListener(jmsTransactedWorkflow);
+    
+    handler = new OnMessageHandler(config);
+    
+    handler.onMessage(jmsMessage);
+    
+    verify(mockSession).commit();
+    verify(mockSession).rollback();
+  }
+  
+  @Test
+  public void testOnMessageHandlerCommitRollbackFailsCaughtExceptions() throws Exception {
+    when(mockSession.getTransacted())
+        .thenReturn(true);
+    
+    doThrow(new JMSException("Expected"))
+        .when(mockSession).commit();
+    
+    doThrow(new JMSException("Expected"))
+        .when(mockSession).rollback();
+    
+    JmsTransactedWorkflow jmsTransactedWorkflow = new JmsTransactedWorkflow();
+    jmsTransactedWorkflow.setConsumer(new NullMessageConsumer());
+    jmsTransactedWorkflow.setProducer(new NullMessageProducer());
+    
+    jmsTransactedWorkflow.registerChannel(mockChannel);
+    
+    config.setCorrelationIdSource(mockCorrelationSourceId);
+    config.setMessageTranslator(mockTranslator);
+    config.registerAdaptrisMessageListener(jmsTransactedWorkflow);
+    
+    handler = new OnMessageHandler(config);
+    
+    handler.onMessage(jmsMessage);
+    
+    verify(mockSession).commit();
+    verify(mockSession).rollback();
+  }
+  
+  @Test
+  public void testOnMessageHandlerProducerFailsRollback() throws Exception {
+    when(mockSession.getTransacted())
+        .thenReturn(true);
+    
+    JmsTransactedWorkflow jmsTransactedWorkflow = new JmsTransactedWorkflow();
+    jmsTransactedWorkflow.setConsumer(new NullMessageConsumer());
+    jmsTransactedWorkflow.setProducer(new MockProducer());
+    jmsTransactedWorkflow.setStrict(true);
+    
+    jmsTransactedWorkflow.registerChannel(mockChannel);
+    
+    config.setCorrelationIdSource(mockCorrelationSourceId);
+    config.setMessageTranslator(mockTranslator);
+    config.registerAdaptrisMessageListener(jmsTransactedWorkflow);
+    
+    handler = new OnMessageHandler(config);
+    
+    handler.onMessage(jmsMessage);
+    
+    verify(mockSession).rollback();
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
+import com.adaptris.core.Channel;
 import com.adaptris.core.ListenerCallbackHelper;
 import com.adaptris.core.ProduceException;
 
@@ -31,7 +32,10 @@ import com.adaptris.core.ProduceException;
  * @author $Author: $
  */
 public class MockMessageListener implements AdaptrisMessageListener, MessageCounter {
+  
   private MockMessageProducer producer;
+  
+  private Channel channel;
 
   private long waitTime = -1;
 
@@ -84,5 +88,13 @@ public class MockMessageListener implements AdaptrisMessageListener, MessageCoun
   @Override
   public String friendlyName() {
     return "MockMessageListener";
+  }
+
+  public Channel obtainChannel() {
+    return channel;
+  }
+
+  public void setChannel(Channel channel) {
+    this.channel = channel;
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
@@ -54,9 +54,11 @@ public class MockMessageListener implements AdaptrisMessageListener, MessageCoun
     ListenerCallbackHelper.prepare(msg, success, failure);
     try {
       producer.produce(msg);
+      ListenerCallbackHelper.handleSuccessCallback(msg);
     } catch (ProduceException e) {
+      ListenerCallbackHelper.handleFailureCallback(msg);
     } finally {
-      ListenerCallbackHelper.handleCallback(msg);
+      
     }
     if (waitTime != -1) {
       try {

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/MockMessageListener.java
@@ -46,12 +46,17 @@ public class MockMessageListener implements AdaptrisMessageListener, MessageCoun
 
   @Override
   public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
-    ListenerCallbackHelper.prepare(msg, success);
+    onAdaptrisMessage(msg, success, null);
+  }
+  
+  @Override
+  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
+    ListenerCallbackHelper.prepare(msg, success, failure);
     try {
       producer.produce(msg);
-      ListenerCallbackHelper.handleSuccessCallback(msg);
-    }
-    catch (ProduceException e) {
+    } catch (ProduceException e) {
+    } finally {
+      ListenerCallbackHelper.handleCallback(msg);
     }
     if (waitTime != -1) {
       try {


### PR DESCRIPTION
## Motivation

This has been a planned 2nd stage in handling success and failure of each processed message; where each consumer can specify the specific callbacks for each.
The first already complete stage allowed us to specify the success callback.

Why now?
Shortly we will be handling async messaging as per the JMS 2.0 spec and vendor specific API's.  This means we cannot use our current consume, process, commit/rollback then consume again model.  Instead the callbacks are futures allowing us to continue to consume messages and at some point later execute success/failure code for each message.
This is very necessary step to break us away from the model described above.

## Modification

This one was quite tricky due to the number of edge cases that needed to be satisfied, therefore I have taken a few liberties rather than giving in to the desire to just rewrite all the things;
 - TransactedWorkflows with strictmode on/off
 - RetryMessageHandler - some messages might not be deemed as failures immediately...
 - NullMessageErrorHandler in unit tests

Firstly, I've added the new onAdaptrisMessage(message, success, failure) method into the workflow chain.  However, backward compatibility is still preserved for those consumers using either onAdaptrisMessage(message) or onAdaptrisMessage(message, success).

I've changed the StandardWorkflowImp such that it will now call the failure should a message be deemed to have failed.

To work around the RetryMessageHandler, which should not trigger the failure callback if we going to retry the message, I have added a new CoreConstant.  This constant simple has a boolean flag to note if the message has failed.
At the top of the MessageErrorHandler chain this flag is set to true, meaning if the error handler is triggered then later the failure callback will also be triggered.
The RetryMessageErrorHandler will not set this flag to true, unless all retries have been exhausted.

With the JmsTransactedWorkflow, even if a message fails, if you configure strict-mode to be false then a message is not actually deemed to have failed, so here I take another little liberty by simply copying the success callback into the failure callback.  Because the workflow thinks the message has failed it will inevitably call the failure callback, so here we trick it into actually calling the success callback.  It does seem like a bit of a liberty; with other potential solutions being re-write the transacted code completely, it's old and needs some love, or overwriting the onAdaptrisMessage of the parent workflow in JmsTransactedWorkflow - although this would be largely copy/pasta with the odd modification to handle this specific case.

It should be noted that it is currently possible if a message fails, that even the failure callback will not be run!
If a message has failed, then we need to make sure we're setting the CoreConstants.OBJ_METADATA_MESSAGE_FAILED to Boolean.true.  As mentioned before this is how we work around the RetryMessageHandler not triggering the failure callback until all retries are exhausted.

## Result

Actually, nothing should change at all!
The benefit being we will be able to later support async callbacks from async producers.

## Testing

Nothing to test other than unit-tests, which all pass and new ones added.
