### PR TITLE
Interlok 3455

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsMessageConsumerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsMessageConsumerFactory.java
@@ -50,13 +50,13 @@ public class JmsMessageConsumerFactory {
           } else {
             log.trace("Creating new durable consumer.");
             consumer = ((ConsumerCreator) (session, dest, filterExpression) -> session
-                .createDurableSubscriber((Topic) dest.getDestination(), filterExpression)).createConsumer(session, destination,
+                .createDurableSubscriber((Topic) dest.getDestination(), dest.subscriptionId())).createConsumer(session, destination,
                     filterExp);
           }
         } else if (!isEmpty(destination.sharedConsumerId())) {
           log.trace("Creating new shared consumer.");
-          consumer = ((ConsumerCreator) (session, dest, filterExpression) -> session.createSharedConsumer((Topic) dest.getDestination(),
-              dest.sharedConsumerId(), filterExpression)).createConsumer(session, destination, filterExp);
+          consumer = ((ConsumerCreator) (session, dest, filterExpression) -> session
+              .createSharedConsumer((Topic) dest.getDestination(), dest.sharedConsumerId(), filterExpression)).createConsumer(session, destination, filterExp);
         }
       }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
@@ -23,20 +23,25 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.jms.MessageConsumer;
+
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
-import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 import com.adaptris.core.jms.activemq.EmbeddedArtemis;
 import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.core.util.LifecycleHelper;
@@ -45,6 +50,8 @@ import com.adaptris.interlok.util.Closer;
 
 public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms.JmsConsumerCase {
 
+  private static EmbeddedArtemis activeMqBroker;
+  
   @Mock private BasicActiveMqImplementation mockVendor;
   @Mock MessageConsumer mockMessageConsumer;
 
@@ -58,12 +65,22 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
   public void tearDown() throws Exception {
     Closer.closeQuietly(openMocks);
   }
-
+  
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedArtemis();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    activeMqBroker.destroy();
+  }
 
   @Test
   public void testDeferConsumerCreationToVendor() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
+//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
 
     when(mockVendor.createConsumer(any(), any(), any(JmsActorConfig.class))).thenReturn(mockMessageConsumer);
 
@@ -76,8 +93,8 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
 
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
-    try {
-      activeMqBroker.start();
+//    try {
+//      activeMqBroker.start();
 
       JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -97,16 +114,16 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
 
       LifecycleHelper.stopAndClose(standaloneConsumer);
 
-    } finally {
-      activeMqBroker.destroy();
-    }
+//    } finally {
+//      activeMqBroker.destroy();
+//    }
   }
 
   @Test
   public void testDefaultFalseDeferConsumerCreationToVendor() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
+//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
 
     when(mockVendor.createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class)))
         .thenReturn(mockMessageConsumer);
@@ -119,8 +136,8 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
 
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
-    try {
-      activeMqBroker.start();
+//    try {
+//      activeMqBroker.start();
 
       JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -142,38 +159,38 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
 
       LifecycleHelper.stopAndClose(standaloneConsumer);
 
-    } finally {
-      activeMqBroker.destroy();
-    }
+//    } finally {
+//      activeMqBroker.destroy();
+//    }
   }
 
   @Test
   public void testDurableTopicConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
+//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
-    try {
-      activeMqBroker.start();
+//    try {
+//      activeMqBroker.start();
 
       JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
 
       MockMessageListener jms = new MockMessageListener();
       standaloneConsumer.registerAdaptrisMessageListener(jms);
 
       StandaloneProducer standaloneProducer =
-          new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), new JmsProducer().withEndpoint(rfc6167));
+          new StandaloneProducer(activeMqBroker.getJmsConnection(), new JmsProducer().withEndpoint(rfc6167));
       // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
       LifecycleHelper.prepare(standaloneConsumer);
       LifecycleHelper.prepare(standaloneProducer);
       execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
       assertMessages(jms, 1);
-    } finally {
-      activeMqBroker.destroy();
-    }
+//    } finally {
+//      activeMqBroker.destroy();
+//    }
 
   }
 
@@ -181,11 +198,11 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
   public void testSharedDurableTopicConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-    EmbeddedArtemis activeMqBroker = new EmbeddedArtemis();
+//    EmbeddedArtemis activeMqBroker = new EmbeddedArtemis();
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=MySubId&sharedConsumerId=" + getName();
 
