### PR TITLE
INTERLOK-3424 pooling split join performance characteristics

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/AppendingMessageAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/AppendingMessageAggregator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,50 +19,54 @@ package com.adaptris.core.services.aggregator;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
-
 import org.apache.commons.io.IOUtils;
-
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * Implementation of {@link MessageAggregator} that just appends payloads.
- * 
+ *
  * <p>
  * This simply iterates over each of the messages; and appends their payloads to the original message. No checking is done of the
  * payloads; it is a raw append using a stream copy.
  * </p>
- * 
+ *
  * @config appending-message-aggregator
  */
 @XStreamAlias("appending-message-aggregator")
 @ComponentProfile(summary = "MessageAggregator that appends all payloads to the original", since = "3.9.1")
 @DisplayOrder(order = {"overwriteMetadata"})
+@NoArgsConstructor
 public class AppendingMessageAggregator extends MessageAggregatorImpl {
-
-  public AppendingMessageAggregator() {
-
-  }
 
   @Override
   public void joinMessage(AdaptrisMessage orig, Collection<AdaptrisMessage> toAggregate) throws CoreException {
-    Collection<AdaptrisMessage> msgs = filter(toAggregate);
+    aggregate(orig, toAggregate);
+  }
+
+  @Override
+  public void aggregate(AdaptrisMessage orig, Iterable<AdaptrisMessage> msgs)
+      throws CoreException {
     try (OutputStream out = orig.getOutputStream()) {
       try (InputStream in = orig.getInputStream()) {
         IOUtils.copy(in, out);
       }
       for (AdaptrisMessage m : msgs) {
-        try (InputStream subIn = m.getInputStream()) {
-          IOUtils.copy(subIn, out);
+        if (filter(m)) {
+          try (InputStream subIn = m.getInputStream()) {
+            IOUtils.copy(subIn, out);
+          }
+          overwriteMetadata(m, orig);
         }
-        overwriteMetadata(m, orig);
       }
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/IgnoreOriginalXmlDocumentAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/IgnoreOriginalXmlDocumentAggregator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,11 +17,7 @@
 package com.adaptris.core.services.aggregator;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
-import java.util.Collection;
-
 import org.w3c.dom.Document;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -32,7 +28,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * {@link MessageAggregator} implementation that creates single XML using each message that needs to be joined up.
- * 
+ *
  * <p>
  * The original pre-split document is completely ignored; you should specify in the template the XML document that will be used to
  * merge split documents.
@@ -41,10 +37,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Use {@link #setDocumentEncoding(String)} to force the encoding of the resulting XML document to the required value; if not set,
  * then either the original {@link com.adaptris.core.AdaptrisMessage#getCharEncoding()} (if set) or <code>UTF-8</code> will be used in that order.
  * </p>
- * 
+ *
  * @config ignore-original-xml-document-aggregator
  * @author lchan
- * 
+ *
  */
 @XStreamAlias("ignore-original-xml-document-aggregator")
 @DisplayOrder(order = {"template", "documentEncoding", "mergeImplementation", "xmlDocumentFactoryConfig"})
@@ -67,21 +63,24 @@ public class IgnoreOriginalXmlDocumentAggregator extends XmlDocumentAggregator {
   }
 
   @Override
-  public void joinMessage(AdaptrisMessage original, Collection<AdaptrisMessage> messages) throws CoreException {
+  public void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> messages)
+      throws CoreException {
     try {
       if (isEmpty(getTemplate())) {
         throw new CoreException("Template is null / empty, cannot continue");
       }
       Document resultDoc = XmlHelper.createDocument(getTemplate(), documentFactoryBuilder());
-      for (AdaptrisMessage m : filter(messages)) {
-        Document mergeDoc = XmlHelper.createDocument(m, documentFactoryBuilder());
-        overwriteMetadata(m, original);
-        resultDoc = getMergeImplementation().merge(resultDoc, mergeDoc);
+      for (AdaptrisMessage m : messages) {
+        if (filter(m)) {
+          Document mergeDoc = XmlHelper.createDocument(m, documentFactoryBuilder());
+          overwriteMetadata(m, original);
+          resultDoc = getMergeImplementation().merge(resultDoc, mergeDoc);
+        }
       }
       XmlHelper.writeXmlDocument(resultDoc, original, getDocumentEncoding());
     }
     catch (Exception e) {
-      ExceptionHelper.rethrowCoreException(e);
+      throw ExceptionHelper.wrapCoreException(e);
     }
   }
 
@@ -94,10 +93,10 @@ public class IgnoreOriginalXmlDocumentAggregator extends XmlDocumentAggregator {
 
   /**
    * Set the template for the resulting XML document
-   * 
+   *
    * @param s the template to set; wrapped in CDATA tags as appropriate.
    */
   public void setTemplate(String s) {
-    this.template = s;
+    template = s;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/MessageAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/MessageAggregator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,29 +16,68 @@
 
 package com.adaptris.core.services.aggregator;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-
+import java.util.List;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.services.splitter.SplitJoinService;
+import com.adaptris.interlok.util.CloseableIterable;
 
 /**
  * Interface for creating a single {@link com.adaptris.core.AdaptrisMessage} instance from multiple Messages.
- * 
+ *
  * @see SplitJoinService
  */
 public interface MessageAggregator {
 
   /**
    * <p>
-   * Joins multiple {@link com.adaptris.core.AdaptrisMessage}s into a single AdaptrisMessage objects. Preservation of metadata is down to the
-   * implementation.
+   * Joins multiple {@link com.adaptris.core.AdaptrisMessage}s into a single AdaptrisMessage
+   * objects. Preservation of metadata is down to the implementation.
    * </p>
-   * 
+   *
    * @param msg the msg to insert all the messages into
    * @param msgs the list of messages to join.
    * @throws CoreException wrapping any other exception
+   * @implNote the default operation throws a {@code UnsupportedOperationException}.
    */
-  void joinMessage(AdaptrisMessage msg, Collection<AdaptrisMessage> msgs) throws CoreException;
+  default void joinMessage(AdaptrisMessage msg, Collection<AdaptrisMessage> msgs)
+      throws CoreException {
+    throw new UnsupportedOperationException(
+        "Use aggregate(AdaptrisMessage, Iterable<AdaptrisMessage>) instead");
+  }
 
+  /**
+   * <p>
+   * Joins multiple {@link com.adaptris.core.AdaptrisMessage}s into a single AdaptrisMessage
+   * objects. Preservation of metadata is down to the implementation.
+   * </p>
+   *
+   * @param original the original message
+   * @param msgs the list of messages to join.
+   * @implNote The default implementation turns the Iterable into a collection and invokes
+   *           {@link #joinMessage(AdaptrisMessage, Collection)} for backwards compatibility
+   *           reasons.
+   */
+  default void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> msgs)
+      throws CoreException, IOException {
+    joinMessage(original, collect(msgs));
+  }
+
+
+  static Collection<AdaptrisMessage> collect(Iterable<AdaptrisMessage> iter)
+      throws IOException, CoreException {
+    if (iter instanceof Collection) {
+      return (Collection<AdaptrisMessage>) iter;
+    }
+    List<AdaptrisMessage> result = new ArrayList<AdaptrisMessage>();
+    try (CloseableIterable<AdaptrisMessage> messages = CloseableIterable.ensureCloseable(iter)) {
+      for (AdaptrisMessage msg : messages) {
+        result.add(msg);
+      }
+    }
+    return result;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/MimeAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/MimeAggregator.java
@@ -108,18 +108,25 @@ public class MimeAggregator extends MessageAggregatorImpl {
 
   @Override
   public void joinMessage(AdaptrisMessage original, Collection<AdaptrisMessage> messages) throws CoreException {
+    aggregate(original, messages);
+  }
+
+  @Override
+  public void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> msgs)
+      throws CoreException {
     try {
       MultiPartOutput output = createInitialPart(original);
-      for (AdaptrisMessage m : filter(messages)) {
-        output.addPart(createBodyPart(m), contentId(m));
-        overwriteMetadata(m, original);
+      for (AdaptrisMessage m : msgs) {
+        if (filter(m)) {
+          output.addPart(createBodyPart(m), contentId(m));
+          overwriteMetadata(m, original);
+        }
       }
       try (OutputStream out = original.getOutputStream()) {
         output.writeTo(out);
       }
       original.addMetadata(CoreConstants.MSG_MIME_ENCODED, Boolean.TRUE.toString());
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ReplaceWithFirstMessage.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ReplaceWithFirstMessage.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +17,9 @@
 package com.adaptris.core.services.aggregator;
 
 import static org.apache.commons.io.IOUtils.copy;
-
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Collection;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.ExceptionHelper;
@@ -31,38 +27,40 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Special implementation of {@link MessageAggregator} that replaces the original payload with the first aggregated message.
- * 
+ *
  * <p>
  * This is primarily designed to be used where there is a one to one relationship between the original and aggregated message. No
  * parsing is done of the first message, it is simply used as is; all other messages that are passed in as part of the collection to
  * be aggregated are ignored.
  * </p>
- * 
+ *
  * @config replace-with-first-message-aggregator
  * @author lchan
- * 
+ *
  */
 @XStreamAlias("replace-with-first-message-aggregator")
 public class ReplaceWithFirstMessage extends MessageAggregatorImpl {
 
   @Override
   public void joinMessage(AdaptrisMessage msg, Collection<AdaptrisMessage> msgs) throws CoreException {
-    if (msgs.size() == 0) {
-      // Ha, nothing to do.
-      return;
-    }
-    AdaptrisMessage first = new ArrayList<AdaptrisMessage>(filter(msgs)).get(0);
-    overwrite(first, msg);
-    overwriteMetadata(first, msg);
+    aggregate(msg, msgs);
   }
 
-  private void overwrite(AdaptrisMessage src, AdaptrisMessage target) throws CoreException {
-    try (InputStream in = src.getInputStream(); OutputStream out = target.getOutputStream()) {
-      copy(in, out);
-    }
-    catch (IOException e) {
-      ExceptionHelper.rethrowCoreException(e);
+  @Override
+  public void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> msgs)
+      throws CoreException {
+    try {
+      for (AdaptrisMessage m : msgs) {
+        if (filter(m)) {
+          try (InputStream in = m.getInputStream(); OutputStream out = original.getOutputStream()) {
+            copy(in, out);
+          }
+          overwriteMetadata(m, original);
+          break;
+        }
+      }
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
     }
   }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/XmlDocumentAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/XmlDocumentAggregator.java
@@ -24,12 +24,14 @@ import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.DocumentMerge;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 
 /**
  * {@link MessageAggregator} implementation that creates single XML using each message that needs to be joined up.
@@ -51,12 +53,28 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @DisplayOrder(order = {"documentEncoding", "mergeImplementation", "xmlDocumentFactoryConfig"})
 public class XmlDocumentAggregator extends MessageAggregatorImpl {
 
+  /**
+   * Set the XML encoding for the resulting document which defaults to 'UTF-8' if not explicitly
+   * configured.
+   *
+   */
+  @Getter
+  @Setter
   @AdvancedConfig
   private String documentEncoding;
+  /**
+   * How to merge the split documents into the main XML document.
+   *
+   */
+  @Getter
+  @Setter
   @NotNull
+  @NonNull
   @Valid
   private DocumentMerge mergeImplementation;
   @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
   private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
 
   public XmlDocumentAggregator() {
@@ -90,48 +108,7 @@ public class XmlDocumentAggregator extends MessageAggregatorImpl {
     }
   }
 
-  /**
-   * @return the documentEncoding
-   */
-  public String getDocumentEncoding() {
-    return documentEncoding;
-  }
-
-  /**
-   * Set the XML encoding for the resulting document.
-   *
-   * @param s the documentEncoding to set (defaults to UTF-8).
-   */
-  public void setDocumentEncoding(String s) {
-    documentEncoding = s;
-  }
-
-  /**
-   * @return the mergeImplementation
-   */
-  public DocumentMerge getMergeImplementation() {
-    return mergeImplementation;
-  }
-
-  /**
-   * Set how to merge the split documents into the main XML document.
-   *
-   * @param dm the mergeImplementation to set
-   */
-  public void setMergeImplementation(DocumentMerge dm) {
-    mergeImplementation = Args.notNull(dm, "mergeImplementation");
-  }
-
-  public DocumentBuilderFactoryBuilder getXmlDocumentFactoryConfig() {
-    return xmlDocumentFactoryConfig;
-  }
-
-
-  public void setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder xml) {
-    xmlDocumentFactoryConfig = xml;
-  }
-
-  DocumentBuilderFactoryBuilder documentFactoryBuilder() {
+  protected DocumentBuilderFactoryBuilder documentFactoryBuilder() {
     return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ZipAggregator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ZipAggregator.java
@@ -16,9 +16,11 @@
 
 package com.adaptris.core.services.aggregator;
 
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.DisplayOrder;
@@ -27,6 +29,9 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * {@link MessageAggregator} implementation that creates single zip using each message as a file in the zip.
@@ -45,19 +50,21 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("zip-aggregator")
 @DisplayOrder(order = {"filenameMetadata", "overwriteMetadata" })
+@NoArgsConstructor
 public class ZipAggregator extends MessageAggregatorImpl {
 
   public static final String DEFAULT_FILENAME_METADATA = "filename";
 
+  /**
+   * The metadata key that contains the filename to use in the zip file when aggregating.
+   * <p>
+   * This defaults to {@code 'filename'} if not explicitly configured.
+   * </p>
+   */
   @InputFieldDefault(value = "filename")
+  @Getter
+  @Setter
   private String filenameMetadata;
-
-  public ZipAggregator(){
-  }
-
-  public ZipAggregator(final String filenameMetadata){
-    setFilenameMetadata(filenameMetadata);
-  }
 
   @Override
   public void joinMessage(AdaptrisMessage msg, Collection<AdaptrisMessage> msgs) throws CoreException {
@@ -71,7 +78,9 @@ public class ZipAggregator extends MessageAggregatorImpl {
       for (AdaptrisMessage m : messages) {
         if (BooleanUtils.and(new boolean[] {filter(m), m.headersContainsKey(filenameMetadata())})) {
           zipOutputStream.putNextEntry(new ZipEntry(m.getMetadataValue(filenameMetadata())));
-          zipOutputStream.write(m.getPayload());
+          try (InputStream in = m.getInputStream()) {
+            IOUtils.copy(in, zipOutputStream);
+          }
           zipOutputStream.closeEntry();
         }
       }
@@ -80,20 +89,8 @@ public class ZipAggregator extends MessageAggregatorImpl {
     }
 
   }
-  public void setFilenameMetadata(String filenameMetadata) {
-    this.filenameMetadata = filenameMetadata;
-  }
 
-  /**
-   * Returns the metadata key  which contains the respective filename.
-   *
-   * @return the metadata key which contains the respective filenames, default: filename.
-   */
-  public String getFilenameMetadata() {
-    return filenameMetadata;
-  }
-
-  protected String filenameMetadata() {
+  private String filenameMetadata() {
     return StringUtils.defaultIfBlank(getFilenameMetadata(), DEFAULT_FILENAME_METADATA);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/DefaultPoolingFutureExceptionStrategy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/DefaultPoolingFutureExceptionStrategy.java
@@ -2,17 +2,21 @@ package com.adaptris.core.services.splitter;
 
 import java.util.List;
 import java.util.concurrent.Future;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * 
+ * @deprecated since 3.11.1 replaced by {@link ServiceErrorHandler} and
+ *             {@link PooledSplitJoinService}.
  * @config default-pooling-future-exception-strategy
  *
  */
 @XStreamAlias("default-pooling-future-exception-strategy")
+@Deprecated
+@Removal(version = "4.0",
+    message = "since 3.11.1 replaced by 'ServiceErrorHandler' and 'PooledSplitJoinService'")
 public class DefaultPoolingFutureExceptionStrategy implements PoolingFutureExceptionStrategy {
 
     public static final String EXCEPTION_MSG = "Timeout exceeded waiting for split services to complete.";

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/FixedSplitJoinService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/FixedSplitJoinService.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.splitter;
+
+import static com.adaptris.core.util.ServiceUtil.discardNulls;
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.EventHandler;
+import com.adaptris.core.EventHandlerAware;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.ServiceWrapper;
+import com.adaptris.core.services.aggregator.MessageAggregator;
+import com.adaptris.core.services.splitter.ServiceWorkerPool.Worker;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.core.util.ManagedThreadFactory;
+import com.adaptris.interlok.util.Closer;
+import com.adaptris.util.NumberUtils;
+import com.adaptris.util.TimeInterval;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * Implementation of the Splitter and Aggregator enterprise integration pattern.
+ *
+ *
+ * @config fixed-split-join-service
+ */
+@XStreamAlias("fixed-split-join-service")
+@AdapterComponent
+@ComponentProfile(summary = "Split a message and then execute the associated services on the split items, aggregating the split messages afterwards", tag = "service,splitjoin")
+@DisplayOrder(order =
+{
+    "splitter", "service", "aggregator", "timeout", "poolsize"
+})
+@NoArgsConstructor
+public class FixedSplitJoinService extends ServiceImp implements EventHandlerAware, ServiceWrapper {
+
+  private static TimeInterval DEFAULT_TTL = new TimeInterval(600L, TimeUnit.SECONDS);
+  private static final int DEFAULT_POOLSIZE = 10;
+
+
+  /**
+   * The {@link com.adaptris.core.Service} to execute over all the split messages.
+   *
+   */
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  @NonNull
+  private Service service;
+
+  /**
+   * The {@link MessageSplitter} implementation to use to split the incoming message.
+   *
+   */
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  @NonNull
+  private MessageSplitter splitter;
+  /**
+   * The {@link MessageAggregator} implementation to use to join messages together.
+   *
+   */
+  @NotNull
+  @Valid
+  @Getter
+  @Setter
+  @NonNull
+  private MessageAggregator aggregator;
+
+  /**
+   * The max amount of time to wait for all the operations to complete.
+   * <p>
+   * If not explicitly specified then is set to be 10 minutes; in the event that the timeout is
+   * exceeded, then an exception will be thrown eventually.
+   * </p>
+   */
+  @Valid
+  @Getter
+  @Setter
+  private TimeInterval timeout;
+  @InputFieldDefault(value = "false")
+  @Getter
+  @Setter
+  private Boolean sendEvents;
+  @Getter
+  @Setter
+  @AdvancedConfig
+  @InputFieldDefault(value = "10")
+  private Integer poolsize;
+
+  private transient ExecutorService executor;
+  private transient EventHandler eventHandler;
+  private transient ServiceWorkerPool workerFactory;
+  private transient GenericObjectPool<ServiceWorkerPool.Worker> objectPool;
+
+
+  @Override
+  public void prepare() throws CoreException {
+    LifecycleHelper.prepare(getService());
+    workerFactory = new ServiceWorkerPool(getService(), eventHandler, poolsize());
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+    try {
+      Args.notNull(getSplitter(), "splitter");
+      Args.notNull(getAggregator(), "aggregator");
+      Args.notNull(getService(), "service");
+      objectPool = workerFactory.createCommonsObjectPool();
+      executor = workerFactory.createExecutor(this.getClass().getSimpleName());
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
+  }
+
+  @Override
+  public void start() throws CoreException {
+    workerFactory.warmup(objectPool);
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+  }
+
+  @Override
+  protected void closeService() {
+    ManagedThreadFactory.shutdownQuietly(executor, new TimeInterval());
+    Closer.closeQuietly(objectPool);
+  }
+
+
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      Iterable<AdaptrisMessage> splits = getSplitter().splitMessage(msg);
+      ServiceExceptionHandler handler = new ServiceExceptionHandler();
+      Iterable<AdaptrisMessage> toAggregate = doSplitService(splits, handler);
+      getAggregator().aggregate(msg, toAggregate);
+      // TODO: how to handle the pooling-future-exception-strategy behaviour?
+      handler.throwFirstException();
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+  protected Iterable<AdaptrisMessage> doSplitService(final Iterable<AdaptrisMessage> msgs,
+      final ServiceExceptionHandler handler) {
+    final LinkedBlockingQueue<AdaptrisMessage> splitQueue = new LinkedBlockingQueue<>();
+    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs());
+    new Thread(() -> {
+      int max = poolsize();
+      for (AdaptrisMessage m : msgs) {
+        try {
+          while (objectPool.getNumActive() >= max) {
+            waitQuietly(handler);
+            checkTimeout(deadline);
+          }
+          executor.submit(new MyServiceExecutor(m, handler, splitQueue));
+        } catch (Exception e) {
+          // probably a timeout at this point.
+          handler.uncaughtException(Thread.currentThread(), e);
+        }
+      }
+    }).start();
+    return new MessageAggregatorIterator(splitQueue, deadline);
+  }
+
+  // Take this + PoolingSplitter -> needs to be abstracted into a helper...
+  protected void waitQuietly(Object monitor) {
+    try {
+      Args.notNull(monitor, "monitor");
+      synchronized (monitor) {
+        monitor.wait();
+      }
+    } catch (InterruptedException | IllegalArgumentException e) {
+    }
+  }
+
+
+  private long timeoutMs() {
+    return TimeInterval.toMillisecondsDefaultIfNull(getTimeout(), DEFAULT_TTL);
+  }
+
+  private int poolsize() {
+    return NumberUtils.toIntDefaultIfNull(getPoolsize(), DEFAULT_POOLSIZE);
+  }
+
+
+  private void checkTimeout(long deadlineNanos) throws Exception {
+    long nanos = deadlineNanos - System.nanoTime();
+    if (nanos <= 0L) {
+      throw new TimeoutException();
+    }
+  }
+
+  @Override
+  public void registerEventHandler(EventHandler eh) {
+    eventHandler = eh;
+  }
+
+  @Override
+  public Service[] wrappedServices() {
+    return discardNulls(getService());
+  }
+
+
+  private boolean sendEvents() {
+    return BooleanUtils.toBooleanDefaultIfNull(getSendEvents(), false);
+  }
+
+  protected AdaptrisMessage sendEvents(AdaptrisMessage msg) throws CoreException {
+    if (eventHandler != null && sendEvents()) {
+      eventHandler.send(msg.getMessageLifecycleEvent(), msg.getMessageHeaders());
+    }
+    return msg;
+  }
+
+  private class MessageAggregatorIterator
+      implements Iterable<AdaptrisMessage>, Iterator<AdaptrisMessage> {
+    private boolean iteratorAvailable = true;
+    private long deadlineNanos = -1;
+    private AdaptrisMessage nextMessage;
+    private LinkedBlockingQueue<AdaptrisMessage> myQueue;
+
+    public MessageAggregatorIterator(LinkedBlockingQueue<AdaptrisMessage> queue, long deadline) {
+      deadlineNanos = deadline;
+      myQueue = queue;
+    }
+
+    @Override
+    public Iterator<AdaptrisMessage> iterator() {
+      if (!iteratorAvailable) {
+        throw new IllegalStateException("iterator() no longer available");
+      }
+      iteratorAvailable = false;
+      return this;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+
+    // How do we know if there's a next, since we can't just peek the queue?
+    // Do we just wait until the timeout has expired?
+    protected AdaptrisMessage constructAdaptrisMessage() throws Exception {
+      AdaptrisMessage next = null;
+      do {
+        checkTimeout(deadlineNanos);
+        next = myQueue.peek();
+      } while (next == null);
+      return myQueue.remove();
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (nextMessage == null) {
+        try {
+          nextMessage = constructAdaptrisMessage();
+        } catch (Exception e) {
+          throw new RuntimeException("Could not construct next AdaptrisMessage", e);
+        }
+      }
+      return nextMessage != null;
+    }
+
+    @Override
+    public AdaptrisMessage next() {
+      AdaptrisMessage ret = nextMessage;
+      nextMessage = null;
+      return ret;
+    }
+
+  }
+
+
+  private class MyServiceExecutor implements Callable<AdaptrisMessage> {
+
+    private ServiceExceptionHandler handler;
+    private AdaptrisMessage myMessage;
+    private LinkedBlockingQueue<AdaptrisMessage> myQueue;
+
+    MyServiceExecutor(AdaptrisMessage msg, ServiceExceptionHandler excHandler,
+        LinkedBlockingQueue<AdaptrisMessage> queue) {
+      handler = excHandler;
+      myMessage = msg;
+      myQueue = queue;
+    }
+
+    @Override
+    public AdaptrisMessage call() throws Exception {
+      Worker w = objectPool.borrowObject();
+      try {
+        w.doService(myMessage);
+      } catch (Exception e) {
+        handler.uncaughtException(Thread.currentThread(), e);
+      } finally {
+        // put the message onto the queue, so that the aggregator can work on it.
+        myQueue.put(myMessage);
+        objectPool.returnObject(w);
+        synchronized (handler) {
+          handler.notifyAll();
+        }
+      }
+      return sendEvents(myMessage);
+    }
+
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/IgnoreAllExceptions.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/IgnoreAllExceptions.java
@@ -44,7 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @XStreamAlias("ignoring-service-exception-handler")
 @Slf4j
 @ComponentProfile(
-    summary = "Ignore all exceptions from fixed-split-join-service",
+    summary = "Ignore all exceptions from pooled-split-join-service",
     since = "3.11.1", tag = "service,splitjoin")
 public class IgnoreAllExceptions implements ServiceErrorHandler {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/IgnoreAllExceptions.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/IgnoreAllExceptions.java
@@ -25,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>
  * This is included for completeness, since there are some obvious gotchas this class as part of a
- * {@link FixedSplitJoinService}
+ * {@link PooledSplitJoinService}
  * <ul>
  * <li>If your aggregator is sensitive to payload structure (e.g you're aggregating as a JSON ARRAY,
  * but because of failures, the message to be aggregated is in fact XML) then you have to use a

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/IgnoreAllExceptions.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/IgnoreAllExceptions.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.adaptris.core.services.splitter;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.aggregator.AppendingMessageAggregator;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ *
+ * Ignore all exceptions coming nested services, including Timeouts
+ *
+ * <p>
+ * This is included for completeness, since there are some obvious gotchas this class as part of a
+ * {@link FixedSplitJoinService}
+ * <ul>
+ * <li>If your aggregator is sensitive to payload structure (e.g you're aggregating as a JSON ARRAY,
+ * but because of failures, the message to be aggregated is in fact XML) then you have to use a
+ * {@link Condition} to filter the message somehow</li>
+ * <li>If your aggregator isn't sensitive to payloads (e.g. an {@link AppendingMessageAggregator}
+ * then you may still end up with a mix of JSON/XML</li>
+ * <li>Exceptions may still be thrown by the aggregator, and they will be propagated to the service;
+ * this only ignores exceptions that come from the service-list executed as part of the
+ * {@code splitter}.</li>
+ * </ul>
+ * </p>
+ *
+ * @config ignoring-service-exception-handler
+ *
+ */
+@XStreamAlias("ignoring-service-exception-handler")
+@Slf4j
+@ComponentProfile(
+    summary = "Ignore all exceptions from fixed-split-join-service",
+    since = "3.11.1", tag = "service,splitjoin")
+public class IgnoreAllExceptions implements ServiceErrorHandler {
+
+  @Override
+  public void uncaughtException(Thread t, Throwable e) {
+    log.error("uncaughtException from {}", t.getName(), e);
+  }
+
+  @Override
+  public void throwExceptionAsRequired() throws ServiceException {
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/MetadataFlagPoolingFutureExceptionStrategy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/MetadataFlagPoolingFutureExceptionStrategy.java
@@ -3,12 +3,10 @@ package com.adaptris.core.services.splitter;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.BooleanUtils;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
@@ -18,24 +16,28 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Ignores exception so long as some messages were considered successful based on a metadata key.
- * 
- * <p>
- * This strategy is useful if messages within a split-join are transient, and can be ignored provided some of them work; it allows
- * you to ignore exceptions processing individual mesages provided one or more messages have set a specific metadata to the value
- * {@code true | 1}.
- * </p>
- * 
- * @config metadata-flag-pooling-future-exception-strategy
  *
+ * <p>
+ * This strategy is useful if messages within a split-join are transient, and can be ignored
+ * provided some of them work; it allows you to ignore exceptions processing individual mesages
+ * provided one or more messages have set a specific metadata to the value {@code true | 1}.
+ * </p>
+ *
+ * @deprecated since 3.11.1 replaced by {@link ServiceErrorHandler} and
+ *             {@link PooledSplitJoinService}.
+ * @config metadata-flag-pooling-future-exception-strategy
  */
 @XStreamAlias("metadata-flag-pooling-future-exception-strategy")
+@Deprecated
+@Removal(version = "4.0",
+    message = "since 3.11.1 replaced by 'ServiceErrorHandler' and 'PooledSplitJoinService'")
 public class MetadataFlagPoolingFutureExceptionStrategy implements PoolingFutureExceptionStrategy {
     @NotNull
     @Valid
     private String metadataFlagKey;
 
-    @NotNull
-    @Valid
+    // This should have been transient; this would be inconfigurable via the UI.
+    // But we can't change it since that would break XSTream.
     private boolean defaultFlagValue = false;
 
 
@@ -84,11 +86,11 @@ public class MetadataFlagPoolingFutureExceptionStrategy implements PoolingFuture
     }
 
     public void setMetadataFlagKey(String metadataKey) {
-        this.metadataFlagKey = Args.notNull(metadataKey, "metadataFlagKey");
+        metadataFlagKey = Args.notNull(metadataKey, "metadataFlagKey");
     }
 
     private String getMetadataFlagKey() {
-        return this.metadataFlagKey;
+        return metadataFlagKey;
     }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/NoExceptionIfWorkDone.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/NoExceptionIfWorkDone.java
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
  * provided one or more messages have set a specific metadata to the value {@code true | 1}.
  * </p>
  * <p>
- * There are some caveats to using this class as part of a {@link FixedSplitJoinService}
+ * There are some caveats to using this class as part of a {@link PooledSplitJoinService}
  * <ul>
  * <li>If your aggregator is sensitive to payload structure (e.g you're aggregating as a JSON ARRAY,
  * but because of failures, the message to be aggregated is in fact XML) then you have to use a
@@ -81,6 +81,8 @@ public class NoExceptionIfWorkDone extends ServiceExceptionHandler {
     if (!workDone) {
       super.throwExceptionAsRequired();
     }
+    // we've done work so reset state.
+    clearExceptions();
     workDone = false;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/NoExceptionIfWorkDone.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/NoExceptionIfWorkDone.java
@@ -56,7 +56,7 @@ import lombok.extern.slf4j.Slf4j;
 @XStreamAlias("no-exception-if-work-done")
 @Slf4j
 @ComponentProfile(
-    summary = "No exceptions if fixed-split-join-service recorded 'some work'",
+    summary = "No exceptions if pooled-split-join-service recorded 'some work'",
     since = "3.11.1", tag = "service,splitjoin")
 public class NoExceptionIfWorkDone extends ServiceExceptionHandler {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/NoExceptionIfWorkDone.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/NoExceptionIfWorkDone.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.adaptris.core.services.splitter;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.aggregator.AppendingMessageAggregator;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Synchronized;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ *
+ * Ignores exception so long as some messages were considered successful based on a metadata key.
+ * <p>
+ * This strategy is useful if messages within a split-join are transient, and can be ignored
+ * provided some of them work; it allows you to ignore exceptions processing individual mesages
+ * provided one or more messages have set a specific metadata to the value {@code true | 1}.
+ * </p>
+ * <p>
+ * There are some caveats to using this class as part of a {@link FixedSplitJoinService}
+ * <ul>
+ * <li>If your aggregator is sensitive to payload structure (e.g you're aggregating as a JSON ARRAY,
+ * but because of failures, the message to be aggregated is in fact XML) then you have to use a
+ * {@link Condition} to filter the message somehow. Presumably via the same metadata flag that
+ * you've set here.</li>
+ * <li>If your aggregator isn't sensitive to payloads (e.g. an {@link AppendingMessageAggregator}
+ * then you may still end up with a mix of JSON/XML</li>
+ * <li>Exceptions may still be thrown by the aggregator, and they will be propagated to the service;
+ * this only ignores exceptions that come from the service-list executed as part of the
+ * {@code splitter}.</li>
+ * </ul>
+ * </p>
+ *
+ * @config no-exception-if-work-done
+ *
+ */
+@XStreamAlias("no-exception-if-work-done")
+@Slf4j
+@ComponentProfile(
+    summary = "No exceptions if fixed-split-join-service recorded 'some work'",
+    since = "3.11.1", tag = "service,splitjoin")
+public class NoExceptionIfWorkDone extends ServiceExceptionHandler {
+
+  public static final String DEFAULT_METADATA_KEY = "serviceResult";
+
+  /**
+   * Set the metadata key that captures if any service did work.
+   * <p>
+   * Defaults to {@value #DEFAULT_METADATA_KEY} if not specified.
+   * </p>
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = DEFAULT_METADATA_KEY)
+  private String metadataKey;
+
+  private transient boolean workDone;
+  private final transient Object locker = new Object();
+
+  @Override
+  public void throwExceptionAsRequired() throws ServiceException {
+    if (!workDone) {
+      super.throwExceptionAsRequired();
+    }
+    workDone = false;
+  }
+
+  @Synchronized("locker")
+  @Override
+  public void markSuccessful(AdaptrisMessage msg) {
+    String metadataValue = msg.getMetadataValue(metadataKey());
+    if (!workDone) {
+      // If there's been no work done (yet) then set the flag.
+      workDone = BooleanUtils.or(new boolean[] {
+          BooleanUtils.toBoolean(metadataValue),
+          BooleanUtils.toBoolean(NumberUtils.toInt(metadataValue))
+      });
+    }
+  }
+
+  private String metadataKey() {
+    return StringUtils.defaultIfBlank(getMetadataKey(), DEFAULT_METADATA_KEY);
+  }
+
+  public NoExceptionIfWorkDone withMetadataKey(String k) {
+    setMetadataKey(k);
+    return this;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PooledSplitJoinService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PooledSplitJoinService.java
@@ -82,8 +82,9 @@ import lombok.Setter;
  * <p>
  * Aggregation may start happening as soon as messages are available to be aggregated (i.e. a split
  * message has been operated on) using the
- * {@link MessageAggregator#aggregate(AdaptrisMessage, Iterable)} method. Performance characterstics
- * will largely depend on how the splitter and aggregator implementations iterate over the messages.
+ * {@link MessageAggregator#aggregate(AdaptrisMessage, Iterable)} method. Performance
+ * characteristics will largely depend on how the splitter and aggregator implementations iterate
+ * over the messages.
  * </p>
  *
  * @config pooled-split-join-service
@@ -148,11 +149,31 @@ public class PooledSplitJoinService extends ServiceImp implements EventHandlerAw
   @Getter
   @Setter
   private TimeInterval timeout;
+  /**
+   * Whether or not to send events for the split message once service execution has completed.
+   * <p>
+   * Note that even if this is set to true, because each child message has its own unique id, you
+   * will have to externally correlate the message lifecycle events together. Child messages will
+   * always have the metadata {@link com.adaptris.core.CoreConstants#PARENT_UNIQUE_ID_KEY} set with
+   * the originating message id.
+   * </p>
+   * <p>
+   * If not explicitly specified then is set to false which means no events are sent for 'split'
+   * messages.
+   * </p>
+   *
+   */
   @InputFieldDefault(value = "false")
   @Getter
   @Setter
   @AdvancedConfig
   private Boolean sendEvents;
+  /**
+   * The size of the underlying object/thread pool used to execute services.
+   * <p>
+   * The default value is '10' unless explicitly configured
+   * </p>
+   */
   @Getter
   @Setter
   @InputFieldDefault(value = "10")

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingFutureExceptionStrategy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingFutureExceptionStrategy.java
@@ -2,11 +2,19 @@ package com.adaptris.core.services.splitter;
 
 import java.util.List;
 import java.util.concurrent.Future;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 
+/**
+ * @deprecated since 3.11.1 replaced by {@link ServiceErrorHandler} and
+ *             {@link PooledSplitJoinService}.
+ *
+ */
 @FunctionalInterface
+@Deprecated
+@Removal(version = "4.0",
+    message = "since 3.11.1 replaced by 'ServiceErrorHandler' and 'PooledSplitJoinService'")
 public interface PoolingFutureExceptionStrategy {
     void handle(ServiceExceptionHandler handler, List<Future<AdaptrisMessage>> results) throws CoreException;
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingSplitJoinService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingSplitJoinService.java
@@ -27,6 +27,7 @@ import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.services.aggregator.MessageAggregator;
@@ -35,22 +36,27 @@ import com.adaptris.util.NumberUtils;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Variant of {@link SplitJoinService} that uses a underlying thread and object pool to execute the service on each split message.
+ * Variant of {@link SplitJoinService} that uses a underlying thread and object pool to execute the
+ * service on each split message.
  *
  * <p>
- * This service splits a message according to the configured {@link MessageSplitter} implementation, executes the configured
- * {@link com.adaptris.core.Service} and subsequently joins all the messages back using the configured {@link MessageAggregator}
- * implementation
+ * This service splits a message according to the configured {@link MessageSplitter} implementation,
+ * executes the configured {@link com.adaptris.core.Service} and subsequently joins all the messages
+ * back using the configured {@link MessageAggregator} implementation
  * <p>
  * <p>
- * This differs from {@link SplitJoinService} in that a pool of {@link com.adaptris.core.Service} instances is maintained and
- * re-used for each message; so the high cost of initialisation for the service, is not incurred (more than the max number of
- * threads specified) as much.
+ * This differs from {@link SplitJoinService} in that a pool of {@link com.adaptris.core.Service}
+ * instances is maintained and re-used for each message; so the high cost of initialisation for the
+ * service, is not incurred (more than the max number of threads specified) as much.
  * </p>
- *
+ * 
+ * @deprecated since 3.11.1 Use {@link PooledSplitJoinService} instead; since performance
+ *             characteristics are unpredictable in constrained environments
+ * 
  * @config pooling-split-join-service
  *
  */
+@Deprecated
 @XStreamAlias("pooling-split-join-service")
 @AdapterComponent
 @ComponentProfile(summary = "Split a message and then execute the associated services on the split items, aggregating the split messages afterwards", tag = "service,splitjoin", since = "3.7.1")
@@ -58,6 +64,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 {
     "splitter", "service", "aggregator", "maxThreads", "timeout", "warmStart"
 })
+@Removal(version = "4.0.0",
+    message = "Use pooled-split-join-service instead; since performance characteristics are unpredictable in constrained environments")
 public class PoolingSplitJoinService extends SplitJoinService {
 
   private static final int DEFAULT_THREADS = 10;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceErrorHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceErrorHandler.java
@@ -1,0 +1,19 @@
+package com.adaptris.core.services.splitter;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+
+public interface ServiceErrorHandler extends Thread.UncaughtExceptionHandler {
+
+  void throwExceptionAsRequired() throws ServiceException;
+
+  /**
+   * @implNote The default implementation is no-op
+   * @param msg the message that was successful
+   */
+  default void markSuccessful(AdaptrisMessage msg) {
+
+  }
+
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceExceptionHandler.java
@@ -25,14 +25,14 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Default {@link ServiceErrorHandler} that captures exceptions thrown and rethrows the first
  * exception when requested.
- * 
+ *
  * @config default-service-exception-handler
  *
  */
 @XStreamAlias("default-service-exception-handler")
 @Slf4j
 @ComponentProfile(
-    summary = "Default behaviour for handling exceptions during fixed-split-join-service execution",
+    summary = "Default behaviour for handling exceptions during pooled-split-join-service execution",
     since = "3.11.1",
     tag = "service,splitjoin")
 public class ServiceExceptionHandler implements ServiceErrorHandler {

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/ServiceExceptionHandler.java
@@ -1,33 +1,42 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *     http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.adaptris.core.services.splitter;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.extern.slf4j.Slf4j;
 
-public class ServiceExceptionHandler implements Thread.UncaughtExceptionHandler {
+/**
+ * Default {@link ServiceErrorHandler} that captures exceptions thrown and rethrows the first
+ * exception when requested.
+ * 
+ * @config default-service-exception-handler
+ *
+ */
+@XStreamAlias("default-service-exception-handler")
+@Slf4j
+@ComponentProfile(
+    summary = "Default behaviour for handling exceptions during fixed-split-join-service execution",
+    since = "3.11.1",
+    tag = "service,splitjoin")
+public class ServiceExceptionHandler implements ServiceErrorHandler {
 
-  private transient Logger log = LoggerFactory.getLogger(this.getClass());
   private List<Throwable> exceptionList = Collections.synchronizedList(new ArrayList<Throwable>());
 
   @Override
@@ -50,11 +59,18 @@ public class ServiceExceptionHandler implements Thread.UncaughtExceptionHandler 
 
   /**
    * Note that this also clears any exceptions.
-   * 
+   *
    * @throws ServiceException if there was an exception.
    * @see #getFirstThrowableException()
+   * @deprecated use {@link #throwExceptionAsRequired()} instead.
    */
+  @Deprecated
   public void throwFirstException() throws ServiceException {
+    throwExceptionAsRequired();
+  }
+
+  @Override
+  public void throwExceptionAsRequired() throws ServiceException {
     Throwable e = getFirstThrowableException();
     if (e != null) {
       log.error("One or more services failed: {}", e.getMessage());

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/AggregatingServiceExample.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/AggregatingServiceExample.java
@@ -18,12 +18,9 @@ package com.adaptris.core.services.aggregator;
 
 import java.util.ArrayList;
 import java.util.List;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
 import com.adaptris.core.services.LogMessageService;
-import com.adaptris.core.services.conditional.conditions.ConditionImpl;
 import com.adaptris.core.services.splitter.MessageSplitter;
 import com.adaptris.core.services.splitter.PoolingSplitJoinService;
 import com.adaptris.core.services.splitter.SplitJoinService;
@@ -62,19 +59,4 @@ public abstract class AggregatingServiceExample
     return service;
   }
 
-  // Have a condition that every other call passes
-  protected class EvenOddCondition extends ConditionImpl {
-    private int numberOfCalls = 0;
-
-    @Override
-    public boolean evaluate(AdaptrisMessage message) throws CoreException {
-      numberOfCalls++;
-      return numberOfCalls % 2 == 0;
-    }
-
-    @Override
-    public void close() {
-      throw new RuntimeException();
-    }
-  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/AggregatingServiceExample.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/AggregatingServiceExample.java
@@ -18,9 +18,12 @@ package com.adaptris.core.services.aggregator;
 
 import java.util.ArrayList;
 import java.util.List;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
 import com.adaptris.core.services.LogMessageService;
+import com.adaptris.core.services.conditional.conditions.ConditionImpl;
 import com.adaptris.core.services.splitter.MessageSplitter;
 import com.adaptris.core.services.splitter.PoolingSplitJoinService;
 import com.adaptris.core.services.splitter.SplitJoinService;
@@ -57,5 +60,21 @@ public abstract class AggregatingServiceExample
     service.setSplitter(splitter);
     service.setService(asCollection(services));
     return service;
+  }
+
+  // Have a condition that every other call passes
+  protected class EvenOddCondition extends ConditionImpl {
+    private int numberOfCalls = 0;
+
+    @Override
+    public boolean evaluate(AdaptrisMessage message) throws CoreException {
+      numberOfCalls++;
+      return numberOfCalls % 2 == 0;
+    }
+
+    @Override
+    public void close() {
+      throw new RuntimeException();
+    }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/AppendinglMessageAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/AppendinglMessageAggregatorTest.java
@@ -26,6 +26,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.Service;
+import com.adaptris.core.services.aggregator.MessageAggregatorTest.EvenOddCondition;
 import com.adaptris.core.services.splitter.LineCountSplitter;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/AppendinglMessageAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/AppendinglMessageAggregatorTest.java
@@ -47,6 +47,19 @@ public class AppendinglMessageAggregatorTest extends AggregatingServiceExample {
   }
 
   @Test
+  public void testAggregate_WithFilter() throws Exception {
+    AppendingMessageAggregator aggr = createAggregatorForTests();
+    aggr.setFilterCondition(new EvenOddCondition());
+    AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage("Goodbye");
+    AdaptrisMessage splitMsg1 = AdaptrisMessageFactory.getDefaultInstance().newMessage(" Cruel ");
+    AdaptrisMessage splitMsg2 = AdaptrisMessageFactory.getDefaultInstance().newMessage("World");
+    aggr.joinMessage(original, Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2}));
+    // First message was skipped, 2nd was merged.
+    assertEquals("GoodbyeWorld", original.getContent());
+  }
+
+
+  @Test
   public void testJoin_WithException() {
     AppendingMessageAggregator aggr = createAggregatorForTests();
     AdaptrisMessage original = new DefectiveMessageFactory(EnumSet.of(WhenToBreak.INPUT, WhenToBreak.OUTPUT)).newMessage("Goodbye");
@@ -85,4 +98,6 @@ public class AppendinglMessageAggregatorTest extends AggregatingServiceExample {
   protected String createBaseFileName(Object object) {
     return super.createBaseFileName(object) + "-" + createAggregatorForTests().getClass().getSimpleName();
   }
+
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/IgnoreOriginalXmlAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/IgnoreOriginalXmlAggregatorTest.java
@@ -29,7 +29,7 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
-import com.adaptris.core.services.conditional.conditions.ConditionImpl;
+import com.adaptris.core.services.aggregator.MessageAggregatorTest.EvenOddCondition;
 import com.adaptris.core.services.splitter.SplitJoinService;
 import com.adaptris.core.services.splitter.SplitJoinServiceTest;
 import com.adaptris.core.services.splitter.SplitterCase;
@@ -147,19 +147,4 @@ public class IgnoreOriginalXmlAggregatorTest extends XmlAggregatorCase {
     return new IgnoreOriginalXmlDocumentAggregator("<envelope/>");
   }
 
-  // Have a condition that every other call passes
-  private class EvenOddCondition extends ConditionImpl {
-    private int numberOfCalls = 0;
-
-    @Override
-    public boolean evaluate(AdaptrisMessage message) throws CoreException {
-      numberOfCalls++;
-      return numberOfCalls %2 == 0;
-    }
-
-    @Override
-    public void close() {
-      throw new RuntimeException();
-    }
-  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MessageAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MessageAggregatorTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.services.conditional.conditions.ConditionImpl;
 
 public class MessageAggregatorTest {
 
@@ -45,5 +47,31 @@ public class MessageAggregatorTest {
         return l.iterator();
       }
     }).size());
+  }
+
+  @Test
+  public void testImplFilter() throws Exception {
+    AppendingMessageAggregator aggregator = new AppendingMessageAggregator();
+    AdaptrisMessage splitMsg1 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m1");
+    AdaptrisMessage splitMsg2 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m2");
+    List<AdaptrisMessage> l = Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2});
+    assertEquals(1, aggregator.filter(l).size());
+  }
+
+
+  // Have a condition that every other call passes
+  public static class EvenOddCondition extends ConditionImpl {
+    private int numberOfCalls = 0;
+
+    @Override
+    public boolean evaluate(AdaptrisMessage message) throws CoreException {
+      numberOfCalls++;
+      return numberOfCalls % 2 == 0;
+    }
+
+    @Override
+    public void close() {
+      throw new RuntimeException();
+    }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MessageAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MessageAggregatorTest.java
@@ -52,6 +52,7 @@ public class MessageAggregatorTest {
   @Test
   public void testImplFilter() throws Exception {
     AppendingMessageAggregator aggregator = new AppendingMessageAggregator();
+    aggregator.setFilterCondition(new EvenOddCondition());
     AdaptrisMessage splitMsg1 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m1");
     AdaptrisMessage splitMsg2 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m2");
     List<AdaptrisMessage> l = Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2});

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MessageAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MessageAggregatorTest.java
@@ -1,0 +1,49 @@
+package com.adaptris.core.services.aggregator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+
+public class MessageAggregatorTest {
+
+  @Test
+  public void testAggregateMessages() throws Exception {
+    MessageAggregator aggregator = new MessageAggregator() {
+      @Override
+      public void joinMessage(AdaptrisMessage msg, Collection<AdaptrisMessage> msgs) {};
+    };
+    AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage("o");
+    AdaptrisMessage splitMsg1 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m1");
+    AdaptrisMessage splitMsg2 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m2");
+    aggregator.aggregate(original, Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2}));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testJoin() throws Exception {
+    MessageAggregator aggregator = new MessageAggregator() {};
+    AdaptrisMessage original = AdaptrisMessageFactory.getDefaultInstance().newMessage("o");
+    AdaptrisMessage splitMsg1 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m1");
+    AdaptrisMessage splitMsg2 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m2");
+    aggregator.joinMessage(original, Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2}));
+  }
+
+  @Test
+  public void testCollect() throws Exception {
+    AdaptrisMessage splitMsg1 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m1");
+    AdaptrisMessage splitMsg2 = AdaptrisMessageFactory.getDefaultInstance().newMessage("m2");
+    List<AdaptrisMessage> l = Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2});
+    assertSame(l, MessageAggregator.collect(l));
+    assertEquals(2,  MessageAggregator.collect(new Iterable<AdaptrisMessage>() {
+      @Override
+      public Iterator<AdaptrisMessage> iterator() {
+        return l.iterator();
+      }
+    }).size());
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MimeAggregatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MimeAggregatorCase.java
@@ -33,6 +33,7 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
+import com.adaptris.core.services.aggregator.MessageAggregatorTest.EvenOddCondition;
 import com.adaptris.core.services.metadata.AddMetadataService;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.util.text.mime.BodyPartIterator;
@@ -249,6 +250,24 @@ public abstract class MimeAggregatorCase extends AggregatorCase {
     System.err.println(payload);
     assertTrue(payload.contains("multipart/form-data"));
   }
+
+  @Test
+  public void testAggregate_WithFilter() throws Exception {
+    MimeAggregator aggr = createAggregatorForTests();
+    aggr.setOverwriteMetadata(false);
+    aggr.setFilterCondition(new EvenOddCondition());
+    AdaptrisMessageFactory fac = AdaptrisMessageFactory.getDefaultInstance();
+    AdaptrisMessage original = fac.newMessage("<envelope/>");
+    AdaptrisMessage splitMsg1 = fac.newMessage("<document>hello</document>");
+    AdaptrisMessage splitMsg2 = fac.newMessage("<document>world</document>");
+    aggr.aggregate(original, Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2}));
+    String payload = original.getContent();
+
+    assertFalse(payload.contains("hello"));
+    assertTrue(payload.contains("world"));
+  }
+
+
 
   @Override
   protected MimeAggregator createAggregatorForTests() {

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MimeAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MimeAggregatorTest.java
@@ -21,10 +21,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
-import com.adaptris.core.services.conditional.conditions.ConditionImpl;
+import com.adaptris.core.services.aggregator.MessageAggregatorTest.EvenOddCondition;
 import com.adaptris.core.services.mime.MimeJunitHelper;
 import com.adaptris.core.services.splitter.LineCountSplitter;
 import com.adaptris.core.services.splitter.MimePartSplitter;
@@ -134,22 +133,5 @@ public class MimeAggregatorTest extends MimeAggregatorCase {
   @Override
   protected String createBaseFileName(Object object) {
     return super.createBaseFileName(object) + "-MimeAggregator";
-  }
-
-  // Have a condition that every other call passes
-
-  private class EvenOddCondition extends ConditionImpl {
-    private int numberOfCalls = 0;
-
-    @Override
-    public boolean evaluate(AdaptrisMessage message) throws CoreException {
-      numberOfCalls++;
-      return numberOfCalls %2 == 0;
-    }
-
-    @Override
-    public void close() {
-      throw new RuntimeException();
-    }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MultiPayloadMessageAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/MultiPayloadMessageAggregatorTest.java
@@ -3,17 +3,18 @@ package com.adaptris.core.services.aggregator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.MultiPayloadAdaptrisMessage;
 import com.adaptris.core.MultiPayloadMessageFactory;
 import com.adaptris.core.Service;
+import com.adaptris.core.services.aggregator.MessageAggregatorTest.EvenOddCondition;
 import com.adaptris.core.services.splitter.MultiPayloadMessageSplitter;
 
 public class MultiPayloadMessageAggregatorTest extends AggregatorCase
@@ -54,19 +55,20 @@ public class MultiPayloadMessageAggregatorTest extends AggregatorCase
 		assertEquals(3, message.getPayloadCount());
 	}
 
-	@Test
-	public void testWrongMessageType()
-	{
-		try
-		{
-			aggregator.joinMessage(DefaultMessageFactory.getDefaultInstance().newMessage(), messages);
-			fail();
-		}
-		catch (CoreException e)
-		{
-			/* expected */
-		}
-	}
+  @Test(expected = CoreException.class)
+  public void testWrongMessageType() throws Exception {
+    aggregator.joinMessage(AdaptrisMessageFactory.getDefaultInstance().newMessage(), messages);
+  }
+
+  @Test
+  public void testWithFilter() throws Exception {
+    aggregator.setReplaceOriginalMessage(false);
+    aggregator.setFilterCondition(new EvenOddCondition());
+    aggregator.aggregate(message, messages);
+    assertFalse(aggregator.getReplaceOriginalMessage());
+    // 2 to merge, of which one will be discarded + the original.
+    assertEquals(2, message.getPayloadCount());
+  }
 
 	@Override
 	protected MultiPayloadMessageAggregator createAggregatorForTests()

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/ReplaceFirstAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/ReplaceFirstAggregatorTest.java
@@ -75,13 +75,28 @@ public class ReplaceFirstAggregatorTest extends AggregatorCase {
   public void testAggregate_BrokenOutput() throws Exception {
     ReplaceWithFirstMessage aggr = createAggregatorForTests();
     aggr.setOverwriteMetadata(true);
+    AdaptrisMessageFactory fac = AdaptrisMessageFactory.getDefaultInstance();
     AdaptrisMessage original =
         new DefectiveMessageFactory(WhenToBreak.OUTPUT).newMessage("Goodbye");
-    AdaptrisMessage splitMsg1 = AdaptrisMessageFactory.getDefaultInstance().newMessage("short");
-    AdaptrisMessage splitMsg2 = AdaptrisMessageFactory.getDefaultInstance().newMessage("justShort");
-    AdaptrisMessage splitMsg3 = AdaptrisMessageFactory.getDefaultInstance().newMessage("ofSufficientLength");
-    AdaptrisMessage splitMsg4 = AdaptrisMessageFactory.getDefaultInstance().newMessage("tooSmall");
-    aggr.joinMessage(original, Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2, splitMsg3, splitMsg4}));
+    AdaptrisMessage splitMsg1 = fac.newMessage("short");
+    AdaptrisMessage splitMsg2 = fac.newMessage("justShort");
+    AdaptrisMessage splitMsg3 = fac.newMessage("ofSufficientLength");
+    AdaptrisMessage splitMsg4 = fac.newMessage("tooSmall");
+    aggr.joinMessage(original, Arrays.asList(splitMsg1, splitMsg2, splitMsg3, splitMsg4));
+  }
+
+  @Test
+  public void testAggregate_NoMatch() throws Exception {
+    ReplaceWithFirstMessage aggr = createAggregatorForTests();
+    aggr.setFilterCondition(new LengthCheckCondition());
+    AdaptrisMessageFactory fac = AdaptrisMessageFactory.getDefaultInstance();
+    AdaptrisMessage original = fac.newMessage("Goodbye");
+    AdaptrisMessage splitMsg1 = fac.newMessage("short");
+    AdaptrisMessage splitMsg2 = fac.newMessage("justShort");
+    AdaptrisMessage splitMsg3 = fac.newMessage("tooShort");
+    AdaptrisMessage splitMsg4 = fac.newMessage("tooSmall");
+    aggr.aggregate(original, Arrays.asList(splitMsg1, splitMsg2, splitMsg3, splitMsg4));
+    assertEquals("Goodbye", original.getContent());
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/ReplaceFirstAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/ReplaceFirstAggregatorTest.java
@@ -26,6 +26,8 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.Service;
 import com.adaptris.core.services.conditional.conditions.ConditionImpl;
 import com.adaptris.core.services.splitter.SplitByMetadata;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
 
 public class ReplaceFirstAggregatorTest extends AggregatorCase {
 
@@ -67,6 +69,19 @@ public class ReplaceFirstAggregatorTest extends AggregatorCase {
     assertEquals("ofSufficientLength", original.getContent());
     // It's part of split message 2 so it gets ignored.
     assertEquals("originalValue", original.getMetadataValue("originalKey"));
+  }
+
+  @Test(expected = CoreException.class)
+  public void testAggregate_BrokenOutput() throws Exception {
+    ReplaceWithFirstMessage aggr = createAggregatorForTests();
+    aggr.setOverwriteMetadata(true);
+    AdaptrisMessage original =
+        new DefectiveMessageFactory(WhenToBreak.OUTPUT).newMessage("Goodbye");
+    AdaptrisMessage splitMsg1 = AdaptrisMessageFactory.getDefaultInstance().newMessage("short");
+    AdaptrisMessage splitMsg2 = AdaptrisMessageFactory.getDefaultInstance().newMessage("justShort");
+    AdaptrisMessage splitMsg3 = AdaptrisMessageFactory.getDefaultInstance().newMessage("ofSufficientLength");
+    AdaptrisMessage splitMsg4 = AdaptrisMessageFactory.getDefaultInstance().newMessage("tooSmall");
+    aggr.joinMessage(original, Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2, splitMsg3, splitMsg4}));
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/XmlAggregatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/XmlAggregatorCase.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ public abstract class XmlAggregatorCase extends AggregatorCase {
       aggr.setMergeImplementation(null);
       fail();
     }
-    catch (IllegalArgumentException expected) {
+    catch (Exception expected) {
 
     }
     assertEquals(inserter, aggr.getMergeImplementation());

--- a/interlok-core/src/test/java/com/adaptris/core/services/aggregator/XmlAggregatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/aggregator/XmlAggregatorTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,17 +19,21 @@ package com.adaptris.core.services.aggregator;
 import static com.adaptris.core.services.splitter.XpathSplitterTest.ENCODING_UTF8;
 import static com.adaptris.core.services.splitter.XpathSplitterTest.ENVELOPE_DOCUMENT;
 import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
+import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.NullService;
 import com.adaptris.core.Service;
+import com.adaptris.core.services.aggregator.MessageAggregatorTest.EvenOddCondition;
 import com.adaptris.core.services.splitter.SplitJoinService;
 import com.adaptris.core.services.splitter.SplitJoinServiceTest;
 import com.adaptris.core.services.splitter.SplitterCase;
 import com.adaptris.core.services.splitter.XpathMessageSplitter;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.TimeInterval;
 import com.adaptris.util.text.xml.InsertNode;
@@ -74,6 +78,21 @@ public class XmlAggregatorTest extends XmlAggregatorCase {
     XPath xpath = new XPath();
     assertEquals(6, xpath.selectNodeList(XmlHelper.createDocument(msg, true), ENVELOPE_DOCUMENT).getLength());
     assertEquals("ISO-8859-1", msg.getContentEncoding());
+  }
+
+  @Test
+  public void testAggregate_WithFilter() throws Exception {
+    XmlDocumentAggregator aggr = createAggregatorForTests();
+    aggr.setMergeImplementation(new InsertNode(SplitJoinServiceTest.XPATH_ENVELOPE));
+    aggr.setFilterCondition(new EvenOddCondition());
+    AdaptrisMessageFactory fac = AdaptrisMessageFactory.getDefaultInstance();
+    AdaptrisMessage original = fac.newMessage("<envelope/>");
+    AdaptrisMessage splitMsg1 = fac.newMessage("<document>hello</document>");
+    AdaptrisMessage splitMsg2 = fac.newMessage("<document>world</document>");
+    aggr.aggregate(original, Arrays.asList(new AdaptrisMessage[] {splitMsg1, splitMsg2}));
+    XPath xpath = new XPath();
+    Document d = XmlHelper.createDocument(original, DocumentBuilderFactoryBuilder.newInstance());
+    assertEquals(1, xpath.selectNodeList(d, ENVELOPE_DOCUMENT).getLength());
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/FixedSplitJoinServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/FixedSplitJoinServiceTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.splitter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.DefaultEventHandler;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.WaitService;
+import com.adaptris.core.services.aggregator.AppendingMessageAggregator;
+import com.adaptris.core.services.exception.ConfiguredException;
+import com.adaptris.core.services.exception.ThrowExceptionService;
+import com.adaptris.core.stubs.MockMessageProducer;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+import com.adaptris.util.TimeInterval;
+
+public class FixedSplitJoinServiceTest {
+
+  @Test
+  public void testService() throws Exception {
+    FixedSplitJoinService service = new FixedSplitJoinService();
+    service.setAggregator(new AppendingMessageAggregator());
+    service.setSplitter(new LineCountSplitter(1));
+    service.setPoolsize(10);
+    service.setTimeout(new TimeInterval(10L, TimeUnit.SECONDS));
+    service.setService(new WaitService(new TimeInterval(100L, TimeUnit.MILLISECONDS), true));
+
+    AdaptrisMessage msg = createLineCountMessageInput(50);
+    ExampleServiceCase.execute(service, msg);
+
+    List<String> result = IOUtils.readLines(msg.getReader());
+    // Using an appending message aggregator just means that we double up on the original message...
+    assertEquals(50 * 2, result.size());
+  }
+
+  @Test
+  public void testService_Events() throws Exception {
+    FixedSplitJoinService service = new FixedSplitJoinService();
+    MockMessageProducer events = new MockMessageProducer();
+    service.setAggregator(new AppendingMessageAggregator());
+    service.setSplitter(new LineCountSplitter(1));
+    service.setPoolsize(10);
+    service.setTimeout(new TimeInterval(10L, TimeUnit.SECONDS));
+    service.setService(new WaitService(new TimeInterval(100L, TimeUnit.MILLISECONDS), true));
+    service.setSendEvents(true);
+    service.registerEventHandler(LifecycleHelper.initAndStart(new DefaultEventHandler(events)));
+    AdaptrisMessage msg = createLineCountMessageInput(50);
+    ExampleServiceCase.execute(service, msg);
+
+    List<String> result = IOUtils.readLines(msg.getReader());
+    // Using an appending message aggregator just means that we double up on the original message...
+    assertEquals(50 * 2, result.size());
+    // Check we got 50 events.
+    assertEquals(50, events.getMessages().size());
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testTimeout() throws Exception {
+    FixedSplitJoinService service = new FixedSplitJoinService();
+    service.setAggregator(new AppendingMessageAggregator());
+    service.setSplitter(new LineCountSplitter(1));
+    service.setPoolsize(10);
+    service.setTimeout(new TimeInterval(50L, TimeUnit.MILLISECONDS));
+    service.setService(new WaitService(new TimeInterval(100L, TimeUnit.MILLISECONDS), false));
+    service.setSendEvents(true);
+
+    AdaptrisMessage msg = createLineCountMessageInput(50);
+    try {
+      ExampleServiceCase.execute(service, msg);
+    } catch (ServiceException e) {
+      // This will be a RuntimeException (from hasNext()?) that wraps a TimeoutException
+      // That's in turn wrapped by a ServiceException.
+      assertNotNull(e.getCause().getCause());
+      throw e;
+    }
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testService_WithException() throws Exception {
+    FixedSplitJoinService service = new FixedSplitJoinService();
+    service.setAggregator(new AppendingMessageAggregator());
+    service.setSplitter(new LineCountSplitter(1));
+    service.setPoolsize(10);
+    service.setTimeout(new TimeInterval(5L, TimeUnit.SECONDS));
+    service.setService(new ThrowExceptionService(new ConfiguredException("always-fail")));
+    service.registerEventHandler(LifecycleHelper.initAndStart(new DefaultEventHandler()));
+    AdaptrisMessage msg = createLineCountMessageInput(50);
+    try {
+      ExampleServiceCase.execute(service, msg);
+    } catch (ServiceException e) {
+      assertEquals("always-fail", e.getMessage());
+      throw e;
+    }
+  }
+
+
+  private static AdaptrisMessage createLineCountMessageInput(int lines) {
+    StringWriter out = new StringWriter();
+    try (PrintWriter print = new PrintWriter(out)) {
+      for (int i = 0; i < lines; i++) {
+        print.println("Pack my jug with a dozen liquor boxes.");
+      }
+    }
+    return AdaptrisMessageFactory.getDefaultInstance().newMessage(out.toString());
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/PooledSplitJoinServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/PooledSplitJoinServiceTest.java
@@ -39,11 +39,11 @@ import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.adaptris.util.TimeInterval;
 
-public class FixedSplitJoinServiceTest {
+public class PooledSplitJoinServiceTest {
 
   @Test
   public void testService() throws Exception {
-    FixedSplitJoinService service = new FixedSplitJoinService();
+    PooledSplitJoinService service = new PooledSplitJoinService();
     service.setAggregator(new AppendingMessageAggregator());
     service.setSplitter(new LineCountSplitter(1));
     service.setPoolsize(10);
@@ -60,7 +60,7 @@ public class FixedSplitJoinServiceTest {
 
   @Test
   public void testService_Events() throws Exception {
-    FixedSplitJoinService service = new FixedSplitJoinService();
+    PooledSplitJoinService service = new PooledSplitJoinService();
     MockMessageProducer events = new MockMessageProducer();
     service.setAggregator(new AppendingMessageAggregator());
     service.setSplitter(new LineCountSplitter(1));
@@ -81,7 +81,7 @@ public class FixedSplitJoinServiceTest {
 
   @Test(expected = ServiceException.class)
   public void testTimeout() throws Exception {
-    FixedSplitJoinService service = new FixedSplitJoinService();
+    PooledSplitJoinService service = new PooledSplitJoinService();
     service.setAggregator(new AppendingMessageAggregator());
     service.setSplitter(new LineCountSplitter(1));
     service.setPoolsize(10);
@@ -102,7 +102,7 @@ public class FixedSplitJoinServiceTest {
 
   @Test(expected = ServiceException.class)
   public void testService_WithException() throws Exception {
-    FixedSplitJoinService service = new FixedSplitJoinService();
+    PooledSplitJoinService service = new PooledSplitJoinService();
     service.setAggregator(new AppendingMessageAggregator());
     service.setSplitter(new LineCountSplitter(1));
     service.setPoolsize(10);
@@ -120,7 +120,7 @@ public class FixedSplitJoinServiceTest {
 
   @Test
   public void testService_DidWorkSuccessfully() throws Exception {
-    FixedSplitJoinService service = new FixedSplitJoinService();
+    PooledSplitJoinService service = new PooledSplitJoinService();
     service.setServiceErrorHandler(
         new NoExceptionIfWorkDone().withMetadataKey(NoExceptionIfWorkDone.DEFAULT_METADATA_KEY));
     service.setSplitter(new LineCountSplitter(1));
@@ -140,7 +140,7 @@ public class FixedSplitJoinServiceTest {
 
   @Test(expected = ServiceException.class)
   public void testService_DidNoWork() throws Exception {
-    FixedSplitJoinService service = new FixedSplitJoinService();
+    PooledSplitJoinService service = new PooledSplitJoinService();
     service.setServiceErrorHandler(new NoExceptionIfWorkDone().withMetadataKey(NoExceptionIfWorkDone.DEFAULT_METADATA_KEY));
     service.setSplitter(new LineCountSplitter(1));
     service.setService(asCollection(new MockExceptionStrategyService(MockExceptionStrategyService.MODE.ERROR)));
@@ -154,7 +154,7 @@ public class FixedSplitJoinServiceTest {
 
   @Test
   public void testService_DidSomeWork() throws Exception {
-    FixedSplitJoinService service = new FixedSplitJoinService();
+    PooledSplitJoinService service = new PooledSplitJoinService();
     service.setServiceErrorHandler(
         new NoExceptionIfWorkDone().withMetadataKey(NoExceptionIfWorkDone.DEFAULT_METADATA_KEY));
     service.setSplitter(new LineCountSplitter(1));
@@ -174,7 +174,7 @@ public class FixedSplitJoinServiceTest {
 
   @Test
   public void testService_IgnoreExceptions() throws Exception {
-    FixedSplitJoinService service = new FixedSplitJoinService();
+    PooledSplitJoinService service = new PooledSplitJoinService();
     service.setServiceErrorHandler(new IgnoreAllExceptions());
     service.setSplitter(new LineCountSplitter(1));
     service.setService(


### PR DESCRIPTION
## Motivation

When you have a message-splliter implementation that returns you a huge number of split messages (e.g. in the order of 80k+) then you end up in a situation where you have a List<> that contains 80k entries. This is generally "handled" but probably isn't efficient on constrained environments. 

The code is effectively (there is nuance but not much) which effectively implies that you have at least the total split count worth of objects sitting in eden space.

```java
Iterable<AdaptrisMessage> list = splitter.splitMessages(); // might be a list, might be lazy iterating
List<Future> futures = doSplit(list); // definitely a list of 80k messages now
List<AdaptrisMessage> done = futures.get();
aggregator.joinMessage(original, done);
```

## Modification

- MessageAggregator interface adds a `default void aggregate(AdaptrisMessage original, Iterable<AdaptrisMessage> msgs)` method which just listifies and calls joinMessage, so by default, no aggregators need to change, but won't give you any performance benefit
- Prototype `PooledSplitJoinService` which behaves slightly different to PoolingSplitJoin. 
  - poolsize is "fixed", and warmed up on start.
  - object.wait()/notify() to inform us when the pool is available
  - Messages are submitted to a pool in a separate thread, which means that aggregating starts happening at the same time as the split.
  - Timeout is handled manually rather than via Executors.submit()
- Additional `ServiceErrorHandler` implementations which allow us to replicate the behaviour of `PoolingFutureExceptionStrategy`
  - If you're going to use a non-default strategy, since aggregation might happen as soon as messages are available; you'll have to be careful about "filtering" conditions.

## Result

- There is a PooledSplitJoinServiceTest which just uses AppendingMessageAggregator to test functionality. Tests pass, which means the interface change is OK.
- PooledSplitJoinService is available to configure, along with supporting `ServiceErrorHandler` implementations which replicate the deprecated `PoolingFutureExceptionStrategy` implementations.
- Since configuration is different, we deprecate SplitJoinService & PoolingSplitJoinService with a view for removing it in 4.0.0
- Usage of Deprecated classes will result in a warning during "prepare()" from 3.11.1

## Testing

Select the PooledSplitJoinService, and monitor the behaviour (via jconsole?) on very very large split messages.

