### PR TITLE
INTERLOK-3405 jetty-consumer can now default encoding

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyMessageConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyMessageConsumer.java
@@ -126,7 +126,7 @@ public class JettyMessageConsumer extends BasicJettyConsumer {
    * this is the defined behaviour
    * <ul>
    * <li>If the {@code HttpServletRequest#getCharacterEncoding()} is valid (according to
-   * {@link Charset#forName(String)} then it is used.</li>
+   * {@link Charset#forName(String)}) then it is used.</li>
    * <li>If the {@code HttpServletRequest#getCharacterEncoding} is not supported then the default
    * content encoding is used, based on your settings for the {@link AdaptrisMessageFactory}
    * instance and {@link CoreConstants#OBJ_METADATA_EXCEPTION} object metadata is populated with a
@@ -136,7 +136,7 @@ public class JettyMessageConsumer extends BasicJettyConsumer {
    * <p>
    * If set to false, then {@link AdaptrisMessage#setContentEncoding(String)} is just invoked with
    * {@code HttpServletRequest#getCharacterEncoding()} which may cause failures when receiving data
-   * from poorly configured clients.
+   * from clients where the supported character sets differs.
    * </p>
    */
   @Getter

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ClearExceptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ClearExceptionService.java
@@ -26,7 +26,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Clears any exception stored against
- * {@value com.adaptris.core.CoreConstants#OBJ_METADATA_EXCEPTION}.
+ * {@link com.adaptris.core.CoreConstants#OBJ_METADATA_EXCEPTION}.
  *
  * @config clear-exception-service
  */

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ClearExceptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ClearExceptionService.java
@@ -25,7 +25,8 @@ import com.adaptris.core.ServiceException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Clears any exception stored against {@value CoreConstants#OBJ_METADATA_EXCEPTION}.
+ * Clears any exception stored against
+ * {@value com.adaptris.core.CoreConstants#OBJ_METADATA_EXCEPTION}.
  *
  * @config clear-exception-service
  */

--- a/interlok-core/src/main/java/com/adaptris/core/services/exception/ClearExceptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/exception/ClearExceptionService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.exception;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.NullService;
+import com.adaptris.core.ServiceException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Clears any exception stored against {@value CoreConstants#OBJ_METADATA_EXCEPTION}.
+ *
+ * @config clear-exception-service
+ */
+@XStreamAlias("clear-exception-service")
+@AdapterComponent
+@ComponentProfile(summary = "Clear any exception stored against object metadata",
+    tag = "service,error-handling", since = "3.11.0")
+public class ClearExceptionService extends NullService {
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_EXCEPTION);
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/exception/ClearExceptionServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/exception/ClearExceptionServiceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.exception;
+
+import static org.junit.Assert.assertFalse;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreConstants;
+
+public class ClearExceptionServiceTest extends ExceptionServiceExample {
+
+
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
+
+  @Test
+  public void testClearException() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, new Exception());
+    execute(new ClearExceptionService(), msg);
+    assertFalse(msg.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION));
+  }
+
+  @Test
+  public void testClearException_NoException() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    execute(new ClearExceptionService(), msg);
+    assertFalse(msg.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION));
+  }
+
+  @Override
+  protected ClearExceptionService retrieveObjectForSampleConfig() {
+    return new ClearExceptionService();
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/util/MessageHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/MessageHelperTest.java
@@ -4,8 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import java.io.IOException;
+import java.nio.charset.UnsupportedCharsetException;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.lms.FileBackedMessageFactory;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
@@ -44,4 +46,40 @@ public class MessageHelperTest {
     assertEquals("hello world", original.getContent());
     assertFalse(original.getObjectHeaders().containsKey(reply.getUniqueId()));
   }
+
+  @Test
+  public void testApplyCharset_Null() {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    MessageHelper.checkCharsetAndApply(msg, null, true);
+  }
+
+  @Test(expected = UnsupportedCharsetException.class)
+  public void testApplyCharset_Passthru_Invalid() {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    MessageHelper.checkCharsetAndApply(msg, "UTF-9", true);
+  }
+
+  @Test
+  public void testApplyCharset_Passthru_Valid() {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    MessageHelper.checkCharsetAndApply(msg, "ISO-8859-2", true);
+    assertEquals("ISO-8859-2", msg.getContentEncoding());
+  }
+
+
+  @Test
+  public void testApplyCharset_PassthruDisabled_Invalid() {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    MessageHelper.checkCharsetAndApply(msg, "UTF-9", false);
+    assertEquals(UnsupportedCharsetException.class,
+        msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION).getClass());
+  }
+
+  @Test
+  public void testApplyCharset_PassthruDisabled_Valid() {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    MessageHelper.checkCharsetAndApply(msg, "ISO-8859-2", false);
+    assertEquals("ISO-8859-2", msg.getContentEncoding());
+  }
+
 }


### PR DESCRIPTION
## Motivation

If you configure a jetty consumer, but the client is a bit shit and does `Content-Type: text/plain; charset=UTF-9`

Then you get this
```
2020-08-17T12:05:31,474 WARN  [qtp1550820587-33] [HttpChannel] /login
java.nio.charset.UnsupportedCharsetException: UTF-9
        at java.nio.charset.Charset.forName(Charset.java:541) ~[?:?]
        at com.adaptris.core.AdaptrisMessageImp.setContentEncoding(AdaptrisMessageImp.java:160) ~[interlok-core.jar:3.10.2-RELEASE]
```

Which means you can't fire normal error handling because well, UTF-9 doesn't exist as a valid charset, so we never get to the stage of entering the workflow. This may also have the side-effect of invalidating the servlet...

## Modification

- If request.getCharacterEncoding() is invalid, then we don't try to set it, and add an exception to ObjectMetadata.
This behaviour is controlled by `check-charset` which is __true__ by default since that's a more sensible default. This is delegated to a MessageHelper utility class for testability.

- Add a `clear-exception-service` for completeness, since you might not care about duff character sets and want to use throw-exception-service for some other reason, and you don't want it to fail.

## Result

If someone does

```
curl -XPOST -d'hello world' -H"Content-Type: text/plain; charset=UTF-9" http://localhost:8081/api/echo
```

Then Interlok no longer "fails"; but attaches the _UnsupportedCharsetException_ as object metadata for use in the workflow.


## Testing

Configure jetty workflow with a service-chain that's just a jetty-response-service :
```
        <standard-workflow>
          <consumer class="jetty-message-consumer">
            <unique-id>gigantic-bassi</unique-id>
            <destination class="configured-consume-destination">
              <destination>/api/echo</destination>
            </destination>
            <parameter-handler class="jetty-http-ignore-parameters"/>
            <header-handler class="jetty-http-ignore-headers"/>
          </consumer>
          <service-collection class="service-list">
            <unique-id>serene-banach</unique-id>
            <services>
              <jetty-response-service>
                <unique-id>send-response</unique-id>
                <http-status>200</http-status>
                <content-type>application/json</content-type>
                <response-header-provider class="jetty-no-response-headers"/>
              </jetty-response-service>
            </services>
          </service-collection>
          <unique-id>echo</unique-id>
        </standard-workflow>
```
And do a curl (as above) and you should just get "hello world" back

Change the configuration to add in a `throw-exception-service`

```
            <services>
              <throw-exception-service>
                <exception-generator class="last-known-exception"/>
              </throw-exception-service>
              <jetty-response-service>
                <unique-id>send-response</unique-id>
                <http-status>200</http-status>
                <content-type>application/json</content-type>
                <response-header-provider class="jetty-no-response-headers"/>
              </jetty-response-service>
            </services>
```

This should change the behaviour (depending on what you have configured, if you have a custom 500 exception handler, you'll get that, otherwise probably an empty payload + 200 OK... since the error will file, and the request will be auto-committed by jetty.

The logging will be something like
```
TRACE [echo@default-channel] [c.a.c.u.MessageHelper.lambda$checkCharsetAndApply$0()] 'UTF-9' is not supported, using default, and marking
DEBUG [echo@default-channel] [c.a.c.StandardWorkflow.handleMessage()] start processing msg [DefaultAdaptrisMessageImp[uniqueId=3c93d38d-7281-4c8f-9f6d-47adf9f88d2b,metadata={[jettyURI]=[/api/echo],[httpmethod]=[POST],[jettyURL]=[http://localhost:8081/api/echo],[_interlokMessageConsumedFrom]=[/api/echo]}]]
DEBUG [echo@default-channel] [c.a.c.ServiceList.applyServices()] Executing doService on [ThrowExceptionService]
ERROR [echo@default-channel] [c.a.c.StandardWorkflow.handleBadMessage()] Exception from ServiceCollection
com.adaptris.core.ServiceException: java.nio.charset.UnsupportedCharsetException: UTF-9
	at com.adaptris.core.services.exception.LastKnownException.create(LastKnownException.java:51)
	at com.adaptris.core.services.exception.ThrowExceptionService.doService(ThrowExceptionService.java:73)
	at com.adaptris.core.ServiceList.applyServices(ServiceList.java:96)
	at com.adaptris.core.ServiceCollectionImp.doService(ServiceCollectionImp.java:204)
...
Caused by: java.nio.charset.UnsupportedCharsetException: UTF-9
	at com.adaptris.core.util.MessageHelper.lambda$checkCharsetAndApply$0(MessageHelper.java:72)
	at java.util.Optional.ifPresent(Optional.java:159)
	at com.adaptris.core.util.MessageHelper.checkCharsetAndApply(MessageHelper.java:66)
	at com.adaptris.core.http.jetty.JettyMessageConsumer.createMessage(JettyMessageConsumer.java:168)
	at com.adaptris.core.http.jetty.BasicJettyConsumer$BasicServlet.processRequest(BasicJettyConsumer.java:441)
	... 29 more
```