### PR TITLE
INTERLOK-3425 pooling splitter wait while busy

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingMessageSplitterService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingMessageSplitterService.java
@@ -89,7 +89,7 @@ public class PoolingMessageSplitterService extends AdvancedMessageSplitterServic
    * more jobs. This means that if you have a large number of split messages, then we don't attempt
    * to flood the queue with thousands of messages causing possible issues within constrained
    * environments. It defaults to false if not explicitly specified, and if set to true will have a
-   * negative impact on performance.
+   * small negative impact on performance.
    * </p>
    */
   @AdvancedConfig(rare = true)

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/PoolingMessageSplitterServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/PoolingMessageSplitterServiceTest.java
@@ -35,6 +35,12 @@ import com.adaptris.util.TimeInterval;
 public class PoolingMessageSplitterServiceTest {
 
   @Test
+  public void testWait() throws Exception {
+    PoolingMessageSplitterService s = new PoolingMessageSplitterService();
+    s.waitQuietly(null);
+  }
+
+  @Test
   public void testServiceWithXmlSplitter() throws Exception {
     MockMessageProducer producer = createMockProducer();
     PoolingMessageSplitterService service = SplitterCase.createPooling(new XpathMessageSplitter("/envelope/document", "UTF-8"),

--- a/interlok-core/src/test/java/com/adaptris/core/util/LifecycleHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/LifecycleHelperTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,6 @@ package com.adaptris.core.util;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.core.Channel;
 import com.adaptris.core.ChannelList;
 import com.adaptris.core.ComponentLifecycle;
@@ -82,4 +81,11 @@ public class LifecycleHelperTest extends LifecycleHelper {
     prepare((ComponentLifecycle) null);
     prepare(new EmptyIdentityBuilder());
   }
+
+  @Test
+  public void testSleepQuietly() throws Exception {
+    waitQuietly(-1);
+    waitQuietly(5);
+  }
+
 }


### PR DESCRIPTION
## Motivation

https://github.com/adaptris/interlok/pull/514 caused a drop in performance while wait-while-busy=true. For a simplistic test, generating 52k split messages, we ended up taking 50times longer than wait-while-busy=false.  Which is expected if we just do the maths.

- There are 52k messages coming out of the split.
- Each split message "takes no time to process"; since it's just a raw write to disk, so we can expect the entire thread pool to be emptied at the same time (near as dammit).
- This means that the total wait time is possibly (52k / 10 (the size of the pool)) * 100 -> which is 520k ms or ~10 minutes.
- The performance measuring shows that the time to process is 320k ms, so we're somewhat faster, however the bulk of this time is spent in Thread.sleep() for no reason.

Needed to fix that, otherwise there's no point to that flag at all.

## Modification

Use wait()/notifyAll() rather than naively sleeping for 100ms when waiting for an object to be returned back to the object pool.

## Result

if wait-while-busy=true, then performance should be comparable to wait-while-busy=false. GC happens when it wants to happen, so memory use characteristics appear to be better (not precisely measured).

## Testing

The existing tests still work, so I anticipate no regressions. Configure a massive file to split (e.g. a line count splitter + file of 80k lines), and the performance with 'wait-while-busy=true' should be comparable to 'wait-while-busy=false' but memory use will go up & down nicely if you hard-fix the memory with `-Xmx`
