### PR TITLE
INTERLOK-2611 split many messages

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/BasicMessageSplitterService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/BasicMessageSplitterService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 
 package com.adaptris.core.services.splitter;
 
-import java.util.concurrent.Future;
+import java.util.function.Consumer;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AdapterComponent;
@@ -33,6 +33,7 @@ import com.adaptris.core.NullMessageProducer;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -44,10 +45,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * This implementation simply uses the configured producer and connection to produce the split message.
  * </p>
- * 
+ *
  * @config basic-message-splitter-service
- * 
- * 
+ *
+ *
  */
 @XStreamAlias("basic-message-splitter-service")
 @AdapterComponent
@@ -77,18 +78,17 @@ public class BasicMessageSplitterService extends MessageSplitterServiceImp imple
     setProducer(new NullMessageProducer());
   }
 
-  /**
-   *
-   * @see MessageSplitterServiceImp#handleSplitMessage(AdaptrisMessage)
-   */
   @Override
-  protected Future<?> handleSplitMessage(AdaptrisMessage msg) throws ServiceException {
+  protected void handleSplitMessage(AdaptrisMessage msg, Consumer<Exception> callback)
+      throws ServiceException {
     try {
       producer.produce(msg);
+      callback.accept(null);
     } catch (ProduceException e) {
-      throw new ServiceException(e);
+      ServiceException exc = ExceptionHelper.wrapServiceException(e);
+      callback.accept(exc);
+      throw exc;
     }
-    return new AlreadyComplete();
   }
 
   @Override
@@ -180,5 +180,6 @@ public class BasicMessageSplitterService extends MessageSplitterServiceImp imple
     LifecycleHelper.prepare(getConnection());
     LifecycleHelper.prepare(getProducer());
   }
+
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/MessageSplitterServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/MessageSplitterServiceImp.java
@@ -153,7 +153,7 @@ public abstract class MessageSplitterServiceImp extends ServiceImp {
     ignoreSplitMessageFailures = b;
   }
 