-    try {
-      activeMqBroker.start();
+//    try {
+//      activeMqBroker.start();
 
       JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -199,9 +216,9 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
               new JmsProducer().withEndpoint(rfc6167));
       execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
       assertMessages(jms, 1);
-    } finally {
-      activeMqBroker.destroy();
-    }
+//    } finally {
+//      activeMqBroker.destroy();
+//    }
 
   }
 
@@ -209,11 +226,11 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
   public void testSharedTopicConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-    EmbeddedArtemis activeMqBroker = new EmbeddedArtemis();
+//    EmbeddedArtemis activeMqBroker = new EmbeddedArtemis();
     String rfc6167 = "jms:topic:" + getName() + "?sharedConsumerId=" + getName();
 
-    try {
-      activeMqBroker.start();
+//    try {
+//      activeMqBroker.start();
 
       JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
@@ -227,9 +244,9 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
               new JmsProducer().withEndpoint(rfc6167));
       execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
       assertMessages(jms, 1);
-    } finally {
-      activeMqBroker.destroy();
-    }
+//    } finally {
+//      activeMqBroker.destroy();
+//    }
 
   }
 
@@ -237,27 +254,27 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
   public void testTopicConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
+//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:topic:" + getName();
 
-    try {
-      activeMqBroker.start();
+//    try {
+//      activeMqBroker.start();
 
       JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);;
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
 
       MockMessageListener jms = new MockMessageListener();
       standaloneConsumer.registerAdaptrisMessageListener(jms);
 
       StandaloneProducer standaloneProducer =
-          new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+          new StandaloneProducer(activeMqBroker.getJmsConnection(),
               new JmsProducer().withEndpoint(rfc6167));
       execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
       assertMessages(jms, 1);
-    } finally {
-      activeMqBroker.destroy();
-    }
+//    } finally {
+//      activeMqBroker.destroy();
+//    }
 
   }
 
@@ -265,36 +282,36 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
   public void testQueueConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
+//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:queue:" + getName();
 
-    try {
-      activeMqBroker.start();
+//    try {
+//      activeMqBroker.start();
       JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
       consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
 
       MockMessageListener jms = new MockMessageListener();
       standaloneConsumer.registerAdaptrisMessageListener(jms);
 
       StandaloneProducer producer =
-          new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+          new StandaloneProducer(activeMqBroker.getJmsConnection(),
               new JmsProducer().withEndpoint(rfc6167));
       // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
       LifecycleHelper.prepare(standaloneConsumer);
       LifecycleHelper.prepare(producer);
       execute(standaloneConsumer, producer, createMessage(null), jms);
       assertMessages(jms, 1);
-    } finally {
-      activeMqBroker.destroy();
-    }
+//    } finally {
+//      activeMqBroker.destroy();
+//    }
   }
 
 
 
-  protected BasicActiveMqImplementation createVendorImpl() {
-    return new BasicActiveMqImplementation();
-  }
+//  protected BasicActiveMqImplementation createVendorImpl() {
+//    return new BasicActiveMqImplementation();
+//  }
 
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
@@ -74,7 +74,8 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
   
   @AfterClass
   public static void tearDownAll() throws Exception {
-    activeMqBroker.destroy();
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConsumerTest.java
@@ -80,7 +80,6 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
   @Test
   public void testDeferConsumerCreationToVendor() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
-//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
 
     when(mockVendor.createConsumer(any(), any(), any(JmsActorConfig.class))).thenReturn(mockMessageConsumer);
 
@@ -93,37 +92,28 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
 
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
-//    try {
-//      activeMqBroker.start();
+    JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setDeferConsumerCreationToVendor(true);
 
-      JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setDeferConsumerCreationToVendor(true);
+    JmsConnection jmsConnection = activeMqBroker.getJmsConnection();
+    jmsConnection.setVendorImplementation(mockVendor);
 
-      JmsConnection jmsConnection = activeMqBroker.getJmsConnection();
-      jmsConnection.setVendorImplementation(mockVendor);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(jmsConnection, consumer);
 
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(jmsConnection, consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    LifecycleHelper.initAndStart(standaloneConsumer);
 
-      LifecycleHelper.initAndStart(standaloneConsumer);
+    verify(mockVendor).createConsumer(any(), any(), any(JmsConsumer.class));
 
-      verify(mockVendor).createConsumer(any(), any(), any(JmsConsumer.class));
-
-      LifecycleHelper.stopAndClose(standaloneConsumer);
-
-//    } finally {
-//      activeMqBroker.destroy();
-//    }
+    LifecycleHelper.stopAndClose(standaloneConsumer);
   }
 
   @Test
   public void testDefaultFalseDeferConsumerCreationToVendor() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
-
-//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
 
     when(mockVendor.createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class)))
         .thenReturn(mockMessageConsumer);
