### PR TITLE
INTERLOK-3472 Stop processing Conditional loops

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -18,6 +18,8 @@ package com.adaptris.core;
 
 import java.util.function.Function;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.validation.constraints.ConfigDeprecated;
 
 /**
@@ -55,8 +57,8 @@ public abstract class CoreConstants {
   /**
    * A simply function check to test if the processing of the given message should stop.
    */
-  public static final Function<AdaptrisMessage, Boolean> shouldStopProcessing = adaptrisMessage ->
-    STOP_PROCESSING_VALUE.equals(adaptrisMessage.getMetadataValue(STOP_PROCESSING_KEY));
+  public static final Function<AdaptrisMessage, Boolean> shouldStopProcessing = adaptrisMessage -> 
+      BooleanUtils.toBoolean(adaptrisMessage.getMetadataValue(STOP_PROCESSING_KEY));
 
   /**
    * <p>

--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core;
 
+import java.util.function.Function;
+
 import com.adaptris.validation.constraints.ConfigDeprecated;
 
 /**
@@ -39,6 +41,23 @@ public abstract class CoreConstants {
    * </p>
    */
   public static final String STOP_PROCESSING_KEY = "adpstopprocessing";
+  
+  /**
+   * <p>
+   * Metadata value which determines whether or not to stop processing additional services and/or producers
+   * </p>
+   *
+   * @see #STOP_PROCESSING_KEY
+   * @see #KEY_WORKFLOW_SKIP_PRODUCER
+   */
+  public static final String STOP_PROCESSING_VALUE = "true";
+  
+  /**
+   * A simply function check to test if the processing of the given message should stop.
+   */
+  public static final Function<AdaptrisMessage, Boolean> shouldStopProcessing = adaptrisMessage -> {
+    return STOP_PROCESSING_VALUE.equals(adaptrisMessage.getMetadataValue(STOP_PROCESSING_KEY));
+  };
 
   /**
    * <p>
@@ -64,16 +83,6 @@ public abstract class CoreConstants {
    * </ul>
    */
   public static final String KEY_WORKFLOW_SKIP_PRODUCER = "adpworkflowskipproducer";
-
-  /**
-   * <p>
-   * Metadata value which determines whether or not to stop processing additional services and/or producers
-   * </p>
-   *
-   * @see #STOP_PROCESSING_KEY
-   * @see #KEY_WORKFLOW_SKIP_PRODUCER
-   */
-  public static final String STOP_PROCESSING_VALUE = "true";
 
   /**
    * <p>

--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -55,9 +55,8 @@ public abstract class CoreConstants {
   /**
    * A simply function check to test if the processing of the given message should stop.
    */
