### PR TITLE
INTERLOK-3432 Only do ServiceLoader once in a singleton

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/interlok/resolver/ExternalResolver.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/resolver/ExternalResolver.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,18 +15,26 @@
 */
 package com.adaptris.interlok.resolver;
 
-import com.adaptris.interlok.types.InterlokMessage;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
 import java.util.ServiceLoader;
+import com.adaptris.interlok.types.InterlokMessage;
+import lombok.AccessLevel;
+import lombok.Getter;
 
 public class ExternalResolver {
 
-  private ServiceLoader<Resolver> resolvers = null;
+  @Getter(AccessLevel.PRIVATE)
+  private Collection<Resolver> resolverList = new ArrayList<>();
 
   private static final ExternalResolver IMPL = new ExternalResolver();
 
   private ExternalResolver() {
-
+    Iterable<Resolver> resolvers = ServiceLoader.load(Resolver.class);
+    for (Resolver r : resolvers) {
+      resolverList.add(r);
+    }
   }
 
   public static String resolve(String lookupValue) {
@@ -43,29 +51,15 @@ public class ExternalResolver {
     return IMPL.tryResolve(value, target);
   }
 
-  private String tryResolve(String lookupValue) {
-    String result = lookupValue;
-    if (resolvers == null) {
-      resolvers = ServiceLoader.load(Resolver.class);
-    }
-    for (Resolver impl : resolvers) {
-      if (impl.canHandle(lookupValue)) {
-        result = impl.resolve(lookupValue);
-        break;
-      }
-    }
-    return result;
+  private String tryResolve(String value) {
+    Optional<Resolver> impl = resolverList.stream().filter((r) -> r.canHandle(value)).findFirst();
+    return impl.map((r) -> r.resolve(value)).orElseGet(() -> value);
   }
 
   private String tryResolve(String value, InterlokMessage target) {
-    if (resolvers == null) {
-      resolvers = ServiceLoader.load(Resolver.class);
-    }
-    for (Resolver resolver : resolvers) {
-      if (resolver.canHandle(value)) {
-        return resolver.resolve(value, target);
-      }
-    }
-    return value;
+    Optional<Resolver> impl = resolverList.stream().filter((r) -> r.canHandle(value)).findFirst();
+    return impl.map((r) -> r.resolve(value, target)).orElseGet(() -> value);
   }
+
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/vcs/RuntimeVersionControlLoader.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/vcs/RuntimeVersionControlLoader.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,9 +17,9 @@
 package com.adaptris.core.management.vcs;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.stream.StreamSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,10 +28,13 @@ public class RuntimeVersionControlLoader {
   private static RuntimeVersionControlLoader INSTANCE;
 
   private transient Logger log = LoggerFactory.getLogger(RuntimeVersionControlLoader.class);
-  private ServiceLoader<RuntimeVersionControl> runtimeVersionControls;
+  private Collection<RuntimeVersionControl> runtimeVersionControls = new ArrayList<>();
 
   private RuntimeVersionControlLoader() {
-    runtimeVersionControls = ServiceLoader.load(RuntimeVersionControl.class);
+    Iterable<RuntimeVersionControl> resolvers = ServiceLoader.load(RuntimeVersionControl.class);
+    for (RuntimeVersionControl r : resolvers) {
+      runtimeVersionControls.add(r);
+    }
   }
 
   public static RuntimeVersionControlLoader getInstance() {
@@ -47,7 +50,7 @@ public class RuntimeVersionControlLoader {
   }
 
   private RuntimeVersionControl loadFirst() {
-    RuntimeVersionControl result = StreamSupport.stream(runtimeVersionControls.spliterator(), false).findFirst().orElse(null);
+    RuntimeVersionControl result = runtimeVersionControls.stream().findFirst().orElse(null);
     log.trace("Version control system found: [{}]", result != null ? result.getImplementationName() : "None");
     return newInstance(result);
   }
@@ -76,13 +79,7 @@ public class RuntimeVersionControlLoader {
    * @return A list of {@link RuntimeVersionControl}
    */
   public List<RuntimeVersionControl> availableImplementations() {
-    List<RuntimeVersionControl> impls = new ArrayList<>();
-
-    for(RuntimeVersionControl vcs : runtimeVersionControls) {
-      impls.add(vcs);
-    }
-
-    return impls;
+    return new ArrayList<>(runtimeVersionControls);
   }
 
   /**
@@ -95,7 +92,7 @@ public class RuntimeVersionControlLoader {
    * If we cannot find the RuntimeVersionControl based on the given implementation name or if there
    * are no RuntimeVersionControl available, this method will return null.
    * </p>
-   * 
+   *
    * @param implementationName
    * @return {@link RuntimeVersionControl}
    */


### PR DESCRIPTION
## Motivation

You can get a 
```
com.adaptris.core.ServiceException: java.util.ConcurrentModificationException
	at com.adaptris.core.transform.json.JsonTransformService.doService(JsonTransformService.java:677) ~[interlok-json.jar:3.11-SNAPSHOT]
	at com.adaptris.core.ServiceList.applyServices(ServiceList.java:96) ~[interlok-core.jar:3.11-SNAPSHOT]
	at com.adaptris.core.ServiceCollectionImp.doService(ServiceCollectionImp.java:204) ~[interlok-core.jar:3.11-SNAPSHOT]
	at com.adaptris.core.services.splitter.ServiceWorkerPool$Worker.doService(ServiceWorkerPool.java:169) ~[interlok-core.jar:3.11-SNAPSHOT]
	at com.adaptris.core.services.splitter.PoolingSplitJoinService$MyServiceExecutor.call(PoolingSplitJoinService.java:183) [interlok-core.jar:3.11-SNAPSHOT]
	at com.adaptris.core.services.splitter.PoolingSplitJoinService$MyServiceExecutor.call(PoolingSplitJoinService.java:169) [interlok-core.jar:3.11-SNAPSHOT]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_262]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_262]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_262]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_262]
Caused by: java.util.ConcurrentModificationException
	at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:719) ~[?:1.8.0_262]
	at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:752) ~[?:1.8.0_262]
	at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:750) ~[?:1.8.0_262]
	at java.util.ServiceLoader$1.next(ServiceLoader.java:479) ~[?:1.8.0_262]
	at com.adaptris.interlok.resolver.ExternalResolver.tryResolve(ExternalResolver.java:64) ~[interlok-common.jar:3.11-SNAPSHOT]
	at com.adaptris.interlok.resolver.ExternalResolver.resolve(ExternalResolver.java:43) ~[interlok-common.jar:3.11-SNAPSHOT]
	at com.adaptris.core.AdaptrisMessageImp.resolve(AdaptrisMessageImp.java:377) ~[interlok-core.jar:3.11-SNAPSHOT]
	at com.adaptris.core.common.ConstantDataInputParameter.extract(ConstantDataInputParameter.java:55) ~[interlok-core.jar:3.11-SNAPSHOT]
	at com.adaptris.core.common.ConstantDataInputParameter.extract(ConstantDataInputParameter.java:39) ~[interlok-core.jar:3.11-SNAPSHOT]
	at com.adaptris.core.transform.json.JsonTransformService.doService(JsonTransformService.java:653) ~[interlok-json.jar:3.11-SNAPSHOT]
	... 9 more
```

When resolving data (since you may repeatedly iterate over the ServiceLoader instance), and you may actually get simultaneous thread access...

## Modification

- Since ExternalResolver is a singleton, then we only need to do ServiceLoader.load() once in the constructor and turn that into a collection for later use.
- Do the same thing for RuntimeVersionControls since there is a small edge case where this might happen.

## Result

No change to the user; shouldn't now get a ConcurrentModificationException since we aren't using the internal ServiceLoaders lazy iterator.

## Testing

If you have a JSON array that you want to split, simplify and join...

```
              <pooling-split-join-service>
                <unique-id>split-join</unique-id>
                <service class="service-list">
                  <unique-id>simplify-json</unique-id>
                  <services>
                    <json-transform-service>
                      <unique-id>high-goodall</unique-id>
                      <source-json class="string-payload-data-input-parameter"/>
                      <mapping-spec class="constant-data-input-parameter">
                        <value>[
  {
    "operation": "shift",
    "spec": {
      "uniqueid": "uniqueid"
      }
    }
  }
]
</value>
                      </mapping-spec>
                      <target-json class="string-payload-data-output-parameter"/>
                      <metadata-filter class="remove-all-metadata-filter"/>
                    </json-transform-service>
                  </services>
                </service>
                <splitter class="large-json-array-splitter">
                  <message-factory class="default-message-factory"/>
                </splitter>
                <aggregator class="json-array-aggregator"/>
              </pooling-split-join-service>
```
