### PR TITLE
Interlok 3398 Config check should also check references from SharedService exist in shared-components

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/config/AdapterConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/AdapterConfigurationChecker.java
@@ -10,7 +10,6 @@ import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.config.ConfigPreProcessorLoader;
 import com.adaptris.core.config.DefaultPreProcessorLoader;
 import com.adaptris.core.management.BootstrapProperties;
-import com.adaptris.core.management.UnifiedBootstrap;
 
 import lombok.NoArgsConstructor;
 
@@ -20,8 +19,7 @@ public abstract class AdapterConfigurationChecker implements ConfigurationChecke
   private transient ConfigPreProcessorLoader loader = new DefaultPreProcessorLoader();
 
   @Override
-  public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties config,
-      UnifiedBootstrap bootstrap) {
+  public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties config) {
     try {
       String xml = loader.load(config).process(readAdapterXml(config));
       Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ClasspathDupConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ClasspathDupConfigurationChecker.java
@@ -6,7 +6,6 @@ import org.apache.commons.lang3.BooleanUtils;
 
 import com.adaptris.core.management.BootstrapProperties;
 import com.adaptris.core.management.Constants;
-import com.adaptris.core.management.UnifiedBootstrap;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.Resource;
@@ -21,8 +20,7 @@ public class ClasspathDupConfigurationChecker implements ConfigurationChecker {
 
   @SuppressWarnings("resource")
   @Override
-  public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties bootProperties,
-      UnifiedBootstrap bootstrapProperties) {
+  public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties bootProperties) {
     boolean passed = true;
     try (ScanResult result = new ClassGraph().scan()) {
       for (Map.Entry<String, ResourceList> dup : result.getAllResources().classFilesOnly().findDuplicatePaths()) {

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
@@ -14,7 +14,7 @@ public class ConfigurationCheckRunner {
   public List<ConfigurationCheckReport> runChecks(BootstrapProperties bootProperties, UnifiedBootstrap bootstrap) {
     List<ConfigurationCheckReport> reports = new ArrayList<>();
     configurationCheckers.forEach(checker -> {
-      reports.add(checker.performConfigCheck(bootProperties, bootstrap));
+      reports.add(checker.performConfigCheck(bootProperties));
     });
 
     return reports;

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationChecker.java
@@ -1,21 +1,19 @@
 package com.adaptris.core.management.config;
 
 import com.adaptris.core.management.BootstrapProperties;
-import com.adaptris.core.management.UnifiedBootstrap;
 
 public interface ConfigurationChecker {
 
   String getFriendlyName();
 
-  ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties bootProperties,
-      UnifiedBootstrap bootstrapProperties);
+  ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties bootProperties);
 
-  default ConfigurationCheckReport performConfigCheck(BootstrapProperties bootProperties, UnifiedBootstrap bootstrapProperties) {
+  default ConfigurationCheckReport performConfigCheck(BootstrapProperties bootProperties) {
     ConfigurationCheckReport report = new ConfigurationCheckReport();
     report.setCheckName(getFriendlyName());
     report.setCheckClassName(getClass().getCanonicalName());
 
-    return performConfigCheck(report, bootProperties, bootstrapProperties);
+    return performConfigCheck(report, bootProperties);
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/SharedComponentConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/SharedComponentConfigurationChecker.java
@@ -24,23 +24,23 @@ public abstract class SharedComponentConfigurationChecker implements Configurati
       XmlUtils xmlUtils = new XmlUtils();
       xmlUtils.setSource(bootProperties.getConfigurationStream());
 
-      List<String> availableConnections = Arrays.asList(xmlUtils.getMultipleTextItems(xpathAvailableComponents));
-      List<String> referencedConnections = Arrays.asList(xmlUtils.getMultipleTextItems(xpathReferencedComponents));
+      List<String> availableComponents = Arrays.asList(xmlUtils.getMultipleTextItems(xpathAvailableComponents));
+      List<String> referencedComponents = Arrays.asList(xmlUtils.getMultipleTextItems(xpathReferencedComponents));
 
       // **********************************
-      // Check all shared connections are used.
-      availableConnections.forEach(connection -> {
-        if(!referencedConnections.contains(connection)) {
-          report.getWarnings().add("Shared " + componentType + " unused: " + connection);
+      // Check all shared components are used.
+      availableComponents.forEach(component -> {
+        if (!referencedComponents.contains(component)) {
+          report.getWarnings().add("Shared " + componentType + " unused: " + component);
         }
       });
 
       // **********************************
-      // Check all referenced connections exist.
-      referencedConnections.forEach(connection -> {
-        if(!availableConnections.contains(connection)) {
+      // Check all referenced components exist.
+      referencedComponents.forEach(component -> {
+        if(!availableComponents.contains(component)) {
           report.getFailureExceptions()
-              .add(new ConfigurationException("Shared " + componentType + " does not exist in shared components: " + connection));
+          .add(new ConfigurationException("Shared " + componentType + " does not exist in shared components: " + component));
         }
       });
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/SharedComponentConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/SharedComponentConfigurationChecker.java
@@ -1,0 +1,54 @@
+package com.adaptris.core.management.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.util.XmlUtils;
+
+public abstract class SharedComponentConfigurationChecker implements ConfigurationChecker {
+
+  private String componentType;
+  private String xpathAvailableComponents;
+  private String xpathReferencedComponents;
+
+  public SharedComponentConfigurationChecker(String componentType, String xpathAvailableComponents, String xpathReferencedComponents) {
+    this.componentType = componentType;
+    this.xpathAvailableComponents = xpathAvailableComponents;
+    this.xpathReferencedComponents = xpathReferencedComponents;
+  }
+
+  @Override
+  public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties bootProperties) {
+    try {
+      XmlUtils xmlUtils = new XmlUtils();
+      xmlUtils.setSource(bootProperties.getConfigurationStream());
+
+      List<String> availableConnections = Arrays.asList(xmlUtils.getMultipleTextItems(xpathAvailableComponents));
+      List<String> referencedConnections = Arrays.asList(xmlUtils.getMultipleTextItems(xpathReferencedComponents));
+
+      // **********************************
+      // Check all shared connections are used.
+      availableConnections.forEach(connection -> {
+        if(!referencedConnections.contains(connection)) {
+          report.getWarnings().add("Shared " + componentType + " unused: " + connection);
+        }
+      });
+
+      // **********************************
+      // Check all referenced connections exist.
+      referencedConnections.forEach(connection -> {
+        if(!availableConnections.contains(connection)) {
+          report.getFailureExceptions()
+              .add(new ConfigurationException("Shared " + componentType + " does not exist in shared components: " + connection));
+        }
+      });
+
+    } catch (Exception ex) {
+      report.getFailureExceptions().add(ex);
+    }
+
+    return report;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/SharedConnectionConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/SharedConnectionConfigurationChecker.java
@@ -1,51 +1,17 @@
 package com.adaptris.core.management.config;
 
-import java.util.Arrays;
-import java.util.List;
-
-import com.adaptris.core.management.BootstrapProperties;
-import com.adaptris.core.management.UnifiedBootstrap;
-import com.adaptris.util.XmlUtils;
-
-public class SharedConnectionConfigurationChecker implements ConfigurationChecker {
+public class SharedConnectionConfigurationChecker extends SharedComponentConfigurationChecker {
 
   private static final String FRIENDLY_NAME = "Shared connection check";
+
+  private static final String COMPONENT_TYPE = "connection";
 
   private static final String XPATH_AVAILABLE_CONNECTIONS = "//shared-components/connections/*/unique-id";
 
   private static final String XPATH_REFERENCED_CONNECTIONS = "//*[@class='shared-connection']/lookup-name";
 
-  @Override
-  public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties bootProperties,
-      UnifiedBootstrap bootstrap) {
-    try {
-      XmlUtils xmlUtils = new XmlUtils();
-      xmlUtils.setSource(bootProperties.getConfigurationStream());
-
-      List<String> availableConnections = Arrays.asList(xmlUtils.getMultipleTextItems(XPATH_AVAILABLE_CONNECTIONS));
-      List<String> referencedConnections = Arrays.asList(xmlUtils.getMultipleTextItems(XPATH_REFERENCED_CONNECTIONS));
-
-      // **********************************
-      // Check all shared connections are used.
-      availableConnections.forEach(connection -> {
-        if(!referencedConnections.contains(connection)) {
-          report.getWarnings().add("Shared connection unused: " + connection);
-        }
-      });
-
-      // **********************************
-      // Check all referenced connections exist.
-      referencedConnections.forEach(connection -> {
-        if(!availableConnections.contains(connection)) {
-          report.getFailureExceptions().add(new ConfigurationException("Shared connection does not exist in shared components: " + connection));
-        }
-      });
-
-    } catch (Exception ex) {
-      report.getFailureExceptions().add(ex);
-    }
-
-    return report;
+  public SharedConnectionConfigurationChecker() {
+    super(COMPONENT_TYPE, XPATH_AVAILABLE_CONNECTIONS, XPATH_REFERENCED_CONNECTIONS);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/SharedServiceConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/SharedServiceConfigurationChecker.java
@@ -1,0 +1,22 @@
+package com.adaptris.core.management.config;
+
+public class SharedServiceConfigurationChecker extends SharedComponentConfigurationChecker {
+
+  private static final String FRIENDLY_NAME = "Shared service check";
+
+  private static final String COMPONENT_TYPE = "service";
+
+  private static final String XPATH_AVAILABLE_CONNECTIONS = "//shared-components/services/*/unique-id";
+
+  private static final String XPATH_REFERENCED_CONNECTIONS = "//shared-service/lookup-name";
+
+  public SharedServiceConfigurationChecker() {
+    super(COMPONENT_TYPE, XPATH_AVAILABLE_CONNECTIONS, XPATH_REFERENCED_CONNECTIONS);
+  }
+
+  @Override
+  public String getFriendlyName() {
+    return FRIENDLY_NAME;
+  }
+
+}

--- a/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationChecker
+++ b/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationChecker
@@ -2,3 +2,4 @@ com.adaptris.core.management.config.DeserializationConfigurationChecker
 com.adaptris.core.management.config.ClasspathDupConfigurationChecker
 com.adaptris.core.management.config.JavaxValidationChecker
 com.adaptris.core.management.config.SharedConnectionConfigurationChecker
+com.adaptris.core.management.config.SharedServiceConfigurationChecker

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/ClasspathDupConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/ClasspathDupConfigurationCheckerTest.java
@@ -26,7 +26,7 @@ public class ClasspathDupConfigurationCheckerTest {
   @Test
   public void testDeDup() throws Exception {
     // this one may actually fail occasionally.
-    ConfigurationCheckReport report = checker.performConfigCheck(null, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(null);
     if(!report.isCheckPassed()) {
       assertTrue(report.getWarnings().size() > 0);
     }
@@ -37,7 +37,7 @@ public class ClasspathDupConfigurationCheckerTest {
   public void testDeDupWithNoLogging() throws Exception {
     // this one may actually fail occasionally.
     checker.setDebug(false);
-    ConfigurationCheckReport report = checker.performConfigCheck(null, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(null);
     if(!report.isCheckPassed()) {
       assertTrue(report.getWarnings().size() > 0);
     }

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeserializationConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeserializationConfigurationCheckerTest.java
@@ -2,56 +2,34 @@ package com.adaptris.core.management.config;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.management.BootstrapProperties;
-import com.adaptris.core.management.UnifiedBootstrap;
-import com.adaptris.core.runtime.AdapterManagerMBean;
-import com.adaptris.interlok.util.Closer;
 
 public class DeserializationConfigurationCheckerTest {
 
   private DeserializationConfigurationChecker checker;
 
-  @Mock private AdapterManagerMBean mockAdapterMBean;
-
-  @Mock private UnifiedBootstrap mockUnifiedBootstrap;
-
-  private AutoCloseable openMocks;
-
   @Before
   public void setUp() throws Exception {
-    openMocks = MockitoAnnotations.openMocks(this);
-
     checker = new DeserializationConfigurationChecker();
-    when(mockUnifiedBootstrap.createAdapter()).thenReturn(mockAdapterMBean);
-    when(mockAdapterMBean.getConfiguration()).thenReturn(createAdapterConfig());
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    Closer.closeQuietly(openMocks);
   }
 
   @Test
   public void testUnmarshallSuccess() throws Exception {
     BootstrapProperties mockBootProperties = new MockBootProperties(createAdapterConfig());
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, mockUnifiedBootstrap);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertTrue(report.isCheckPassed());
   }
 
   @Test
   public void testUnmarshallFailureBadXml() throws Exception {
     BootstrapProperties mockBootProperties = new MockBootProperties("xxx");
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, mockUnifiedBootstrap);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertFalse(report.isCheckPassed());
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/JavaxValidationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/JavaxValidationCheckerTest.java
@@ -20,7 +20,7 @@ public class JavaxValidationCheckerTest {
 
     BootstrapProperties mockBootProperties =
         new MockBootProperties(toString(createAdapterConfig(true)));
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertTrue(report.isCheckPassed());
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/SharedConnectionConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/SharedConnectionConfigurationCheckerTest.java
@@ -30,7 +30,7 @@ public class SharedConnectionConfigurationCheckerTest {
   @Test
   public void testCompleteFailureBadXml() throws Exception {
     BootstrapProperties mockBootProperties = new MockBootProperties("bad-data");
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertFalse(report.isCheckPassed());
     assertTrue(report.getFailureExceptions().size() > 0);
   }
@@ -39,7 +39,7 @@ public class SharedConnectionConfigurationCheckerTest {
   public void testNoConnections() throws Exception {
     BootstrapProperties mockBootProperties =
         new MockBootProperties(createAdapterConfig(null, null, null, null));
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertTrue(report.isCheckPassed());
   }
 
@@ -48,7 +48,7 @@ public class SharedConnectionConfigurationCheckerTest {
     BootstrapProperties mockBootProperties =
         new MockBootProperties(
             createAdapterConfig(new NullConnection("SharedNullConnection"), null, null, null));
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertFalse(report.isCheckPassed());
   }
 
@@ -57,7 +57,7 @@ public class SharedConnectionConfigurationCheckerTest {
     BootstrapProperties mockBootProperties = new MockBootProperties(
         createAdapterConfig(null, new SharedConnection("DoesNotExist"), null, null));
 
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertFalse(report.isCheckPassed());
     assertTrue(report.getFailureExceptions().size() > 0);
   }
@@ -66,7 +66,7 @@ public class SharedConnectionConfigurationCheckerTest {
   public void testProduceConnectionNoShared() throws Exception {
     BootstrapProperties mockBootProperties = new MockBootProperties(
         createAdapterConfig(null, null, new SharedConnection("DoesNotExist"), null));
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertFalse(report.isCheckPassed());
     assertTrue(report.getFailureExceptions().size() > 0);
   }
@@ -78,7 +78,7 @@ public class SharedConnectionConfigurationCheckerTest {
             new SharedConnection("SharedNullConnection"),
             new SharedConnection("SharedNullConnection"), null));
 
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertTrue(report.isCheckPassed());
     assertNotNull(report.toString());
   }
@@ -88,7 +88,7 @@ public class SharedConnectionConfigurationCheckerTest {
     BootstrapProperties mockBootProperties =
         new MockBootProperties(createAdapterConfig(new NullConnection("SharedNullConnection"), null,
             null, new SharedConnection("DoesNotExist")));
-    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties, null);
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
     assertFalse(report.isCheckPassed());
     assertTrue(report.getFailureExceptions().size() > 0);
     assertNotNull(report.toString());

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/SharedServiceConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/SharedServiceConfigurationCheckerTest.java
@@ -1,0 +1,124 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.adaptris.core.Adapter;
+import com.adaptris.core.Channel;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.NullService;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceList;
+import com.adaptris.core.SharedService;
+import com.adaptris.core.StandardWorkflow;
+import com.adaptris.core.management.BootstrapProperties;
+
+public class SharedServiceConfigurationCheckerTest {
+
+  private SharedServiceConfigurationChecker checker;
+
+  @Before
+  public void setUp() throws Exception {
+    checker = new SharedServiceConfigurationChecker();
+  }
+
+  @Test
+  public void testCompleteFailureBadXml() throws Exception {
+    BootstrapProperties mockBootProperties = new MockBootProperties("bad-data");
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertFalse(report.isCheckPassed());
+    assertTrue(report.getFailureExceptions().size() > 0);
+  }
+
+  @Test
+  public void testNoService() throws Exception {
+    BootstrapProperties mockBootProperties =
+        new MockBootProperties(createAdapterConfig(null, null));
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertTrue(report.isCheckPassed());
+  }
+
+  @Test
+  public void testSharedNotUsed() throws Exception {
+    BootstrapProperties mockBootProperties =
+        new MockBootProperties(
+            createAdapterConfig(new NullService("SharedNullService"), null));
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertFalse(report.isCheckPassed());
+  }
+
+  @Test
+  public void testServiceNoShared() throws Exception {
+    BootstrapProperties mockBootProperties = new MockBootProperties(
+        createAdapterConfig(null, new SharedService("DoesNotExist")));
+
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertFalse(report.isCheckPassed());
+    assertTrue(report.getFailureExceptions().size() > 0);
+  }
+
+  @Test
+  public void testServiceExist() throws Exception {
+    BootstrapProperties mockBootProperties =
+        new MockBootProperties(createAdapterConfig(new NullService("SharedNullService"),
+            new SharedService("SharedNullService")));
+
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertTrue(report.isCheckPassed());
+    assertNotNull(report.toString());
+  }
+
+  @Test
+  public void testServiceCollectionExist() throws Exception {
+    ServiceList sharedComponent = new ServiceList();
+    sharedComponent.setUniqueId("SharedNullService");
+    BootstrapProperties mockBootProperties = new MockBootProperties(
+        createAdapterConfig(sharedComponent, new SharedService("SharedNullService")));
+
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertTrue(report.isCheckPassed());
+    assertNotNull(report.toString());
+  }
+
+  @Test
+  public void testServiceInServiceCollectionExist() throws Exception {
+    BootstrapProperties mockBootProperties = new MockBootProperties(
+        createAdapterConfig(new NullService("SharedNullService"), new ServiceList(new SharedService("SharedNullService"))));
+
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertTrue(report.isCheckPassed());
+    assertNotNull(report.toString());
+  }
+
+  @Test
+  public void testServiceConnectionDoesNotExist() throws Exception {
+    BootstrapProperties mockBootProperties =
+        new MockBootProperties(createAdapterConfig(new NullService("SharedNullConnection"), new SharedService("DoesNotExist")));
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertFalse(report.isCheckPassed());
+    assertTrue(report.getFailureExceptions().size() > 0);
+    assertNotNull(report.toString());
+  }
+
+  private static String createAdapterConfig(Service sharedComponent, Service service) throws Exception {
+    Adapter adapter = new Adapter();
+    if(sharedComponent != null) {
+      adapter.getSharedComponents().addService(sharedComponent);
+    }
+
+    Channel channel = new Channel();
+    StandardWorkflow standardWorkflow = new StandardWorkflow();
+    channel.getWorkflowList().add(standardWorkflow);
+    adapter.getChannelList().add(channel);
+
+    if (service != null) {
+      standardWorkflow.getServiceCollection().add(service);
+    }
+    return DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
+  }
+
+}


### PR DESCRIPTION
## Motivation

Since we are already checking shared connections we should also have a configuration check that checks shared-services via XML in the same way

## Modification

- Add a new config checker that make sure that all the SharedService lookupName are valid and exists in shared components services.
- Add a test class that validate the new config checker
- Extract the common code between the shared service and shared connection config checker into an abstract class.
- Remove the UnifiedBoostrap param from ConfigurationChecker#performConfigCheck as it isn't use anywhere.

## Result

An error is reported in the config check runner if the a SharedService has a lookupName  which doesn't reference a valid SharedComponents Service.

## Testing

The tests should be successful.

Add a shared service in a workflow with an invalid lookupName:

```
<shared-service>
  <lookup-name>some-lookup-name-that-doesn't-exist</lookup-name>
</shared-service>
```
Run the config check: `java -jar lib/interlok-boot.jar -configcheck`

You should get an error: "Shared service does not exist in shared components: some-lookup-name-that-doesn't-exist"