@@ -136,117 +126,87 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
 
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
-//    try {
-//      activeMqBroker.start();
-
-      JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
 //      consumer.setDeferConsumerCreationToVendor(true);
 
-      JmsConnection jmsConnection = activeMqBroker.getJmsConnection();
-      jmsConnection.setVendorImplementation(mockVendor);
+    JmsConnection jmsConnection = activeMqBroker.getJmsConnection();
+    jmsConnection.setVendorImplementation(mockVendor);
 
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(jmsConnection, consumer);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(jmsConnection, consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      try {
-        LifecycleHelper.initAndStart(standaloneConsumer);
-      } catch (Exception ex) {}
+    try {
+      LifecycleHelper.initAndStart(standaloneConsumer);
+    } catch (Exception ex) {}
 
-      verify(mockVendor, times(0)).createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class));
+    verify(mockVendor, times(0)).createConsumer(any(JmsDestination.class), any(String.class), any(JmsActorConfig.class));
 
-      LifecycleHelper.stopAndClose(standaloneConsumer);
-
-//    } finally {
-//      activeMqBroker.destroy();
-//    }
+    LifecycleHelper.stopAndClose(standaloneConsumer);
   }
 
   @Test
   public void testDurableTopicConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=" + getName();
 
-//    try {
-//      activeMqBroker.start();
+    JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
 
-      JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-
-      StandaloneProducer standaloneProducer =
-          new StandaloneProducer(activeMqBroker.getJmsConnection(), new JmsProducer().withEndpoint(rfc6167));
-      // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
-      LifecycleHelper.prepare(standaloneConsumer);
-      LifecycleHelper.prepare(standaloneProducer);
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-//    } finally {
-//      activeMqBroker.destroy();
-//    }
-
+    StandaloneProducer standaloneProducer =
+        new StandaloneProducer(activeMqBroker.getJmsConnection(), new JmsProducer().withEndpoint(rfc6167));
+    // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
+    LifecycleHelper.prepare(standaloneConsumer);
+    LifecycleHelper.prepare(standaloneProducer);
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testSharedDurableTopicConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-//    EmbeddedArtemis activeMqBroker = new EmbeddedArtemis();
     String rfc6167 = "jms:topic:" + getName() + "?subscriptionId=MySubId&sharedConsumerId=" + getName();
 
-//    try {
-//      activeMqBroker.start();
+    JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
 
-      JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-
-      StandaloneProducer standaloneProducer =
-          new StandaloneProducer(activeMqBroker.getJmsConnection(),
-              new JmsProducer().withEndpoint(rfc6167));
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-//    } finally {
-//      activeMqBroker.destroy();
-//    }
-
+    StandaloneProducer standaloneProducer =
+        new StandaloneProducer(activeMqBroker.getJmsConnection(),
+            new JmsProducer().withEndpoint(rfc6167));
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testSharedTopicConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-//    EmbeddedArtemis activeMqBroker = new EmbeddedArtemis();
     String rfc6167 = "jms:topic:" + getName() + "?sharedConsumerId=" + getName();
 
-//    try {
-//      activeMqBroker.start();
+    JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
 
-      JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-
-      StandaloneProducer standaloneProducer =
-          new StandaloneProducer(activeMqBroker.getJmsConnection(),
-              new JmsProducer().withEndpoint(rfc6167));
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-//    } finally {
-//      activeMqBroker.destroy();
-//    }
+    StandaloneProducer standaloneProducer =
+        new StandaloneProducer(activeMqBroker.getJmsConnection(),
+            new JmsProducer().withEndpoint(rfc6167));
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
 
   }
 
@@ -254,65 +214,44 @@ public class JmsConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
   public void testTopicConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:topic:" + getName();
 
-//    try {
-//      activeMqBroker.start();
+    JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);;
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
 
