### PR TITLE
Feature/interlok 3287 new extended validation reporting for deprecated items

### DIFF
--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/BooleanExpression.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/BooleanExpression.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.validation.constraints;
 
 import java.lang.annotation.Documented;

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/BooleanExpressionValidator.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/BooleanExpressionValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.validation.constraints;
 
 public class BooleanExpressionValidator extends ExpressionValidator<BooleanExpression> {

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/ConfigDeprecated.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/ConfigDeprecated.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.validation.constraints;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Annotation that specifies when a deprecated field/type will be removed.
+ *
+ * @since 3.8.2
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = ConfigDeprecatedValidator.class)
+public @interface ConfigDeprecated {
+
+  String MESSAGE_TEMPLATE = "{com.adaptris.validation.constraints.ConfigDeprecated.message}";
+  String DEFAULT_VERSION = "a future version";
+
+  /**
+   * The deprecation message
+   */
+  String message() default MESSAGE_TEMPLATE;
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  /**
+   * The version when it will be removed.
+   *
+   */
+  String removalVersion() default DEFAULT_VERSION;
+
+}

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/ConfigDeprecated.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/ConfigDeprecated.java
@@ -24,9 +24,10 @@ import javax.validation.Constraint;
 import javax.validation.Payload;
 
 /**
- * Annotation that specifies when a deprecated field/type will be removed.
+ * Annotation that specifies when a deprecated field/type will be removed. It should be used with the Deprecated.class group to be used with
+ * the deprecation config checker: <em>@ConfigDeprecated(groups = Deprecated.class)</em>
  *
- * @since 3.8.2
+ * @since 3.11.1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/ConfigDeprecatedValidator.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/ConfigDeprecatedValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.validation.constraints;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ConfigDeprecatedValidator implements ConstraintValidator<ConfigDeprecated, Object> {
+
+  @Override
+  public boolean isValid(Object value, ConstraintValidatorContext context) {
+    boolean isValid = value == null;
+
+    if (!isValid && "".equals(context.getDefaultConstraintMessageTemplate())) {
+      context.disableDefaultConstraintViolation();
+      context.buildConstraintViolationWithTemplate(ConfigDeprecated.MESSAGE_TEMPLATE)
+      .addConstraintViolation();
+    }
+
+    return isValid;
+  }
+
+}

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/ExpressionValidator.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/ExpressionValidator.java
@@ -1,6 +1,20 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.validation.constraints;
-
-
 
 import java.lang.annotation.Annotation;
 

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/NumberExpression.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/NumberExpression.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.validation.constraints;
 
 import java.lang.annotation.Documented;

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/NumberExpressionValidator.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/NumberExpressionValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.validation.constraints;
 
 public class NumberExpressionValidator extends ExpressionValidator<NumberExpression> {

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/UrlExpression.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/UrlExpression.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.validation.constraints;
 
 import java.lang.annotation.Documented;

--- a/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/UrlExpressionValidator.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/validation/constraints/UrlExpressionValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.validation.constraints;
 
 import java.net.MalformedURLException;

--- a/interlok-core-apt/src/main/resources/ValidationMessages.properties
+++ b/interlok-core-apt/src/main/resources/ValidationMessages.properties
@@ -3,3 +3,5 @@ com.adaptris.validation.constraints.BooleanExpression.message=Should be a boolea
 com.adaptris.validation.constraints.NumberExpression.message=Should be a number or an expression matching "{pattern}"
 
 com.adaptris.validation.constraints.UrlExpression.message=Should be a url or an expression matching "{pattern}"
+
+com.adaptris.validation.constraints.ConfigDeprecated.message=Is deprecated. It will be removed in {removalVersion}

--- a/interlok-core-apt/src/test/java/com/adaptris/validation/constraints/ConfigDeprecatedValidatorTest.java
+++ b/interlok-core-apt/src/test/java/com/adaptris/validation/constraints/ConfigDeprecatedValidatorTest.java
@@ -1,0 +1,141 @@
+package com.adaptris.validation.constraints;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConfigDeprecatedValidatorTest {
+  private final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+
+  @Test
+  public void testValidConfig() {
+    TestBean testBean = new TestBean();
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean, Deprecated.class);
+
+    Assert.assertTrue(constraintViolations.isEmpty());
+  }
+
+  @Test
+  public void testValidHasDeprecatedGroupNotProvided() {
+    TestBean testBean = new TestBean();
+    testBean.deprecatedString = "value";
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean);
+
+    Assert.assertTrue(constraintViolations.isEmpty());
+  }
+
+  @Test
+  public void testValidHasDeprecated() {
+    TestBean testBean = new TestBean();
+    testBean.deprecatedString = "value";
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean, Deprecated.class);
+
+    Assert.assertEquals(1, constraintViolations.size());
+    ConstraintViolation<TestBean> constraintViolation = constraintViolations.iterator().next();
+    Assert.assertEquals(ConfigDeprecated.MESSAGE_TEMPLATE, constraintViolation.getMessageTemplate());
+    Assert.assertEquals("Is deprecated. It will be removed in " + ConfigDeprecated.DEFAULT_VERSION, constraintViolation.getMessage());
+  }
+
+  @Test
+  public void testValidHasDeprecatedWithVersion() {
+    TestBean testBean = new TestBean();
+    testBean.deprecatedStringWithVersion = "value";
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean, Deprecated.class);
+
+    Assert.assertEquals(1, constraintViolations.size());
+    ConstraintViolation<TestBean> constraintViolation = constraintViolations.iterator().next();
+    Assert.assertEquals(ConfigDeprecated.MESSAGE_TEMPLATE, constraintViolation.getMessageTemplate());
+    Assert.assertEquals("Is deprecated. It will be removed in 4.0.0", constraintViolation.getMessage());
+  }
+
+  @Test
+  public void testValidHasDeprecatedNoMessage() {
+    TestBean testBean = new TestBean();
+    testBean.deprecatedStringNoMessage = "value";
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean, Deprecated.class);
+
+    Assert.assertEquals(1, constraintViolations.size());
+    ConstraintViolation<TestBean> constraintViolation = constraintViolations.iterator().next();
+    Assert.assertEquals(ConfigDeprecated.MESSAGE_TEMPLATE, constraintViolation.getMessageTemplate());
+    Assert.assertEquals("Is deprecated. It will be removed in " + ConfigDeprecated.DEFAULT_VERSION, constraintViolation.getMessage());
+  }
+
+  @Test
+  public void testValidConfigWithNestedObject() {
+    TestBean testBean = new TestBean();
+    testBean.object = new TestBean();
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean, Deprecated.class);
+
+    Assert.assertTrue(constraintViolations.isEmpty());
+  }
+
+  @Test
+  public void testValidHasDeprecatedNestedObject() {
+    TestBean testBean = new TestBean();
+    testBean.object = new DeprecatedTestBean();
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean, Deprecated.class);
+
+    Assert.assertEquals(1, constraintViolations.size());
+    ConstraintViolation<TestBean> constraintViolation = constraintViolations.iterator().next();
+    Assert.assertEquals(ConfigDeprecated.MESSAGE_TEMPLATE, constraintViolation.getMessageTemplate());
+  }
+
+  @Test
+  public void testValidConfigWithNestedListObject() {
+    TestBean testBean = new TestBean();
+    testBean.objects = Arrays.asList(new TestBean());
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean, Deprecated.class);
+
+    Assert.assertTrue(constraintViolations.isEmpty());
+  }
+
+  @Test
+  public void testValidHasDeprecatedNestedListObject() {
+    TestBean testBean = new TestBean();
+    testBean.objects = Arrays.asList(new DeprecatedTestBean());
+
+    Set<ConstraintViolation<TestBean>> constraintViolations = validatorFactory.getValidator().validate(testBean, Deprecated.class);
+
+    Assert.assertEquals(1, constraintViolations.size());
+    ConstraintViolation<TestBean> constraintViolation = constraintViolations.iterator().next();
+    Assert.assertEquals(ConfigDeprecated.MESSAGE_TEMPLATE, constraintViolation.getMessageTemplate());
+  }
+
+  public interface TestInterface {
+  }
+
+  public static class TestBean implements TestInterface {
+    String string;
+    @ConfigDeprecated(groups = Deprecated.class)
+    String deprecatedString;
+    @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
+    String deprecatedStringWithVersion;
+    @ConfigDeprecated(message = "", groups = Deprecated.class)
+    String deprecatedStringNoMessage;
+    @Valid
+    TestInterface object;
+    @Valid
+    List<TestInterface> objects;
+  }
+
+  @ConfigDeprecated(groups = Deprecated.class)
+  public static class DeprecatedTestBean implements TestInterface {
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageProducer.java
@@ -49,7 +49,7 @@ public interface AdaptrisMessageProducer extends AdaptrisMessageWorker, Adaptris
    * @deprecated since 3.11.0 {@link ProduceDestination} is deprecated
    */
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination destination) throws ProduceException;
 
   /**
@@ -66,7 +66,7 @@ public interface AdaptrisMessageProducer extends AdaptrisMessageWorker, Adaptris
    * @deprecated since 3.11.0 {@link ProduceDestination} is deprecated
    */
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination destination, long timeoutMs) throws ProduceException;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageSender.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageSender.java
@@ -44,7 +44,7 @@ public interface AdaptrisMessageSender extends ComponentLifecycle {
    * @deprecated since 3.11.0 {@link ProduceDestination} is deprecated
    */
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   void produce(AdaptrisMessage msg, ProduceDestination destination) throws ProduceException;
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -16,7 +16,7 @@
 
 package com.adaptris.core;
 
-import com.adaptris.annotation.Removal;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 
 /**
  * <p>
@@ -180,11 +180,11 @@ public abstract class CoreConstants {
 
   /**
    * Metadata key for the FTP reply to name override.
-   * 
+   *
    * @deprecated since 3.11.0 if you're using FTP to do request reply, then please don't.
    */
   @Deprecated
-  @Removal(version = "4.0")
+  @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
   public static final String FTP_REPLYTO_NAME = "ftpreplytoname";
 
   /**
@@ -274,15 +274,15 @@ public abstract class CoreConstants {
    * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer)
    */
   public static final String OBJ_METADATA_MESSAGE_FAILED = "_messageFailed";
-  
+
   /**
    * Object metadata that stores the on success callback.
    *
    * @see Workflow#onAdaptrisMessage(AdaptrisMessage, java.util.function.Consumer)
    */
   public static final String OBJ_METADATA_ON_SUCCESS_CALLBACK = "_onSuccessCallback";
-  
-  
+
+
   /**
    * Object metadata that stores the on failure callback.
    *

--- a/interlok-core/src/main/java/com/adaptris/core/DefaultAdapterStartUpEvent.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DefaultAdapterStartUpEvent.java
@@ -1,35 +1,37 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
 import com.adaptris.core.event.StandardAdapterStartUpEvent;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
  * Event containing <code>Adapter</code> start-up information..
  * </p>
- * 
+ *
  * @config default-adapter-start-up-event
- * 
+ *
  * @see AdapterStartUpEvent
  */
 @XStreamAlias("default-adapter-start-up-event")
 @Deprecated
+@ConfigDeprecated(groups = Deprecated.class)
 public class DefaultAdapterStartUpEvent extends StandardAdapterStartUpEvent {
   private static final long serialVersionUID = 2014012301L;
 

--- a/interlok-core/src/main/java/com/adaptris/core/MleMarker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MleMarker.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.adaptris.core.util.Args;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -31,9 +32,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Records information about activities (generally {@link com.adaptris.core.Service} implementations) performed on a {@link com.adaptris.core.AdaptrisMessage} during a
  * workflow.
  * </p>
- * 
+ *
  * @config mle-marker
- * 
+ *
  * @see MessageLifecycleEvent
  */
 @XStreamAlias("mle-marker")
@@ -45,10 +46,12 @@ public class MleMarker implements Cloneable, Serializable {
   private String name;
   private String qualifier;
   @Deprecated
+  @ConfigDeprecated(groups = Deprecated.class)
   private String confirmationId;
   private boolean wasSuccessful;
   private boolean isTrackingEndpoint;
   @Deprecated
+  @ConfigDeprecated(groups = Deprecated.class)
   private boolean isConfirmation;
   private long sequenceNumber;
   private long creationTime;

--- a/interlok-core/src/main/java/com/adaptris/core/NullMessageConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NullMessageConsumer.java
@@ -12,18 +12,21 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
+
 import javax.validation.Valid;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -48,7 +51,7 @@ public class NullMessageConsumer extends AdaptrisMessageConsumerImp {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0")
+  @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
   private ConsumeDestination destination;
 
   private transient boolean destWarning;

--- a/interlok-core/src/main/java/com/adaptris/core/NullMessageProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NullMessageProducer.java
@@ -15,12 +15,16 @@
 package com.adaptris.core;
 
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
+
 import javax.validation.Valid;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -34,7 +38,7 @@ import lombok.Setter;
 @XStreamAlias("null-message-producer")
 @AdapterComponent
 @ComponentProfile(summary = "Default NO-OP producer implementation", tag = "producer,base",
-    recommended = {NullConnection.class})
+recommended = {NullConnection.class})
 public class NullMessageProducer extends AdaptrisMessageProducerImp {
 
   /**
@@ -42,10 +46,10 @@ public class NullMessageProducer extends AdaptrisMessageProducerImp {
    *
    */
   @Deprecated
-  @Valid
-  @Removal(version = "4.0.0", message = "Destination has no meaning for a no-op producer")
   @Getter
   @Setter
+  @Valid
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Destination has no meaning for a no-op producer", groups = Deprecated.class)
   private ProduceDestination destination;
 
 

--- a/interlok-core/src/main/java/com/adaptris/core/PollingTrigger.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PollingTrigger.java
@@ -12,22 +12,26 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.ObjectUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -43,7 +47,7 @@ import lombok.Setter;
 @XStreamAlias("polling-trigger")
 @AdapterComponent
 @ComponentProfile(summary = "Generate a static trigger message on a schedule", tag = "consumer,base",
-    recommended = {NullConnection.class})
+recommended = {NullConnection.class})
 @DisplayOrder(order = {"poller", "messageProvider"})
 public class PollingTrigger extends AdaptrisPollingConsumer {
 
@@ -60,8 +64,7 @@ public class PollingTrigger extends AdaptrisPollingConsumer {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0",
-      message = "Destination doesn't have much meaning for a polling-trigger")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Destination doesn't have much meaning for a polling-trigger", groups = Deprecated.class)
   private ConsumeDestination destination;
 
   public PollingTrigger() {

--- a/interlok-core/src/main/java/com/adaptris/core/ProduceOnlyProducerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ProduceOnlyProducerImp.java
@@ -59,7 +59,7 @@ public abstract class ProduceOnlyProducerImp extends AdaptrisMessageProducerImp 
    */
   @Override
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public final AdaptrisMessage request(AdaptrisMessage msg,
                                        ProduceDestination destination)
       throws ProduceException {
@@ -75,7 +75,7 @@ public abstract class ProduceOnlyProducerImp extends AdaptrisMessageProducerImp 
    */
   @Override
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public final AdaptrisMessage request(AdaptrisMessage msg,
                                        ProduceDestination destination,
                                        long timeout) throws ProduceException {
@@ -92,7 +92,7 @@ public abstract class ProduceOnlyProducerImp extends AdaptrisMessageProducerImp 
    * @deprecated since 3.11.0 {@link ProduceDestination} is deprecated
    */
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   @Override
   public final void produce(AdaptrisMessage msg, ProduceDestination destination)
       throws ProduceException {

--- a/interlok-core/src/main/java/com/adaptris/core/RequestReplyProducerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RequestReplyProducerImp.java
@@ -31,7 +31,7 @@ public abstract class RequestReplyProducerImp extends RequestReplyProducerBase {
   }
 
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   @Override
   public final void produce(AdaptrisMessage msg, ProduceDestination dest) throws ProduceException {
     doProduce(msg, DestinationHelper.resolveProduceDestination(endpoint(msg), dest, msg));
@@ -49,7 +49,7 @@ public abstract class RequestReplyProducerImp extends RequestReplyProducerBase {
 
   @Override
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public final AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination destination)
       throws ProduceException {
     return request(msg, destination, defaultTimeout());
@@ -57,7 +57,7 @@ public abstract class RequestReplyProducerImp extends RequestReplyProducerBase {
 
   @Override
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public final AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination destination,
       long timeout) throws ProduceException {
     return request(msg, DestinationHelper.resolveProduceDestination(endpoint(msg), destination, msg),

--- a/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
@@ -27,7 +27,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @deprecated since 3.10.2
  */
 @Deprecated
-@ConfigDeprecated(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", version = "3.12.0", groups = Deprecated.class)
+@ConfigDeprecated(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "3.12.0", groups = Deprecated.class)
 @XStreamAlias("restart-produce-exception-handler")
 public class RestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
@@ -1,39 +1,40 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
-import com.adaptris.annotation.Removal;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Implementation of {@link ProduceExceptionHandler} which attempts to restart the {@link Workflow} that had the failure.
- * 
+ *
  * @config restart-produce-exception-handler
- * 
+ *
  * @deprecated since 3.10.2
  */
 @Deprecated
-@Removal(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", version = "3.12.0")
+@ConfigDeprecated(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", version = "3.12.0", groups = Deprecated.class)
 @XStreamAlias("restart-produce-exception-handler")
 public class RestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 
   /**
    * @see com.adaptris.core.ProduceExceptionHandler#handle(com.adaptris.core.Workflow)
    */
+  @Override
   public void handle(Workflow workflow) {
     restart(workflow);
   }

--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataOutputStreamWrapper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataOutputStreamWrapper.java
@@ -1,38 +1,41 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.common;
 
 import static com.adaptris.core.common.MetadataDataOutputParameter.DEFAULT_METADATA_KEY;
+
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
+
 import org.apache.commons.io.output.WriterOutputStream;
+
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.types.InterlokMessage;
 import com.adaptris.interlok.types.MessageWrapper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * {@link MessageWrapper} implementation wraps a metadata value as an {@link OutputStream}.
- * 
+ *
  * @config metadata-output-stream-wrapper
  * @since 3.9.0
  * @deprecated since 3.10.1
@@ -41,16 +44,16 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-output-stream-wrapper")
 @DisplayOrder(order = {"metadataKey", "contentEncoding"})
 @ComponentProfile(summary = "MessageWrapper implementation wraps a metadata value as an Outputstream", since = "3.9.0")
-@Removal(version = "4.0", message = "Use metadata-stream-output instead")
+@ConfigDeprecated(removalVersion = "4.0.0", message = "Use metadata-stream-output instead", groups = Deprecated.class)
 public class MetadataOutputStreamWrapper extends MetadataStreamParameter implements MessageWrapper<OutputStream> {
-    
+
   private transient boolean warningLogged = false;
 
   public MetadataOutputStreamWrapper() {
     super();
-    this.setMetadataKey(DEFAULT_METADATA_KEY);
+    setMetadataKey(DEFAULT_METADATA_KEY);
   }
-  
+
   @Override
   public OutputStream wrap(InterlokMessage m) throws Exception {
     LoggingHelper.logDeprecation(warningLogged, () -> warningLogged = true, this.getClass().getSimpleName(),

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
@@ -22,6 +22,7 @@ import static com.adaptris.core.CoreConstants.FS_CONSUME_PARENT_DIR;
 import static com.adaptris.core.CoreConstants.FS_FILE_SIZE;
 import static com.adaptris.core.CoreConstants.ORIGINAL_NAME_KEY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -29,16 +30,18 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import javax.management.MalformedObjectNameException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisPollingConsumer;
@@ -58,6 +61,8 @@ import com.adaptris.fs.FsWorker;
 import com.adaptris.fs.NioWorker;
 import com.adaptris.interlok.util.FileFilterBuilder;
 import com.adaptris.util.TimeInterval;
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -166,7 +171,7 @@ public abstract class FsConsumerImpl extends AdaptrisPollingConsumer {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'base-directory-url' instead")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'base-directory-url' instead", groups = Deprecated.class)
   private ConsumeDestination destination;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -1,22 +1,23 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.fs;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -26,9 +27,11 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.fs.FsException;
 import com.adaptris.fs.FsFilenameExistsException;
 import com.adaptris.fs.FsWorker;
@@ -42,7 +45,7 @@ public abstract class FsHelper {
 
   /**
    * Go straight to a {@link File} from a url style string.
-   * 
+   *
    */
   public static File toFile(String s) throws IOException, URISyntaxException {
     try {
@@ -55,7 +58,7 @@ public abstract class FsHelper {
 
   /**
    * Create a file reference from a URL using the platform default encoding for the URL.
-   * 
+   *
    * @see #createFileReference(URL, String)
    */
   public static File createFileReference(URL url) throws UnsupportedEncodingException {
@@ -64,7 +67,7 @@ public abstract class FsHelper {
 
   /**
    * Create a file reference from a URL using the platform default encoding for the URL.
-   * 
+   *
    * @param url the URL.
    * @param charset the encoding that the url is considered to be in.
    * @return a File object
@@ -93,7 +96,7 @@ public abstract class FsHelper {
    * with a URISyntaxException; use {@link #createUrlFromString(String, boolean)} to convert backslashes into forward slashes prior
    * to processing.
    * </p>
-   * 
+   *
    * @param s the String to convert to a URL.
    * @return a new URL
    * @see #createUrlFromString(String, boolean)
@@ -111,10 +114,10 @@ public abstract class FsHelper {
    * as is. If the {@code scheme} is null then the URL is considered a {@code "file"} URL, and <strong>relative</strong>> to the
    * current working directory.
    * </p>
-   * 
+   *
    * @param s the string to convert to a URL.
    * @param backslashConvert whether or not to convert backslashes into forward slashes.
-   * 
+   *
    */
   public static URL createUrlFromString(String s, boolean backslashConvert) throws IOException, URISyntaxException {
     String destToConvert = backslashConvert ? backslashToSlash(s) : s;
@@ -156,7 +159,7 @@ public abstract class FsHelper {
 
   public static FileFilter logWarningIfRequired(FileFilter f) {
     try {
-      Class clz = Class.forName("org.apache.oro.io.RegexFilenameFilter");
+      Class<?> clz = Class.forName("org.apache.oro.io.RegexFilenameFilter");
       if (clz.isAssignableFrom(f.getClass())) {
         log.warn("{} is deprecated, use a java.util.regex.Pattern based filter instead", f.getClass().getCanonicalName());
       }

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsProducer.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.fs;
 
@@ -21,12 +21,16 @@ import static com.adaptris.core.CoreConstants.PRODUCED_NAME_KEY;
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
 import static com.adaptris.core.util.DestinationHelper.resolveProduceDestination;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -34,7 +38,6 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.FileNameCreator;
@@ -46,7 +49,9 @@ import com.adaptris.core.ProduceOnlyProducerImp;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.fs.FsWorker;
 import com.adaptris.fs.NioWorker;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -60,13 +65,13 @@ import lombok.Setter;
 @XStreamAlias("fs-producer")
 @AdapterComponent
 @ComponentProfile(summary = "Write the current message to the filesystem", tag = "producer,fs,filesystem",
-    recommended =
-    {
-        NullConnection.class
-    }, metadata =
-    {
-        "producedname", "fsProduceDir"
-    })
+recommended =
+{
+    NullConnection.class
+}, metadata =
+  {
+      "producedname", "fsProduceDir"
+  })
 @DisplayOrder(
     order = {"baseDirectoryUrl", "createDirs", "filenameCreator", "tempDirectory", "fsWorker"})
 public class FsProducer extends ProduceOnlyProducerImp {
@@ -130,7 +135,7 @@ public class FsProducer extends ProduceOnlyProducerImp {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'base-directory-url' instead")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'base-directory-url' instead", groups = Deprecated.class)
   private ProduceDestination destination;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumerImpl.java
@@ -18,15 +18,18 @@ package com.adaptris.core.ftp;
 
 import static com.adaptris.core.CoreConstants.FS_CONSUME_DIRECTORY;
 import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
+
 import java.io.FileFilter;
 import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.ObjectUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageConsumer;
 import com.adaptris.core.AdaptrisPollingConsumer;
@@ -41,6 +44,8 @@ import com.adaptris.filetransfer.FileTransferClient;
 import com.adaptris.filetransfer.FileTransferException;
 import com.adaptris.interlok.util.FileFilterBuilder;
 import com.adaptris.util.TimeInterval;
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -55,7 +60,7 @@ public abstract class FtpConsumerImpl extends AdaptrisPollingConsumer {
    */
   @Deprecated
   protected static final String DEFAULT_FILE_FILTER_IMPL =
-      FileFilterBuilder.DEFAULT_FILE_FILTER_IMP;
+  FileFilterBuilder.DEFAULT_FILE_FILTER_IMP;
 
   /**
    * Set the filename filter implementation that will be used for filtering files.
@@ -91,10 +96,10 @@ public abstract class FtpConsumerImpl extends AdaptrisPollingConsumer {
    *
    */
   @Deprecated
-  @Valid
-  @Removal(version = "4.0.0", message = "Use 'ftp-endpoint' instead")
   @Getter
   @Setter
+  @Valid
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'ftp-endpoint' instead", groups = Deprecated.class)
   private ConsumeDestination destination;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpProducer.java
@@ -12,18 +12,22 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.ftp;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
+
 import java.io.InputStream;
 import java.io.OutputStream;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -45,7 +49,9 @@ import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.filetransfer.FileTransferClient;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -96,11 +102,11 @@ import lombok.Setter;
 @XStreamAlias("ftp-producer")
 @AdapterComponent
 @ComponentProfile(summary = "Put a file on a FTP/SFTP server; uses PUT, RNFR and RNTO for atomicity",
-    tag = "producer,ftp,ftps,sftp",
- recommended = {FileTransferConnection.class})
+tag = "producer,ftp,ftps,sftp",
+recommended = {FileTransferConnection.class})
 @DisplayOrder(
     order = {"ftpEndpoint", "buildDirectory", "destDirectory", "replyDirectory",
-        "replyProcDirectory"})
+    "replyProcDirectory"})
 public class FtpProducer extends RequestReplyProducerImp {
 
   private static final String SLASH = "/";
@@ -121,8 +127,7 @@ public class FtpProducer extends RequestReplyProducerImp {
   @Getter
   @Setter
   @Deprecated
-  @Removal(version = "4.0.0",
-      message = "We strongly discourage anyone from trying to implement request reply using FTP")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "We strongly discourage anyone from trying to implement request reply using FTP", groups = Deprecated.class)
   private String replyDirectory = null;
   /**
    * Once the reply has been handled move it here.
@@ -136,8 +141,7 @@ public class FtpProducer extends RequestReplyProducerImp {
   @Getter
   @Setter
   @Deprecated
-  @Removal(version = "4.0",
-      message = "We strongly discourage anyone from trying to implement request reply using FTP")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "We strongly discourage anyone from trying to implement request reply using FTP", groups = Deprecated.class)
   private String replyProcDirectory = null;
 
   /**
@@ -155,8 +159,7 @@ public class FtpProducer extends RequestReplyProducerImp {
   @Getter
   @Setter
   @Deprecated
-  @Removal(version = "4.0",
-      message = "We strongly discourage anyone from trying to implement request reply using FTP")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "We strongly discourage anyone from trying to implement request reply using FTP", groups = Deprecated.class)
   private Boolean replyUsesEncoder;
 
   @Valid
@@ -169,7 +172,7 @@ public class FtpProducer extends RequestReplyProducerImp {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0", message = "Use 'ftp-endpoint' instead")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'ftp-endpoint' instead", groups = Deprecated.class)
   private ProduceDestination destination;
 
   /**
@@ -399,7 +402,7 @@ public class FtpProducer extends RequestReplyProducerImp {
   }
 
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public boolean replyUsesEncoder() {
     return BooleanUtils.toBooleanDefaultIfNull(getReplyUsesEncoder(), true);
   }

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/RelaxedFtpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/RelaxedFtpProducer.java
@@ -12,21 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.ftp;
 
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
+
 import java.io.InputStream;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.ObjectUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
@@ -38,7 +41,9 @@ import com.adaptris.core.ProduceOnlyProducerImp;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.filetransfer.FileTransferClient;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -77,7 +82,7 @@ import lombok.Setter;
 @XStreamAlias("relaxed-ftp-producer")
 @AdapterComponent
 @ComponentProfile(summary = "Put a file on a FTP/SFTP server; uses PUT only", tag = "producer,ftp,ftps,sftp",
-    recommended = {FileTransferConnection.class})
+recommended = {FileTransferConnection.class})
 @DisplayOrder(order = {"ftpEndpoint", "filenameCreator"})
 public class RelaxedFtpProducer extends ProduceOnlyProducerImp {
 
@@ -97,7 +102,7 @@ public class RelaxedFtpProducer extends ProduceOnlyProducerImp {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'ftp-endpoint' instead")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'ftp-endpoint' instead", groups = Deprecated.class)
   private ProduceDestination destination;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpProducer.java
@@ -12,26 +12,29 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.http.client.net;
 
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ProduceDestination;
@@ -46,6 +49,8 @@ import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
 import com.adaptris.core.http.client.ResponseHeaderHandler;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -154,7 +159,7 @@ public abstract class HttpProducer<A, B> extends RequestReplyProducerImp {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'url' instead")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'url' instead", groups = Deprecated.class)
   private ProduceDestination destination;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.http.jetty;
 
@@ -24,6 +24,7 @@ import static com.adaptris.core.http.jetty.JettyConstants.JETTY_USER_ROLES;
 import static com.adaptris.core.http.jetty.JettyConstants.JETTY_USER_ROLE_ATTR;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.join;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -41,18 +42,20 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageConsumerImp;
 import com.adaptris.core.ClosedState;
@@ -64,6 +67,8 @@ import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.util.TimeInterval;
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -109,10 +114,10 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
    *
    */
   @Deprecated
-  @Valid
-  @Removal(version = "4.0.0", message = "Use 'path' instead")
   @Getter
   @Setter
+  @Valid
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'path' instead", groups = Deprecated.class)
   private ConsumeDestination destination;
 
   /**
@@ -206,9 +211,9 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
       p.println("URL " + req.getRequestURL());
       p.println("URI " + req.getRequestURI());
       p.println("Query " + req.getQueryString());
-      for (Enumeration e = req.getHeaderNames(); e.hasMoreElements();) {
-        String key = (String) e.nextElement();
-        Enumeration values = req.getHeaders(key);
+      for (Enumeration<String> e = req.getHeaderNames(); e.hasMoreElements();) {
+        String key = e.nextElement();
+        Enumeration<String> values = req.getHeaders(key);
         StringBuffer sb = new StringBuffer();
         while (values.hasMoreElements()) {
           sb.append(values.nextElement()).append(",");
@@ -417,7 +422,7 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
 
     protected Map<String, HttpOperation> handlers() {
       if (httpHandlers == null) {
-        httpHandlers = new HashMap<String, HttpOperation>();
+        httpHandlers = new HashMap<>();
         HttpOperation defaultHandler = new HttpOperation() {
           @Override
           public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyRouteSpec.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyRouteSpec.java
@@ -1,27 +1,28 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 package com.adaptris.core.http.jetty;
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+
 import org.apache.commons.lang3.ObjectUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.Removal;
@@ -32,6 +33,7 @@ import com.adaptris.core.services.metadata.ExtractMetadataService;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
@@ -52,7 +54,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
           <metadata-key>parentId</metadata-key>
           <metadata-key>childId</metadata-key>
         </condition>
-        <service-id>handleInsert</service-id>   
+        <service-id>handleInsert</service-id>
       </jetty-route-spec>
    }
  * </pre>
@@ -66,18 +68,16 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @XStreamAlias("jetty-route-spec")
 public class JettyRouteSpec implements ComponentLifecycle {
 
-  private transient Logger log = LoggerFactory.getLogger(this.getClass());
-
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
   private String urlPattern;
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
   private String method;
   @XStreamImplicit(itemFieldName = "metadata-key")
   @AffectsMetadata
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
   private List<String> metadataKeys;
   @NotBlank
   private String serviceId;
@@ -121,18 +121,18 @@ public class JettyRouteSpec implements ComponentLifecycle {
   }
 
   /**
-   * 
+   *
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
   public String getUrlPattern() {
     return urlPattern;
   }
 
   /**
    * Set the URL pattern that you want to match against.
-   * 
+   *
    * @param urlPattern the pattern.
    * @deprecated since 3.9.0 use a condition instead
    */
@@ -147,18 +147,18 @@ public class JettyRouteSpec implements ComponentLifecycle {
   }
 
   /**
-   * 
+   *
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
   public String getMethod() {
     return method;
   }
 
   /**
    * Specify a method to match against (optional).
-   * 
+   *
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
@@ -168,11 +168,11 @@ public class JettyRouteSpec implements ComponentLifecycle {
   }
 
   /**
-   * 
+   *
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
   public List<String> getMetadataKeys() {
     return metadataKeys;
   }
@@ -186,14 +186,14 @@ public class JettyRouteSpec implements ComponentLifecycle {
    * <p>
    * The list of keys is processed in order, against each capturing match group in order
    * </p>
-   * 
+   *
    * @param s list of keys.
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
   @Removal(version = "3.12.0", message = "Use a condition instead")
   public void setMetadataKeys(List<String> s) {
-    this.metadataKeys = s;
+    metadataKeys = s;
   }
 
   public String getServiceId() {
@@ -218,7 +218,7 @@ public class JettyRouteSpec implements ComponentLifecycle {
 
   /**
    * Specify the conditions for the route.
-   * 
+   *
    * @param condition the condition.
    */
   public void setCondition(JettyRouteCondition condition) {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/ResponseProducerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/ResponseProducerImpl.java
@@ -12,19 +12,21 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.http.jetty;
 
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
+
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ProduceDestination;
@@ -38,6 +40,8 @@ import com.adaptris.core.http.server.HttpStatusProvider.HttpStatus;
 import com.adaptris.core.http.server.HttpStatusProvider.Status;
 import com.adaptris.core.http.server.ResponseHeaderProvider;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -124,7 +128,7 @@ public abstract class ResponseProducerImpl extends ProduceOnlyProducerImp {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Has no meaning, and will be removed")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Has no meaning, and will be removed", groups = Deprecated.class)
   private ProduceDestination destination;
 
   private transient boolean destWarning;

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessToken.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/AccessToken.java
@@ -2,6 +2,7 @@ package com.adaptris.core.http.oauth;
 
 import java.io.Serializable;
 import java.util.Date;
+
 import com.adaptris.util.text.DateFormatUtil;
 
 /**
@@ -38,7 +39,6 @@ public class AccessToken implements Serializable {
   /**
    * Calls {@link #AccessToken(String, String, long)} with {@code -1} as the expiry
    */
-  @SuppressWarnings("deprecation")
   public AccessToken(String type, String token) {
     this(type, token, -1);
   }
@@ -75,7 +75,7 @@ public class AccessToken implements Serializable {
   }
 
   public void setType(String tokenType) {
-    this.type = tokenType;
+    type = tokenType;
   }
 
   public String getToken() {

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/GetOauthToken.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/GetOauthToken.java
@@ -1,6 +1,7 @@
 package com.adaptris.core.http.oauth;
 
 import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AffectsMetadata;
@@ -13,14 +14,15 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Simplified framework for retrieving OAUTH tokens from verious 3rd party resources (such as Salesforce, or Google).
- * 
- * 
+ *
+ *
  * @config get-oauth-token
- * 
+ *
  */
 @XStreamAlias("get-oauth-token")
 @AdapterComponent
@@ -34,17 +36,17 @@ public class GetOauthToken extends OauthTokenGetter {
   @AffectsMetadata
   @InputFieldDefault(value = "Authorization")
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   private String tokenKey;
   @AffectsMetadata
   @AdvancedConfig
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   private String tokenExpiryKey;
   @AffectsMetadata
   @AdvancedConfig
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   private String refreshTokenKey;
 
   private transient boolean warningLogged = false;
@@ -82,20 +84,20 @@ public class GetOauthToken extends OauthTokenGetter {
 
 
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   public String getTokenKey() {
     return tokenKey;
   }
 
   /**
    * Set the metadata to store the token against.
-   * 
+   *
    * @param key the key.
    */
   @Deprecated
   @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
   public void setTokenKey(String key) {
-    this.tokenKey = Args.notBlank(key, "tokenMetadataKey");
+    tokenKey = Args.notBlank(key, "tokenMetadataKey");
   }
 
 
@@ -107,7 +109,7 @@ public class GetOauthToken extends OauthTokenGetter {
   }
 
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   public String getTokenExpiryKey() {
     return tokenExpiryKey;
   }
@@ -117,13 +119,13 @@ public class GetOauthToken extends OauthTokenGetter {
    * <p>
    * In some cases, there is no expiry date for a token, in which case, the metadata key will never be set even if configured.
    * </p>
-   * 
+   *
    * @param key key.
    */
   @Deprecated
   @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
   public void setTokenExpiryKey(String key) {
-    this.tokenExpiryKey = Args.notBlank(key, "tokenExpiryKey");
+    tokenExpiryKey = Args.notBlank(key, "tokenExpiryKey");
   }
 
   @Deprecated
@@ -134,7 +136,7 @@ public class GetOauthToken extends OauthTokenGetter {
   }
 
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-write instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-write instead", groups = Deprecated.class)
   public String getRefreshTokenKey() {
     return refreshTokenKey;
   }
@@ -144,12 +146,12 @@ public class GetOauthToken extends OauthTokenGetter {
    * <p>
    * In some cases, there is no refresh token, in which case, the metadata key will never be set even if configured.
    * </p>
-   * 
+   *
    * @param key key.
    */
   @Deprecated
   @Removal(version = "3.12.0", message = "Use a access-token-write instead")
   public void setRefreshTokenKey(String key) {
-    this.refreshTokenKey = key;
+    refreshTokenKey = key;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/interceptor/LoggingContextWorkflowInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/interceptor/LoggingContextWorkflowInterceptor.java
@@ -1,37 +1,45 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.interceptor;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import com.adaptris.annotation.*;
-import com.adaptris.core.*;
-import com.adaptris.core.util.Args;
-import com.adaptris.util.KeyValuePair;
-import com.adaptris.util.KeyValuePairList;
+import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.MDC;
 
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.services.AddLoggingContext;
 import com.adaptris.core.services.RemoveLoggingContext;
+import com.adaptris.core.util.Args;
 import com.adaptris.util.GuidGenerator;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairList;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import javax.validation.constraints.NotNull;
 
 /**
  * WorkflowInterceptor implementation that adds a mapped diagnostic context via {@code org.slf4j.MDC#put(String, String)}.
@@ -39,16 +47,16 @@ import javax.validation.constraints.NotNull;
  * An alternative to this interceptor might be {@link AddLoggingContext} and {@link RemoveLoggingContext} as part of the
  * service execution chain.
  * </p>
- * 
+ *
  * @config logging-context-workflow-interceptor
  * @see AddLoggingContext
  * @see RemoveLoggingContext
- * 
+ *
  */
 @XStreamAlias("logging-context-workflow-interceptor")
 @AdapterComponent
 @ComponentProfile(summary = "Interceptor that adds Logging Context at the start of a workflow, removes it at the end",
-    tag = "interceptor")
+tag = "interceptor")
 public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
 
   private static final GuidGenerator GUID = new GuidGenerator();
@@ -67,9 +75,11 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
   private KeyValuePairList valuesToSet;
 
   @Deprecated
+  @ConfigDeprecated(groups = Deprecated.class)
   private String key;
 
   @Deprecated
+  @ConfigDeprecated(groups = Deprecated.class)
   @InputFieldHint(expression = true)
   private String value;
 
@@ -163,7 +173,7 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
    * <li>The parent channel unique id</li>
    * <li>A generated unique id</li>
    * </ul>
-   * 
+   *
    * @param key the contextKey to set.
    */
   @Deprecated
@@ -172,8 +182,9 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
   }
 
   private String resolve(String s, AdaptrisMessage msg) {
-    if (!isEmpty(s))
+    if (!isEmpty(s)) {
       return msg.resolve(s);
+    }
     if (!isEmpty(getUniqueId())) {
       return getUniqueId();
     }
@@ -202,12 +213,12 @@ public class LoggingContextWorkflowInterceptor extends WorkflowInterceptorImpl {
    * <li>The parent channel unique id</li>
    * <li>A Generated unique id</li>
    * </ul>
-   * 
+   *
    * @param val the contextValue to set
    */
   @Deprecated
   public void setValue(String val) {
-    this.value = val;
+    value = val;
   }
 
   public KeyValuePairList getValuesToSet() {

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcStoredProcedureProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcStoredProcedureProducer.java
@@ -12,26 +12,28 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jdbc;
 
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ProduceDestination;
@@ -50,7 +52,9 @@ import com.adaptris.jdbc.ParameterType;
 import com.adaptris.jdbc.StoredProcedure;
 import com.adaptris.jdbc.StoredProcedureParameter;
 import com.adaptris.util.TimeInterval;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -150,7 +154,7 @@ public class JdbcStoredProcedureProducer extends RequestReplyProducerImp {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'procedure-name' instead")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'procedure-name' instead", groups = Deprecated.class)
   private ProduceDestination destination;
 
   /**
@@ -284,7 +288,7 @@ public class JdbcStoredProcedureProducer extends RequestReplyProducerImp {
   }
 
   private List<StoredProcedureParameter> parseInParameters(AdaptrisMessage msg) throws JdbcParameterException {
-    ArrayList<StoredProcedureParameter> params = new ArrayList<StoredProcedureParameter>();
+    ArrayList<StoredProcedureParameter> params = new ArrayList<>();
 
     for (InParameter p : getInParameters().getParameters()) {
       params.add(new StoredProcedureParameter(p.getName(), p.getOrder(), p.getType(), ParameterType.IN, p.applyInputParam(msg)));

--- a/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
@@ -48,7 +48,7 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
 
   @Override
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public void produce(AdaptrisMessage msg, ProduceDestination destination) throws ProduceException {
     try {
       setupSession(msg);
@@ -109,7 +109,7 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
 
   @Override
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination dest, long timeout)
       throws ProduceException {
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jms;
 
@@ -21,13 +21,17 @@ import static com.adaptris.core.jms.JmsConstants.JMS_ASYNC_STATIC_REPLY_TO;
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.util.Optional;
+
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -42,7 +46,9 @@ import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.util.Args;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -94,7 +100,7 @@ public class JmsProducer extends JmsProducerImpl {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'endpoint' instead if possible")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'endpoint' instead if possible", groups = Deprecated.class)
   private ProduceDestination destination;
 
   /**
@@ -119,7 +125,7 @@ public class JmsProducer extends JmsProducerImpl {
 
   @Override
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public void produce(AdaptrisMessage msg, ProduceDestination dest) throws ProduceException {
     try {
       setupSession(msg);
@@ -152,7 +158,7 @@ public class JmsProducer extends JmsProducerImpl {
 
   @Override
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination dest, long timeout)
       throws ProduceException {
 
@@ -192,7 +198,7 @@ public class JmsProducer extends JmsProducerImpl {
     Message jmsReply = receiver.receive(timeout);
     AdaptrisMessage translatedReply =
         Optional.ofNullable(MessageTypeTranslatorImp.translate(getMessageTranslator(), jmsReply))
-            .orElseThrow(() -> new JMSException("No Reply Received within " + timeout + "ms"));
+        .orElseThrow(() -> new JMSException("No Reply Received within " + timeout + "ms"));
     acknowledge(jmsReply);
     return translatedReply;
   }
@@ -235,7 +241,7 @@ public class JmsProducer extends JmsProducerImpl {
    */
   protected Destination createReplyTo(AdaptrisMessage msg, JmsDestination target,
       boolean createTmpDest)
-      throws JMSException {
+          throws JMSException {
     Destination replyTo = null;
     if (target.getReplyToDestination() == null) {
       if (msg.headersContainsKey(JMS_ASYNC_STATIC_REPLY_TO)) {

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducerImpl.java
@@ -21,11 +21,13 @@ import static com.adaptris.core.jms.JmsConstants.JMS_DELIVERY_MODE;
 import static com.adaptris.core.jms.JmsConstants.JMS_EXPIRATION;
 import static com.adaptris.core.jms.JmsConstants.JMS_PRIORITY;
 import static com.adaptris.core.jms.NullCorrelationIdSource.defaultIfNull;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -35,9 +37,11 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -196,9 +200,8 @@ public abstract class JmsProducerImpl extends RequestReplyProducerBase implement
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   @Deprecated
-  @Removal(version = "4.0")
+  @Removal(version = "4.0.0")
   public AdaptrisMessage request(AdaptrisMessage msg, ProduceDestination destination)
       throws ProduceException {
     return request(msg, destination, defaultTimeout());
@@ -208,7 +211,6 @@ public abstract class JmsProducerImpl extends RequestReplyProducerBase implement
   public AdaptrisMessage request(AdaptrisMessage msg) throws ProduceException {
     return request(msg, defaultTimeout());
   }
-
 
   protected ProducerSession setupSession(AdaptrisMessage msg) throws JMSException {
     if (!msg.getUniqueId().equals(CURRENT_MESSAGE_ID) || producerSession == null) {
@@ -619,7 +621,7 @@ public abstract class JmsProducerImpl extends RequestReplyProducerBase implement
   protected void captureOutgoingMessageDetails(Message jmsMsg, AdaptrisMessage msg) {
     if (captureOutgoingMessageDetails()) {
       String objectMetadataPrefix = Message.class.getCanonicalName() + ".";
-      Map<String, String> jmsDetails = new HashMap<String, String>();
+      Map<String, String> jmsDetails = new HashMap<>();
       for (MetadataHandler.JmsPropertyHandler handler : MetadataHandler.JmsPropertyHandler
           .values()) {
         try {

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsReplyToWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsReplyToWorkflow.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jms;
 
@@ -22,13 +22,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import javax.jms.Destination;
 import javax.jms.Queue;
 import javax.jms.Topic;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ProduceException;
@@ -37,6 +38,7 @@ import com.adaptris.core.StandardWorkflow;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.util.Args;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -68,30 +70,30 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @Deprecated
 @AdapterComponent
 @ComponentProfile(summary = "Deprecated: use StandardWorkflow+StandaloneProducer+JmsReplyToDestination instead",
-    tag = "workflow,jms")
+tag = "workflow,jms")
 @DisplayOrder(order = {"disableDefaultMessageCount", "sendEvents", "logPayload"})
-@Removal(version = "4.0.0")
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public final class JmsReplyToWorkflow extends StandardWorkflow {
   private transient boolean warningLogged;
 
-  private static final Map<Class, List<Class>> VALID_PRODUCER_FOR_CONSUMER;
-  private static final Map<Class, ProducerType> PRODUCER_BY_TYPE;
+  private static final Map<Class<?>, List<Class<?>>> VALID_PRODUCER_FOR_CONSUMER;
+  private static final Map<Class<?>, ProducerType> PRODUCER_BY_TYPE;
 
 
   static {
-    Map<Class, List<Class>> consumerToProducers = new HashMap<>();
+    Map<Class<?>, List<Class<?>>> consumerToProducers = new HashMap<>();
     consumerToProducers.put(PasConsumer.class, Arrays.asList(PasProducer.class));
     consumerToProducers.put(PtpConsumer.class, Arrays.asList(PtpProducer.class));
     VALID_PRODUCER_FOR_CONSUMER = Collections.unmodifiableMap(consumerToProducers);
 
-    Map<Class, ProducerType> producersToType = new HashMap<>();
+    Map<Class<?>, ProducerType> producersToType = new HashMap<>();
     producersToType.put(PtpProducer.class, ProducerType.QueueProducer);
     producersToType.put(PasProducer.class, ProducerType.TopicProducer);
     PRODUCER_BY_TYPE = Collections.unmodifiableMap(producersToType);
   }
 
 
-  protected static enum ProducerType {
+  protected enum ProducerType {
     TopicProducer {
 
       @Override
@@ -135,9 +137,9 @@ public final class JmsReplyToWorkflow extends StandardWorkflow {
   }
 
   private void validateConfiguration() throws CoreException {
-    Class consumerClass = getConsumer().getClass();
-    Class producerClass = getProducer().getClass();
-    List<Class> validProducers = Optional.ofNullable(VALID_PRODUCER_FOR_CONSUMER.get(consumerClass))
+    Class<?> consumerClass = getConsumer().getClass();
+    Class<?> producerClass = getProducer().getClass();
+    List<Class<?>> validProducers = Optional.ofNullable(VALID_PRODUCER_FOR_CONSUMER.get(consumerClass))
         .orElseThrow(
             () -> new CoreException(
                 "Can't handle consumer : " + consumerClass.getSimpleName()));

--- a/interlok-core/src/main/java/com/adaptris/core/jms/PasConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/PasConsumer.java
@@ -12,22 +12,25 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jms;
 
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.util.Args;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -42,7 +45,7 @@ import lombok.Setter;
 @XStreamAlias("jms-topic-consumer")
 @AdapterComponent
 @ComponentProfile(summary = "Listen for JMS messages on the specified topic", tag = "consumer,jms",
-    recommended = {JmsConnection.class})
+recommended = {JmsConnection.class})
 @DisplayOrder(order = {"topic", "messageSelector", "destination", "durable",
     "subscriptionId", "acknowledgeMode", "messageTranslator"})
 public class PasConsumer extends JmsConsumerImpl {
@@ -53,8 +56,7 @@ public class PasConsumer extends JmsConsumerImpl {
    */
   @InputFieldDefault(value = "false")
   @Deprecated
-  @Removal(version = "4.0.0",
-      message = "Durable subscriptions will be implied if subscription-id is not empty")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Durable subscriptions will be implied if subscription-id is not empty", groups = Deprecated.class)
   @Getter
   @Setter
   private Boolean durable;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/PasProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/PasProducer.java
@@ -12,22 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jms;
 
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
+
 import java.util.Optional;
+
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Topic;
 import javax.validation.Valid;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.CoreException;
@@ -35,7 +37,9 @@ import com.adaptris.core.ProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -116,7 +120,7 @@ public class PasProducer extends DefinedJmsProducer {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'topic' instead if possible")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'topic' instead if possible", groups = Deprecated.class)
   private ProduceDestination destination;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/jms/PtpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/PtpProducer.java
@@ -12,22 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jms;
 
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
+
 import java.util.Optional;
+
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Queue;
 import javax.validation.Valid;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.CoreException;
@@ -35,7 +37,9 @@ import com.adaptris.core.ProduceDestination;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -117,7 +121,7 @@ public class PtpProducer extends DefinedJmsProducer {
   @Setter
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'queue' instead if possible")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'queue' instead if possible", groups = Deprecated.class)
   private ProduceDestination destination;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/jmx/JmxNotificationConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jmx/JmxNotificationConsumer.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServerConnection;
 import javax.management.Notification;
@@ -26,14 +27,15 @@ import javax.management.NotificationListener;
 import javax.management.ObjectName;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageConsumerImp;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -47,15 +49,17 @@ import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.core.util.ManagedThreadFactory;
 import com.adaptris.util.FifoMutexLock;
 import com.adaptris.util.TimeInterval;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
 @XStreamAlias("jmx-notification-consumer")
 @AdapterComponent
 @ComponentProfile(summary = "Listen for notifications against the specified ObjectName", tag = "consumer,jmx",
-    metadata = {com.adaptris.core.jmx.JmxNotificationConsumer.JMX_NOTIF_SOURCE},
-    recommended = {JmxConnection.class})
+metadata = {com.adaptris.core.jmx.JmxNotificationConsumer.JMX_NOTIF_SOURCE},
+recommended = {JmxConnection.class})
 @DisplayOrder(order = {"objectName", "serializer"})
 public class JmxNotificationConsumer extends AdaptrisMessageConsumerImp implements NotificationListener {
 
@@ -77,7 +81,7 @@ public class JmxNotificationConsumer extends AdaptrisMessageConsumerImp implemen
    */
   @Deprecated
   @Valid
-  @Removal(version = "4.0.0", message = "Use 'object-name' instead")
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'object-name' instead", groups = Deprecated.class)
   @Getter
   @Setter
   private ConsumeDestination destination;
@@ -117,7 +121,7 @@ public class JmxNotificationConsumer extends AdaptrisMessageConsumerImp implemen
     DestinationHelper.logWarningIfNotNull(destinationWarningLogged,
         () -> destinationWarningLogged = true, getDestination(),
         "{} uses destination, use objectName instead",
-          LoggingHelper.friendlyName(this));
+        LoggingHelper.friendlyName(this));
     DestinationHelper.mustHaveEither(getObjectName(), getDestination());
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
@@ -29,6 +29,7 @@ import static com.adaptris.core.management.Constants.DEFAULT_PROPS_RESOURCE;
 import static com.adaptris.core.management.Constants.PROTOCOL_FILE;
 import static com.adaptris.core.util.PropertyHelper.getPropertyIgnoringCase;
 import static com.adaptris.core.util.PropertyHelper.getPropertySubset;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -43,11 +44,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.management.logging.LoggingConfigurator;
@@ -190,7 +193,7 @@ public class BootstrapProperties extends Properties {
   }
 
   public String[] getConfigurationUrls() {
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     Properties p = getPropertySubset(this, CFG_KEY_CONFIG_URL, true);
     Object[] urlKeys = p.keySet().toArray();
     Arrays.sort(urlKeys);
@@ -205,7 +208,6 @@ public class BootstrapProperties extends Properties {
     return list.toArray(new String[0]);
   }
 
-  @SuppressWarnings("deprecation")
   public String findAdapterResource() {
     String[] urls = getConfigurationUrls();
     String adapterXml = null;

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigurationChecker.java
@@ -10,22 +10,20 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
 import com.adaptris.core.Adapter;
-import com.adaptris.core.CoreException;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class JavaxValidationChecker extends AdapterConfigurationChecker {
+public class DeprecatedConfigurationChecker extends AdapterConfigurationChecker {
 
-  private static final String FRIENDLY_NAME = "javax.validation checks";
+  private static final String FRIENDLY_NAME = "Deprecated checks";
   private static final ValidatorFactory JAVAX_VALIDATOR_FACTORY = Validation.buildDefaultValidatorFactory();
 
   @Override
   protected void validate(Adapter adapter, ConfigurationCheckReport report) {
     try {
       Validator validator = JAVAX_VALIDATOR_FACTORY.getValidator();
-      // There are no warnings; everything is a hard failure.
-      report.setFailureExceptions(violationsToException(validator.validate(adapter)));
+      report.setWarnings(violationsToWarning(validator.validate(adapter, Deprecated.class)));
     } catch (Exception ex) {
       report.getFailureExceptions().add(ex);
     }
@@ -36,9 +34,9 @@ public class JavaxValidationChecker extends AdapterConfigurationChecker {
     return FRIENDLY_NAME;
   }
 
-  private List<Exception> violationsToException(Set<ConstraintViolation<Adapter>> violations) {
-    return violations.stream().map(v -> new CoreException(
-        String.format("Interlok Validation Error: [%1$s]=[%2$s]", v.getPropertyPath(), v.getMessage())))
+  private List<String> violationsToWarning(Set<ConstraintViolation<Adapter>> violations) {
+    return violations.stream()
+        .map(v -> String.format("Interlok Deprecation Warning: [%1$s] is deprecated. %2$s", v.getPropertyPath(), v.getMessage()))
         .collect(Collectors.toList());
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/AlwaysFailService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/AlwaysFailService.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services;
 
@@ -24,28 +24,30 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
 import com.adaptris.core.services.exception.ThrowExceptionService;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Always fail.
- * 
+ *
  * @config always-fail-service
- * 
- * 
+ *
+ *
  * @author lchan
- * @deprecated since 3.0.0 consider using {@link ThrowExceptionService} instead which wils give you a better exception message.
+ * @deprecated since 3.0.0 consider using {@link ThrowExceptionService} instead which will give you a better exception message.
  */
 @Deprecated
 @XStreamAlias("always-fail-service")
 @AdapterComponent
 @ComponentProfile(summary = "Deprecated: use ThrowExceptionService instead", tag = "service")
+@ConfigDeprecated(groups = Deprecated.class)
 public class AlwaysFailService extends ServiceImp {
 
   private static transient boolean warningLogged;
 
   public AlwaysFailService() {
     super();
-    LoggingHelper.logDeprecation(warningLogged, ()-> { warningLogged=true;}, this.getClass().getSimpleName(), ThrowExceptionService.class.getName());      
+    LoggingHelper.logDeprecation(warningLogged, ()-> { warningLogged=true;}, this.getClass().getSimpleName(), ThrowExceptionService.class.getName());
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromMetadataService.java
@@ -1,23 +1,25 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.metadata;
 
 import java.util.regex.Matcher;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -26,6 +28,7 @@ import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -37,7 +40,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <li>multi-line-expression defaults to FALSE in the constructor for backwards compatibility reasons</li>
  * </ul>
  * </p>
- * 
+ *
  * @config payload-from-metadata-service
  * @deprecated since 3.10.0 use {@link PayloadFromTemplateService} or {@link MetadataToPayloadService} instead; most of the time
  *             you're abusing it...
@@ -47,13 +50,13 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Construct a new payload based on metadata and a template", tag = "service,metadata")
 @DisplayOrder(order = {"template", "metadataTokens", "multiLineExpression", "quoteReplacement", "escapeBackslash", "quiet"})
-@Removal(version = "4.0", message = "use payload-from-template or metadata-to-payload instead")
+@ConfigDeprecated(removalVersion = "4.0.0", message = "use payload-from-template or metadata-to-payload instead", groups = Deprecated.class)
 public class PayloadFromMetadataService extends PayloadFromTemplateService {
-  
+
   @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "true")
   @Deprecated
-  @Removal(version = "3.12.0", message = "use quote-replacement instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "use quote-replacement instead", groups = Deprecated.class)
   private Boolean escapeBackslash;
 
   private transient boolean warningLogged = false;
@@ -78,11 +81,11 @@ public class PayloadFromMetadataService extends PayloadFromTemplateService {
 
 
   /**
-   * 
+   *
    * @deprecated since 3.10.0, use {@link #setQuoteReplacement(Boolean)} instead.
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "use quote-replacement instead")
+  @ConfigDeprecated(removalVersion = "3.12.0", message = "use quote-replacement instead", groups = Deprecated.class)
   public Boolean getEscapeBackslash() {
     return escapeBackslash;
   }
@@ -92,7 +95,7 @@ public class PayloadFromMetadataService extends PayloadFromTemplateService {
    * <p>
    * Set this flag to make sure that special characters are treated literally by the regular expression engine.
    * <p>
-   * 
+   *
    * @deprecated since 3.10.0, use {@link #setQuoteReplacement(Boolean)} instead.
    * @see Matcher#quoteReplacement(String)
    * @param b the value to set
@@ -104,13 +107,13 @@ public class PayloadFromMetadataService extends PayloadFromTemplateService {
   }
 
   /**
-   * 
+   *
    * @deprecated since 3.10.0, use {@link #setQuoteReplacement(Boolean)} instead.
    */
   @Deprecated
   @Removal(version = "3.12.0", message = "use quote-replacement instead")
   public PayloadFromMetadataService withEscapeBackslash(Boolean b) {
-    setEscapeBackslash(b); 
+    setEscapeBackslash(b);
     return this;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/DefaultPoolingFutureExceptionStrategy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/DefaultPoolingFutureExceptionStrategy.java
@@ -2,9 +2,10 @@ package com.adaptris.core.services.splitter;
 
 import java.util.List;
 import java.util.concurrent.Future;
-import com.adaptris.annotation.Removal;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -15,20 +16,19 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("default-pooling-future-exception-strategy")
 @Deprecated
-@Removal(version = "4.0",
-    message = "since 3.11.1 replaced by 'ServiceErrorHandler' and 'PooledSplitJoinService'")
+@ConfigDeprecated(removalVersion = "4.0.0", message = "since 3.11.1 replaced by 'ServiceErrorHandler' and 'PooledSplitJoinService'", groups = Deprecated.class)
 public class DefaultPoolingFutureExceptionStrategy implements PoolingFutureExceptionStrategy {
 
-    public static final String EXCEPTION_MSG = "Timeout exceeded waiting for split services to complete.";
+  public static final String EXCEPTION_MSG = "Timeout exceeded waiting for split services to complete.";
 
-    @Override
-    public void handle(ServiceExceptionHandler handler, List<Future<AdaptrisMessage>> results) throws CoreException {
-        handler.throwFirstException();
-        // Now check the futures to see if any were cancelled.
-        for (Future<AdaptrisMessage> f : results) {
-            if (f.isCancelled()) {
-                throw new CoreException(EXCEPTION_MSG);
-            }
-        }
+  @Override
+  public void handle(ServiceExceptionHandler handler, List<Future<AdaptrisMessage>> results) throws CoreException {
+    handler.throwFirstException();
+    // Now check the futures to see if any were cancelled.
+    for (Future<AdaptrisMessage> f : results) {
+      if (f.isCancelled()) {
+        throw new CoreException(EXCEPTION_MSG);
+      }
     }
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingFutureExceptionStrategy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingFutureExceptionStrategy.java
@@ -2,9 +2,10 @@ package com.adaptris.core.services.splitter;
 
 import java.util.List;
 import java.util.concurrent.Future;
-import com.adaptris.annotation.Removal;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 
 /**
  * @deprecated since 3.11.1 replaced by {@link ServiceErrorHandler} and
@@ -13,8 +14,7 @@ import com.adaptris.core.CoreException;
  */
 @FunctionalInterface
 @Deprecated
-@Removal(version = "4.0",
-    message = "since 3.11.1 replaced by 'ServiceErrorHandler' and 'PooledSplitJoinService'")
+@ConfigDeprecated(removalVersion = "4.0.0", message = "since 3.11.1 replaced by 'ServiceErrorHandler' and 'PooledSplitJoinService'", groups = Deprecated.class)
 public interface PoolingFutureExceptionStrategy {
-    void handle(ServiceExceptionHandler handler, List<Future<AdaptrisMessage>> results) throws CoreException;
+  void handle(ServiceExceptionHandler handler, List<Future<AdaptrisMessage>> results) throws CoreException;
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingSplitJoinService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/PoolingSplitJoinService.java
@@ -20,19 +20,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.pool2.impl.GenericObjectPool;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.services.aggregator.MessageAggregator;
 import com.adaptris.core.services.splitter.ServiceWorkerPool.Worker;
 import com.adaptris.util.NumberUtils;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -49,10 +51,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * instances is maintained and re-used for each message; so the high cost of initialisation for the
  * service, is not incurred (more than the max number of threads specified) as much.
  * </p>
- * 
+ *
  * @deprecated since 3.11.1 Use {@link PooledSplitJoinService} instead; since performance
  *             characteristics are unpredictable in constrained environments
- * 
+ *
  * @config pooling-split-join-service
  *
  */
@@ -64,8 +66,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 {
     "splitter", "service", "aggregator", "maxThreads", "timeout", "warmStart"
 })
-@Removal(version = "4.0.0",
-    message = "Use pooled-split-join-service instead; since performance characteristics are unpredictable in constrained environments")
+@ConfigDeprecated(removalVersion = "4.0.0", message = "Use pooled-split-join-service instead; since performance characteristics are unpredictable in constrained environments", groups = Deprecated.class)
 public class PoolingSplitJoinService extends SplitJoinService {
 
   private static final int DEFAULT_THREADS = 10;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/SplitJoinService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/SplitJoinService.java
@@ -12,11 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.splitter;
 
 import static com.adaptris.core.util.ServiceUtil.discardNulls;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,15 +27,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMarshaller;
@@ -52,6 +55,7 @@ import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.core.util.ManagedThreadFactory;
 import com.adaptris.interlok.util.CloseableIterable;
 import com.adaptris.util.TimeInterval;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -81,8 +85,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
     "splitter", "service", "aggregator", "maxThreads", "timeout"
 })
 @Deprecated
-@Removal(version = "4.0.0",
-    message = "Use pooled-split-join-service instead; since performance characteristics are unpredictable in constrained environments")
+@ConfigDeprecated(removalVersion = "4.0.0", message = "Use pooled-split-join-service instead; since performance characteristics are unpredictable in constrained environments", groups = Deprecated.class)
 public class SplitJoinService extends ServiceImp implements EventHandlerAware, ServiceWrapper {
 
   private static TimeInterval DEFAULT_TTL = new TimeInterval(600L, TimeUnit.SECONDS);
@@ -157,7 +160,7 @@ public class SplitJoinService extends ServiceImp implements EventHandlerAware, S
     if (iter instanceof List) {
       return (List<AdaptrisMessage>) iter;
     }
-    List<AdaptrisMessage> result = new ArrayList<AdaptrisMessage>();
+    List<AdaptrisMessage> result = new ArrayList<>();
     try (CloseableIterable<AdaptrisMessage> messages = CloseableIterable.ensureCloseable(iter)) {
       for (AdaptrisMessage msg : messages) {
         result.add(msg);
@@ -176,8 +179,9 @@ public class SplitJoinService extends ServiceImp implements EventHandlerAware, S
       Args.notNull(getSplitter(), "splitter");
       Args.notNull(getAggregator(), "aggregator");
       Args.notNull(getService(), "service");
-      if (exceptionStrategy == null)
+      if (exceptionStrategy == null) {
         exceptionStrategy = new DefaultPoolingFutureExceptionStrategy();
+      }
       executors = createExecutor();
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.transform;
 
@@ -22,23 +22,25 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
 import javax.xml.XMLConstants;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -53,6 +55,7 @@ import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.util.TimeInterval;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -76,7 +79,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
     CacheConnection.class
 })
 @Deprecated
-@Removal(version = "3.12.0", message="Use basic-xml-schema-validator or extended-xml-schema-validator instead")
+@ConfigDeprecated(removalVersion = "3.12.0", message="Use basic-xml-schema-validator or extended-xml-schema-validator instead", groups = Deprecated.class)
 public class XmlSchemaValidator extends MessageValidatorImpl {
 
   private static final int DEFAULT_CACHE_SIZE = 16;

--- a/interlok-core/src/main/java/com/adaptris/core/util/Args.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/Args.java
@@ -22,7 +22,7 @@ package com.adaptris.core.util;
  */
 // Not deprecated because it's madness, also because really interlok-common probably shouldn't exist.
 // @Deprecated
-// @Removal(version = "4.0", message = "Use com.adaptris.interlok.util.Args instead")
+// @Removal(version = "4.0.0", message = "Use com.adaptris.interlok.util.Args instead")
 public abstract class Args extends com.adaptris.interlok.util.Args {
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/CloseableIterable.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/CloseableIterable.java
@@ -12,20 +12,22 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.util;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
+
 import com.adaptris.annotation.Removal;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 
 /**
  * @deprecated since 3.10.2 moved to com.adaptris.interlok.util package.
  */
 @Deprecated
-@Removal(version="3.12.0")
+@ConfigDeprecated(removalVersion = "3.12.0", groups = Deprecated.class)
 public interface CloseableIterable<E> extends com.adaptris.interlok.util.CloseableIterable<E> {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/util/EncodingHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/EncodingHelper.java
@@ -2,9 +2,11 @@ package com.adaptris.core.util;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+
 import javax.mail.internet.MimeUtility;
-import com.adaptris.annotation.Removal;
+
 import com.adaptris.util.text.mime.MimeConstants;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 
 public class EncodingHelper {
 
@@ -12,7 +14,7 @@ public class EncodingHelper {
    * Standard supported encodings
    */
   public enum Encoding {
-    @Removal(version = "4.0.0", message = "Use Base64_MIME / Base64_URL / Base64_Basic instead")
+    @ConfigDeprecated(removalVersion = "4.0.0", message = "Use Base64_MIME / Base64_URL / Base64_Basic instead", groups = Deprecated.class)
     Base64 {
       @Override
       public OutputStream wrap(OutputStream orig) throws Exception {

--- a/interlok-core/src/main/java/com/adaptris/security/password/Password.java
+++ b/interlok-core/src/main/java/com/adaptris/security/password/Password.java
@@ -67,7 +67,7 @@ public abstract class Password {
    *
    */
   @Deprecated
-  @Removal(version = "4.0",
+  @Removal(version = "4.0.0",
       message = "This uses PBEWithSHA1AndDESede which is now cryptographically weak")
   public static final String NON_PORTABLE_PASSWORD = "ALTPW:";
 

--- a/interlok-core/src/main/java/com/adaptris/security/password/PbeCrypto.java
+++ b/interlok-core/src/main/java/com/adaptris/security/password/PbeCrypto.java
@@ -32,7 +32,7 @@ import com.adaptris.util.text.Base64ByteTranslator;
  *
  */
 @Deprecated
-@Removal(version = "4.0",
+@Removal(version = "4.0.0",
     message = "This uses PBEWithSHA1AndDESede which is now cryptographically weak")
 public class PbeCrypto extends PasswordImpl {
 

--- a/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationChecker
+++ b/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationChecker
@@ -1,5 +1,6 @@
 com.adaptris.core.management.config.DeserializationConfigurationChecker
 com.adaptris.core.management.config.ClasspathDupConfigurationChecker
 com.adaptris.core.management.config.JavaxValidationChecker
+com.adaptris.core.management.config.DeprecatedConfigurationChecker
 com.adaptris.core.management.config.SharedConnectionConfigurationChecker
 com.adaptris.core.management.config.SharedServiceConfigurationChecker

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
@@ -1,0 +1,147 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.adaptris.core.Adapter;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.management.BootstrapProperties;
+import com.adaptris.core.services.metadata.AddTimestampMetadataService;
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class DeprecatedConfigurationCheckerTest {
+
+  @Test
+  public void testPerformCheck_Valid() throws Exception {
+    DeprecatedConfigurationChecker checker = new DeprecatedConfigurationChecker();
+
+    BootstrapProperties mockBootProperties =
+        new MockBootProperties(toString(createAdapterConfig(true)));
+    ConfigurationCheckReport report = checker.performConfigCheck(mockBootProperties);
+    assertTrue(report.isCheckPassed());
+  }
+
+  @Test
+  public void testValidate_Valid() throws Exception {
+    DeprecatedConfigurationChecker checker = new DeprecatedConfigurationChecker();
+
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(createAdapterConfig(true), report);
+    assertTrue(report.isCheckPassed());
+    assertEquals(0, report.getFailureExceptions().size());
+    assertEquals(0, report.getWarnings().size());
+  }
+
+  @Test
+  public void testValidate_Invalid() throws Exception {
+    DeprecatedConfigurationChecker checker = new DeprecatedConfigurationChecker();
+
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(createAdapterConfig(false), report);
+
+    assertFalse(report.isCheckPassed());
+    // Should be 2 warning, 1 for the deprecated class and 1 for the deprecated member
+    assertEquals(2, report.getWarnings().size());
+    assertTrue(report.getWarnings().contains(
+        "Interlok Deprecation Warning: [sharedComponents.services[1]] is deprecated. It will be removed in a future version. No replacement."));
+    assertTrue(report.getWarnings().contains(
+        "Interlok Deprecation Warning: [sharedComponents.services[2].deprecated] is deprecated. It will be removed in a future version. No replacement."));
+    assertEquals(0, report.getFailureExceptions().size());
+  }
+
+  @Test
+  public void testValidate_Null() throws Exception {
+    DeprecatedConfigurationChecker checker = new DeprecatedConfigurationChecker();
+
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(null, report);
+    assertFalse(report.isCheckPassed());
+    assertEquals(1, report.getFailureExceptions().size());
+  }
+
+  private String toString(Adapter adapter) throws Exception {
+    return DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
+  }
+
+  private Adapter createAdapterConfig(boolean validates) throws Exception {
+
+    Adapter adapter = new Adapter();
+
+    // have a unique-id
+    adapter.setUniqueId("MyAdapter");
+    AddTimestampMetadataService atms = new AddTimestampMetadataService();
+    atms.setUniqueId("valid-add-timestamp-service");
+    adapter.getSharedComponents().addService(atms);
+
+    if (!validates) {
+      // Add a deprecated service
+      DeprecatedService ds = new DeprecatedService();
+      adapter.getSharedComponents().addService(ds);
+
+      // Add a service with deprecated member
+      DeprecatedMemberService dms = new DeprecatedMemberService();
+      dms.setDeprecated("value");
+      adapter.getSharedComponents().addService(dms);
+    }
+    return adapter;
+  }
+
+  @ConfigDeprecated(message = "It will be removed in a future version. No replacement.", groups = Deprecated.class)
+  public static class DeprecatedService extends ServiceImp {
+
+    @Override
+    public void doService(AdaptrisMessage msg) throws ServiceException {
+    }
+
+    @Override
+    public void prepare() throws CoreException {
+    }
+
+    @Override
+    protected void initService() throws CoreException {
+    }
+
+    @Override
+    protected void closeService() {
+    }
+
+  }
+
+  public static class DeprecatedMemberService extends ServiceImp {
+
+    @Getter
+    @Setter
+    @ConfigDeprecated(message = "It will be removed in a future version. No replacement.", groups = Deprecated.class)
+    private String deprecated;
+
+    @Override
+    public void doService(AdaptrisMessage msg) throws ServiceException {
+    }
+
+    @Override
+    public void prepare() throws CoreException {
+    }
+
+    @Override
+    protected void initService() throws CoreException {
+    }
+
+    @Override
+    protected void closeService() {
+    }
+
+  }
+}


### PR DESCRIPTION
## Motivation

We want a better way to generate a deprecated report similar to the one used for config validation without parsing the console deprecated warning.
We want to be able to run this check when running -configcheck

## Modification

- Add a new annotation constraint ConfigDepecated to be use like @ConfigDepecated(groups = Deprecated.class)
We can also add a message and a removal version. The groups is important as it is required to call the validation.
- Add a default message when the annotation is used: Is deprecated. It will be removed in {removalVersion}
- Add a new validator for the new constraint. The validator will fail if the value is not null (a deprecated value is used).
- Add a new DeprecatedConfigurationChecker that run validator.validate(adapter, Deprecated.class)
- Add tests for the new constraint validatoe and the new deprecated checker.
- Use the new @ConfigDepecated instead of @Removal for config classes and members. @Removal is still used for non getter methods.

Once those change have been approve we will need to support this new annotation in the UI and added to optional components where appropriated.

## Result

We get a deprecated warning report when running configcheck or with interlok-verify-report

## Testing

- The test should be successful
- Running _java -jar lib\interlok-boot.jar -configcheck_ with a config that used deprecated classes or members should have warning in the Deprecated checks report.
