### PR TITLE
INTERLOK-3460 xpath service attribute node support

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/path/XPathService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/path/XPathService.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.path;
 
@@ -191,25 +191,25 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @ComponentProfile(summary = "Extract data via XPath and store it", tag = "service,xml")
 @DisplayOrder(order = {"xmlSource", "executions", "namespaceContext", "xmlDocumentFactoryConfig"})
 public class XPathService extends ServiceImp {
-  
+
   @NotNull
   @AutoPopulated
   @Valid
   private DataInputParameter<String> xmlSource;
-  
+
   @NotNull
   @Valid
   @AutoPopulated
   @XStreamImplicit(itemFieldName="xpath-execution")
   private List<Execution> executions;
-  
+
   @AdvancedConfig(rare = true)
   @Valid
   private KeyValuePairSet namespaceContext;
   @AdvancedConfig(rare = true)
   @Valid
   private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
-  
+
   public XPathService() {
     this.setExecutions(new ArrayList<Execution>());
     this.setXmlSource(new StringPayloadDataInputParameter());
@@ -246,21 +246,21 @@ public class XPathService extends ServiceImp {
     }
     return stringBuilder.toString();
   }
-  
+
   private String serializeNode(Node node) throws TransformerException {
-	  DOMSource source = new DOMSource(node);
-	    StringWriter stringWriter = new StringWriter();
-		StreamResult xmlOutput = new StreamResult(stringWriter);
-	    Transformer transformer = TransformerFactory.newInstance().newTransformer();
-	    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-	    if (source.getNode().getNodeType() != Node.ATTRIBUTE_NODE) {
-	        transformer.transform(source, xmlOutput);
-	      } else {
-	        stringWriter.write(source.getNode().getNodeValue());
-	      }
-	    return stringWriter.toString();
+    DOMSource source = new DOMSource(node);
+    StringWriter stringWriter = new StringWriter();
+    StreamResult xmlOutput = new StreamResult(stringWriter);
+    Transformer transformer = TransformerFactory.newInstance().newTransformer();
+    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+    if (source.getNode().getNodeType() != Node.ATTRIBUTE_NODE) {
+      transformer.transform(source, xmlOutput);
+    } else {
+      stringWriter.write(source.getNode().getNodeValue());
+    }
+    return stringWriter.toString();
   }
-  
+
   @Override
   public void prepare() throws CoreException {
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/path/XPathService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/path/XPathService.java
@@ -248,11 +248,17 @@ public class XPathService extends ServiceImp {
   }
   
   private String serializeNode(Node node) throws TransformerException {
-    StreamResult xmlOutput = new StreamResult(new StringWriter());
-    Transformer transformer = TransformerFactory.newInstance().newTransformer();
-    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-    transformer.transform(new DOMSource(node), xmlOutput);
-    return xmlOutput.getWriter().toString();
+	  DOMSource source = new DOMSource(node);
+	    StringWriter stringWriter = new StringWriter();
+		StreamResult xmlOutput = new StreamResult(stringWriter);
+	    Transformer transformer = TransformerFactory.newInstance().newTransformer();
+	    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+	    if (source.getNode().getNodeType() != Node.ATTRIBUTE_NODE) {
+	        transformer.transform(source, xmlOutput);
+	      } else {
+	        stringWriter.write(source.getNode().getNodeValue());
+	      }
+	    return stringWriter.toString();
   }
   
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/XpathMetadataServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/XpathMetadataServiceTest.java
@@ -28,6 +28,10 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.Execution;
+import com.adaptris.core.common.MetadataDataOutputParameter;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.services.metadata.xpath.ConfiguredXpathQuery;
 import com.adaptris.core.services.metadata.xpath.MetadataXpathQuery;
 import com.adaptris.core.services.metadata.xpath.MultiItemConfiguredXpathQuery;
@@ -43,7 +47,7 @@ public class XpathMetadataServiceTest extends MetadataServiceExample {
 
   public static final String XML = "<?xml version=\"1.0\"?><message><message-type>order"
       + "</message-type><source-id>partnera</source-id><destination-id>" + "partnerb</destination-id><body>...</body>"
-      + "<extra att=\"att\">one</extra><extra att=\"two\">two</extra>" + "<extra att=\"two\">three</extra></message>";
+      + "<extra att=\"att\">one</extra><extraa att=\"two\">two</extraa>" + "<extrab att=\"two\">three</extrab></message>";
 
   public static final String XML_WITH_NAMESPACE = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
       + "<svrl:schematron-output xmlns:svrl=\"http://purl.oclc.org/dsdl/svrl\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:sch=\"http://www.ascc.net/xml/schematron\" xmlns:iso=\"http://purl.oclc.org/dsdl/schematron\" xmlns:dp=\"http://www.dpawson.co.uk/ns#\" title=\"Anglia Farmers AF xml Invoice Schematron File\" schemaVersion=\"ISO19757-3\">\n"
@@ -98,6 +102,26 @@ public class XpathMetadataServiceTest extends MetadataServiceExample {
     execute(service, msg);
     assertEquals("partnera", msg.getMetadataValue("source"));
     assertEquals("partnerb", msg.getMetadataValue("destination"));
+  }
+  
+  @Test
+  public void testPayloadSingleAttributeValueXPathIntoMetadata() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
+    XpathMetadataService service = new XpathMetadataService();
+    service.addXpathQuery(new ConfiguredXpathQuery("attribute", "//extra/@att"));
+    service.addXpathQuery(new ConfiguredXpathQuery("attr", "//extraa/@att"));
+    execute(service, msg);
+    assertEquals("att", msg.getMetadataValue("attribute"));
+    assertEquals("two", msg.getMetadataValue("attr"));
+  }
+  
+  @Test
+  public void testPayloadMultipleAttributeValuesXPathIntoMetadata() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
+    XpathMetadataService service = new XpathMetadataService();
+    service.addXpathQuery(new MultiItemConfiguredXpathQuery("attribute", "//@att"));
+    execute(service, msg);
+    assertEquals("att|two|two", msg.getMetadataValue("attribute"));
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/path/XPathServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/path/XPathServiceTest.java
@@ -83,6 +83,26 @@ public class XPathServiceTest
   }
 
   @Test
+  public void testPayloadAttributeValueXPathIntoMetadata() throws Exception {
+    message.setContent(attributeXml, message.getContentEncoding());
+
+    MetadataDataOutputParameter metadataDataDestination1 = new MetadataDataOutputParameter("targetMetadataKey");
+
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter("//some/random/xml/node1/@attr");
+
+    Execution execution = new Execution(constantDataDestination, metadataDataDestination1);
+
+    List<Execution> executions = new ArrayList<>();
+    executions.add(execution);
+
+    service.setXmlSource(new StringPayloadDataInputParameter());
+    service.setExecutions(executions);
+    execute(service, message);
+
+    assertEquals("attribute value", message.getMetadataValue("targetMetadataKey"));
+  }
+
+  @Test
   public void testForCoveragePurposesInvalidXml() throws Exception {
     message.setContent("not valid xml!", message.getContentEncoding());
 
@@ -268,6 +288,17 @@ public class XPathServiceTest
           + "</xml>"
         + "</random>"
       + "</some>";
+  
+  private String attributeXml = ""
+	      + "<some>"
+	        + "<random>"
+	          + "<xml>"
+	            + "<node1 attr=\"attribute value\">value1</node1>"
+	            + "<node2>value2</node2>"
+	            + "<node3>value3</node3>"
+	          + "</xml>"
+	        + "</random>"
+	      + "</some>";
 
   private String sampleXmlWithInternalNamespaces = ""
       + "<some xmlns:some=\"http://adaptris.com/xml/some\">"

--- a/interlok-core/src/test/java/com/adaptris/core/services/path/XPathServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/path/XPathServiceTest.java
@@ -84,7 +84,7 @@ public class XPathServiceTest
 
   @Test
   public void testPayloadAttributeValueXPathIntoMetadata() throws Exception {
-    message.setContent(attributeXml, message.getContentEncoding());
+    message.setContent(sampleXml, message.getContentEncoding());
 
     MetadataDataOutputParameter metadataDataDestination1 = new MetadataDataOutputParameter("targetMetadataKey");
 
@@ -161,7 +161,7 @@ public class XPathServiceTest
     service.setExecutions(executions);
     execute(service, message);
 
-    assertEquals("<node1>value1</node1>", message.getMetadataValue("targetMetadataKey"));
+    assertEquals("<node1 attr=\"attribute value\">value1</node1>", message.getMetadataValue("targetMetadataKey"));
   }
 
   @Test
@@ -282,23 +282,12 @@ public class XPathServiceTest
       + "<some>"
         + "<random>"
           + "<xml>"
-            + "<node1>value1</node1>"
+            + "<node1 attr=\"attribute value\">value1</node1>"
             + "<node2>value2</node2>"
             + "<node3>value3</node3>"
           + "</xml>"
         + "</random>"
       + "</some>";
-  
-  private String attributeXml = ""
-	      + "<some>"
-	        + "<random>"
-	          + "<xml>"
-	            + "<node1 attr=\"attribute value\">value1</node1>"
-	            + "<node2>value2</node2>"
-	            + "<node3>value3</node3>"
-	          + "</xml>"
-	        + "</random>"
-	      + "</some>";
 
   private String sampleXmlWithInternalNamespaces = ""
       + "<some xmlns:some=\"http://adaptris.com/xml/some\">"


### PR DESCRIPTION
## Motivation

Why am I doing this

I discovered that when retrieving a single attribute node in the XPath Service the service would simply throw an exception rather than return the value

## Modification

What did I change

I updated the Xpath service to resolve attribute nodes and updated the service's tests to reflect this.

## Result

What's the end result for the user

The user can now resolve single attribute nodes with the Xpath service

## Testing

How can I test this if I'm reviewing this.

The tests have been updated and cover the changes.
You can also build the project, drop the jar into a working adapter and query an xpath attribute node to confirm