-      JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);;
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-
-      StandaloneProducer standaloneProducer =
-          new StandaloneProducer(activeMqBroker.getJmsConnection(),
-              new JmsProducer().withEndpoint(rfc6167));
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-//    } finally {
-//      activeMqBroker.destroy();
-//    }
-
+    StandaloneProducer standaloneProducer =
+        new StandaloneProducer(activeMqBroker.getJmsConnection(),
+            new JmsProducer().withEndpoint(rfc6167));
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testQueueConsume() throws Exception {
     Assume.assumeTrue(JmsConfig.jmsTestsEnabled());
 
-//    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String rfc6167 = "jms:queue:" + getName();
 
-//    try {
-//      activeMqBroker.start();
-      JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
+    JmsConsumer consumer = new JmsConsumer().withEndpoint(rfc6167);
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer producer =
-          new StandaloneProducer(activeMqBroker.getJmsConnection(),
-              new JmsProducer().withEndpoint(rfc6167));
-      // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
-      LifecycleHelper.prepare(standaloneConsumer);
-      LifecycleHelper.prepare(producer);
-      execute(standaloneConsumer, producer, createMessage(null), jms);
-      assertMessages(jms, 1);
-//    } finally {
-//      activeMqBroker.destroy();
-//    }
+    StandaloneProducer producer =
+        new StandaloneProducer(activeMqBroker.getJmsConnection(),
+            new JmsProducer().withEndpoint(rfc6167));
+    // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
+    LifecycleHelper.prepare(standaloneConsumer);
+    LifecycleHelper.prepare(producer);
+    execute(standaloneConsumer, producer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
-
-
-
-//  protected BasicActiveMqImplementation createVendorImpl() {
-//    return new BasicActiveMqImplementation();
-//  }
-
 
   @Override
   protected List<?> retrieveObjectsForSampleConfig() {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsMessageConsumerFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsMessageConsumerFactoryTest.java
@@ -89,7 +89,7 @@ public class JmsMessageConsumerFactoryTest {
     mockCreateDestinationAndConsumer(jmsDestination, RFC6167_SUBSCRIPTION);
 
     TopicSubscriber topicSubscriber = mock(TopicSubscriber.class);
-    when(session.createDurableSubscriber(any(Topic.class), eq(FILTER))).thenReturn(topicSubscriber);
+    when(session.createDurableSubscriber(any(Topic.class), eq(SUBSCRIPTION_ID))).thenReturn(topicSubscriber);
 
     JmsMessageConsumerFactory jmsMessageConsumerFactory = new JmsMessageConsumerFactory(mockVendor, session, RFC6167_SUBSCRIPTION, false,
         FILTER,
@@ -98,7 +98,7 @@ public class JmsMessageConsumerFactoryTest {
     MessageConsumer messageConsumer = jmsMessageConsumerFactory.create();
 
     assertEquals(topicSubscriber, messageConsumer);
-    verify(session).createDurableSubscriber(any(Topic.class), eq(FILTER));
+    verify(session).createDurableSubscriber(any(Topic.class), eq(SUBSCRIPTION_ID));
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/EmbeddedArtemis.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/EmbeddedArtemis.java
@@ -20,6 +20,8 @@ import static com.adaptris.interlok.junit.scaffolding.util.PortManager.nextUnuse
 import static com.adaptris.interlok.junit.scaffolding.util.PortManager.release;
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import org.apache.activemq.artemis.core.config.Configuration;
@@ -35,6 +37,7 @@ import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.IdGenerator;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.PlainIdGenerator;
+import com.adaptris.util.TimeInterval;
 
 public class EmbeddedArtemis {
   private static final long MAX_WAIT = 20000;
@@ -149,6 +152,9 @@ public class EmbeddedArtemis {
  private JmsConnection applyCfg(JmsConnection con, StandardJndiImplementation impl, boolean useTcp) {
    con.setClientId(createSafeUniqueId(impl));
    con.setVendorImplementation(impl);
+   con.setConnectionRetryInterval(new TimeInterval(3L, TimeUnit.SECONDS));
+   con.setConnectionAttempts(1);
+   
    return con;
  }
 


### PR DESCRIPTION
## Motivation

Creating a durable subscriber was broken.  However, we were probably getting away with it while testing against ActiveMq because it didn't check to make sure the subscription name was null/empty.  The artemis broker does however which threw an pointed out this error.

## Modification

We're now using the  subscription name when creating a durable subscriber in the JmsMessageConsumerFactory.

I've also used a static embedded broker and set the connection reconnects in an attempt to fix timing issues in the JmsConsumerTest.

## Result

Fingers crossed the unit tests won't fail periodically.

Durable subscribers can now be created correctly.
