### PR TITLE
ADR-0009 proxy message factory.

### DIFF
--- a/docs/adr/0009-mutable-messages.md
+++ b/docs/adr/0009-mutable-messages.md
@@ -28,8 +28,7 @@ What are the options that we can provide to mitigate the problem.
 
 ## Decision Outcome
 
-Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver , which resolves force force , ... , comes out best (see below)].
-
+...
 
 ### Do Nothing
 

--- a/docs/adr/0009-mutable-messages.md
+++ b/docs/adr/0009-mutable-messages.md
@@ -25,6 +25,7 @@ What are the options that we can provide to mitigate the problem.
 - Do Nothing
 - Custom JSON parsing message factory
 - Mutable Message
+- Streaming Workflow
 
 ## Decision Outcome
 
@@ -155,3 +156,9 @@ Since it's a readonly message; it still has the same caveats as mentioned above.
 - Unknown, Does S3 give us an InputStream or is it the case that the DownloadManager doesn't expose that to us.
 - Unknown, We use TransferManager which multiplexes the download (to make it faster) -> if we're reading directly from the InputStream does this even help?
 - Unknown, Needs prototyping and testing for speed...
+
+
+## Streaming Workflow
+
+- Or Streaming Service... TBC
+

--- a/docs/adr/0009-mutable-messages.md
+++ b/docs/adr/0009-mutable-messages.md
@@ -151,6 +151,7 @@ Since it's a readonly message; it still has the same caveats as mentioned above.
 - Good, because this isn't "tied" to the specific use-case.
 - Bad, because we have to guarantee that nothing ever touches the payload
 - Bad, If you use `%payload{jsonpath:$.1.2.3}` is still possible but has a huge performance hit every every time (might just throw an UnsupportedOperationException here)
+- Bad, The internal shortcuts that know about FileBackedMessageFactory would be broken because `instanceOf` is no longer valid.
 - Unknown, Does S3 give us an InputStream or is it the case that the DownloadManager doesn't expose that to us.
 - Unknown, We use TransferManager which multiplexes the download (to make it faster) -> if we're reading directly from the InputStream does this even help?
 - Unknown, Needs prototyping and testing for speed...

--- a/docs/adr/0009-mutable-messages.md
+++ b/docs/adr/0009-mutable-messages.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: 0009-mutable-message-factory
+title: 0009-mutable-messages
 ---
-# Mutable message factory
+# Mutable message
 
 * Status: DRAFT
 * Deciders: Lewin Chan, Matt Warman, Aaron McGrath, Sebastien Belin
@@ -12,65 +12,148 @@ Technical Story: [description , ticket/issue URL] <!-- optional -->
 
 ## Context and Problem Statement
 
-[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+There is a specific use-case where Interlok may have possibly been the wrong choice (gasp!) and it is essentially doing this
 
-## Decision Drivers <!-- optional -->
+![Sequence](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/adaptris/interlok/ADR-0009-mutable-messages/docs/adr/assets/0009-mutable-messages-usecase.puml)
 
-* [driver 1, e.g., a force, facing concern, ...]
-* [driver 2, e.g., a force, facing concern, ...]
-* ... <!-- numbers of drivers can vary -->
+It's essentially behaving as a passthrough stream of data into Elasticsearch. It's arguable that this is the wrong approach but ![Interlok Hammer](https://img.shields.io/badge/certified-interlok%20hammer-red.svg)
+
+- There is an IOPS cost for Interlok to download and then subsequently stream it into Elasticsearch; we aren't doing any thing with the payload.
+
+What are the options that we can provide to mitigate the problem.
 
 ## Considered Options
 
-* [option 1]
-* [option 2]
-* [option 3]
-* ... <!-- numbers of options can vary -->
+- Do Nothing
+- Custom JSON parsing message factory
+- Mutable Message
 
 ## Decision Outcome
 
 Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver , which resolves force force , ... , comes out best (see below)].
 
-### Positive Consequences <!-- optional -->
 
-* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, ...]
-* ...
+### Do Nothing
 
-### Negative consequences <!-- optional -->
+Behaviour remains the same, they can probably scale the EC2 instance so that it has more performance in situations like this.
+Since it's primarily an asynchronous process; then it's perfectly reasonable to offload this to a messaging backbone for horizontal scalability.
 
-* [e.g., compromising quality attribute, follow-up decisions required, ...]
-* ...
+#### Good/bad considerations.
 
-## Pros and Cons of the Options <!-- optional -->
+* Good, because work is hard.
 
-### [option 1]
+### JSON + S3 aware AdaptrisMessageFactory
 
-[example , description , pointer to more information , ...] <!-- optional -->
+Since this is a specialised use case we can effectively write our own splitter instance such that the message factory knows how to connect to S3, and have a read only inputStream that streams directly from the file.
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+Since the large-json-array-splitter effectively does this (in code)
 
