### PR TITLE
INTERLOK-340 Deprecate PbeCrypto

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/security/password/Password.java
+++ b/interlok-core/src/main/java/com/adaptris/security/password/Password.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.adaptris.annotation.Removal;
 import com.adaptris.security.exc.PasswordException;
 
 /**
@@ -56,18 +57,23 @@ public abstract class Password {
    */
   public static final String PORTABLE_PASSWORD = "PW:";
   /**
-   * Alternative password style which is not portable across environments and
-   * machines
+   * Alternative password style which is not portable across environments and machines
    * <p>
-   * It is not considered especially secure, but is enough to stop casual
-   * interrogation
+   * It is not considered especially secure, but is enough to stop casual interrogation
    * </p>
+   *
+   * @deprecated since 3.11.1 since the implementation {@link PbeCrypto} this uses
+   *             PBEWithSHA1AndDESede which is a weak algorithm. This will be removed w/o warning.
+   *
    */
+  @Deprecated
+  @Removal(version = "4.0",
+      message = "This uses PBEWithSHA1AndDESede which is now cryptographically weak")
   public static final String NON_PORTABLE_PASSWORD = "ALTPW:";
 
   private static final String[] STYLES =
   {
-      MSCAPI_STYLE, PORTABLE_PASSWORD, NON_PORTABLE_PASSWORD
+          MSCAPI_STYLE, PORTABLE_PASSWORD
   };
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/security/password/PbeCrypto.java
+++ b/interlok-core/src/main/java/com/adaptris/security/password/PbeCrypto.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,18 +17,23 @@
 package com.adaptris.security.password;
 
 import static com.adaptris.security.password.Password.NON_PORTABLE_PASSWORD;
-
 import java.net.InetAddress;
-
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.PBEParameterSpec;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.security.exc.PasswordException;
 import com.adaptris.util.text.Base64ByteTranslator;
 
