### PR TITLE
INTERLOK-3434 Change package of resovler class

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ResolveFromPayloadUsingXPath.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ResolveFromPayloadUsingXPath.java
@@ -1,4 +1,4 @@
-package com.adaptris.core.resolver;
+package com.adaptris.core;
 
 import java.io.InputStream;
 import java.util.regex.Matcher;
@@ -17,7 +17,7 @@ import com.adaptris.util.KeyValuePairSet;
 import com.adaptris.util.text.xml.SimpleNamespaceContext;
 import com.adaptris.util.text.xml.XPath;
 
-public class FromPayloadUsingXPath extends ResolverImp
+public class ResolveFromPayloadUsingXPath extends ResolverImp
 {
   private static final String RESOLVE_PAYLOAD_REGEXP = "^.*%payload\\{xpath:([\\w!\\$\"#&%'\\*\\+,\\-\\.:=\\(\\)\\[\\]\\/@\\|]+)\\}.*$";
   private static final transient Pattern PAYLOAD_RESOLVER = Pattern.compile(RESOLVE_PAYLOAD_REGEXP, Pattern.DOTALL);
@@ -25,7 +25,7 @@ public class FromPayloadUsingXPath extends ResolverImp
   private final DocumentBuilderFactoryBuilder factoryBuilder;
   private final NamespaceContext namespaceContext;
 
-  public FromPayloadUsingXPath()
+  public ResolveFromPayloadUsingXPath()
   {
     factoryBuilder = DocumentBuilderFactoryBuilder.newRestrictedInstance();
     KeyValuePairSet result = new KeyValuePairSet();

--- a/interlok-core/src/main/resources/META-INF/services/com.adaptris.interlok.resolver.Resolver
+++ b/interlok-core/src/main/resources/META-INF/services/com.adaptris.interlok.resolver.Resolver
@@ -1,1 +1,1 @@
-com.adaptris.core.resolver.FromPayloadUsingXPath
+com.adaptris.core.ResolveFromPayloadUsingXPath

--- a/interlok-core/src/test/java/com/adaptris/core/resolver/ResolveFromPayloadUsingXPathTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/resolver/ResolveFromPayloadUsingXPathTest.java
@@ -1,11 +1,11 @@
 package com.adaptris.core.resolver;
 
+import com.adaptris.core.ResolveFromPayloadUsingXPath;
 import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.interlok.types.InterlokMessage;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class FromPayloadUsingXPathTest
+public class ResolveFromPayloadUsingXPathTest
 {
   private static final String REGEX_POOR = "%payload{xpath:/something[0--]invalid}";
   private static final String REGEX_MISS = "%payload{xpath:/text/para/quote/text()}";
@@ -28,7 +28,7 @@ public class FromPayloadUsingXPathTest
   static final String DATA = "<text><para><sent>Hipster ipsum dolor amet portland asymmetrical try-hard roof party poke, schlitz blue bottle pop-up 3 wolf moon kogi hammock kitsch austin health goth.</sent><sent>Ethical mlkshk crucifix pug, hexagon XOXO tote bag portland typewriter celiac cornhole lumbersexual 8-bit pop-up.</sent><sent>Cred typewriter seitan, narwhal quinoa master cleanse mlkshk freegan.</sent><sent>Whatever vape paleo, mustache taiyaki XOXO chia ethical viral.</sent></para></text>";
   static final String RESULT = "Cred typewriter seitan, narwhal quinoa master cleanse mlkshk freegan.";
 
-  private FromPayloadUsingXPath resolver = new FromPayloadUsingXPath();
+  private ResolveFromPayloadUsingXPath resolver = new ResolveFromPayloadUsingXPath();
   private InterlokMessage message = new InterlokMessage()
   {
     @Override public String getUniqueId() { return null; }


### PR DESCRIPTION
## Motivation

Using the same package as the resolver in interlok-core causes issues with the JavaDoc.

## Modification

Move the JSON resolver package.

## Result

The JavaDoc should no longer be broken.

## Testing

https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-json/3.11.0-RELEASE/com/adaptris/core/resolver/package-summary.html should not include broken JavaDoc links.