### PR TITLE
INTERLOK-3437 Shared component checker now uses pre-processors

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/config/ConfigPreProcessorLoader.java
+++ b/interlok-core/src/main/java/com/adaptris/core/config/ConfigPreProcessorLoader.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,9 @@
 
 package com.adaptris.core.config;
 
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import org.apache.commons.io.IOUtils;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.management.BootstrapProperties;
 import com.adaptris.util.KeyValuePairSet;
@@ -25,4 +28,18 @@ public interface ConfigPreProcessorLoader {
   ConfigPreProcessors load(BootstrapProperties bootstrapProperties) throws CoreException;
 
   ConfigPreProcessors load(String preProcessors, KeyValuePairSet config) throws CoreException;
+
+  /**
+   * Helper method to use the default pre-processor chain to read configuration.
+   *
+   * @since 3.11.0
+   */
+  static String loadInterlokConfig(BootstrapProperties config) throws Exception {
+    String result = "";
+    try (InputStream in = config.getConfigurationStream()) {
+      result = IOUtils.toString(in, Charset.defaultCharset());
+    }
+    return new DefaultPreProcessorLoader().load(config).process(result);
+  }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/AdapterConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/AdapterConfigurationChecker.java
@@ -1,27 +1,18 @@
 package com.adaptris.core.management.config;
 
-import java.io.InputStream;
-import java.nio.charset.Charset;
-
-import org.apache.commons.io.IOUtils;
-
 import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.config.ConfigPreProcessorLoader;
-import com.adaptris.core.config.DefaultPreProcessorLoader;
 import com.adaptris.core.management.BootstrapProperties;
-
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 public abstract class AdapterConfigurationChecker implements ConfigurationChecker {
 
-  private transient ConfigPreProcessorLoader loader = new DefaultPreProcessorLoader();
-
   @Override
   public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties config) {
     try {
-      String xml = loader.load(config).process(readAdapterXml(config));
+      String xml = ConfigPreProcessorLoader.loadInterlokConfig(config);
       Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);
       validate(adapter, report);
     } catch (Exception ex) {
@@ -29,15 +20,6 @@ public abstract class AdapterConfigurationChecker implements ConfigurationChecke
     }
     return report;
   }
-
-  private String readAdapterXml(BootstrapProperties config) throws Exception {
-    String result = "";
-    try (InputStream in = config.getConfigurationStream()) {
-      result = IOUtils.toString(in, Charset.defaultCharset());
-    }
-    return result;
-  }
-
 
   protected abstract void validate(Adapter adapter, ConfigurationCheckReport report);
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/SharedComponentConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/SharedComponentConfigurationChecker.java
@@ -1,8 +1,11 @@
 package com.adaptris.core.management.config;
 
+import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
-
+import org.apache.commons.io.IOUtils;
+import com.adaptris.core.config.ConfigPreProcessorLoader;
 import com.adaptris.core.management.BootstrapProperties;
 import com.adaptris.util.XmlUtils;
 
@@ -21,29 +24,33 @@ public abstract class SharedComponentConfigurationChecker implements Configurati
   @Override
   public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties bootProperties) {
     try {
-      XmlUtils xmlUtils = new XmlUtils();
-      xmlUtils.setSource(bootProperties.getConfigurationStream());
+      String xml = ConfigPreProcessorLoader.loadInterlokConfig(bootProperties);
+      try (InputStream in = IOUtils.toInputStream(xml, Charset.defaultCharset())) {
+        XmlUtils xmlUtils = new XmlUtils();
+        xmlUtils.setSource(in);
 
-      List<String> availableComponents = Arrays.asList(xmlUtils.getMultipleTextItems(xpathAvailableComponents));
-      List<String> referencedComponents = Arrays.asList(xmlUtils.getMultipleTextItems(xpathReferencedComponents));
+        List<String> availableComponents =
+            Arrays.asList(xmlUtils.getMultipleTextItems(xpathAvailableComponents));
+        List<String> referencedComponents =
+            Arrays.asList(xmlUtils.getMultipleTextItems(xpathReferencedComponents));
 
-      // **********************************
-      // Check all shared components are used.
-      availableComponents.forEach(component -> {
-        if (!referencedComponents.contains(component)) {
-          report.getWarnings().add("Shared " + componentType + " unused: " + component);
-        }
-      });
+        // **********************************
+        // Check all shared components are used.
+        availableComponents.forEach(component -> {
+          if (!referencedComponents.contains(component)) {
+            report.getWarnings().add("Shared " + componentType + " unused: " + component);
+          }
+        });
 
-      // **********************************
-      // Check all referenced components exist.
-      referencedComponents.forEach(component -> {
-        if(!availableComponents.contains(component)) {
-          report.getFailureExceptions()
-          .add(new ConfigurationException("Shared " + componentType + " does not exist in shared components: " + component));
-        }
-      });
-
+        // **********************************
+        // Check all referenced components exist.
+        referencedComponents.forEach(component -> {
+          if (!availableComponents.contains(component)) {
+            report.getFailureExceptions().add(new ConfigurationException(
+                "Shared " + componentType + " does not exist in shared components: " + component));
+          }
+        });
+      }
     } catch (Exception ex) {
       report.getFailureExceptions().add(ex);
     }


### PR DESCRIPTION
## Motivation

If your configuration is 
```
<adapter xmlns:xi="http://www.w3.org/2001/XInclude">
  <shared-components>
     <xi:include href="connections.xml"/>
  </shared-components>
  </channel-list>
    <channel>
       <consume-connection class="shared-connection">
          <lookup-name>something defined in connections.xml</lookup-name>
       </consume-connection>
    </channel>
  </channel-list>
</adapter>
```
Because you love xincludes then java -jar lib/interlok-boot.jar does not work since the shared confugiration checker doesn't believe in pre-processors.

## Modification

Add a helper method into ConfigPreProcessorLoader that does the right thing as a helper method which basically looks like this : 
```
  static String loadInterlokConfig(BootstrapProperties config) throws Exception {
    String result = "";
    try (InputStream in = config.getConfigurationStream()) {
      result = IOUtils.toString(in, Charset.defaultCharset());
    }
    return new DefaultPreProcessorLoader().load(config).process(result);
  }
```

- Make the config checkers use it.

## Result

No change for most people; but xinclude lovers can now use the parent gradle.

## Testing

See motivation above
