### PR TITLE
Fix an edge case issue around ensuring Closeable

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/interlok/util/CloseableIterable.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/util/CloseableIterable.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,9 +22,9 @@ import java.util.Iterator;
 
 /**
  * This Iterable exists for the purpose of being able to iterate over a list of indeterminate size
- * (possibly too large for memory), while still guaranteeing that whatever resource is being held (like 
+ * (possibly too large for memory), while still guaranteeing that whatever resource is being held (like
  * a Stream) will be closed when iteration finishes (or it goes out of scope).
- * 
+ *
  */
 public interface CloseableIterable<E> extends Closeable, Iterable<E> {
 
@@ -32,7 +32,19 @@ public interface CloseableIterable<E> extends Closeable, Iterable<E> {
     if (iter instanceof CloseableIterable) {
       return (CloseableIterable<E>) iter;
     }
+    if (iter instanceof Closeable) {
+      return new CloseableIterable<E>() {
+        @Override
+        public void close() throws IOException {
+          ((Closeable) iter).close();
+        }
 
+        @Override
+        public Iterator<E> iterator() {
+          return iter.iterator();
+        }
+      };
+    }
     return new CloseableIterable<E>() {
       @Override
       public void close() throws IOException {

--- a/interlok-common/src/test/java/com/adaptris/interlok/util/CloseableIterableTest.java
+++ b/interlok-common/src/test/java/com/adaptris/interlok/util/CloseableIterableTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,8 +15,12 @@
 */
 package com.adaptris.interlok.util;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.*;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -28,22 +32,32 @@ public class CloseableIterableTest implements CloseableIterable<Object> {
   public void testEnsureCloseable_List() throws Exception {
     try (CloseableIterable i = CloseableIterable.ensureCloseable(new ArrayList())) {
       assertTrue(i instanceof CloseableIterable);
-      assertNotNull(i.iterator());      
-    };    
+      assertNotNull(i.iterator());
+    };
+  }
+
+  @Test
+  public void testEnsureCloseable_CloseableIterable() throws Exception {
+    try (CloseableIterable i = CloseableIterable.ensureCloseable(this)) {
+      assertTrue(i instanceof CloseableIterable);
+      assertSame(this, i);
+      assertNull(i.iterator());
+    };
   }
 
   @Test
   public void testEnsureCloseable_AlreadyCloseable() throws Exception {
-    try (CloseableIterable i = CloseableIterable.ensureCloseable(this)) {
+    DummyCloser dc = new DummyCloser();
+    try (CloseableIterable i = CloseableIterable.ensureCloseable(dc)) {
       assertTrue(i instanceof CloseableIterable);
-      assertSame(this, i);
-      assertNull(i.iterator());      
-    }; 
+      assertNull(i.iterator());
+      assertFalse(i.getClass().equals(DummyCloser.class));
+    }
   }
 
 
   @Override
-  public void close() throws IOException {    
+  public void close() throws IOException {
   }
 
   @Override
@@ -51,4 +65,13 @@ public class CloseableIterableTest implements CloseableIterable<Object> {
     return null;
   }
 
+  private class DummyCloser implements Closeable, Iterable<Object> {
+    @Override
+    public void close() throws IOException {}
+
+    @Override
+    public Iterator<Object> iterator() {
+      return null;
+    }
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/CloseableIterable.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/CloseableIterable.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.adaptris.core.util;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import com.adaptris.annotation.Removal;
@@ -24,19 +25,31 @@ import com.adaptris.annotation.Removal;
  * @deprecated since 3.10.2 moved to com.adaptris.interlok.util package.
  */
 @Deprecated
-@Removal(version="3.12.0") 
+@Removal(version="3.12.0")
 public interface CloseableIterable<E> extends com.adaptris.interlok.util.CloseableIterable<E> {
 
   /**
    * @deprecated since 3.10.2 use {@link com.adaptris.interlok.util.CloseableIterable#ensureCloseable(Iterable)} instead.
    */
   @Deprecated
-  @Removal(version="3.12.0") 
+  @Removal(version="3.12.0")
   static <E> CloseableIterable<E> ensureCloseable(final Iterable<E> iter) {
     if (iter instanceof CloseableIterable) {
       return (CloseableIterable<E>) iter;
     }
+    if (iter instanceof Closeable) {
+      return new CloseableIterable<E>() {
+        @Override
+        public void close() throws IOException {
+          ((Closeable) iter).close();
+        }
 
+        @Override
+        public Iterator<E> iterator() {
+          return iter.iterator();
+        }
+      };
+    }
     return new CloseableIterable<E>() {
       @Override
       public void close() throws IOException {

--- a/interlok-core/src/test/java/com/adaptris/core/util/CloseableIterableTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/CloseableIterableTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,8 +15,12 @@
 */
 package com.adaptris.core.util;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.*;
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -29,22 +33,32 @@ public class CloseableIterableTest implements CloseableIterable<Object> {
   public void testEnsureCloseable_List() throws Exception {
     try (CloseableIterable i = CloseableIterable.ensureCloseable(new ArrayList())) {
       assertTrue(i instanceof CloseableIterable);
-      assertNotNull(i.iterator());      
-    };    
+      assertNotNull(i.iterator());
+    };
+  }
+
+  @Test
+  public void testEnsureCloseable_CloseableIterable() throws Exception {
+    try (CloseableIterable i = CloseableIterable.ensureCloseable(this)) {
+      assertTrue(i instanceof CloseableIterable);
+      assertSame(this, i);
+      assertNull(i.iterator());
+    };
   }
 
   @Test
   public void testEnsureCloseable_AlreadyCloseable() throws Exception {
-    try (CloseableIterable i = CloseableIterable.ensureCloseable(this)) {
+    DummyCloser dc = new DummyCloser();
+    try (CloseableIterable i = CloseableIterable.ensureCloseable(dc)) {
       assertTrue(i instanceof CloseableIterable);
-      assertSame(this, i);
-      assertNull(i.iterator());      
-    }; 
+      assertNull(i.iterator());
+      assertFalse(i.getClass().equals(DummyCloser.class));
+    }
   }
 
 
   @Override
-  public void close() throws IOException {    
+  public void close() throws IOException {
   }
 
   @Override
@@ -52,4 +66,14 @@ public class CloseableIterableTest implements CloseableIterable<Object> {
     return null;
   }
 
+
+  private class DummyCloser implements Closeable, Iterable<Object> {
+    @Override
+    public void close() throws IOException {}
+
+    @Override
+    public Iterator<Object> iterator() {
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
## Motivation

`CloseableIterable` was moved out of com.adaptris.core.util (interlok-core) into com.adaptris.interlok.util (interlok-common) in 3.10.2; The core.util version was deprecated at the same time. 

The relationship is one way from interlok-core to interlok-common; since we can't really have a relationship from interlok-common to interlok-core as that would cause circular package dependencies. Traditionally, I would have made the core.util version the parent super-class to the interlok.util version and deprecated it, which would avoid the complication that we have now).

However, because of this if we have classes that mix and match the old and the new (either knowingly or indirectly).

`com.adaptris.core.util.CloseableIterable#ensureClosable(com.adaptris.interlok.util.CloseableIterable)` will  effectively give you something that __never calls close__ when you think it should; (This would not be true in the reverse situation). We should fix that before we start "upgrading things that use com.adaptris.core.util.ClosableIterable"... 

## Modification

- Add detection to ensure  that it checks if the iterator is Closeable before wrapping it in a no-op. If it's Closable then make sure we call close() at the right time.
This needed to be cut and pasted into both classes; that's the expedient and boring thing to do, since core.util.CloseableIterable will eventually go the way of the Norwegian Blue.

## Result

No Change

## Testing

Erm, trust the tests.
