### PR TITLE
Async producer now handles success and failure callbacks.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -1,19 +1,19 @@
 package com.adaptris.core.jms;
 
-import javax.jms.CompletionListener;
 import javax.jms.JMSException;
 import javax.jms.Message;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.StandardProcessingExceptionHandler;
-import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * JMS 2.0 Producer implementation that extends all features of {@link JmsProducer}, but allows us to send messages asynchronously. <br />
@@ -24,23 +24,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * At some future point in time, the JMS provider will call us back with confirmation or inform us of an error for each sent message.
  * </p>
  * <p>
- * Should the message have failed to be fully received or persisted, you can configure an async-message-error-handler.
- * </p>
- * <p>
- * An important note about the async-message-error-handle, is that it will process the message in the state it was in just before the produce was attempted.
- * If you have modified the message in the workflow before producing then attempting to "retry" this failed message through the same workflow may therefore be problematic.
- * </p>
- * <p>
  * One of the benefits to sending messages asynchronously simply comes down to processing speed.  During any producer, it is generally the time waiting for the JMS provider
  * to return control back to the client after the client submits a message that takes the most time.  With asynchronous message producing, we no longer have to wait for the JMS
  * provider, allowing us to move onto the next message.
- * </p>
- * <p>
- * <b>NOTE:</b> Once this producer has sent a message it is assumed to have succeeded, at least until a success or failure callback is received. <br />
- * This means that if this producer is one of your workflow producers, the workflow itself will immediately deem this
- * message to have been processed and will move onto the next available message. <br/>
- * Generally this may not be an issue, however if processing a message triggers a form of transaction committing or JMS acknowledging,
- * then the commit or ack could be completed regardless if the sent JMS message eventually succeeds or fails.
  * </p>
  *
  * @config jms-async-producer
@@ -51,66 +37,52 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Place message on a JMS queue or topic asynchronously", tag = "producer,jms", recommended = {JmsConnection.class})
 @DisplayOrder(order = {"endpoint", "destination", "asyncMessageErrorHandler",
     "messageTranslator", "deliveryMode", "priority", "ttl", "acknowledgeMode"})
-public class JmsAsyncProducer extends JmsProducer implements CompletionListener {
+public class JmsAsyncProducer extends JmsProducer {
 
-  @NotNull
-  @Valid
-  private StandardProcessingExceptionHandler asyncMessageErrorHandler;
+  private static final String ID_HEADER = "interlokMessageId";
+  
+  @Getter
+  @Setter
+  private transient JmsAsyncProducerEventHandler eventHandler; 
 
+  public JmsAsyncProducer() {
+    setEventHandler(new JmsAsyncProducerEventHandler(this));
+  }
+  
   @Override
   protected void produce(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException, CoreException {
     try {
       setupSession(msg);
       Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());
+      jmsMsg.setStringProperty(ID_HEADER, msg.getUniqueId());
+      
       if (!perMessageProperties()) {
-        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg, this);
+        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg, getEventHandler());
       } else {
         producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg,
             calculateDeliveryMode(msg, jmsDest.deliveryMode()),
             calculatePriority(msg, jmsDest.priority()),
             calculateTimeToLive(msg, jmsDest.timeToLive()),
-            this);
+            getEventHandler());
       }
+      // in real time speed JMSMessageID may not yet be set, therefore we set a header.
+      getEventHandler().addUnAckedMessage(jmsMsg.getStringProperty(ID_HEADER), msg);
+      // Standard workflow will attempt to execute this after the produce, 
+      // let's remove them so it's handled by our async event handler.
+      msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK);
+      msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK);
+      
       captureOutgoingMessageDetails(jmsMsg, msg);
       log.info("msg produced to destination [{}]", jmsDest);
     } catch (Throwable ex) {
-      throw new CoreException("JMS runtime exception", ex);
+      ExceptionHelper.rethrowProduceException(ex);
     }
   }
-
-  @Override
-  public void onCompletion(Message message) {
-    try {
-      log.trace("Async message succesfully received with id {}", message.getJMSMessageID());
-    } catch (JMSException e) {}
-  }
-
-  @Override
-  public void onException(Message message, Exception exception) {
-    log.error("Async Message failed.", exception);
-
-    try {
-      getAsyncMessageErrorHandler().handleProcessingException(getMessageTranslator().translate(message));
-    } catch (JMSException e) {
-      log.error("Failed to translate the failed JMS message to execute the exception handler.", e);
-    }
-  }
-
-  public StandardProcessingExceptionHandler getAsyncMessageErrorHandler() {
-    return asyncMessageErrorHandler;
-  }
-
-  public void setAsyncMessageErrorHandler(StandardProcessingExceptionHandler asyncMessageErrorHandler) {
-    this.asyncMessageErrorHandler = asyncMessageErrorHandler;
-  }
-
+  
   @Override
   public void init() throws CoreException {
-    try {
-      Args.notNull(getAsyncMessageErrorHandler(), "asyncMessageErrorHandler");
-      super.init();
-    } catch (IllegalArgumentException e) {
-      throw ExceptionHelper.wrapCoreException(e);
-    }
+    super.init();
+    getEventHandler().init();
   }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducerEventHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducerEventHandler.java
