### PR TITLE
INTERLOK-3393 DefaultServiceId needs to be "" rather than null.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/BranchingHttpRequestService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/BranchingHttpRequestService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,12 +18,14 @@ package com.adaptris.core.http.client.net;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
@@ -32,15 +34,17 @@ import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandaloneRequestor;
 import com.adaptris.core.http.client.StatusEvaluator;
 import com.adaptris.core.services.BranchingServiceEnabler;
-import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 
 /**
  * Branch support for HTTP via interrogation of the HTTP status.
- * 
+ *
  * <p>
  * This service allows you to branch based on the {@code HTTP status code} returned by the web server. Use a specific
  * {@link StatusEvaluator} to determine the appropriate value for {@link AdaptrisMessage#setNextServiceId(String)}. It differs from
@@ -57,7 +61,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * values as part of a constant string e.g. {@code setUrl("%message{http_url}")} will use the metadata value associated with the key
  * {@code http_url}.
  * </p>
- * 
+ *
  * @config branching-http-request-service
  */
 @XStreamAlias("branching-http-request-service")
@@ -71,20 +75,34 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
     "responseHeaderHandler", "statusMatches"})
 public class BranchingHttpRequestService extends HttpRequestServiceImpl {
 
+  /**
+   * Set the {@code nextServiceId} based on these evaluators.
+   *
+   */
   @NotNull
   @AutoPopulated
   @Valid
   @XStreamImplicit
+  @Getter
+  @Setter
+  @NonNull
   private List<StatusEvaluator> statusMatches;
 
   // Allow this to be null, which just means no branching...
-  private String defaultServiceId;
+  /**
+   * Set the default service-id in the event that no matches are found (optional).
+   *
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(style = "BLANKABLE")
+  private String defaultServiceId = "";
 
   public BranchingHttpRequestService() {
     super();
     setStatusMatches(new ArrayList<StatusEvaluator>());
   }
-  
+
   public BranchingHttpRequestService(String url) {
     this();
     setUrl(url);
@@ -101,8 +119,8 @@ public class BranchingHttpRequestService extends HttpRequestServiceImpl {
     p.setIgnoreServerResponseCode(true);
     try {
       LifecycleHelper.initAndStart(p, false).request(msg);
+      Optional.ofNullable(getDefaultServiceId()).ifPresent((s) -> msg.setNextServiceId(s));
       int responseCode = ((Integer) msg.getObjectHeaders().get(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE)).intValue();
-      msg.setNextServiceId(getDefaultServiceId());
       for (StatusEvaluator rp : getStatusMatches()) {
         if (rp.matches(responseCode)) {
           msg.setNextServiceId(rp.serviceId());
@@ -119,22 +137,8 @@ public class BranchingHttpRequestService extends HttpRequestServiceImpl {
   }
 
   /**
-   * @return the responseMatches
-   */
-  public List<StatusEvaluator> getStatusMatches() {
-    return statusMatches;
-  }
-
-  /**
-   * @param matchers the statusMatches to set
-   */
-  public void setStatusMatches(List<StatusEvaluator> matchers) {
-    this.statusMatches = Args.notNull(matchers, "statusMatches");
-  }
-
-  /**
    * @since 3.9.0
-   * 
+   *
    */
   public BranchingHttpRequestService withStatusMatches(List<StatusEvaluator> matchers) {
     setStatusMatches(matchers);
@@ -143,29 +147,15 @@ public class BranchingHttpRequestService extends HttpRequestServiceImpl {
 
   /**
    * @since 3.9.0
-   * 
+   *
    */
   public BranchingHttpRequestService withStatusMatches(StatusEvaluator... matchers) {
     return withStatusMatches(new ArrayList(Arrays.asList(matchers)));
   }
 
   /**
-   * @return the defaultServiceId
-   */
-  public String getDefaultServiceId() {
-    return defaultServiceId;
-  }
-
-  /**
-   * @param s the defaultServiceId to set
-   */
-  public void setDefaultServiceId(String s) {
-    this.defaultServiceId = s;
-  }
-
-  /**
    * @since 3.9.0
-   * 
+   *
    */
   public BranchingHttpRequestService withDefaultServiceId(String s) {
     setDefaultServiceId(s);


### PR DESCRIPTION
## Motivation

When branching on return codes from an Http Request, one HAS to set a default service ID, even though the modal does not show it as a required field.

If you don't set it; then you get a runtime exception (since it defaults to null).

```
Caused by: java.lang.IllegalArgumentException:  may not be null
        at com.adaptris.interlok.util.Args.notNull(Args.java:32) ~[interlok-common.jar:3.10.2B2-RELEASE]
        at com.adaptris.core.AdaptrisMessageImp.setNextServiceId(AdaptrisMessageImp.java:389) ~[interlok-core.jar:3.10.2B2-RELEASE]
        at com.adaptris.core.http.apache.BranchingHttpRequestService.doService(BranchingHttpRequestService.java:111) ~[interlok-apache-http.jar:3.10.2B2-RELEASE]
        at com.adaptris.core.BranchingServiceCollection.applyServices(BranchingServiceCollection.java:92) ~[interlok-core.jar:3.10.2B2-RELEASE]
        at com.adaptris.core.ServiceCollectionImp.doService(ServiceCollectionImp.java:210) ~[interlok-core.jar:3.10.2B2-RELEASE]
        at com.adaptris.core.ServiceList.applyServices(ServiceList.java:96) ~[interlok-core.jar:3.10.2B2-RELEASE]
        ... 18 more
```

## Modification

If we look at the semantics of BranchingServiceCollection we need to set the `next-service-id` to be the empty string in order to disable the next branch.
- Mark the member with the BLANKABLE annotation.
- Use Optional to handle "nulls"
- Add specific tests

## Result

Fixes INTERLOK-3393; default-service-id is no longer "mandatory, but not marked as such".

## Testing

Create a `branch-http-request-service` and don't configure a default-service-id; it should still work.