+/**
+ * deprecated since 3.11.1 since this uses PBEWithSHA1AndDESede which is a weak algorithm.
+ *
+ */
+@Deprecated
+@Removal(version = "4.0",
+    message = "This uses PBEWithSHA1AndDESede which is now cryptographically weak")
 public class PbeCrypto extends PasswordImpl {
 
     private static final byte[] SALT = { (byte)0xE1, (byte)0x1D, (byte)0x2B, (byte)0xE2, (byte)0x89, (byte)0x45, (byte)0x53, (byte)0xF7,
@@ -37,7 +42,7 @@ public class PbeCrypto extends PasswordImpl {
                                          (byte)0x4C, (byte)0x0F, (byte)0x96, (byte)0x3F, (byte)0x8F, (byte)0x18, (byte)0xC8, (byte)0x7C };
 
   private static final int ITERATIONS = 20;
-  private static final String ALGORITHM = "PBEWithSHA1AndDESede";
+  private static final String ALGORITHM = "PBEWithSHA1AndDESede"; // lgtm [java/weak-cryptographic-algorithm]
   private Base64ByteTranslator base64;
 
   private String hostname;
@@ -52,10 +57,12 @@ public class PbeCrypto extends PasswordImpl {
     }
   }
 
+  @Override
   public boolean canHandle(String type) {
     return type != null && type.startsWith(NON_PORTABLE_PASSWORD);
   }
 
+  @Override
   public String decode(String encrypted, String charset) throws PasswordException {
     String encryptedString = encrypted;
     String result = null;
@@ -65,9 +72,9 @@ public class PbeCrypto extends PasswordImpl {
     try {
       PBEParameterSpec pbeParamSpec = new PBEParameterSpec(SALT, ITERATIONS);
       PBEKeySpec pbeKeySpec = new PBEKeySpec(hostname.toCharArray());
-      SecretKeyFactory keyFac = SecretKeyFactory.getInstance(ALGORITHM);
+      SecretKeyFactory keyFac = SecretKeyFactory.getInstance(ALGORITHM); // lgtm [java/weak-cryptographic-algorithm]
       SecretKey pbeKey = keyFac.generateSecret(pbeKeySpec);
-      Cipher pbeCipher = Cipher.getInstance(ALGORITHM);
+      Cipher pbeCipher = Cipher.getInstance(ALGORITHM); // lgtm [java/weak-cryptographic-algorithm]
       pbeCipher.init(Cipher.DECRYPT_MODE, pbeKey, pbeParamSpec);
       byte[] decrypted = pbeCipher.doFinal(base64.translate(encryptedString));
       result = unseed(decrypted, charset);
@@ -78,14 +85,15 @@ public class PbeCrypto extends PasswordImpl {
     return result;
   }
 
+  @Override
   public String encode(String plainText, String charset) throws PasswordException {
     byte[] encrypted = new byte[0];
     try {
       PBEParameterSpec pbeParamSpec = new PBEParameterSpec(SALT, ITERATIONS);
       PBEKeySpec pbeKeySpec = new PBEKeySpec(hostname.toCharArray());
-      SecretKeyFactory keyFac = SecretKeyFactory.getInstance(ALGORITHM);
+      SecretKeyFactory keyFac = SecretKeyFactory.getInstance(ALGORITHM); // lgtm [java/weak-cryptographic-algorithm]
       SecretKey pbeKey = keyFac.generateSecret(pbeKeySpec);
-      Cipher pbeCipher = Cipher.getInstance(ALGORITHM);
+      Cipher pbeCipher = Cipher.getInstance(ALGORITHM); // lgtm [java/weak-cryptographic-algorithm]
       pbeCipher.init(Cipher.ENCRYPT_MODE, pbeKey, pbeParamSpec);
       encrypted = pbeCipher.doFinal(seed(plainText, charset));
     }

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/PasswordProtectedDatabaseConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/PasswordProtectedDatabaseConnectionTest.java
@@ -71,7 +71,7 @@ public class PasswordProtectedDatabaseConnectionTest
   public void testConnect_WithEncryptedPassword() throws Exception {
     if (Boolean.parseBoolean(PROPERTIES.getProperty(KEY_TESTS_ENABLED, "false"))) {
       DatabaseConnection con = createConnection();
-      con.setPassword(Password.encode(PROPERTIES.getProperty(KEY_JDBC_PASSWORD), Password.NON_PORTABLE_PASSWORD));
+      con.setPassword(Password.encode(PROPERTIES.getProperty(KEY_JDBC_PASSWORD), Password.PORTABLE_PASSWORD));
       LifecycleHelper.init(con);
       Connection sqlConnection = con.connect();
     }

--- a/interlok-core/src/test/java/com/adaptris/core/security/EncryptionServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/EncryptionServiceCase.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -123,7 +123,8 @@ public abstract class EncryptionServiceCase extends SecurityServiceCase {
 
     DecryptionService output = new DecryptionService();
     applyConfigForTests(output,
-        new ConfiguredUrl(url, Password.encode(PROPERTIES.getProperty(SECURITY_PASSWORD), Password.NON_PORTABLE_PASSWORD)));
+        new ConfiguredUrl(url, Password.encode(PROPERTIES.getProperty(SECURITY_PASSWORD),
+            Password.PORTABLE_PASSWORD)));
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(EXAMPLE_MSG);
     execute(input, msg);
     execute(output, msg);

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/jms/JndiImplementationCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/jms/JndiImplementationCase.java
@@ -214,7 +214,7 @@ public abstract class JndiImplementationCase {
 
     jv.getJndiParams().addKeyValuePair(new KeyValuePair("UserName", RequiresCredentialsBroker.DEFAULT_USERNAME));
     jv.getJndiParams().addKeyValuePair(
-        new KeyValuePair("Password", Password.encode(RequiresCredentialsBroker.DEFAULT_PASSWORD, Password.NON_PORTABLE_PASSWORD)));
+        new KeyValuePair("Password", Password.encode(RequiresCredentialsBroker.DEFAULT_PASSWORD, Password.PORTABLE_PASSWORD)));
     jv.setEncodedPasswordKeys("Password");
     StandaloneProducer standaloneProducer = new StandaloneProducer(c, producer);
     try {
@@ -239,7 +239,7 @@ public abstract class JndiImplementationCase {
 
     jv.getJndiParams().addKeyValuePair(new KeyValuePair("UserName", RequiresCredentialsBroker.DEFAULT_USERNAME));
     jv.getJndiParams().addKeyValuePair(
-        new KeyValuePair("Password", Password.encode(RequiresCredentialsBroker.DEFAULT_PASSWORD, Password.NON_PORTABLE_PASSWORD)));
+        new KeyValuePair("Password", Password.encode(RequiresCredentialsBroker.DEFAULT_PASSWORD, Password.PORTABLE_PASSWORD)));
     jv.setEncodedPasswordKeys("Password");
     jv.setEnableEncodedPasswords(true);
     StandaloneProducer standaloneProducer = new StandaloneProducer(c, producer);
@@ -264,7 +264,7 @@ public abstract class JndiImplementationCase {
     JmsConnection c = broker.getJndiPasConnection(jv, false, queueName, topicName);
     jv.getJndiParams().addKeyValuePair(new KeyValuePair("UserName", RequiresCredentialsBroker.DEFAULT_USERNAME));
     jv.getJndiParams().addKeyValuePair(
-        new KeyValuePair("Password", Password.encode(RequiresCredentialsBroker.DEFAULT_PASSWORD, Password.NON_PORTABLE_PASSWORD)));
+        new KeyValuePair("Password", Password.encode(RequiresCredentialsBroker.DEFAULT_PASSWORD, Password.PORTABLE_PASSWORD)));
     StandaloneProducer standaloneProducer = new StandaloneProducer(c, producer);
     try {
       broker.start();

--- a/interlok-core/src/test/java/com/adaptris/security/TestPassword.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestPassword.java
@@ -44,12 +44,14 @@ public class TestPassword {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testNonPortableStyle() throws Exception {
     PasswordCodec pw = Password.create(Password.NON_PORTABLE_PASSWORD);
     assertEquals(PW, pw.decode(pw.encode(PW)));
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testNonPortaableStyleWithCharset() throws Exception {
     PasswordCodec pw = Password.create(Password.NON_PORTABLE_PASSWORD);
     assertEquals(PW, pw.decode(pw.encode(PW, CHARSET), CHARSET));

--- a/interlok-core/src/test/java/com/adaptris/security/password/PasswordTest.java
+++ b/interlok-core/src/test/java/com/adaptris/security/password/PasswordTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.interlok.junit.scaffolding.util.Os;
@@ -57,6 +58,7 @@ public class PasswordTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testNonPortable() throws Exception {
     String encoded = Password.encode(TEXT, Password.NON_PORTABLE_PASSWORD);
     assertEquals(TEXT, Password.decode(encoded));
@@ -64,9 +66,8 @@ public class PasswordTest {
 
   @Test
   public void testMicrosoftCrypto() throws Exception {
-    if (Os.isFamily(Os.WINDOWS_NT_FAMILY)) {
-      String encoded = Password.encode(TEXT, Password.MSCAPI_STYLE);
-      assertEquals(TEXT, Password.decode(encoded));
-    }
+    Assume.assumeTrue(Os.isFamily(Os.WINDOWS_NT_FAMILY));
+    String encoded = Password.encode(TEXT, Password.MSCAPI_STYLE);
+    assertEquals(TEXT, Password.decode(encoded));
   }
 }


### PR DESCRIPTION
## Motivation

https://lgtm.com/rules/7870098/ rightly marks `PBEWithSHA1AndDESede` as weak crypto.

Since as a style `ALTPW` is unloved (the UI doesn't support, it's not effectively transferable across hosts); it is of little impact to deprecate it and mark it for removal

## Modification

- Deprecate ALTPW: and supporting files; marking for removal in 4.0
- Remove from the list that's emitted as the help for Password#main()
- Remove use of ALTPW internally within the tests.
- Mark with lgtm exclusion on the line's using the weak crypto.


## Result

- The UI doesn't support it, so there's no change to the user.

## Testing

- The tests still pass; since the only change is annotational / documentation.
