### PR TITLE
INTERLOK-3404  startQuietly=false now does system.exit()

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
@@ -117,7 +117,7 @@ public class BootstrapProperties extends Properties {
     super();
   }
 
-  public BootstrapProperties(String resourceName) throws Exception {
+  public BootstrapProperties(String resourceName) {
     this();
     putAll(overrideWithSystemProperties(createProperties(resourceName)));
     setProperty(BOOTSTRAP_PROPERTIES_RESOURCE_KEY, resourceName);
@@ -128,7 +128,7 @@ public class BootstrapProperties extends Properties {
     putAll(overrideWithSystemProperties(p));
   }
 
-  private static Properties createProperties(final String resourceName) throws Exception {
+  private static Properties createProperties(final String resourceName) {
     String propertiesFile = StringUtils.defaultIfBlank(resourceName, DEFAULT_PROPS_RESOURCE);
     log.trace("Properties resource is [{}]", propertiesFile);
     Properties config = PropertyHelper.loadQuietly(() -> {

--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -50,11 +50,16 @@ abstract class CmdLineBootstrap {
   private transient String bootstrapResource;
   private transient ArgUtil arguments;
   private transient boolean configCheckOnly = false;
+  private transient BootstrapProperties bootProperties;
 
   protected boolean configCheckOnly() {
     return configCheckOnly;
   }
 
+  protected boolean startQuietly() {
+    return bootProperties.isEnabled(CFG_KEY_START_QUIETLY);
+
+  }
 
   protected String getBootstrapResource() {
     return bootstrapResource;
@@ -62,6 +67,10 @@ abstract class CmdLineBootstrap {
 
   protected ArgUtil getCommandlineArguments() {
     return arguments;
+  }
+
+  protected BootstrapProperties bootProperties() {
+    return bootProperties;
   }
 
   protected CmdLineBootstrap(String[] argv) throws Exception {
@@ -77,7 +86,6 @@ abstract class CmdLineBootstrap {
 
   protected void standardBoot() throws Exception {
     LoggingConfigurator.newConfigurator().defaultInitialisation();
-    BootstrapProperties bootProperties = new BootstrapProperties(getBootstrapResource());
     SystemPropertiesUtil.addSystemProperties(bootProperties);
     SystemPropertiesUtil.addJndiProperties(bootProperties);
     ProxyAuthenticator.register(bootProperties);
@@ -86,12 +94,11 @@ abstract class CmdLineBootstrap {
   }
 
   protected void startAdapter(BootstrapProperties bootProperties) throws Exception {
-    boolean startQuietly = bootProperties.isEnabled(CFG_KEY_START_QUIETLY);
     final UnifiedBootstrap bootstrap = new UnifiedBootstrap(bootProperties);
     if (!configCheckOnly()) {
       bootstrap.init(bootstrap.createAdapter());
       Runtime.getRuntime().addShutdownHook(new ShutdownHandler(bootProperties));
-      launchAdapter(bootstrap, startQuietly);
+      launchAdapter(bootstrap, startQuietly());
     }
     else {
       final List<Exception> fatals = new ArrayList<>();
@@ -124,6 +131,7 @@ abstract class CmdLineBootstrap {
       }
       configCheckOnly = true;
     }
+    bootProperties = new BootstrapProperties(getBootstrapResource());
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/management/NoAdapterBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/NoAdapterBootstrap.java
@@ -42,19 +42,18 @@ public class NoAdapterBootstrap extends CmdLineBootstrap {
     logVersionInformation();
     // standard boot
     LoggingConfigurator.newConfigurator().defaultInitialisation();
-    BootstrapProperties bootProperties = new BootstrapProperties(getBootstrapResource());
-    SystemPropertiesUtil.addSystemProperties(bootProperties);
-    SystemPropertiesUtil.addJndiProperties(bootProperties);
-    ProxyAuthenticator.register(bootProperties);
+    SystemPropertiesUtil.addSystemProperties(bootProperties());
+    SystemPropertiesUtil.addJndiProperties(bootProperties());
+    ProxyAuthenticator.register(bootProperties());
 
     // don't start adapter
-    bootProperties.reconfigureLogging();
-    ManagementComponentFactory.create(bootProperties);
-    ManagementComponentFactory.initCreated(bootProperties);
-    Runtime.getRuntime().addShutdownHook(new ShutdownHandler(bootProperties));
+    bootProperties().reconfigureLogging();
+    ManagementComponentFactory.create(bootProperties());
+    ManagementComponentFactory.initCreated(bootProperties());
+    Runtime.getRuntime().addShutdownHook(new ShutdownHandler(bootProperties()));
 
     // don't launch adapter
-    ManagementComponentFactory.startCreated(bootProperties);
+    ManagementComponentFactory.startCreated(bootProperties());
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/management/ShutdownHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ShutdownHandler.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,14 +20,11 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import javax.management.JMX;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.CoreException;
 import com.adaptris.core.runtime.AdapterManagerMBean;
 import com.adaptris.core.runtime.AdapterRegistry;
@@ -47,7 +44,6 @@ public class ShutdownHandler extends Thread {
 
   private transient Logger log = LoggerFactory.getLogger(Thread.class.getName());
 
-  private transient Thread mainThread;
   private transient ManagedThreadFactory threadFactory = new ManagedThreadFactory(ShutdownHandler.class.getSimpleName());
   private transient BootstrapProperties bootProperties;
 
@@ -59,8 +55,7 @@ public class ShutdownHandler extends Thread {
    * @param bp the adapter to shut down
    */
   public ShutdownHandler(BootstrapProperties bp) throws Exception {
-    mainThread = Thread.currentThread();
-    this.bootProperties = bp;
+    bootProperties = bp;
   }
 
   /**
@@ -84,17 +79,6 @@ public class ShutdownHandler extends Thread {
       AdapterRegistry.sendShutdownEvent(adapterRegistry.getAdapters());
       log.info("Shutting down Adapter(s)");
       shutdown(adapterRegistry.getAdapters());
-      while (mainThread.isAlive() && !mainThread.isInterrupted()) {
-        mainThread.interrupt();
-        try {
-          Thread.sleep(1000);
-        } catch (InterruptedException e) {
-          mainThread.interrupt();
-          break;
-        }
-      }
-      // log.info("Unregistering Adapter(s)");
-      // AdapterRegistry.unregister(adapterRegistry.getAdapters());
     } catch (Exception e) {
       log.debug(e.getMessage(), e);
     }
@@ -158,8 +142,8 @@ public class ShutdownHandler extends Thread {
     private CountDownLatch barrier;
 
     ShutdownAdapter(ObjectName name, CountDownLatch barrier, boolean force) {
-      this.forceShutdown = force;
-      this.objName = name;
+      forceShutdown = force;
+      objName = name;
       this.barrier = barrier;
     }
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/SimpleBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/SimpleBootstrap.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,6 @@ import com.adaptris.core.management.logging.LoggingConfigurator;
  * Basically the same as StandardBootstrap but without the classpath initialization.
  * </p>
  *
- * @author gcsiki
  */
 public class SimpleBootstrap extends CmdLineBootstrap {
 
@@ -48,12 +47,16 @@ public class SimpleBootstrap extends CmdLineBootstrap {
    * @throws Exception upon some unrecoverable error.
    */
   public static void main(String[] argv) throws Exception {
+    SimpleBootstrap simpleBoot = new SimpleBootstrap(argv);
     try {
-      new SimpleBootstrap(argv).boot();
+      simpleBoot.boot();
     }
     catch (Exception e) {
+      if (!simpleBoot.startQuietly()) {
+        e.printStackTrace();
+        System.exit(1);
+      }
       LoggingConfigurator.newConfigurator().requestShutdown();
-      throw e;
     }
   }
 }


### PR DESCRIPTION
## Motivation

If you set startQuietly=false in your bootstrap properties, then there's a high chance that the JVM won't exit, although multiple errors are logged.

You might expect startQuietly=false to kill the JVM, because you're deploying w/o the UI into production... (you could use alive/readiness instead which would probably do the same thing).

## Modification

- Change the shutdown handler so that we don't wait for the mainThread since either a) it's already dead (normal), or b) it's about to call system.exit()
- Change BootstrapProperties so that we don't throw exceptions in the constructor since we don't need to.
- SimpleBootstrap now checks if we're starting quietly, and does sysexit if we aren't.

## Result

Probably no change for the user, since the default is `startQuietly=true`

## Testing

Configure something like
```
<adapter>
  <unique-id>MyInterlokInstance</unique-id>
  <start-up-event-imp>com.adaptris.core.event.StandardAdapterStartUpEvent</start-up-event-imp>
  <heartbeat-event-imp>com.adaptris.core.HeartbeatEvent</heartbeat-event-imp>
  <shared-components>
    <connections>
      <jetty-http-connection>
        <unique-id>shared-jetty</unique-id>
        <port>8081</port>
      </jetty-http-connection>
      <jetty-http-connection>
        <unique-id>shared-jetty-with-same-port</unique-id>
        <port>8081</port>
      </jetty-http-connection>
    </connections>
    <services/>
  </shared-components>
</adapter>
```

If you set startQuietly=false then should now fail and exit the JVM.
If you set setartQuietly=true then errors are logged, but it will not exit the JVM.
If you have enabled the alive/ready then in the 2nd instance you get. You'll get what you get in the first instance.

```
$ curl -si http://localhost:8080/health/alive
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked


$ curl -si http://localhost:8080/health/ready
HTTP/1.1 503 Service Unavailable
Content-Type: application/json
Transfer-Encoding: chunked

{"failure": "MyInterlokInstance is not started"}
```




