### PR TITLE
Feature/interlok 3420 jms consumer synch mode

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/BaseJmsPollingConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/BaseJmsPollingConsumerImpl.java
@@ -1,0 +1,281 @@
+package com.adaptris.core.jms;
+
+import static com.adaptris.core.jms.NullCorrelationIdSource.defaultIfNull;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.IllegalStateException;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.apache.commons.lang3.BooleanUtils;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.core.AdaptrisMessageListener;
+import com.adaptris.core.AdaptrisPollingConsumer;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.TimeInterval;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+public abstract class BaseJmsPollingConsumerImpl extends AdaptrisPollingConsumer implements JmsActorConfig {
+
+  private static final TimeInterval DEFAULT_RECEIVE_WAIT = new TimeInterval(2L, TimeUnit.SECONDS);
+
+  /**
+   * <p>
+   * Sets the JMS acknowledge mode to use.
+   * </p>
+   * <p>
+   * The value may be AUTO_KNOWLEDGE, CLIENT_ACKNOWLEDGE, DUPS_OK_ACKNOWLEDGE or the int values corresponding to the JMS Session Constant
+   * </p>
+   *
+   * @param i
+   *          the JMS acknowledge mode to use
+   */
+  @NotNull
+  @AutoPopulated
+  @Pattern(regexp = "AUTO_ACKNOWLEDGE|CLIENT_ACKNOWLEDGE|DUPS_OK_ACKNOWLEDGE|[0-9]+")
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private String acknowledgeMode;
+
+  /**
+   * <p>
+   * Sets the MessageTypeTranslator to use.
+   * </p>
+   *
+   * @param translator
+   *          the MessageTypeTranslator to use
+   */
+  @NotNull
+  @AutoPopulated
+  @Valid
+  @NonNull
+  @Getter
+  @Setter
+  private MessageTypeTranslator messageTranslator;
+
+  /**
+   * <p>
+   * Sets correlationIdSource.
+   * </p>
+   *
+   * @param c
+   *          the correlationIdSource to set
+   */
+  @Valid
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private CorrelationIdSource correlationIdSource;
+
+  /**
+   * Sets the period that this class should wait for the broker to deliver a message.
+   * <p>
+   * The default value of 2 seconds should be suitable in most situations. If there is a high degree of network latency and this class does
+   * not consume messages from Queues / Topics as expected try setting a higher value.
+   * </p>
+   *
+   * @param l
+   *          the period that this class should wait for the broker to deliver a message, if < 0 then the default (2secs) will be used.
+   */
+  @Valid
+  @Getter
+  @Setter
+  private TimeInterval receiveTimeout;
+
+  /**
+   * The filter expression to use when matching messages to consume
+   */
+  @Getter
+  @Setter
+  private String messageSelector;
+
+  private transient Boolean transacted;
+  private transient boolean managedTransaction;
+  private transient long rollbackTimeout = 30000;
+  private transient Session session;
+  private transient MessageConsumer messageConsumer;
+  private transient OnMessageHandler messageHandler;
+
+  public BaseJmsPollingConsumerImpl() {
+    // defaults...
+    setAcknowledgeMode(AcknowledgeMode.Mode.CLIENT_ACKNOWLEDGE.name());
+    setMessageTranslator(new AutoConvertMessageTranslator());
+  }
+
+  @Override
+  public void init() throws CoreException {
+    super.init();
+    messageHandler = new OnMessageHandler(this);
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    configuredMessageTranslator().registerSession(null);
+    LifecycleHelper.stopAndClose(messageTranslator);
+    closeMessageConsumer();
+    closeSession();
+  }
+
+  protected void initConsumer() throws JMSException, CoreException {
+    messageConsumer = createConsumer();
+  }
+
+  protected abstract MessageConsumer createConsumer() throws JMSException, CoreException;
+
+  public MessageConsumer messageConsumer() {
+    return messageConsumer;
+  }
+
+  protected void closeMessageConsumer() {
+    JmsUtils.closeQuietly(messageConsumer);
+    messageConsumer = null;
+  }
+
+  public OnMessageHandler messageHandler() {
+    return messageHandler;
+  }
+
+  protected int doProcessMessage() {
+    int count = 0;
+
+    try {
+      Message jmsMsg = null;
+
+      do { // always want to try to obtain a Message
+        try {
+          jmsMsg = messageConsumer.receive(receiveTimeout());
+        } catch (IllegalStateException e) {
+          log.debug("Session closed upon attempt to process message");
+          break;
+        }
+
+        if (jmsMsg != null) {
+          messageHandler.onMessage(jmsMsg); // no Exc. ever
+          if (!continueProcessingMessages(++count)) {
+            break;
+          }
+        }
+      } while (jmsMsg != null);
+
+    } catch (Throwable e) {
+      log.error("Unhandled Throwable processing message", e);
+    }
+
+    // log.debug("processed [" + count + "] messages");
+
+    return count;
+  }
+
+  boolean isTransacted() {
+    return isManagedTransaction() || BooleanUtils.toBooleanDefaultIfNull(transacted, false);
+  }
+
+  void setTransacted(Boolean b) {
+    transacted = b;
+  }
+
+  Boolean getTransacted() {
+    return transacted;
+  }
+
+  /**
+   * @return the rollbackTimeout
+   */
+  long getRollbackTimeout() {
+    return rollbackTimeout;
+  }
+
+  /**
+   * Not directly configurable, as it is done by JmsTransactedWorkflow.
+   *
+   * @param l
+   *          the rollbackTimeout to set
+   */
+  void setRollbackTimeout(long l) {
+    rollbackTimeout = l;
+  }
+
+  @Override
+  public long rollbackTimeout() {
+    return getRollbackTimeout();
+  }
+
+  long receiveTimeout() {
+    long period = TimeInterval.toMillisecondsDefaultIfNull(getReceiveTimeout(), DEFAULT_RECEIVE_WAIT);
+    if (period < 0) {
+      period = DEFAULT_RECEIVE_WAIT.toMilliseconds();
+    }
+    return period;
+  }
+
+  @Override
+  public CorrelationIdSource configuredCorrelationIdSource() {
+    return defaultIfNull(getCorrelationIdSource());
+  }
+
+  @Override
+  public MessageTypeTranslator configuredMessageTranslator() {
+    return getMessageTranslator();
+  }
+
+  @Override
+  public int configuredAcknowledgeMode() {
+    return AcknowledgeMode.getMode(getAcknowledgeMode());
+  }
+
+  protected void initSession() throws JMSException, CoreException {
+    session = createSession(configuredAcknowledgeMode(), isTransacted());
+  }
+
+  protected abstract Session createSession(int acknowledgeMode, boolean transacted) throws JMSException;
+
+  @Override
+  public Session currentSession() {
+    return session;
+  }
+
+  protected void closeSession() {
+    JmsUtils.closeQuietly(session);
+    session = null;
+  }
+
+  public void setManagedTransaction(boolean managedTransaction) {
+    this.managedTransaction = managedTransaction;
+  }
+
+  @Override
+  public boolean isManagedTransaction() {
+    return managedTransaction;
+  }
+
+  @Override
+  public AdaptrisMessageListener configuredMessageListener() {
+    return retrieveAdaptrisMessageListener();
+  }
+
+  /**
+   * Provides the metadata key {@value com.adaptris.core.jms.JmsConstants#JMS_DESTINATION} which will only be populated if
+   * {@link MessageTypeTranslatorImp#getMoveJmsHeaders()} is true.
+   *
+   * @since 3.9.0
+   */
+  @Override
+  public String consumeLocationKey() {
+    return JmsConstants.JMS_DESTINATION;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnectionConfig.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnectionConfig.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jms;
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsMessageConsumerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsMessageConsumerFactory.java
@@ -1,0 +1,73 @@
+package com.adaptris.core.jms;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adaptris.core.jms.JmsDestination.DestinationType;
+
+public class JmsMessageConsumerFactory {
+
+  private Logger log = LoggerFactory.getLogger(this.getClass().getName());
+
+  private VendorImplementation vendor;
+  private Session session;
+  private String rfc6167;
+  private boolean deferConsumerCreationToVendor;
+  private String filterExp;
+  private JmsActorConfig jmsActorConfig;
+
+  public JmsMessageConsumerFactory(VendorImplementation vendor, Session session, String rfc6167, boolean deferConsumerCreationToVendor,
+      String filterExp, JmsActorConfig jmsActorConfig) {
+    this.vendor = vendor;
+    this.session = session;
+    this.rfc6167 = rfc6167;
+    this.deferConsumerCreationToVendor = deferConsumerCreationToVendor;
+    this.filterExp = filterExp;
+    this.jmsActorConfig = jmsActorConfig;
+  }
+
+  public MessageConsumer create() throws JMSException {
+    JmsDestination destination = vendor.createDestination(rfc6167, jmsActorConfig);
+
+    MessageConsumer consumer = null;
+    if (deferConsumerCreationToVendor) {
+      consumer = vendor.createConsumer(destination, filterExp, jmsActorConfig);
+    } else {
+      if (destination.destinationType().equals(DestinationType.TOPIC)) {
+        if (!isEmpty(destination.subscriptionId())) { // then durable, maybe shared
+          if (!isEmpty(destination.sharedConsumerId())) {
+            log.trace("Creating new shared durable consumer.");
+            consumer = ((ConsumerCreator) (session, dest, filterExpression) -> session
+                .createSharedDurableConsumer((Topic) dest.getDestination(), dest.subscriptionId(), filterExpression))
+                .createConsumer(session, destination, filterExp);
+          } else {
+            log.trace("Creating new durable consumer.");
+            consumer = ((ConsumerCreator) (session, dest, filterExpression) -> session
+                .createDurableSubscriber((Topic) dest.getDestination(), filterExpression)).createConsumer(session, destination,
+                    filterExp);
+          }
+        } else if (!isEmpty(destination.sharedConsumerId())) {
+          log.trace("Creating new shared consumer.");
+          consumer = ((ConsumerCreator) (session, dest, filterExpression) -> session.createSharedConsumer((Topic) dest.getDestination(),
+              dest.sharedConsumerId(), filterExpression)).createConsumer(session, destination, filterExp);
+        }
+      }
+
+      if (consumer == null) {
+        log.trace("Creating new standard consumer.");
+        consumer = ((ConsumerCreator) (session, dest, filterExpression) -> session.createConsumer(dest.getDestination(), filterExpression))
+            .createConsumer(session, destination, filterExp);
+      }
+    }
+
+    return consumer;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsPollingConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsPollingConsumer.java
@@ -33,7 +33,7 @@ import lombok.Setter;
  * Concrete {@link JmsPollingConsumerImpl} implementation that can target queues or topics via an
  * RFC6167 style destination.
  * <p>
- * This differs from the standard {@link PtpPollingConsumer} and {@link PtpPollingConsumer} in that
+ * This differs from the standard {@link PtpPollingConsumer} and {@link PasPollingConsumer} in that
  * it supports a destination that is specified in RFC6167 style. For instance
  * {@code jms:queue:myQueueName} will consume from a queue called {@code myQueueName} and
  * {@code jms:topic:myTopicName} from a topic called {@code myTopicName}

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -277,7 +277,7 @@ public class JmsProducer extends JmsProducerImpl {
     return BooleanUtils.toBooleanDefaultIfNull(getPerMessageProperties(), true);
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("unchecked")
   public <T extends JmsProducer> T withEndpoint(String s) {
     setEndpoint(s);
     return (T) this;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsSyncConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsSyncConsumer.java
@@ -25,6 +25,38 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 
+/**
+ * JMS synchronous consumer implementation that can target queues or topics via an
+ * RFC6167 style endpoint.
+ * <p>
+ * For instance
+ * {@code jms:queue:myQueueName} will consume from a queue called {@code myQueueName} and
+ * {@code jms:topic:myTopicName} from a topic called {@code myTopicName}
+ * </p>
+ * <p>
+ * While RFC6167 defines the ability to use jndi to lookup the (as part of the 'jndi' variant section); this is not supported. There
+ * is also support for {@code subscriptionId} which indicates the subscriptionId that should be used when attaching a subscriber to
+ * a topic; {@code jms:topic:MyTopicName?subscriptionId=myId} would return a {@link JmsDestination#subscriptionId()} of
+ * {@code myId}. If a subscription ID is not specified, then a durable subscriber is never created; specifying a subscription ID
+ * automatically means a durable subscriber.
+ * </p>
+ * <p>
+ * Also supported is the JMS 2.0 sharedConsumerId, should you wish to create a multiple load balancing consumers on a single topic endpoint;
+ * {@code jms:topic:MyTopicName?sharedConsumerId=12345}
+ * </p>
+ * For instance you could have the following destinations:
+ * <ul>
+ * <li>jms:queue:MyQueueName</li>
+ * <li>jms:topic:MyTopicName</li>
+ * <li>jms:topic:MyTopicName?subscriptionId=mySubscriptionId</li>
+ * <li>jms:topic:MyTopicName?sharedConsumerId=mySharedConsumerId</li>
+ * <li>jms:topic:MyTopicName?subscriptionId=mySubscriptionId&sharedConsumerId=mySharedConsumerId</li>
+ * </ul>
+ * </p>
+ *
+ * @config jms-poller
+ *
+ */
 @XStreamAlias("jms-sync-consumer")
 @AdapterComponent
 @ComponentProfile(summary = "Pickup messages from a JMS broker (queue or topic) by actively polling it", tag = "consumer,jms", recommended = {
@@ -46,7 +78,7 @@ public class JmsSyncConsumer extends BaseJmsPollingConsumerImpl {
   private Boolean deferConsumerCreationToVendor;
 
   /**
-   * The JMS destination in RFC6167 format.
+   * The RFC6167 format topic/queue.
    *
    */
   @NotBlank

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsSyncConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsSyncConsumer.java
@@ -1,0 +1,131 @@
+package com.adaptris.core.jms;
+
+import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
+
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.slf4j.Logger;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.DestinationHelper;
+import com.adaptris.core.util.LifecycleHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+@XStreamAlias("jms-sync-consumer")
+@AdapterComponent
+@ComponentProfile(summary = "Pickup messages from a JMS broker (queue or topic) by actively polling it", tag = "consumer,jms", recommended = {
+    JmsConnection.class })
+@DisplayOrder(order = { "endpoint", "messageSelector", "poller", "acknowledgeMode", "messageTranslator" })
+public class JmsSyncConsumer extends BaseJmsPollingConsumerImpl {
+
+  /**
+   * Set to true if you wish to let the JMS message consumer be delegated by the configured vendor implementation.
+   * <p>
+   * The default is false such that we use standard JMS 1.1/2.0 methods to create the appropriate consumers.
+   * </p>
+   */
+  @AdvancedConfig(rare = true)
+  @AutoPopulated
+  @InputFieldDefault(value = "false")
+  @Getter
+  @Setter
+  private Boolean deferConsumerCreationToVendor;
+
+  /**
+   * The JMS destination in RFC6167 format.
+   *
+   */
+  @NotBlank
+  @NonNull
+  @Getter
+  @Setter
+  private String endpoint;
+
+  public JmsSyncConsumer() {
+    super();
+  }
+
+  public JmsSyncConsumer withEndpoint(String s) {
+    setEndpoint(s);
+    return this;
+  }
+
+  @Override
+  public Logger currentLogger() {
+    return log;
+  }
+
+  /** @see com.adaptris.core.AdaptrisComponent#init() */
+  @Override
+  public void init() throws CoreException {
+    super.init();
+    try {
+      initSession();
+      initConsumer();
+      configuredMessageTranslator().registerSession(currentSession());
+      configuredMessageTranslator().registerMessageFactory(defaultIfNull(getMessageFactory()));
+      LifecycleHelper.init(configuredMessageTranslator());
+    } catch (JMSException e) {
+      throw new CoreException(e);
+    }
+  }
+
+  @Override
+  protected MessageConsumer createConsumer() throws JMSException {
+    String rfc6167 = endpoint();
+    String filterExp = messageSelector();
+
+    VendorImplementation vendor = retrieveConnection(JmsConnection.class).configuredVendorImplementation();
+    return new JmsMessageConsumerFactory(vendor, currentSession(), rfc6167, deferConsumerCreationToVendor(), filterExp, this)
+        .create();
+  }
+
+  @Override
+  protected int processMessages() {
+    String oldName = renameThread();
+    int count = doProcessMessage();
+    Thread.currentThread().setName(oldName);
+    return count;
+  }
+
+  @Override
+  protected void prepareConsumer() throws CoreException {
+  }
+
+  protected String messageSelector() {
+    return getMessageSelector();
+  }
+
+  protected String endpoint() {
+    return getEndpoint();
+  }
+
+  @Override
+  protected String newThreadName() {
+    return DestinationHelper.threadName(retrieveAdaptrisMessageListener(), null);
+  }
+
+  @Override
+  protected Session createSession(int acknowledgeMode, boolean transacted) throws JMSException {
+    return retrieveConnection(JmsConnection.class).createSession(isTransacted(), AcknowledgeMode.getMode(getAcknowledgeMode()));
+  }
+
+  protected Boolean deferConsumerCreationToVendor() {
+    return BooleanUtils.toBooleanDefaultIfNull(getDeferConsumerCreationToVendor(), false);
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsMessageConsumerFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsMessageConsumerFactoryTest.java
@@ -48,12 +48,14 @@ public class JmsMessageConsumerFactoryTest {
   private static final String RFC6167_SUBSCRIPTION = RFC6167 + "?subscriptionId=" + SUBSCRIPTION_ID;
   private static final String FILTER = "filter";
 
-  @Mock private BasicActiveMqImplementation mockVendor;
-  @Mock MessageConsumer mockMessageConsumer;
   @Mock
-  Session session;
+  private BasicActiveMqImplementation mockVendor;
   @Mock
-  JmsActorConfig jmsActorConfig;
+  private MessageConsumer mockMessageConsumer;
+  @Mock
+  private Session session;
+  @Mock
+  private JmsActorConfig jmsActorConfig;
 
   private AutoCloseable openMocks;
   @Before

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsMessageConsumerFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsMessageConsumerFactoryTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.jms;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.Topic;
+import javax.jms.TopicSubscriber;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.jms.JmsDestination.DestinationType;
+import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
+import com.adaptris.interlok.util.Closer;
+
+public class JmsMessageConsumerFactoryTest {
+
+  private static final String SUBSCRIPTION_ID = "mySubscriptionId";
+  private static final String SHARED_CONSUMER_ID = "mySharedConsumerId";
+  private static final String RFC6167 = "jms:topic:myTopic";
+  private static final String RFC6167_SUBSCRIPTION = RFC6167 + "?subscriptionId=" + SUBSCRIPTION_ID;
+  private static final String FILTER = "filter";
+
+  @Mock private BasicActiveMqImplementation mockVendor;
+  @Mock MessageConsumer mockMessageConsumer;
+  @Mock
+  Session session;
+  @Mock
+  JmsActorConfig jmsActorConfig;
+
+  private AutoCloseable openMocks;
+  @Before
+  public void setUp() throws Exception {
+    openMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    Closer.closeQuietly(openMocks);
+  }
+
+  @Test
+  public void testDeferConsumerCreationToVendor() throws Exception {
+    JmsDestination jmsDestination = mockTopicJmsDestination(false);
+    mockCreateDestinationAndConsumer(jmsDestination, RFC6167_SUBSCRIPTION);
+
+    JmsMessageConsumerFactory jmsMessageConsumerFactory = new JmsMessageConsumerFactory(mockVendor, session, RFC6167_SUBSCRIPTION, true,
+        FILTER,
+        jmsActorConfig);
+
+    MessageConsumer messageConsumer = jmsMessageConsumerFactory.create();
+
+    assertEquals(mockMessageConsumer, messageConsumer);
+    verify(mockVendor).createConsumer(eq(jmsDestination), eq(FILTER), any(JmsActorConfig.class));
+  }
+
+  @Test
+  public void testDurableTopicConsumer() throws Exception {
+    JmsDestination jmsDestination = mockTopicJmsDestination(false);
+    mockCreateDestinationAndConsumer(jmsDestination, RFC6167_SUBSCRIPTION);
+
+    TopicSubscriber topicSubscriber = mock(TopicSubscriber.class);
+    when(session.createDurableSubscriber(any(Topic.class), eq(FILTER))).thenReturn(topicSubscriber);
+
+    JmsMessageConsumerFactory jmsMessageConsumerFactory = new JmsMessageConsumerFactory(mockVendor, session, RFC6167_SUBSCRIPTION, false,
+        FILTER,
+        jmsActorConfig);
+
+    MessageConsumer messageConsumer = jmsMessageConsumerFactory.create();
+
+    assertEquals(topicSubscriber, messageConsumer);
+    verify(session).createDurableSubscriber(any(Topic.class), eq(FILTER));
+  }
+
+  @Test
+  public void testSharedDurableTopicConsumer() throws Exception {
+    String rfc6167 = RFC6167_SUBSCRIPTION + "&sharedConsumerId=" + SHARED_CONSUMER_ID;
+    JmsDestination jmsDestination = mockTopicJmsDestination(true);
+    mockCreateDestinationAndConsumer(jmsDestination, rfc6167);
+
+    when(session.createSharedDurableConsumer(any(Topic.class), eq(SUBSCRIPTION_ID), eq(FILTER))).thenReturn(mockMessageConsumer);
+
+    JmsMessageConsumerFactory jmsMessageConsumerFactory = new JmsMessageConsumerFactory(mockVendor, session, rfc6167, false, FILTER,
+        jmsActorConfig);
+
+    MessageConsumer messageConsumer = jmsMessageConsumerFactory.create();
+
+    assertEquals(mockMessageConsumer, messageConsumer);
+    verify(session).createSharedDurableConsumer(any(Topic.class), eq(SUBSCRIPTION_ID), eq(FILTER));
+  }
+
+  @Test
+  public void testSharedTopicConsumer() throws Exception {
+    String rfc6167 = RFC6167 + "?sharedConsumerId=" + SHARED_CONSUMER_ID;
+    JmsDestination jmsDestination = mockTopicJmsDestination(false, true);
+    mockCreateDestinationAndConsumer(jmsDestination, rfc6167);
+
+    when(session.createSharedConsumer(any(Topic.class), eq(SHARED_CONSUMER_ID), eq(FILTER))).thenReturn(mockMessageConsumer);
+
+    JmsMessageConsumerFactory jmsMessageConsumerFactory = new JmsMessageConsumerFactory(mockVendor, session, rfc6167, false, FILTER,
+        jmsActorConfig);
+
+    MessageConsumer messageConsumer = jmsMessageConsumerFactory.create();
+
+    assertEquals(mockMessageConsumer, messageConsumer);
+    verify(session).createSharedConsumer(any(Topic.class), eq(SHARED_CONSUMER_ID), eq(FILTER));
+  }
+
+  @Test
+  public void testTopicConsumer() throws Exception {
+    String rfc6167 = RFC6167;
+    JmsDestination jmsDestination = mockTopicJmsDestination(false, false);
+    mockCreateDestinationAndConsumer(jmsDestination, rfc6167);
+
+    when(session.createConsumer(any(Topic.class), eq(FILTER))).thenReturn(mockMessageConsumer);
+
+    JmsMessageConsumerFactory jmsMessageConsumerFactory = new JmsMessageConsumerFactory(mockVendor, session, rfc6167, false, FILTER,
+        jmsActorConfig);
+
+    MessageConsumer messageConsumer = jmsMessageConsumerFactory.create();
+
+    assertEquals(mockMessageConsumer, messageConsumer);
+    verify(session).createConsumer(any(Topic.class), eq(FILTER));
+  }
+
+  @Test
+  public void testQueueConsumer() throws Exception {
+    String rfc6167 = "jms:queue:myQueue";
+    JmsDestination jmsDestination = mockQueueJmsDestination();
+    mockCreateDestinationAndConsumer(jmsDestination, rfc6167);
+
+    when(session.createConsumer(any(Queue.class), eq(FILTER))).thenReturn(mockMessageConsumer);
+
+    JmsMessageConsumerFactory jmsMessageConsumerFactory = new JmsMessageConsumerFactory(mockVendor, session, rfc6167, false, FILTER,
+        jmsActorConfig);
+
+    MessageConsumer messageConsumer = jmsMessageConsumerFactory.create();
+
+    assertEquals(mockMessageConsumer, messageConsumer);
+    verify(session).createConsumer(any(Queue.class), eq(FILTER));
+  }
+
+  private void mockCreateDestinationAndConsumer(JmsDestination jmsDestination, String rfc6167) throws JMSException {
+    when(mockVendor.createDestination(eq(rfc6167), any(JmsActorConfig.class))).thenReturn(jmsDestination);
+    when(mockVendor.createConsumer(eq(jmsDestination), eq(FILTER), any(JmsActorConfig.class))).thenReturn(mockMessageConsumer);
+  }
+
+  private JmsDestination mockTopicJmsDestination(boolean shareable) {
+    return mockTopicJmsDestination(true, shareable);
+  }
+
+  private JmsDestination mockTopicJmsDestination(boolean subscription, boolean shareable) {
+    JmsDestination jmsDestination = mock(JmsDestination.class);
+    when(jmsDestination.destinationType()).thenReturn(DestinationType.TOPIC);
+    if (subscription) {
+      when(jmsDestination.subscriptionId()).thenReturn(SUBSCRIPTION_ID);
+    }
+    if (shareable) {
+      when(jmsDestination.sharedConsumerId()).thenReturn(SHARED_CONSUMER_ID);
+    }
+    when(jmsDestination.getDestination()).thenReturn(mock(Topic.class));
+    return jmsDestination;
+  }
+
+  private JmsDestination mockQueueJmsDestination() {
+    JmsDestination jmsDestination = mock(JmsDestination.class);
+    when(jmsDestination.destinationType()).thenReturn(DestinationType.QUEUE);
+    when(jmsDestination.getDestination()).thenReturn(mock(Queue.class));
+    return jmsDestination;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsSyncConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsSyncConsumerTest.java
@@ -47,7 +47,7 @@ import com.adaptris.interlok.junit.scaffolding.jms.JmsConfig;
 import com.adaptris.interlok.util.Closer;
 import com.adaptris.util.TimeInterval;
 
-public class JmsSynchConsumerTest extends PollingJmsConsumerCase {
+public class JmsSyncConsumerTest extends PollingJmsConsumerCase {
 
   @Mock
   private BasicActiveMqImplementation mockVendor;

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsSynchConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsSynchConsumerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.jms;
+
+import static com.adaptris.interlok.junit.scaffolding.jms.JmsConfig.MESSAGE_TRANSLATOR_LIST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.MessageConsumer;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.FixedIntervalPoller;
+import com.adaptris.core.StandaloneConsumer;
+import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
+import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
+import com.adaptris.core.stubs.MockMessageListener;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.jms.JmsConfig;
+import com.adaptris.interlok.util.Closer;
+import com.adaptris.util.TimeInterval;
+
+public class JmsSynchConsumerTest extends PollingJmsConsumerCase {
+
+  @Mock
+  private BasicActiveMqImplementation mockVendor;
+  @Mock
+  private MessageConsumer mockMessageConsumer;
+
+  private AutoCloseable openMocks;
+
+  @Before
+  public void setUp() throws Exception {
+    openMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    Closer.closeQuietly(openMocks);
+  }
+
+  @Override
+  protected List<?> retrieveObjectsForSampleConfig() {
+    JmsConnection connection = new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:61616"));
+    ArrayList<StandaloneConsumer> result = new ArrayList<>();
+    boolean useQueue = true;
+    for (MessageTypeTranslator t : MESSAGE_TRANSLATOR_LIST) {
+      StandaloneConsumer p = createStandaloneConsumer(connection, useQueue, false);
+      ((JmsSyncConsumer) p.getConsumer()).setMessageTranslator(t);
+      result.add(p);
+      useQueue = !useQueue;
+    }
+    return result;
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    return null;
+  }
+
+  private StandaloneConsumer createStandaloneConsumer(AdaptrisConnection connection, boolean destQueue,
+      boolean deferConsumerCreationToVendor) {
+    JmsSyncConsumer consumer = createConsumer(destQueue, deferConsumerCreationToVendor);
+    return new StandaloneConsumer(connection, consumer);
+  }
+
+  @Override
+  protected JmsSyncConsumer createConsumer() {
+    return createConsumer(false, false);
+  }
+
+  protected JmsSyncConsumer createConsumer(boolean destQueue, boolean deferConsumerCreationToVendor) {
+    JmsSyncConsumer consumer = new JmsSyncConsumer();
+    consumer.setPoller(new FixedIntervalPoller(new TimeInterval(1L, TimeUnit.MINUTES)));
+    consumer.setReacquireLockBetweenMessages(true);
+    String dest = "jms:topic:MyTopicName?subscriptionId=mySubscriptionId";
+    if (destQueue) {
+      dest = "jms:queue:MyQueueName";
+    }
+    consumer.setEndpoint(dest);
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setDeferConsumerCreationToVendor(deferConsumerCreationToVendor);
+
+    return consumer;
+  }
+
+  @Test
+  public void testDeferConsumerCreationToVendor() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
+
+    when(mockVendor.createConsumer(any(), any(), any(JmsActorConfig.class))).thenReturn(mockMessageConsumer);
+
+    when(mockVendor.getBrokerUrl()).thenReturn("vm://" + activeMqBroker.getName());
+
+    ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://" + activeMqBroker.getName());
+    when(mockVendor.createConnectionFactory()).thenReturn(factory);
+    when(mockVendor.createConnection(any(), any())).thenReturn(factory.createConnection());
+
+    try {
+      activeMqBroker.start();
+
+      JmsConnection jmsConnection = activeMqBroker.getJmsConnection();
+      jmsConnection.setVendorImplementation(mockVendor);
+
+      StandaloneConsumer standaloneConsumer = createStandaloneConsumer(jmsConnection, false, true);
+
+      MockMessageListener jms = new MockMessageListener();
+      standaloneConsumer.registerAdaptrisMessageListener(jms);
+
+      LifecycleHelper.initAndStart(standaloneConsumer);
+
+      verify(mockVendor).createConsumer(any(), any(), any(JmsSyncConsumer.class));
+
+      LifecycleHelper.stopAndClose(standaloneConsumer);
+
+    } finally {
+      activeMqBroker.destroy();
+    }
+  }
+
+  @Test
+  public void testDefaultFalseDeferConsumerCreationToVendor() throws Exception {
+    Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
+
+    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
+
+    when(mockVendor.createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class)))
+    .thenReturn(mockMessageConsumer);
+
+    when(mockVendor.getBrokerUrl()).thenReturn("vm://" + activeMqBroker.getName());
+
+    when(mockVendor.createConnectionFactory()).thenReturn(new ActiveMQConnectionFactory("vm://" + activeMqBroker.getName()));
+
+    try {
+      activeMqBroker.start();
+
+      JmsConnection jmsConnection = activeMqBroker.getJmsConnection();
+      jmsConnection.setVendorImplementation(mockVendor);
+
+      StandaloneConsumer standaloneConsumer = createStandaloneConsumer(jmsConnection, false, false);
+      MockMessageListener jms = new MockMessageListener();
+      standaloneConsumer.registerAdaptrisMessageListener(jms);
+
+      try {
+        LifecycleHelper.initAndStart(standaloneConsumer);
+      } catch (Exception ex) {
+      }
+
+      verify(mockVendor, times(0)).createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class));
+
+      LifecycleHelper.stopAndClose(standaloneConsumer);
+
+    } finally {
+      activeMqBroker.destroy();
+    }
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PollingJmsConsumerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PollingJmsConsumerCase.java
@@ -12,23 +12,26 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jms;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
 import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
+
 import com.adaptris.util.TimeInterval;
 
 public abstract class PollingJmsConsumerCase
-    extends com.adaptris.interlok.junit.scaffolding.jms.JmsConsumerCase {
+extends com.adaptris.interlok.junit.scaffolding.jms.JmsConsumerCase {
 
-  protected abstract JmsPollingConsumerImpl createConsumer();
+  protected abstract BaseJmsPollingConsumerImpl createConsumer();
 
   @Test
   public void testSetReceiveWait() throws Exception {
-    JmsPollingConsumerImpl consumer = createConsumer();
+    BaseJmsPollingConsumerImpl consumer = createConsumer();
     assertNull(consumer.getReceiveTimeout());
     assertEquals(2000, consumer.receiveTimeout());
 
@@ -46,6 +49,6 @@ public abstract class PollingJmsConsumerCase
     consumer.setReceiveTimeout(null);
     assertNull(consumer.getReceiveTimeout());
     assertEquals(2000, consumer.receiveTimeout());
-
   }
+
 }


### PR DESCRIPTION
## Motivation

Now that we can use JMS 2.0 async producers and native API's that also have multi threaded future callback mechanisms we need to have a synchronous consumer that will allow separate threads to acknowledge messages.

## Modification

I abstracted some code from JmsPollingConsumerImpl to a new BaseJmsPollingConsumerImpl (I ran out of idea for the name).
Created a new JmsSyncConsumer class that extend BaseJmsPollingConsumerImpl and it's basically a polling consumer that use an adapter JmsConnection instead of initiating/closing a jms connection everytime.

I also added a new JmsMessageConsumerFactory class the create a JMS MessageConsumer depending on destination type, subscription id, shared consumer id ...
This new class is used in JmsConsumer and in the new JmsSyncConsumer.

Added some test for all this new code.

## Result

We now have a new synch jms consumer that doesn't reset the connection and that can be used with the new JmsAsyncProducer.

## Testing

All the existing JMS consumer tests should still pass and the test in JmsSyncConsumerTest and JmsSyncConsumerTest should also pass.
It should look good in the UI and work fine in an adapter:

```
<consumer class="jms-sync-consumer">
  <unique-id>MyJmsSyncConsumer</unique-id>
  <poller class="fixed-interval-poller">
    <poll-interval>
      <unit>SECONDS</unit>
      <interval>5</interval>
    </poll-interval>
  </poller>
  <acknowledge-mode>CLIENT_ACKNOWLEDGE</acknowledge-mode>
  <message-translator class="auto-convert-message-translator">
    <jms-output-type>Text</jms-output-type>
  </message-translator>
  <endpoint>jms:topic:myTopic</endpoint>
</consumer>
```