@@ -1,0 +1,129 @@
+package com.adaptris.core.jms;
+
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.jms.CompletionListener;
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ComponentLifecycle;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.CoreException;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class JmsAsyncProducerEventHandler implements CompletionListener, ComponentLifecycle {
+
+  protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+  
+  private static final String ID_HEADER = "interlokMessageId";
+    
+  @Getter
+  @Setter
+  private transient Map<String, CallbackConsumers> unAckedMessages;
+  
+  private transient JmsProducer producer;
+  @Getter
+  @Setter
+  private volatile boolean acceptSuccessCallbacks;
+  
+  public JmsAsyncProducerEventHandler(JmsProducer producer) {
+    this.registerProducer(producer);
+  }
+  
+  @Override
+  public void onCompletion(Message message) {
+    if(this.getAcceptSuccessCallbacks()) {
+      try {
+        log.debug("Success callback received for message id {}", message.getStringProperty(ID_HEADER));
+        CallbackConsumers callbackConsumers = this.getUnAckedMessages().get(message.getStringProperty(ID_HEADER));
+        if(callbackConsumers == null) {
+          log.warn("Received success callback for an unknown message {}", message.getStringProperty(ID_HEADER));
+        } else {
+          defaultIfNull(callbackConsumers.getOnSuccess(), (msg) -> {   }).accept(callbackConsumers.getMessage());
+          getUnAckedMessages().remove(message.getStringProperty(ID_HEADER));
+        }
+      } catch (JMSException ex) {
+        log.error("Error retriving the Jms message ID while handling a success callback.  Executing failure callback.", ex);
+        this.onException(message, ex);
+      }
+      logRemainingUnAckedMessages();
+    } else {
+      log.warn("Executing producer restart, not accepting further success callbacks until complete.");
+    }
+  }
+
+  @Override
+  public void onException(Message message, Exception exception) {
+    try {
+      setAcceptSuccessCallbacks(false);
+      log.error("Received failure callback for message id {}", message.getStringProperty(ID_HEADER));
+      logRemainingUnAckedMessages();
+      
+      CallbackConsumers callbackConsumers = this.getUnAckedMessages().get(message.getStringProperty(ID_HEADER));
+      if(callbackConsumers == null) {
+        log.warn("Received failure callback for an unknown message {}", message.getStringProperty(ID_HEADER));
+      } else {
+        defaultIfNull(callbackConsumers.getOnFailure(), (msg) -> {   }).accept(callbackConsumers.getMessage());
+        getUnAckedMessages().remove(message.getStringProperty(ID_HEADER));
+      }
+    } catch (JMSException ex) {
+      log.error("Error retrieving JMs message ID when handling an error.", ex);
+    } finally {
+      registeredProducer().retrieveConnection(JmsConnection.class).getConnectionErrorHandler().handleConnectionException();
+    }
+  }
+  
+  public void addUnAckedMessage(String messageId, AdaptrisMessage message) {
+    log.trace("Adding message to un'acked list with id {}", messageId);
+    CallbackConsumers callbackConsumers = new CallbackConsumers(message,
+        (Consumer<AdaptrisMessage>) message.getObjectHeaders().get(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK),
+        (Consumer<AdaptrisMessage>) message.getObjectHeaders().get(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK));
+    this.getUnAckedMessages().put(messageId, callbackConsumers);
+  }
+
+  private void logRemainingUnAckedMessages() {
+    log.trace("{} messages waiting for async callback.", this.getUnAckedMessages().size());
+  }
+  
+  @Override
+  public void init() throws CoreException {
+    this.setUnAckedMessages(new HashMap<>());
+    this.setAcceptSuccessCallbacks(true);
+  }
+
+  class CallbackConsumers {
+   @Getter
+   @Setter
+    private AdaptrisMessage message;
+   @Getter
+   @Setter
+    private Consumer<AdaptrisMessage> onSuccess;
+   @Getter
+   @Setter
+    private Consumer<AdaptrisMessage> onFailure;
+    
+    CallbackConsumers(AdaptrisMessage message, Consumer<AdaptrisMessage> onSuccess, Consumer<AdaptrisMessage> onFailure) {
+      setMessage(message);
+      setOnSuccess(onSuccess);
+      setOnFailure(onFailure);
+    }
+  }
+
+  public JmsProducer registeredProducer() {
+    return producer;
+  }
+
+  public void registerProducer(JmsProducer producer) {
+    this.producer = producer;
+  }
+}


### PR DESCRIPTION
## Motivation

After recently adding onAdaptrisMessage(message, success, failure) we have needed to update the async producer to take advantage of these callbacks when a future event of success or failure comes in.

## Modification

The JmsAsyncProducer now uses a common method to that of SolaceJcsmpProducer in that it has a JMS 2.0 callback event handler (CompletionListener) registered.  The producer will register the JMS message with the adaptris message callbacks in the event handler.  Later when a success/failure event is caught we recall the adaptris message with the callbacks in it and execute them.

## Result

The async producer is now fully functional according to the JMS 2.0 spec.  In testing it's just as fast producing to WMQ (which supports jms 2.0 from version 8.0) as the solace native stuff.

## Testing

You'll need a JMS 2.0 compliant broker like Artemis or WMQ.
Simply configure this producer instead of a JMS 1.1 producer and away you go!
You'll see additional trace logging informing you messages have been added to the pile of un ack'd messages, then further logging telling you of the success/failure events received.