-  public static final Function<AdaptrisMessage, Boolean> shouldStopProcessing = adaptrisMessage -> {
-    return STOP_PROCESSING_VALUE.equals(adaptrisMessage.getMetadataValue(STOP_PROCESSING_KEY));
-  };
+  public static final Function<AdaptrisMessage, Boolean> shouldStopProcessing = adaptrisMessage ->
+    STOP_PROCESSING_VALUE.equals(adaptrisMessage.getMetadataValue(STOP_PROCESSING_KEY));
 
   /**
    * <p>

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceListBase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceListBase.java
@@ -17,6 +17,7 @@ package com.adaptris.core;
 
 import static com.adaptris.core.CoreConstants.STOP_PROCESSING_KEY;
 import static com.adaptris.core.CoreConstants.STOP_PROCESSING_VALUE;
+import static com.adaptris.core.CoreConstants.shouldStopProcessing;
 
 public abstract class ServiceListBase extends ServiceCollectionImp {
 
@@ -41,7 +42,7 @@ public abstract class ServiceListBase extends ServiceCollectionImp {
   }
 
   protected boolean haltProcessing(AdaptrisMessage msg) {
-    if (STOP_PROCESSING_VALUE.equals(msg.getMetadataValue(STOP_PROCESSING_KEY))) {
+    if(shouldStopProcessing.apply(msg)) {
       log.trace("{}={} detected, halt processing", STOP_PROCESSING_KEY, STOP_PROCESSING_VALUE);
       return true;
     }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/DoWhile.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/DoWhile.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core.services.conditional;
 
+import static com.adaptris.core.CoreConstants.shouldStopProcessing;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -59,7 +61,7 @@ public class DoWhile extends While {
         }
         log.trace("Testing condition for 'DO-WHILE', with condition class {}",
             this.getCondition().getClass().getSimpleName());
-      } while (getCondition().evaluate(msg));
+      } while ((!shouldStopProcessing.apply(msg)) && (getCondition().evaluate(msg)));
       log.trace("Logical 'DO-WHILE' completed, exiting.");
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/ForEach.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/ForEach.java
@@ -1,5 +1,15 @@
 package com.adaptris.core.services.conditional;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -10,20 +20,10 @@ import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.MultiPayloadAdaptrisMessage;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.services.StopProcessingService;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import static com.adaptris.core.CoreConstants.shouldStopProcessing;
-
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A for-each implementation that iterates over the payloads in a
@@ -44,6 +44,10 @@ import java.util.concurrent.TimeUnit;
  *   <thread-count>1</thread-count>
  * </for-each-payload>
  * }</pre>
+ * 
+ * <p>
+ * Note: If your service list for each payload contains a {@link StopProcessingService} it will not stop the processing of each payload.
+ * </p>
  *
  * @author amanderson
  * @config for-each-payload
@@ -164,9 +168,6 @@ public class ForEach extends ServiceImp
 					{
 						log.error("Could not clone message [{}]", id, e);
 					}
-					
-					if(shouldStopProcessing.apply(msg))
-					  break;
 				}
 			}
 		}

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/ForEach.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/ForEach.java
@@ -18,6 +18,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
+import static com.adaptris.core.CoreConstants.shouldStopProcessing;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -161,6 +164,9 @@ public class ForEach extends ServiceImp
 					{
 						log.error("Could not clone message [{}]", id, e);
 					}
+					
+					if(shouldStopProcessing.apply(msg))
+					  break;
 				}
 			}
 		}

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/While.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/While.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core.services.conditional;
 
+import static com.adaptris.core.CoreConstants.shouldStopProcessing;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -104,7 +106,7 @@ public class While extends ServiceImp {
     try {
       log.trace("Running logical test on 'WHILE', with condition class {}",
           this.getCondition().getClass().getSimpleName());
-      while(this.getCondition().evaluate(msg)) {
+      while((!shouldStopProcessing.apply(msg)) && (this.getCondition().evaluate(msg))) {
         log.trace("Logical 'IF' evaluated to true on WHILE test, running service.");
         getThen().getService().doService(msg);
         loopCount ++;

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/DoWhileTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/DoWhileTest.java
@@ -31,7 +31,10 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.Service;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceList;
+import com.adaptris.core.StartedState;
 import com.adaptris.core.services.LogMessageService;
+import com.adaptris.core.services.StopProcessingService;
 import com.adaptris.core.services.conditional.conditions.ConditionMetadata;
 import com.adaptris.core.services.conditional.conditions.ConditionOr;
 import com.adaptris.core.services.conditional.operator.IsNull;
@@ -56,6 +59,9 @@ public class DoWhileTest extends ConditionalServiceExample {
   @Before
   public void setUp() throws Exception {
     openMocks = MockitoAnnotations.openMocks(this);
+    
+    when(mockService.retrieveComponentState())
+        .thenReturn(StartedState.getInstance());
 
     thenService = new ThenService();
     thenService.setService(mockService);
@@ -150,6 +156,32 @@ public class DoWhileTest extends ConditionalServiceExample {
     } catch (ServiceException ex) {
       // expected.
     }
+  }
+  
+  @Test
+  public void testStopProcessingServiceCancelsLoop() throws Exception {
+    when(mockCondition.evaluate(message))
+        .thenReturn(true);
+    
+    Service stopProcessingService = new StopProcessingService();
+
+    ServiceList services = new ServiceList();
+    services.add(stopProcessingService);
+    services.add(mockService);
+    
+    thenService = new ThenService();
+    thenService.setService(services);
+    
+    doWhile = new DoWhile().withThen(thenService).withCondition(mockCondition);
+    
+    LifecycleHelper.init(doWhile);
+    LifecycleHelper.start(doWhile);
+    
+    doWhile.doService(message);
+
+    // The default would loop 10 times, but the stop-processing-service should 
+    // limit us to only a single loop and the condition will never be tested.
+    verify(mockCondition, times(0)).evaluate(message);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/ForEachTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/ForEachTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,10 +26,8 @@ import com.adaptris.core.MultiPayloadAdaptrisMessageImp;
 import com.adaptris.core.MultiPayloadMessageFactory;
 import com.adaptris.core.Service;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceList;
+import com.adaptris.core.StartedState;
 import com.adaptris.core.services.LogMessageService;
-import com.adaptris.core.services.StopProcessingService;
-import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.GuidGenerator;
 
 public class ForEachTest extends ConditionalServiceExample
@@ -46,6 +45,12 @@ public class ForEachTest extends ConditionalServiceExample
 	public void setUp() throws Exception
 	{
 		MockitoAnnotations.openMocks(this);
+		
+		when(mock.retrieveComponentState())
+            .thenReturn(StartedState.getInstance());
+		when(mock.createName())
+		    .thenReturn(mock.getClass().getName());
+		
 		forEach = new ForEach();
 		then = new ThenService();
 		then.setService(mock);
@@ -94,27 +99,6 @@ public class ForEachTest extends ConditionalServiceExample
 		verify(mock, times(2)).doService(any(AdaptrisMessage.class));
 	}
 	
-	@Test
-	  public void testStopProcessingServiceCancelsLoop() throws Exception {
-	    Service stopProcessingService = new StopProcessingService();
-
-	    ServiceList services = new ServiceList();
-	    services.add(stopProcessingService);
-	    services.add(mock);
-	    
-	    then = new ThenService();
-	    then.setService(services);
-	    
-	    forEach.setThen(then);
-	    
-	    LifecycleHelper.init(forEach);
-	    LifecycleHelper.start(forEach);
-	    
-	    forEach.doService(message);
-
-	    verify(mock, times(0)).doService(any(AdaptrisMessage.class));
-	  }
-
 	@Test
   @SuppressWarnings("serial")
 	public void testNonCloneableMessage() throws Exception


### PR DESCRIPTION
## Motivation

A recent QandA message suggested that our conditional loops (while and do-while) continue looping after a stop-processing-service.
ServiceList's do actually test for the metadata set by the stop-processing-service, so you could argue that even though the conditional loops will continue spinning, no services will be applied.
But what if you use a service that has nested services and one of those nested services is a stop-processing-service.

This behaviour doesn't make sense for the for-loop, considering that loop uses a different payload for each iteration.  Also each payload has the services run in parallel threads making the behaviour of stopping exactly as soon as one of the threads runs a stop-processing thread difficult to predict.  

I think this PR can be argued either way.

## Modification

CoreConstants now has a static function that is reused in place of having to know the core constants set by the stop-processing-service.  Each conditional loop executes this function to break free from the loop.  

We might even consider adding a new class CoreFunctions; with a static list of commonly used functions such as checking if there is exception data held within a message.

## Result

Conditional loops will break from their loop if the stop-processing-service has been run.

## Testing

Difficult to test considering eventual functionality doesn't really change.
New unit tests added though show the breaking of the loops.