-  protected static class SplitterCallback implements Consumer<Exception> {
+  private static class SplitterCallback implements Consumer<Exception> {
 
     private transient Exception lastException = null;
     private transient long count = 0;
@@ -170,15 +170,15 @@ public abstract class MessageSplitterServiceImp extends ServiceImp {
       count++;
     }
 
-    public boolean hadFailures() {
+    private boolean hadFailures() {
       return lastException != null;
     }
 
-    public Exception lastException() {
+    private Exception lastException() {
       return lastException;
     }
 
-    public long count() {
+    private long count() {
       return count;
     }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/MessageSplitterServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/MessageSplitterServiceImp.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,11 +16,7 @@
 
 package com.adaptris.core.services.splitter;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.BooleanUtils;
@@ -33,6 +29,7 @@ import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.util.CloseableIterable;
+import lombok.Synchronized;
 
 /**
  * <p>
@@ -42,13 +39,13 @@ import com.adaptris.interlok.util.CloseableIterable;
 public abstract class MessageSplitterServiceImp extends ServiceImp {
   public static final String KEY_SPLIT_MESSAGE_COUNT = "splitCount";
   public static final String KEY_CURRENT_SPLIT_MESSAGE_COUNT = "currentSplitCount";
-  
+
   @NotNull
   @Valid
   private MessageSplitter splitter;
   @InputFieldDefault(value = "false")
   private Boolean ignoreSplitMessageFailures;
-  
+
   /**
    */
   public MessageSplitterServiceImp() {
@@ -60,14 +57,14 @@ public abstract class MessageSplitterServiceImp extends ServiceImp {
    */
   @Override
   public final void doService(AdaptrisMessage msg) throws ServiceException {
-    List<Future> tasks = new ArrayList<Future>();
     try (CloseableIterable<AdaptrisMessage> messages = CloseableIterable.ensureCloseable(splitter.splitMessage(msg))) {
       long count = 0;
+      SplitterCallback callback = new SplitterCallback();
       for (AdaptrisMessage splitMessage : messages) {
         count++;
         try {
           splitMessage.addMetadata(KEY_CURRENT_SPLIT_MESSAGE_COUNT, Long.toString(count));
-          tasks.add(handleSplitMessage(splitMessage));
+          handleSplitMessage(splitMessage, callback);
         } catch (ServiceException e) {
           log.debug("Split msg {} failed", splitMessage.getUniqueId());
           if (ignoreSplitMessageFailures()) {
@@ -77,28 +74,26 @@ public abstract class MessageSplitterServiceImp extends ServiceImp {
           }
         }
       }
-      waitForCompletion(tasks);
+      waitForCompletion(callback, count);
       msg.addMetadata(KEY_SPLIT_MESSAGE_COUNT, Long.toString(count));
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
     }
   }
 
-  protected abstract Future<?> handleSplitMessage(AdaptrisMessage msg)
-      throws ServiceException;
+  protected abstract void handleSplitMessage(AdaptrisMessage msg,
+      java.util.function.Consumer<Exception> successOrFailure) throws ServiceException;
 
-  protected void waitForCompletion(List<Future> tasks) throws ServiceException {
+  protected void waitForCompletion(SplitterCallback tasks, long expected) throws ServiceException {
+    long count = -1;
+    boolean ignore = ignoreSplitMessageFailures();
     do {
-      for (Iterator<Future> i = tasks.iterator(); i.hasNext();) {
-        Future f = i.next();
-        if (f.isDone()) {
-          i.remove();
-        }
+      count = tasks.count();
+      if (BooleanUtils.and(new boolean[] {tasks.hadFailures(), !ignore})) {
+        throw ExceptionHelper.wrapServiceException(tasks.lastException());
       }
-      if (tasks.size() > 0) {
-        LifecycleHelper.waitQuietly(100);
-      }
-    } while (tasks.size() > 0);
+      LifecycleHelper.waitQuietly(100);
+    } while (count < expected);
   }
 
   @Override
@@ -158,33 +153,35 @@ public abstract class MessageSplitterServiceImp extends ServiceImp {
     ignoreSplitMessageFailures = b;
   }
 
-  // In the current thread, by the time the future returns everything is complete.
-  protected static class AlreadyComplete implements Future<Boolean> {
+  protected static class SplitterCallback implements Consumer<Exception> {
 
+    private transient Exception lastException = null;
+    private transient long count = 0;
+    private final transient Object locker = new Object();
+
+    // The question here is, should the callback use AtomicXXX rather than
+    // making this synchronized?
     @Override
-    public boolean cancel(boolean mayInterruptIfRunning) {
-      return false;
+    @Synchronized("locker")
+    public void accept(Exception e) {
+      if (e != null) {
+        lastException = e;
+      }
+      count++;
     }
 
-    @Override
-    public boolean isCancelled() {
-      return false;
+    public boolean hadFailures() {
+      return lastException != null;
     }
 
-    @Override
-    public boolean isDone() {
-      return true;
+    public Exception lastException() {
+      return lastException;
     }
 
-    @Override
-    public Boolean get() {
-      return Boolean.TRUE;
-    }
-
-    @Override
-    public Boolean get(long timeout, TimeUnit unit) {
-      return Boolean.TRUE;
+    public long count() {
+      return count;
     }
 
   }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingMessageSplitterService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingMessageSplitterService.java
@@ -89,7 +89,8 @@ public class PoolingMessageSplitterService extends AdvancedMessageSplitterServic
    * If set to true, then we check that the underlying object pool has enough space for us to submit
    * more jobs. This means that if you have a large number of split messages, then we don't attempt
    * to flood the queue with thousands of messages causing possible issues within constrained
-   * environments. It defaults to false if not explicitly specified.
+   * environments. It defaults to false if not explicitly specified, and if set to true will have a
+   * negative impact on performance.
    * </p>
    */
   @AdvancedConfig(rare = true)

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceWorkerPool.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceWorkerPool.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,6 +40,7 @@ import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.ManagedThreadFactory;
+import com.adaptris.interlok.util.Closer;
 import com.adaptris.util.TimeInterval;
 
 public class ServiceWorkerPool {
@@ -52,8 +53,8 @@ public class ServiceWorkerPool {
 
   public ServiceWorkerPool(Service s, EventHandler eh, int maxThreads) throws CoreException {
     try {
-      this.wrappedService = Args.notNull(s, "service");
-      this.eventHandler = eh;
+      wrappedService = Args.notNull(s, "service");
+      eventHandler = eh;
       this.maxThreads = maxThreads;
     } catch (IllegalArgumentException e) {
       throw ExceptionHelper.wrapCoreException(e);
@@ -86,15 +87,16 @@ public class ServiceWorkerPool {
   }
 
 
+  /**
+   * @deprecated since 3.11.0 use {@link Closer#closeQuietly(Closeable)} instead.
+   *
+   */
+  @Deprecated
   public static void closeQuietly(ObjectPool<?> pool) {
-    try {
-      if (pool != null) pool.close();
-    } catch (Exception ignored) {
-
-    }
+    Closer.closeQuietly(pool);
   }
 
-  
+
   public void warmup(final GenericObjectPool<Worker> objectPool) throws CoreException {
     ExecutorService populator = Executors.newCachedThreadPool(new ManagedThreadFactory(this.getClass().getSimpleName()));
     try {
@@ -123,7 +125,7 @@ public class ServiceWorkerPool {
       populator.shutdownNow();
     }
   }
-  
+
   private List<Worker> waitFor(List<Future<Worker>> tasks) throws Exception {
     List<Worker> result = new ArrayList<>();
     do {

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/BasicMessageSplitterServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/BasicMessageSplitterServiceTest.java
@@ -33,6 +33,8 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullConnection;
 import com.adaptris.core.NullMessageProducer;
+import com.adaptris.core.ProduceException;
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.stubs.MockConnection;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
@@ -222,6 +224,16 @@ public class BasicMessageSplitterServiceTest {
   }
 
 
+  @Test(expected = ServiceException.class)
+  public void testService_ProduceException() throws Exception {
+    FailingProducer producer = new FailingProducer();
+    MessageSplitterServiceImp service =
+        createServiceImpl(new XpathMessageSplitter("/envelope/document", "UTF-8"), producer);
+    AdaptrisMessage msg = createMessage(XML_MESSAGE);
+    XpathMessageSplitter splitter = new XpathMessageSplitter("/envelope/document", "UTF-8");
+    execute(service, msg);
+  }
+
   protected MessageSplitterServiceImp createServiceImpl(MessageSplitter splitter, MockMessageProducer producer) {
     BasicMessageSplitterService service = new BasicMessageSplitterService();
     service.setConnection(new NullConnection());
@@ -237,5 +249,13 @@ public class BasicMessageSplitterServiceTest {
   protected AdaptrisMessage createMessage(AdaptrisMessage src) {
     src.addMetadata(METADATA_KEY, METADATA_VALUE);
     return src;
+  }
+
+  private class FailingProducer extends MockMessageProducer {
+    @Override
+    protected void doProduce(AdaptrisMessage msg, String endpoint) throws ProduceException {
+      throw new ProduceException();
+    }
+
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/BasicMessageSplitterServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/BasicMessageSplitterServiceTest.java
@@ -27,8 +27,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -223,32 +221,6 @@ public class BasicMessageSplitterServiceTest {
     }
   }
 
-  // BackReference Test no longer valid due to INTERLOK-145
-  // public void testBackReferences() throws Exception {
-  // BasicMessageSplitterService testObject = new BasicMessageSplitterService();
-  // testObject.setConnection(new NullConnection());
-  // assertEquals(1, testObject.getConnection().retrieveExceptionListeners().size());
-  // assertTrue(testObject == testObject.getConnection().retrieveExceptionListeners().toArray()[0]);
-  //
-  // // Now marshall and see if it's the same.
-  // XStreamMarshaller m = new XStreamMarshaller();
-  // String xml = m.marshal(testObject);
-  // BasicMessageSplitterService testObject2 = (BasicMessageSplitterService) m.unmarshal(xml);
-  // // If the setter has been used, then these two will be "true"
-  // assertNotNull(testObject2.getConnection());
-  // assertEquals(1, testObject2.getConnection().retrieveExceptionListeners().size());
-  // assertTrue(testObject2 == testObject2.getConnection().retrieveExceptionListeners().toArray()[0]);
-  // }
-
-  @Test
-  public void testAlreadyComplete() throws Exception {
-    Future<Boolean> future = new MessageSplitterServiceImp.AlreadyComplete();
-    assertFalse(future.cancel(true));
-    assertTrue(future.isDone());
-    assertFalse(future.isCancelled());
-    assertTrue(future.get());
-    assertTrue(future.get(1, TimeUnit.SECONDS));
-  }
 
   protected MessageSplitterServiceImp createServiceImpl(MessageSplitter splitter, MockMessageProducer producer) {
     BasicMessageSplitterService service = new BasicMessageSplitterService();

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/PoolingMessageSplitterServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/PoolingMessageSplitterServiceTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,35 +15,24 @@
 */
 package com.adaptris.core.services.splitter;
 
-import static com.adaptris.core.ServiceCase.execute;
 import static com.adaptris.core.services.splitter.SplitterCase.XML_MESSAGE;
+import static com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase.execute;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.services.AlwaysFailService;
+import com.adaptris.core.services.WaitService;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.stubs.StaticMockMessageProducer;
+import com.adaptris.util.TimeInterval;
 
 @SuppressWarnings("deprecation")
 public class PoolingMessageSplitterServiceTest {
-
-  @Test
-  public void testMaxThreads() throws Exception {
-    PoolingMessageSplitterService service = new PoolingMessageSplitterService();
-    assertNull(service.getMaxThreads());
-    assertEquals(10, service.maxThreads());
-    service.setMaxThreads(20);
-    assertEquals(20, service.maxThreads());
-    service.setMaxThreads(null);
-    assertEquals(10, service.maxThreads());
-  }
 
   @Test
   public void testServiceWithXmlSplitter() throws Exception {
@@ -58,11 +47,12 @@ public class PoolingMessageSplitterServiceTest {
   }
 
   @Test
-  public void testServiceWithXmlSplitter_WarmStart() throws Exception {
+  public void testServiceWithXmlSplitter_WarmStart_WaitWhileBusy() throws Exception {
     MockMessageProducer producer = createMockProducer();
     PoolingMessageSplitterService service = SplitterCase.createPooling(new XpathMessageSplitter("/envelope/document", "UTF-8"),
-        new StandaloneProducer(producer)).withWarmStart(true);
-    service.setMaxThreads(1);
+            new WaitService(new TimeInterval(500L, TimeUnit.MILLISECONDS)),
+            new StandaloneProducer(producer))
+        .withWarmStart(true).withMaxThreads(1).withWaitWhileBusy(true);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_MESSAGE);
     XpathMessageSplitter splitter = new XpathMessageSplitter("/envelope/document", "UTF-8");
     execute(service, msg);
@@ -73,7 +63,7 @@ public class PoolingMessageSplitterServiceTest {
   public void testServiceWithFailures() throws Exception {
 
     PoolingMessageSplitterService service = SplitterCase.createPooling(new XpathMessageSplitter("/envelope/document", "UTF-8"),
-        new AlwaysFailService());
+            new AlwaysFailService()).withWaitWhileBusy(true);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_MESSAGE);
     XpathMessageSplitter splitter = new XpathMessageSplitter("/envelope/document", "UTF-8");
     try {

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/ServiceExceptionHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/ServiceExceptionHandlerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package com.adaptris.core.services.splitter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import com.adaptris.core.ServiceException;
+
+public class ServiceExceptionHandlerTest {
+
+  @Before
+  public void setUp() throws Exception {
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void testUncaughtException() throws Exception {
+    ServiceExceptionHandler handler = new ServiceExceptionHandler();
+    handler.uncaughtException(Thread.currentThread(), new ServiceException("first"));
+    handler.uncaughtException(Thread.currentThread(), new ServiceException("second"));
+    assertNotNull(handler.getFirstThrowableException());
+    assertEquals("first", handler.getFirstThrowableException().getMessage());
+    handler.clearExceptions();
+    assertNull(handler.getFirstThrowableException());
+  }
+
+  @Test
+  public void testThrowFirst_NoExceptions() throws Exception {
+    ServiceExceptionHandler handler = new ServiceExceptionHandler();
+    handler.throwFirstException();
+    assertNull(handler.getFirstThrowableException());
+  }
+
+  @Test
+  public void testThrowFirst() throws Exception {
+    ServiceExceptionHandler handler = new ServiceExceptionHandler();
+    handler.uncaughtException(Thread.currentThread(), new ServiceException("first"));
+    handler.uncaughtException(Thread.currentThread(), new ServiceException("second"));
+    try {
+      handler.throwFirstException();
+      fail();
+    } catch (ServiceException expected) {
+      assertEquals("first", expected.getMessage());
+      assertEquals(1, expected.getSuppressed().length);
+    }
+    assertNull(handler.getFirstThrowableException());
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/ServiceWorkerPoolTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/ServiceWorkerPoolTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,16 +19,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import java.util.concurrent.ExecutorService;
-
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullService;
@@ -70,6 +67,7 @@ public class ServiceWorkerPoolTest extends ServiceWorkerPool {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testCloseQuietly() {
     closeQuietly((GenericObjectPool) null);
     closeQuietly(new GenericObjectPool(new DummyPooledObjectFactory()));
@@ -108,9 +106,9 @@ public class ServiceWorkerPoolTest extends ServiceWorkerPool {
     GenericObjectPool<ServiceWorkerPool.Worker> objPool = createCommonsObjectPool();
     warmup(objPool);
     assertEquals(10, objPool.getNumIdle());
-    closeQuietly(objPool);    
+    closeQuietly(objPool);
   }
-  
+
   @Test
   public void testWarmup_WithException() throws Exception {
     GenericObjectPool<ServiceWorkerPool.Worker> objPool = null;
@@ -120,13 +118,13 @@ public class ServiceWorkerPoolTest extends ServiceWorkerPool {
       worker.warmup(objPool);
       fail();
     } catch (CoreException expected) {
-      
+
     } finally {
       closeQuietly(objPool);
     }
   }
-  
-  
+
+
   private class DummyPooledObjectFactory implements PooledObjectFactory {
 
     @Override


### PR DESCRIPTION
## Motivation

If have a message that has many many messages when split (e.g. a LineCountSplitter on a 80k line file) then you end up with a list of 80k futures. This is undesirable from an object count of point of view vis-a-vis object creation, since this effectively doubles the number of object references (1 for the split message, and 1 for the future).

## Modification

- Add a Consumer<Exception> callback to MessageSplitterServiceImp that concrete sub-classes know about
- Make the concrete subclasses use the callback on success or failure which is then tracked to make sure that we throw
an exception as required.
- Add a "wait-while-busy (default=false)" mode to pooling-message-splitter so that it proactively checks the size of the object pool before submitting; waits a while if num-active >= max-allowed.
    - This has the effect of ensuring that 'max-threads' number of AdaptrisMessages are in memory, since the splitter itself will be a lazy iterable in most cases (line-count-splitter / large-json-array-splitter) etc.
- Add explicit tests for ServiceExceptionHandler since we shouldn't rely on the kindness of strangers for unit-testing it.

Ideally we would be able to use the same methodology for reducing the object count when using PoolingSplitJoin or similar (but from a cursory glance we can't since we need to keep a reference to all the Futures so that we can cancel them if the timeout expires -> there's no such requirement for a split).

## Result

No configuration changes; but if people are using PoolingMessageSplitterService in a constrained environment, they might see some improvements vis a vis memory use.

## Testing

Only needed to change 1 test (BasicMessageSplitter) to remove the custom Future that we had (the test was only for coverage); so we should be able to trust the tests...
Probably want to test it with a massive file to check "memory use" before and after .