-### [option 2]
+```java
+protected AdaptrisMessage constructAdaptrisMessage() throws IOException {
+  AdaptrisMessage tmpMessage = newMessage();
+  if (parser.nextToken() == JsonToken.START_OBJECT) {
+    ObjectNode node = mapper.readTree(parser);
+    tmpMessage.setStringPayload(node.toString());
+    return addMetadata(tmpMessage);
+  }
+  return null;
+}
+```
 
-[example , description , pointer to more information , ...] <!-- optional -->
+Then we can have additional behaviour the "first time" we call setStringPayload()/setContent() around parsing the JSON payload and then attempting to wrap the S3 blob effectively replace the _N>1 JSON path operations_ and _Get JSON Blob_ steps inside the message factory.
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+Our caveats would have to be
+- getInputStream / getReader() can be called multiple times, and each call will open a direct inputstream to the S3 object.
+- getOutputStream / getWriter() always throws an exception (so we don't replace the S3 blob)
+  - Or it's allowed once and once only.
+- setStringPayload/setContent is allowed once and once only.
+- If you use `%payload{jsonpath:$.1.2.3}` is still possible but has a huge performance hit every every time (might just throw an UnsupportedOperationException here)
 
-### [option 3]
+How this manifests itself is something like this :
 
-[example , description , pointer to more information , ...] <!-- optional -->
+```xml
+<services>
+  <advanced-message-splitter-service>
+    <unique-id>iterate-over-list-files-results</unique-id>
+    <splitter class=”json-array-splitter”>
+      <message-factory class=”json-readonly-s3-message-factory”>
+        <s3-connection class=”aws-s3-connection”/>
+        <path-to-s3-bucket>$.bucketName</path-to-s3-bucket>
+        <path-to-prefix>$.prefix</path-to-prefix>
+        <path-to-name>$.name</path-to-name>
+      </message-factory>
+    </splitter>
+    <service class="service-list">
+      <services>
+        <standalone-producer>
+          <producer class="elastic-rest-bulk-operation"/>
+        </standalone-producer>
+      </services>
+    </service>
+  </advanced-message-splitter>
+</services>
+```
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+#### Good/bad considerations.
 
-## Links <!-- optional -->
+- Good, we never "download the file" until we need to.
+- Bad, because we have to guarantee that nothing ever touches the payload
+- Bad, If you use `%payload{jsonpath:$.1.2.3}` is still possible but has a huge performance hit every every time (might just throw an UnsupportedOperationException here)
+- Unknown, Does S3 give us an InputStream or is it the case that the DownloadManager doesn't expose that to us.
+- Unknown, We use TransferManager which multiplexes the download (to make it faster) -> if we're reading directly from the InputStream does this even help?
+- Unknown, Needs prototyping and testing for speed...
 
-* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
-* ... <!-- numbers of links can vary -->
+### Mutable Message / Mutable Message Factory.
+
+AdaptrisMessage beheaviour isn't mutable at the moment; it's either FileBacked / ZipFileBacked or all in memory. You make that decision when you configure the consumer.
+
+What if we had effectively an AdaptrisMessage implementation that simply proxies other AdaptrisMessage instances. This means we can change the underlying type without impacting behaviour that much.
+
+What does this mean in terms of configuration. I see it as something like this.
+
+```xml
+<services>
+  <advanced-message-splitter-service>
+    <unique-id>iterate-over-list-files-results</unique-id>
+    <splitter class="json-array-splitter">
+       <message-factory class="mutable-message-factory">
+         <base-factory class="default-message-factory"/>
+       </message-factory>
+    </splitter>
+    <service class="service-list">
+      <services>
+        <json-path-service selecting the stuffs/>
+        <mutate-message>
+          <message-factory class="s3-read-only-backed-message-factory">
+            <connection class="s3-aws-connection"/>
+            <bucket>%message{bucket}</bucket>
+            <object-name>%message{id}</object-name>
+          </message-factory>
+        </mutate-message>
+        <standalone-producer>
+          <producer class="elastic-rest-bulk-operation"/>
+        </standalone-producer>
+      </services>
+    </service>
+  </advanced-message-splitter-service>
+</services>
+```
+
+For the use-case in question it's effectively a few new classes.
+- a new `mutable-message-factory` that creates a proxy message instance.
+   - a new `mutable-message` that does the proxying.
+- a new `mutate-message` service that allows you to switch the underlying message implementation.
+- a new `s3-readonly-message-factory` that knows to build an inputstream from s3://
+   - a new s3-readonly-message.
+
+Since it's a readonly message; it still has the same caveats as mentioned above.
+
+#### Good/bad considerations.
+
+- Good, we never "download the file" until we need to.
+- Good, because this isn't "tied" to the specific use-case.
+- Bad, because we have to guarantee that nothing ever touches the payload
+- Bad, If you use `%payload{jsonpath:$.1.2.3}` is still possible but has a huge performance hit every every time (might just throw an UnsupportedOperationException here)
+- Unknown, Does S3 give us an InputStream or is it the case that the DownloadManager doesn't expose that to us.
+- Unknown, We use TransferManager which multiplexes the download (to make it faster) -> if we're reading directly from the InputStream does this even help?
+- Unknown, Needs prototyping and testing for speed...

--- a/docs/adr/0009-mutable-messages.md
+++ b/docs/adr/0009-mutable-messages.md
@@ -6,9 +6,7 @@ title: 0009-mutable-messages
 
 * Status: DRAFT
 * Deciders: Lewin Chan, Matt Warman, Aaron McGrath, Sebastien Belin
-* Date: 2020-10-07
-
-Technical Story: [description , ticket/issue URL] <!-- optional -->
+* Date: 2020-10-08
 
 ## Context and Problem Statement
 

--- a/docs/adr/assets/0009-mutable-messages-usecase.puml
+++ b/docs/adr/assets/0009-mutable-messages-usecase.puml
@@ -1,0 +1,50 @@
+@startuml "Triggered Error Handler"
+
+participant External
+participant Interlok
+participant S3
+
+== Runtime Processing ==
+External->Interlok: start processing
+activate Interlok
+alt happy
+  Interlok->Interlok: process
+else sad
+  Interlok->Interlok: trigger error handler
+  note left of Interlok
+  workflowId should already be populated as
+  metadata upon entry into the error-handler
+  end note
+  Interlok->S3: write raw payload
+  Interlok->S3: write metadata
+  note left of S3
+  The "resulting blobs" should be
+  /bucket/<interlok-uid>/<msg-id>/payload.bin
+  (application/octet-stream)
+  /bucket/<interlok-uid>/<msg-id>/metadata.properties
+  (text/plain)
+  end note
+  Interlok->External: Alert?
+end
+deactivate Interlok
+
+== Retry Message ==
+opt RetryFromJetty
+  External->Interlok: POST /api/retry/<msgid>
+  activate Interlok
+  Interlok->S3: GET /bucket/<interlok-uid>/<msg-id>/payload.bin
+  Interlok->S3: GET /bucket/<interlok-uid>/<msg-id>/metadata.properties
+  Interlok->Interlok: Submit to workflow.
+  return 200 OK
+end
+
+== View Failed Messages ==
+opt RetryFromJetty
+  External->Interlok: GET /api/list-failed
+  activate Interlok
+  Interlok->S3: List the contents of /bucket/<interlok-uid>/
+  Interlok->Interlok: Render as JSON
+  return 200 OK + data
+end
+
+@enduml

--- a/docs/adr/assets/0009-mutable-messages-usecase.puml
+++ b/docs/adr/assets/0009-mutable-messages-usecase.puml
@@ -1,50 +1,23 @@
-@startuml "Triggered Error Handler"
+@startuml
 
+title Stream to Elastic
 participant External
 participant Interlok
 participant S3
+participant Elastic
 
-== Runtime Processing ==
 External->Interlok: start processing
 activate Interlok
-alt happy
-  Interlok->Interlok: process
-else sad
-  Interlok->Interlok: trigger error handler
-  note left of Interlok
-  workflowId should already be populated as
-  metadata upon entry into the error-handler
-  end note
-  Interlok->S3: write raw payload
-  Interlok->S3: write metadata
-  note left of S3
-  The "resulting blobs" should be
-  /bucket/<interlok-uid>/<msg-id>/payload.bin
-  (application/octet-stream)
-  /bucket/<interlok-uid>/<msg-id>/metadata.properties
-  (text/plain)
-  end note
-  Interlok->External: Alert?
+Interlok->S3: list bucket
+activate S3
+return JSON Array
+loop for each element in array
+  Interlok->Interlok: N>1 JSON path operations
+  Interlok->S3: Get JSON blob
+  activate S3
+  return  JSON blob
+  Interlok->Elastic: BatchIndex
 end
-deactivate Interlok
-
-== Retry Message ==
-opt RetryFromJetty
-  External->Interlok: POST /api/retry/<msgid>
-  activate Interlok
-  Interlok->S3: GET /bucket/<interlok-uid>/<msg-id>/payload.bin
-  Interlok->S3: GET /bucket/<interlok-uid>/<msg-id>/metadata.properties
-  Interlok->Interlok: Submit to workflow.
-  return 200 OK
-end
-
-== View Failed Messages ==
-opt RetryFromJetty
-  External->Interlok: GET /api/list-failed
-  activate Interlok
-  Interlok->S3: List the contents of /bucket/<interlok-uid>/
-  Interlok->Interlok: Render as JSON
-  return 200 OK + data
-end
+return 202
 
 @enduml


### PR DESCRIPTION
## Motivation

There is a specific use-case where Interlok may have possibly been the wrong choice. It's essentially behaving as a passthrough stream of data into Elasticsearch. It's arguable that this is the wrong approach but ![Interlok Hammer](https://img.shields.io/badge/certified-interlok%20hammer-red.svg)

What can we do to mitigate the IOPS cost that happens when we download an S3 blob and then essentially call some other relatively expensive operation with the contents of the blob.

Pre Merge : https://github.com/adaptris/interlok/blob/ADR-0009-mutable-messages/docs/adr/0009-mutable-messages.md
Post Merge : https://github.com/adaptris/interlok/blob/develop/docs/adr/0009-mutable-messages.md
