### PR TITLE
INTERLOK-3465 Trigger retries from jetty.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/Adapter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/Adapter.java
@@ -174,6 +174,7 @@ public final class Adapter implements StateManagedComponentContainer, ComponentL
     getMessageErrorHandler().registerDigester(getMessageErrorDigester());
     injectErrorHandler();
     registerWorkflowsInRetrier();
+    LifecycleHelper.prepare(getFailedMessageRetrier());
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrier.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrier.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@ import java.util.Collection;
  * originally.
  * </p>
  */
-public interface FailedMessageRetrier extends AdaptrisComponent, AdaptrisMessageListener, ComponentLifecycleExtension {
+public interface FailedMessageRetrier extends AdaptrisComponent, ComponentLifecycleExtension {
 
   /**
    * Add a {@linkplain Workflow} to the internal register of workflows
@@ -33,7 +33,7 @@ public interface FailedMessageRetrier extends AdaptrisComponent, AdaptrisMessage
    * Add a {@linkplain Workflow} to the internal store. If the generated key is
    * not unique a{@linkplain CoreException} is thrown.
    * </p>
-   * 
+   *
    * @param workflow the workflow to add
    * @throws CoreException if it is considered a duplicate
    */

--- a/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
@@ -51,12 +51,17 @@ public abstract class FailedMessageRetrierImp implements FailedMessageRetrier {
   }
 
   protected Workflow getWorkflow(AdaptrisMessage msg) throws CoreException {
-    Workflow workflow = getWorkflows().get(msg.getMetadataValue(Workflow.WORKFLOW_ID_KEY));
+    return getWorkflow(msg.getMetadataValue(Workflow.WORKFLOW_ID_KEY));
+  }
+
+  protected Workflow getWorkflow(String workflowId) throws CoreException {
+    Workflow workflow = getWorkflows().get(workflowId);
     if (workflow == null) {
-      throw new CoreException("No Workflow [" + msg.getMetadataValue(Workflow.WORKFLOW_ID_KEY) + "] found");
+      throw new CoreException(String.format("No Workflow [%s] found", workflowId));
     }
     if (!StartedState.getInstance().equals(workflow.retrieveComponentState())) {
-      throw new CoreException("Workflow [" + workflow.obtainWorkflowId() + "] is not started.");
+      throw new CoreException(
+          String.format("Workflow [%s] is not started", workflow.obtainWorkflowId()));
     }
     return workflow;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FailedMessageRetrierImp.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,15 +21,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.adaptris.annotation.AutoPopulated;
-import com.adaptris.core.util.Args;
-import com.adaptris.core.util.LifecycleHelper;
-import com.adaptris.core.util.LoggingHelper;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * <p>
@@ -41,11 +36,9 @@ public abstract class FailedMessageRetrierImp implements FailedMessageRetrier {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-  @NotNull
-  @Valid
-  @AutoPopulated
-  private StandaloneConsumer standaloneConsumer;
   private transient Map<String, Workflow> workflows;
+  @Getter
+  @Setter
   private String uniqueId;
 
   /**
@@ -55,25 +48,6 @@ public abstract class FailedMessageRetrierImp implements FailedMessageRetrier {
    */
   public FailedMessageRetrierImp() {
     workflows = Collections.synchronizedMap(new HashMap<String, Workflow>());
-    setStandaloneConsumer(new StandaloneConsumer());
-  }
-
-  @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
-    onAdaptrisMessage(msg, success, null);
-  }
-  
-  @Override
-  public synchronized void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
-    try {
-      Workflow workflow = getWorkflow(msg);
-      updateRetryCountMetadata(msg);
-      workflow.onAdaptrisMessage(msg, success, failure); // workflow.onAM is sync'd...
-    }
-    catch (Exception e) { // inc. runtime, exc. Workflow
-      log.error("exception retrying message", e);
-      log.error("message {}", MessageLoggerImpl.LAST_RESORT_LOGGER.toString(msg));
-    }
   }
 
   protected Workflow getWorkflow(AdaptrisMessage msg) throws CoreException {
@@ -106,46 +80,16 @@ public abstract class FailedMessageRetrierImp implements FailedMessageRetrier {
     msg.addMetadata(CoreConstants.RETRY_COUNT_KEY, String.valueOf(count));
   }
 
-  /** @see com.adaptris.core.AdaptrisComponent#init() */
   @Override
-  public void init() throws CoreException {
-    if (standaloneConsumer != null) {
-      standaloneConsumer.registerAdaptrisMessageListener(this);
+  public void addWorkflow(Workflow workflow) throws CoreException {
+    String key = workflow.obtainWorkflowId();
+    if (getWorkflows().keySet().contains(key)) {
+      log.warn("duplicate workflow ID [" + key + "]");
+      throw new CoreException("Workflows cannot be uniquely identified");
     }
-    LifecycleHelper.init(standaloneConsumer);
+    log.debug("adding workflow with key [{}]", key);
+    getWorkflows().put(key, workflow);
   }
-
-  /** @see com.adaptris.core.AdaptrisComponent#start() */
-  @Override
-  public void start() throws CoreException {
-    LifecycleHelper.start(standaloneConsumer);
-  }
-
-  /** @see com.adaptris.core.AdaptrisComponent#stop() */
-  @Override
-  public void stop() {
-    LifecycleHelper.stop(standaloneConsumer);
-  }
-
-  /** @see com.adaptris.core.AdaptrisComponent#close() */
-  @Override
-  public void close() {
-    LifecycleHelper.close(standaloneConsumer);
-  }
-
-
-  /**
-   * Add a <code>Workflow</code>.
-   * <p>
-   * Add a <code>Workflow</code> to the internal store. If the generated key is not unique a <code>CoreException</code> can be
-   * thrown.
-   * </p>
-   * 
-   * @param workflow the workflow to add
-   * @throws CoreException if it is considered a duplicate
-   */
-  @Override
-  public abstract void addWorkflow(Workflow workflow) throws CoreException;
 
   @Override
   public void clearWorkflows() {
@@ -157,58 +101,8 @@ public abstract class FailedMessageRetrierImp implements FailedMessageRetrier {
     return new ArrayList<String>(workflows.keySet());
   }
 
-  /**
-   * <p>
-   * Returns the <code>StandaloneConsumer</code> to use.
-   * </p>
-   * 
-   * @return the <code>StandaloneConsumer</code> to use
-   */
-  public StandaloneConsumer getStandaloneConsumer() {
-    return standaloneConsumer;
-  }
-
-  /**
-   * <p>
-   * Sets the <code>StandaloneConsumer</code> to use. May not be null. Sets <code>this</code> as the consumer's
-   * <code>AdaptrisMessageListener</code>.
-   * </p>
-   * 
-   * @param consumer the <code>StandaloneConsumer</code> to use
-   */
-  public void setStandaloneConsumer(StandaloneConsumer consumer) {
-    standaloneConsumer = Args.notNull(consumer, "consumer");
-    standaloneConsumer.registerAdaptrisMessageListener(this);
-  }
-
   protected Map<String, Workflow> getWorkflows() {
     return workflows;
-  }
-
-  /**
-   * @return the uniqueId
-   */
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
-  }
-
-  /**
-   * @param uniqueId the uniqueId to set
-   */
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public void prepare() throws CoreException {
-    LifecycleHelper.prepare(getStandaloneConsumer());
-  }
-
-
-  @Override
-  public String friendlyName() {
-    return LoggingHelper.friendlyName(this);
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/NoRetries.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NoRetries.java
@@ -18,10 +18,8 @@ package com.adaptris.core;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.function.Consumer;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -61,10 +59,6 @@ public class NoRetries implements FailedMessageRetrier {
   }
 
   @Override
-  public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
-  }
-
-  @Override
   public void clearWorkflows() {
   }
 
@@ -85,11 +79,6 @@ public class NoRetries implements FailedMessageRetrier {
 
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String friendlyName() {
-    return LoggingHelper.friendlyName(this);
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/HttpConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/HttpConstants.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -249,7 +249,8 @@ public interface HttpConstants extends MimeConstants {
   /**
    * Fields Values.
    */
-  String WWW_FORM_URLENCODE = "application/x-www-form-urlencoded";
+  String WWW_FORM_URLENCODE = CONTENT_TYPE_WWW_FORM_URLENCODE;
+
   // The default server socket timeout, 6 secs
   /**
    * Default server socket timeout, 6secs

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
@@ -24,7 +24,6 @@ import static com.adaptris.core.http.jetty.JettyConstants.JETTY_USER_ROLES;
 import static com.adaptris.core.http.jetty.JettyConstants.JETTY_USER_ROLE_ATTR;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.join;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -42,18 +41,15 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
@@ -68,7 +64,6 @@ import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.util.TimeInterval;
 import com.adaptris.validation.constraints.ConfigDeprecated;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -377,6 +372,18 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
   @Override
   public String consumeLocationKey() {
     return JettyConstants.JETTY_URI;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends BasicJettyConsumer> T withPath(String path) {
+    setPath(path);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends BasicJettyConsumer> T withMethods(String methods) {
+    setMethods(methods);
+    return (T) this;
   }
 
   protected class BasicServlet extends HttpServlet {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
@@ -380,12 +380,6 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
     return (T) this;
   }
 
-  @SuppressWarnings("unchecked")
-  public <T extends BasicJettyConsumer> T withMethods(String methods) {
-    setMethods(methods);
-    return (T) this;
-  }
-
   protected class BasicServlet extends HttpServlet {
 
     private static final long serialVersionUID = 2007082301L;

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -1,0 +1,185 @@
+package com.adaptris.core.http.jetty.retry;
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotBlank;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.fs.FsHelper;
+import com.adaptris.core.lms.FileBackedMessage;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.MetadataHelper;
+import com.adaptris.fs.FsWorker;
+import com.adaptris.fs.NioWorker;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.util.Args;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Writes data into local storage for retry.
+ * <p>
+ * While not tightly coupled with {@link RetryFromJetty} it is designed somewhat exclusively for
+ * that. You may be able to make use of it in other ways, but behaviour may change unexpectedly due
+ * to changes in {@link RetryFromJetty}.
+ * </p>
+ * <p>
+ * The behaviour of this store will assume that each {@code message-id} will form a sub-directory
+ * off {@code baseUrl}. Metadata will be stored {@code [baseUrl]/[msgId]/metadata.properties} as a
+ * standard properties file; the payload will be stored in {@code [baseUrl]/[msgId]/payload.blob}.
+ * <p>
+ *
+ * @since 3.11.1
+ * @config retry-store-filesystem
+ */
+@XStreamAlias("retry-store-filesystem")
+@ComponentProfile(summary = "Store message for retry on the filesystem.", since = "3.11.1")
+@DisplayOrder(order = {"baseUrl"})
+@Slf4j
+public class FilesystemRetryStore implements RetryStore {
+
+  private static final String PAYLOAD_FILE_NAME = "payload.blob";
+  private static final String METADATA_FILE_NAME = "metadata.properties";
+
+  /**
+   * The base URL {@code file:///...} where we can discover files.
+   *
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  private String baseUrl;
+
+  private transient NioWorker fsWorker = new NioWorker();
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notBlank(getBaseUrl(), "baseUrl");
+  }
+
+  @Override
+  public void write(AdaptrisMessage msg) throws InterlokException {
+    try {
+      File dir = validateMsgId(msg.getUniqueId(), false);
+      log.trace("Created [{}]", dir.getCanonicalPath());
+      File payloadFile = new File(dir, PAYLOAD_FILE_NAME);
+      File metadataFile = new File(dir, METADATA_FILE_NAME);
+      if (msg instanceof FileBackedMessage) {
+        FileUtils.copyFile(((FileBackedMessage) msg).currentSource(), payloadFile);
+      } else {
+        try (InputStream in = msg.getInputStream();
+            OutputStream out = new FileOutputStream(payloadFile)) {
+          IOUtils.copy(in, out);
+        }
+      }
+      log.trace("Wrote [{}]", payloadFile.getCanonicalPath());
+      try (OutputStream out = new FileOutputStream(metadataFile)) {
+        Properties p = MetadataHelper.convertToProperties(msg.getMetadata());
+        p.store(out, "Metadata for " + msg.getUniqueId());
+      }
+      log.trace("Wrote [{}]", metadataFile.getCanonicalPath());
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    }
+  }
+
+  private File validateMsgId(String msgId, boolean mustAlreadyExist) throws Exception {
+    File target = new File(FsHelper.toFile(getBaseUrl()), msgId);
+    return validateDir(target, mustAlreadyExist);
+  }
+
+  private File validateDir(File target, boolean mustAlreadyExist) throws Exception {
+    if (mustAlreadyExist) {
+      FsWorker.checkReadable(FsWorker.isDirectory(target));
+    } else {
+      target.mkdirs();
+    }
+    return target;
+  }
+
+  @Override
+  public AdaptrisMessage buildForRetry(String msgId, Map<String, String> metadata,
+      AdaptrisMessageFactory msgFac) throws InterlokException {
+    try {
+      File dir = validateMsgId(msgId, true);
+      File payloadFile = FsWorker.isFile(FsWorker.checkReadable(new File(dir, PAYLOAD_FILE_NAME)));
+      AdaptrisMessage msg = DefaultMessageFactory.defaultIfNull(msgFac).newMessage();
+      if (msg instanceof FileBackedMessage) {
+        ((FileBackedMessage) msg).initialiseFrom(payloadFile);
+      } else {
+        try (InputStream in = new FileInputStream(payloadFile);
+            OutputStream out = msg.getOutputStream()) {
+          IOUtils.copy(in, out);
+        }
+      }
+      msg.setMessageHeaders(metadata);
+      msg.setUniqueId(msgId);
+      return msg;
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    }
+  }
+
+  @Override
+  public Map<String, String> getMetadata(String msgId) throws InterlokException {
+    try {
+      File dir = validateMsgId(msgId, true);
+      File metaFile = FsWorker.isFile(FsWorker.checkReadable(new File(dir, METADATA_FILE_NAME)));
+      Properties meta = new Properties();
+      try (InputStream in = new FileInputStream(metaFile)) {
+        meta.load(in);
+      }
+      // The compiler works in mysterious ways.
+      return (Map) meta;
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    }
+  }
+
+  @Override
+  public Iterable<RemoteBlob> report() throws InterlokException {
+    try {
+      File target = validateDir(FsHelper.toFile(getBaseUrl()), false);
+      File[] files = fsWorker.listFiles(target, DirectoryFileFilter.DIRECTORY);
+      return Arrays.stream(files)
+          .map((e) -> new RemoteBlob.Builder().setBucket(e.getParent())
+              .setLastModified(e.lastModified()).setName(e.getName()).setSize(e.length()).build())
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    }
+  }
+
+  @Override
+  public boolean delete(String msgId) throws InterlokException {
+    try {
+      File target = new File(FsHelper.toFile(getBaseUrl()), msgId);
+      return FileUtils.deleteQuietly(target);
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    }
+  }
+
+  public FilesystemRetryStore withBaseUrl(String s) {
+    setBaseUrl(s);
+    return this;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/ReportBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/ReportBuilder.java
@@ -1,0 +1,58 @@
+package com.adaptris.core.http.jetty.retry;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ComponentLifecycle;
+import com.adaptris.interlok.cloud.BlobListRenderer;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.util.text.mime.MimeConstants;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ *
+ * Supports reporting of what's in the retry store.
+ * <p>
+ * This is tightly coupled with {@link RetryFromJetty} and probably can't be used elsewhere.
+ * </p>
+ */
+@XStreamAlias("jetty-retry-report-builder")
+@ComponentProfile(summary = "Generate a report on the files stored in the retry store.",
+    since = "3.11.1")
+@DisplayOrder(order = {"reportRenderer", "contentType"})
+public class ReportBuilder implements ComponentLifecycle {
+
+  @Getter
+  @Setter
+  @InputFieldDefault(value = "just the names newline separated")
+  private BlobListRenderer reportRenderer;
+
+  /**
+   * Set the content type to be associated with the report.
+   *
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = MimeConstants.CONTENT_TYPE_TEXT_PLAIN)
+  private String contentType;
+
+  public AdaptrisMessage build(Iterable<RemoteBlob> list, AdaptrisMessage msg) throws Exception {
+    renderer().render(list, msg);
+    msg.addMessageHeader(RetryFromJetty.CONTENT_TYPE_METADATA_KEY, contentType());
+    return msg;
+  }
+
+  private BlobListRenderer renderer() {
+    return ObjectUtils.defaultIfNull(getReportRenderer(), new BlobListRenderer() {});
+  }
+
+  private String contentType() {
+    return StringUtils.defaultIfBlank(getContentType(), MimeConstants.CONTENT_TYPE_TEXT_PLAIN);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -1,0 +1,365 @@
+package com.adaptris.core.http.jetty.retry;
+
+import static com.adaptris.core.CoreConstants.HTTP_METHOD;
+import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URI;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageListener;
+import com.adaptris.core.ComponentLifecycle;
+import com.adaptris.core.ComponentLifecycleExtension;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.FailedMessageRetrier;
+import com.adaptris.core.FailedMessageRetrierImp;
+import com.adaptris.core.Service;
+import com.adaptris.core.StandaloneConsumer;
+import com.adaptris.core.Workflow;
+import com.adaptris.core.http.jetty.EmbeddedConnection;
+import com.adaptris.core.http.jetty.JettyConnection;
+import com.adaptris.core.http.jetty.JettyMessageConsumer;
+import com.adaptris.core.http.jetty.JettyResponseService;
+import com.adaptris.core.http.jetty.JettyRouteCondition;
+import com.adaptris.core.http.jetty.JettyRouteCondition.JettyRoute;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.core.util.ManagedThreadFactory;
+import com.adaptris.interlok.util.Args;
+import com.adaptris.util.TimeInterval;
+import com.adaptris.util.text.mime.MimeConstants;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.Synchronized;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link FailedMessageRetrier} implementation that retries upon demand.
+ * <p>
+ * This implementation listens on the specified jetty endpoint(s) and allows you to retry failed
+ * message by ID and list the contents of the data store that contains failed messages. Sometimes we
+ * can't rely on standard error handlers/retriers to retry failed messages. This is intended to
+ * codify some of the concepts discussed
+ * <a href="https://interlok.adaptris.net/blog/2017/10/19/interlok-s3-error-store.html">here</a>
+ * into a simpler configuration chain.
+ * </p>
+ * <p>
+ * This jetty implementation allows two modes of operation. Listing the failed messages, and
+ * retrying a message.
+ * <ul>
+ * <li>{@code curl -XGET http://localhost:8080/api/failed/list} gives you a list of message ids that
+ * are listed in the store</li>
+ * <li>{@code curl -XPOST http://localhost:8080/api/retry/[msgId]} will attempt to resubmit the
+ * message to the appropriate workflow; returning a 202 upon success</li>
+ * <ul>
+ * Note that this implementation expects that you have a separate tooling that allows you to delete
+ * failed messages.
+ * </p>
+ *
+ * @since 3.11.1
+ * @config retry-via-jetty
+ */
+@NoArgsConstructor
+@Slf4j
+@ComponentProfile(summary = "Listen for HTTP traffic on the specified URI and retry messages",
+    recommended = {EmbeddedConnection.class, JettyConnection.class}, since = "3.11.1")
+@DisplayOrder(order = {"retryEndpointPrefix", "reportingEndpoint", "retryHttpMethod", "connection",
+    "retryStore", "reportBuilder"})
+@XStreamAlias("retry-via-jetty")
+public class RetryFromJetty extends FailedMessageRetrierImp {
+
+  public static final String DEFAULT_ENDPOINT_PREFIX = "/api/retry/";
+  public static final String DEFAULT_REPORTING_ENDPOINT = "/api/failed/list";
+  private static final String HTTP_RETRY_METHOD = "POST";
+  private static final TimeInterval DEFAULT_SHUTDOWN_WAIT = new TimeInterval(30L, TimeUnit.SECONDS.name());
+
+  public static final String CONTENT_TYPE_METADATA_KEY = "__Content-Type";
+  public static final String CONTENT_TYPE_EXPR = "%message{__Content-Type}";
+
+  private static final String HTTP_STATUS_KEY = "__httpResponseCode";
+  private static final String HTTP_STATUS_EXPR = "%message{__httpResponseCode}";
+  private static final String RETRY_MSG_ID_KEY = "__retryMsgId";
+
+  protected static final String HTTP_OK = "" + HttpURLConnection.HTTP_OK;
+  protected static final String HTTP_ACCEPTED = "" + HttpURLConnection.HTTP_ACCEPTED;
+  protected static final String HTTP_ERROR = "" + HttpURLConnection.HTTP_INTERNAL_ERROR;
+  protected static final String HTTP_BAD = "" + HttpURLConnection.HTTP_BAD_REQUEST;
+
+  /**
+   * The retry endpoint.
+   * <p>
+   * The default if not explicitly specified is {@value DEFAULT_ENDPOINT_PREFIX}, note the trailing
+   * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
+   * form {@code /prefix/'msgId'}
+   * </p>
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = DEFAULT_ENDPOINT_PREFIX)
+  private String retryEndpointPrefix;
+  /**
+   * The endpoint that allows reporting on what has failed.
+   * <p>
+   * The default if not explicitly specified is {@value DEFAULT_REPORTING_ENDPOINT}.
+   * </p>
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = DEFAULT_REPORTING_ENDPOINT)
+  private String reportingEndpoint;
+
+  @Getter
+  @Setter
+  @NotNull
+  private AdaptrisConnection connection = new EmbeddedConnection();
+
+
+  /**
+   * How to build reports.
+   *
+   */
+  @Getter
+  @Setter
+  @NotNull
+  @NonNull
+  private ReportBuilder reportBuilder = new ReportBuilder();
+
+  /**
+   * Where messages are stored for retries.
+   *
+   */
+  @Getter
+  @Setter
+  @NotNull
+  @NonNull
+  private RetryStore retryStore;
+
+  /**
+   * The HTTP method which is required for retries; the default is POST.
+   */
+  @AdvancedConfig(rare=true)
+  @Getter
+  @Setter
+  @InputFieldDefault(value = HTTP_RETRY_METHOD)
+  private String retryHttpMethod;
+
+  private transient String retryServletPath;
+  private transient String retryServletRegexp;
+  private transient StandaloneConsumer reporting;
+  private transient StandaloneConsumer retrying;
+  private transient ReportListener reporter;
+  private transient RetryListener retrier;
+  private transient ExecutorService workflowSubmitter;
+  private transient JettyRouteCondition routing;
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notNull(getReportBuilder(), "report-builder");
+    Args.notNull(getRetryStore(), "retry-store");
+    retryServletPath = retryEndpointPrefix() + "*";
+    retryServletRegexp = "^" + retryEndpointPrefix() + "(.*)";
+    routing = new JettyRouteCondition().withUrlPattern(retryServletRegexp)
+        .withMetadataKeys(RETRY_MSG_ID_KEY)
+        .withMethod(retryHttpMethod());
+    reporter = new ReportListener();
+    retrier = new RetryListener();
+    // By not dictating the method in the consumer; we accept all methods in jetty, but we use the
+    // jetty route filter to filter it out.
+    retrying = new StandaloneConsumer(getConnection(),
+        new JettyMessageConsumer().withPath(retryServletPath));
+    reporting = new StandaloneConsumer(getConnection(), new JettyMessageConsumer().withPath(reportingEndpoint()));
+    retrying.registerAdaptrisMessageListener(retrier);
+    reporting.registerAdaptrisMessageListener(reporter);
+    LifecycleHelper.prepare(routing, getRetryStore(), getReportBuilder(), reporter, retrier,
+        retrying, reporting);
+  }
+
+  @Override
+  public void init() throws CoreException {
+    LifecycleHelper.init(routing, getRetryStore(), getReportBuilder(), reporter, retrier, retrying,
+        reporting);
+    workflowSubmitter = Executors.newSingleThreadExecutor();
+  }
+
+  @Override
+  public void start() throws CoreException {
+    LifecycleHelper.start(routing, getRetryStore(), getReportBuilder(), reporter, retrier, retrying,
+        reporting);
+  }
+
+  @Override
+  public void stop() {
+    LifecycleHelper.stop(routing, retrying, reporting, reporter, retrier, getRetryStore(),
+        getReportBuilder());
+  }
+
+  @Override
+  public void close() {
+    LifecycleHelper.close(routing, retrying, reporting, reporter, retrier, getRetryStore(),
+        getReportBuilder());
+    ManagedThreadFactory.shutdownQuietly(workflowSubmitter, DEFAULT_SHUTDOWN_WAIT);
+  }
+
+  public RetryFromJetty withRetryStore(RetryStore rs) {
+    setRetryStore(rs);
+    return this;
+  }
+
+  public RetryFromJetty withReportBuilder(ReportBuilder b) {
+    setReportBuilder(b);
+    return this;
+  }
+
+  private String retryEndpointPrefix() {
+    return StringUtils.defaultIfBlank(getRetryEndpointPrefix(), DEFAULT_ENDPOINT_PREFIX);
+  }
+
+  private String reportingEndpoint() {
+    return StringUtils.defaultIfBlank(getRetryEndpointPrefix(), DEFAULT_REPORTING_ENDPOINT);
+  }
+
+  private String retryHttpMethod() {
+    return StringUtils.defaultIfBlank(getRetryHttpMethod(), HTTP_RETRY_METHOD);
+  }
+
+  protected static void executeQuietly(Service service, AdaptrisMessage msg) {
+    try {
+      service.doService(msg);
+    } catch (Exception e) {
+
+    }
+  }
+
+  private abstract class ListenerImpl
+      implements AdaptrisMessageListener, ComponentLifecycle, ComponentLifecycleExtension {
+
+    private JettyResponseService service;
+
+    public ListenerImpl() {
+      service = new JettyResponseService().withHttpStatus(HTTP_STATUS_EXPR)
+          .withContentType(CONTENT_TYPE_EXPR);
+    }
+
+    protected void sendResponse(String httpResponseCode, AdaptrisMessage msg) {
+      msg.addMessageHeader(HTTP_STATUS_KEY, httpResponseCode);
+      // Default a Content-Type if not available
+      msg.addMessageHeader(CONTENT_TYPE_METADATA_KEY, StringUtils.defaultIfBlank(
+          msg.getMetadataValue(CONTENT_TYPE_METADATA_KEY), MimeConstants.CONTENT_TYPE_TEXT_PLAIN));
+      executeQuietly(service, msg);
+    }
+
+    @Override
+    public void prepare() throws CoreException {
+      LifecycleHelper.prepare(service);
+    }
+
+    @Override
+    public void init() throws CoreException {
+      LifecycleHelper.init(service);
+    }
+
+    @Override
+    public void start() throws CoreException {
+      LifecycleHelper.start(service);
+    }
+
+    @Override
+    public void stop() {
+      LifecycleHelper.stop(service);
+
+    }
+
+    @Override
+    public void close() {
+      LifecycleHelper.close(service);
+    }
+  }
+
+  @NoArgsConstructor
+  private class ReportListener extends ListenerImpl {
+    @Override
+    public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
+        Consumer<AdaptrisMessage> failure) {
+      String httpCode = HTTP_ERROR;
+      try {
+        getReportBuilder().build(getRetryStore().report(), jettyMsg);
+        httpCode = HTTP_OK;
+      } catch (Exception e) {
+        jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+      } finally {
+        sendResponse(httpCode, jettyMsg);
+      }
+    }
+
+    @Override
+    public String friendlyName() {
+      return "RetryFromJetty::Reporting";
+    }
+  }
+
+  private class RetryListener extends ListenerImpl {
+    private transient Object locker = new Object();
+
+    @Override
+    @Synchronized(value = "locker")
+    public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
+        Consumer<AdaptrisMessage> failure) {
+      try {
+        JettyRoute route = routing.build(jettyMsg.getMetadataValue(HTTP_METHOD),
+            jettyMsg.getMetadataValue(JETTY_URI));
+        if (route.matches()) {
+          String msgId =
+              route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(RETRY_MSG_ID_KEY))
+                  .findFirst().get().getValue();
+          // There's a decision point here because we need to decide between
+          // large or small message factory.
+          // Do we want people to configure it?
+          // Therefore we look up the metadata from the store;
+          // Figure out the workflow, and then get the consumer.getMessageFactory()
+
+          Map<String, String> metadata = retryStore.getMetadata(msgId);
+          Workflow workflow = getWorkflow(metadata.get(Workflow.WORKFLOW_ID_KEY));
+          AdaptrisMessage msgForRetry =
+              retryStore.buildForRetry(msgId, metadata, workflow.getConsumer().getMessageFactory());
+          // We know at this point we have something to retry.
+          // So, we can fire a 202 before submission.
+          sendResponse(HTTP_ACCEPTED, jettyMsg);
+          updateRetryCountMetadata(msgForRetry);
+          // pooling workflow returns immediately, standard workflow does not.
+          // so submit to an Executor Service.
+          workflowSubmitter.execute(new Thread() {
+            @Override
+            public void run() {
+              Thread.currentThread().setName("Retry Failed Message");
+              workflow.onAdaptrisMessage(msgForRetry, success, failure);
+            }
+          });
+        } else {
+          sendResponse(HTTP_BAD, jettyMsg);
+        }
+      } catch (Exception e) {
+        jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+        sendResponse(HTTP_ERROR, jettyMsg);
+      }
+    }
+
+
+    @Override
+    public String friendlyName() {
+      return "RetryFromJetty::Retry";
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
@@ -1,0 +1,90 @@
+package com.adaptris.core.http.jetty.retry;
+
+import java.util.Collections;
+import java.util.Map;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ComponentLifecycle;
+import com.adaptris.core.ComponentLifecycleExtension;
+import com.adaptris.core.CoreException;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.cloud.RemoteBlob;
+
+public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtension {
+  /**
+   * Report on a list of blobs that is present in the store (optional operation).
+   *
+   * @implNote The default implementation just returns an empty list.
+   */
+  default Iterable<RemoteBlob> report() throws InterlokException {
+    return Collections.EMPTY_LIST;
+  }
+
+  /**
+   * Write a message to the store.
+   *
+   */
+  void write(AdaptrisMessage msg) throws InterlokException;
+
+  /**
+   * Retrieve the message id from the store.
+   *
+   * @implNote The default implementation delegates to {@link #buildForRetry(String, Map)} via
+   *           {@link #getMetadata(String)}
+   */
+  default AdaptrisMessage buildForRetry(String msgId) throws InterlokException {
+    return buildForRetry(msgId, getMetadata(msgId));
+  }
+
+  /**
+   * Retrieve the message id from the store.
+   *
+   * @implNote The default implementation delegates to
+   *           {@link #buildForRetry(String, Map, AdaptrisMessageFactory)} via
+   *           {@link #getMetadata(String)}
+   *
+   */
+  default AdaptrisMessage buildForRetry(String msgId, Map<String, String> metadata)
+      throws InterlokException {
+    return buildForRetry(msgId, metadata, null);
+  }
+
+
+  /**
+   * Build the message for retrying from the store.
+   *
+   * @param msgId the message id.
+   * @param metadata the metadata you want to apply to the message
+   * @param factory the message factory to use
+   * @return a message.
+   * @throws CoreException
+   */
+  AdaptrisMessage buildForRetry(String msgId, Map<String, String> metadata,
+      AdaptrisMessageFactory factory) throws InterlokException;
+
+  /**
+   * Retrieve the metadata associated with the msgId the store.
+   * <p>
+   * This is used to assert that the workflow exists in this instance for that message; there is no
+   * point building the whole message only to fail because the workflow doesn't exist.
+   * </p>
+   *
+   */
+  Map<String, String> getMetadata(String msgId) throws InterlokException;
+
+
+  /**
+   * Delete a message from the store (optional operation).
+   *
+   * @implNote The default implementation throws an instance of
+   *           {@link UnsupportedOperationException} and performs no other action.
+   */
+  default boolean delete(String msgId) throws InterlokException {
+    throw new UnsupportedOperationException("delete(String)");
+  }
+
+  @Override
+  default void prepare() throws CoreException {
+
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreDeleteService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreDeleteService.java
@@ -28,7 +28,7 @@ import lombok.Setter;
 @XStreamAlias("retry-store-delete-service")
 @NoArgsConstructor
 @ComponentProfile(summary = "Delete a message from the retry store",
-    since = "3.11.1")
+    since = "3.11.1", tag = "retry")
 @DisplayOrder(order = {"messageId", "retryStore"})
 public class RetryStoreDeleteService extends RetryStoreServiceImpl {
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreDeleteService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreDeleteService.java
@@ -1,0 +1,68 @@
+package com.adaptris.core.http.jetty.retry;
+
+import javax.validation.constraints.NotNull;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.util.Args;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Delete a message from the configured retry store.
+ *
+ * <p>
+ * While not tightly coupled it is designed as a supporting service for use with
+ * {@link RetryFromJetty}.
+ * </p>
+ *
+ * @since 3.11.1
+ * @config retry-store-delete-service
+ */
+@XStreamAlias("retry-store-delete-service")
+@NoArgsConstructor
+@ComponentProfile(summary = "Delete a message from the retry store",
+    since = "3.11.1")
+@DisplayOrder(order = {"messageId", "retryStore"})
+public class RetryStoreDeleteService extends RetryStoreServiceImpl {
+
+  /**
+   * The messageID to delete.
+   * <p>
+   * This supports metadata resolution via {@link AdaptrisMessage#resolve(String)} since it is not
+   * expected that it should be deleting the current messages unique-id.
+   * </p>
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression = true)
+  @NotNull
+  private String messageId;
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      getRetryStore().delete(msg.resolve(getMessageId()));
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notNull(messageId, "messageId");
+    super.prepare();
+  }
+
+  public RetryStoreDeleteService withMessageId(String s) {
+    setMessageId(s);
+    return this;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreListService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreListService.java
@@ -26,7 +26,7 @@ import lombok.Setter;
 @XStreamAlias("retry-store-list-service")
 @NoArgsConstructor
 @ComponentProfile(summary = "List messages available to be retried from the retry store",
-    since = "3.11.1")
+    since = "3.11.1", tag = "retry")
 @DisplayOrder(order = {"reportRenderer", "retryStore"})
 public class RetryStoreListService extends RetryStoreServiceImpl {
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreListService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreListService.java
@@ -1,0 +1,50 @@
+package com.adaptris.core.http.jetty.retry;
+
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.cloud.BlobListRenderer;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * List messages in the configured retry store.
+ *
+ * <p>
+ * While not tightly coupled it is designed as a supporting service for use with
+ * {@link RetryFromJetty}.
+ * </p>
+ *
+ * @since 3.11.1
+ * @config retry-store-list-service
+ */
+@XStreamAlias("retry-store-list-service")
+@NoArgsConstructor
+@ComponentProfile(summary = "List messages available to be retried from the retry store",
+    since = "3.11.1")
+@DisplayOrder(order = {"reportRenderer", "retryStore"})
+public class RetryStoreListService extends RetryStoreServiceImpl {
+
+  @Getter
+  @Setter
+  private BlobListRenderer reportRenderer;
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      renderer().render(getRetryStore().report(), msg);
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+
+  }
+
+  private BlobListRenderer renderer() {
+    return ObjectUtils.defaultIfNull(getReportRenderer(), new BlobListRenderer() {});
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreServiceImpl.java
@@ -1,0 +1,63 @@
+package com.adaptris.core.http.jetty.retry;
+
+import javax.validation.constraints.NotNull;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.util.Args;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * @since 3.11.1
+ */
+@NoArgsConstructor
+public abstract class RetryStoreServiceImpl extends ServiceImp {
+  /**
+   * Where messages are stored for retries.
+   *
+   */
+  @Getter
+  @Setter
+  @NotNull
+  @NonNull
+  private RetryStore retryStore;
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notNull(getRetryStore(), "retry-store");
+    LifecycleHelper.prepare(getRetryStore());
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+    LifecycleHelper.init(getRetryStore());
+
+  }
+
+  @Override
+  public void start() throws CoreException {
+    LifecycleHelper.start(getRetryStore());
+    super.start();
+
+  }
+
+  @Override
+  public void stop() {
+    LifecycleHelper.stop(getRetryStore());
+    super.stop();
+
+  }
+
+  @Override
+  protected void closeService() {
+    LifecycleHelper.close(getRetryStore());
+  }
+
+  public <T extends RetryStoreServiceImpl> T withRetryStore(RetryStore rs) {
+    setRetryStore(rs);
+    return (T) this;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteService.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @XStreamAlias("retry-store-write-message")
 @NoArgsConstructor
 @ComponentProfile(summary = "Write a message to the retry store for future retries",
-    since = "3.11.1")
+    since = "3.11.1", tag = "retry")
 @DisplayOrder(order = {"retryStore"})
 public class RetryStoreWriteService extends RetryStoreServiceImpl {
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteService.java
@@ -1,0 +1,33 @@
+package com.adaptris.core.http.jetty.retry;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
+
+/**
+ * Write a message for retry with {@link RetryFromJetty}.
+ *
+ * @since 3.11.1
+ * @config retry-store-write-message
+ */
+@XStreamAlias("retry-store-write-message")
+@NoArgsConstructor
+@ComponentProfile(summary = "Write a message to the retry store for future retries",
+    since = "3.11.1")
+@DisplayOrder(order = {"retryStore"})
+public class RetryStoreWriteService extends RetryStoreServiceImpl {
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      getRetryStore().write(msg);
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/package-info.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/package-info.java
@@ -1,0 +1,1 @@
+package com.adaptris.core.http.jetty.retry;

--- a/interlok-core/src/main/java/com/adaptris/core/util/ExceptionHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/ExceptionHelper.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,12 +19,13 @@ package com.adaptris.core.util;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.InterlokException;
 
 /**
  * Helper class that assists converting exceptions.
- * 
+ *
  * @author lchan
- * 
+ *
  */
 public abstract class ExceptionHelper {
 
@@ -92,5 +93,16 @@ public abstract class ExceptionHelper {
       return (ProduceException) e;
     }
     return new ProduceException(msg, e);
+  }
+
+  public static InterlokException wrapInterlokException(Throwable e) {
+    return wrapInterlokException(e.getMessage(), e);
+  }
+
+  public static InterlokException wrapInterlokException(String msg, Throwable e) {
+    if (e instanceof InterlokException) {
+      return (InterlokException) e;
+    }
+    return new InterlokException(msg, e);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/mime/MimeConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/mime/MimeConstants.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,4 +47,8 @@ public interface MimeConstants {
   String ENCODING_QUOTED = "quoted-printable";
   /** binary Encoding type */
   String ENCODING_BINARY = "binary";
+
+  String CONTENT_TYPE_WWW_FORM_URLENCODE = "application/x-www-form-urlencoded";
+  String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
+  String CONTENT_TYPE_OCTET_STREAM = "application/octet-stream";
 }

--- a/interlok-core/src/test/java/com/adaptris/core/DefaultFailedMessageRetrierTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/DefaultFailedMessageRetrierTest.java
@@ -16,14 +16,32 @@
 
 package com.adaptris.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.util.UUID;
 import org.junit.Test;
 import com.adaptris.core.fs.FsConsumer;
+import com.adaptris.core.stubs.FailFirstMockMessageProducer;
+import com.adaptris.core.stubs.MockMessageConsumer;
+import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.stubs.StubEventHandler;
 
+@SuppressWarnings("deprecation")
 public class DefaultFailedMessageRetrierTest
     extends com.adaptris.interlok.junit.scaffolding.FailedMessageRetrierCase {
+
+
+  @Test
+  public void testSetter() throws Exception {
+    DefaultFailedMessageRetrier retrier = create();
+    try {
+      retrier.setStandaloneConsumer(null);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
 
   @Test
   public void testDuplicateWorkflows() throws Exception {
@@ -38,14 +56,204 @@ public class DefaultFailedMessageRetrierTest
     }
   }
 
+
+  @Test
+  public void testRetry() throws Exception {
+    DefaultFailedMessageRetrier retrier = create();
+    StandardWorkflow wf = createWorkflow();
+    try {
+      MockMessageProducer p = (MockMessageProducer) wf.getProducer();
+      retrier.addWorkflow(wf);
+      retrier.addWorkflow(createWorkflow());
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
+      msg.addMetadata(Workflow.WORKFLOW_ID_KEY, wf.obtainWorkflowId());
+      start(wf);
+      start(retrier);
+      retrier.onAdaptrisMessage(msg);
+      assertEquals(1, p.getMessages().size());
+    } finally {
+      stop(retrier);
+      stop(wf);
+    }
+  }
+
+  @Test
+  public void testRetryNoWorkflowId() throws Exception {
+    DefaultFailedMessageRetrier retrier = create();
+    StandardWorkflow wf = createWorkflow();
+    try {
+      MockMessageProducer p = (MockMessageProducer) wf.getProducer();
+      retrier.addWorkflow(wf);
+      retrier.addWorkflow(createWorkflow());
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
+      start(wf);
+      start(retrier);
+      retrier.onAdaptrisMessage(msg);
+      assertFalse(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
+      assertEquals(0, p.getMessages().size());
+    } finally {
+      stop(retrier);
+      stop(wf);
+    }
+  }
+
+  @Test
+  public void testRetryNoMatchForWorkflowId() throws Exception {
+    DefaultFailedMessageRetrier retrier = create();
+    StandardWorkflow wf = createWorkflow();
+    try {
+      MockMessageProducer p = (MockMessageProducer) wf.getProducer();
+      retrier.addWorkflow(wf);
+      retrier.addWorkflow(createWorkflow());
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
+      msg.addMetadata(Workflow.WORKFLOW_ID_KEY, createWorkflow().obtainWorkflowId());
+      start(retrier);
+      start(wf);
+      retrier.onAdaptrisMessage(msg);
+      assertEquals(0, p.getMessages().size());
+      assertFalse(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
+    } finally {
+      stop(retrier);
+      stop(wf);
+    }
+  }
+
+  @Test
+  public void testRetryInvalidCounter() throws Exception {
+    DefaultFailedMessageRetrier retrier = create();
+    StandardWorkflow wf = createWorkflow();
+    try {
+      MockMessageProducer p = (MockMessageProducer) wf.getProducer();
+      retrier.addWorkflow(wf);
+      retrier.addWorkflow(createWorkflow());
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
+      msg.addMetadata(Workflow.WORKFLOW_ID_KEY, wf.obtainWorkflowId());
+      msg.addMetadata(CoreConstants.RETRY_COUNT_KEY, "fred");
+      start(retrier);
+      start(wf);
+      retrier.onAdaptrisMessage(msg);
+      assertTrue(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
+      assertEquals("1", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
+
+    } finally {
+      stop(retrier);
+      stop(wf);
+    }
+  }
+
+  @Test
+  public void testMultipleRetries() throws Exception {
+    DefaultFailedMessageRetrier retrier = create();
+    StandardWorkflow wf = createWorkflow();
+    try {
+      wf.setProducer(new FailFirstMockMessageProducer());
+      FailFirstMockMessageProducer p = (FailFirstMockMessageProducer) wf.getProducer();
+      retrier.addWorkflow(wf);
+      retrier.addWorkflow(createWorkflow());
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
+      msg.addMetadata(Workflow.WORKFLOW_ID_KEY, wf.obtainWorkflowId());
+      start(retrier);
+      start(wf);
+      retrier.onAdaptrisMessage(msg);
+      assertTrue(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
+      assertEquals("1", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
+      retrier.onAdaptrisMessage(msg);
+      assertEquals(1, p.getMessages().size());
+      assertEquals("2", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
+
+    } finally {
+      stop(retrier);
+      stop(wf);
+    }
+  }
+
+  @Test
+  public void testAdapterRetry() throws Exception {
+    DefaultFailedMessageRetrier retrier = create();
+    MockMessageProducer errProd = new MockMessageProducer();
+    StandardProcessingExceptionHandler speh =
+        new StandardProcessingExceptionHandler(new StandaloneProducer(errProd));
+    Adapter adapter = createAdapterForRetry(retrier, speh);
+    try {
+      FailFirstMockMessageProducer workflowProducer = (FailFirstMockMessageProducer) adapter
+          .getChannelList().get(0).getWorkflowList().get(0).getProducer();
+      MockMessageConsumer consumer = (MockMessageConsumer) adapter.getChannelList().get(0)
+          .getWorkflowList().get(0).getConsumer();
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
+      start(adapter);
+      consumer.submitMessage(msg);
+      // SHould have failed
+      assertEquals(1, errProd.messageCount());
+      retrier.onAdaptrisMessage(errProd.getMessages().get(0));
+      assertTrue(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
+      assertEquals("1", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
+      assertEquals(1, workflowProducer.getMessages().size());
+    } finally {
+      stop(adapter);
+    }
+  }
+
+  @Test
+  public void testRoundTrip_AdapterRetry() throws Exception {
+    AdaptrisMarshaller marshaller = DefaultMarshaller.getDefaultMarshaller();
+    Adapter adapter = (Adapter) marshaller.unmarshal(
+        marshaller.marshal(createAdapterForRetry(create(), new StandardProcessingExceptionHandler(
+            new StandaloneProducer(new MockMessageProducer())))));
+    DefaultFailedMessageRetrier retrier =
+        (DefaultFailedMessageRetrier) adapter.getFailedMessageRetrier();
+    MockMessageProducer errProd = getErrorHandler(adapter);
+    try {
+      FailFirstMockMessageProducer workflowProducer = (FailFirstMockMessageProducer) adapter
+          .getChannelList().get(0).getWorkflowList().get(0).getProducer();
+      MockMessageConsumer consumer = (MockMessageConsumer) adapter.getChannelList().get(0)
+          .getWorkflowList().get(0).getConsumer();
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
+      start(adapter);
+      consumer.submitMessage(msg);
+      // SHould have failed
+      assertEquals(1, errProd.messageCount());
+      retrier.onAdaptrisMessage(errProd.getMessages().get(0));
+      assertTrue(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
+      assertEquals("1", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
+      assertEquals(1, workflowProducer.getMessages().size());
+    } finally {
+      stop(adapter);
+    }
+  }
+
+  private Adapter createAdapterForRetry(FailedMessageRetrier retrier,
+      ProcessingExceptionHandler errorHandler) throws Exception {
+    Adapter adapter = AdapterTest.createAdapter(getName());
+    adapter.setFailedMessageRetrier(retrier);
+    adapter.setMessageErrorHandler(errorHandler);
+    adapter.getChannelList().clear();
+    Channel c = new Channel();
+    c.setUniqueId(getName());
+    StandardWorkflow wf = new StandardWorkflow();
+    wf.setUniqueId(getName());
+    wf.setConsumer(new MockMessageConsumer());
+    wf.setProducer(new FailFirstMockMessageProducer());
+    c.getWorkflowList().add(wf);
+    adapter.getChannelList().add(c);
+    return adapter;
+  }
+
+  private MockMessageProducer getErrorHandler(Adapter adapter) {
+    ServiceList list =
+        (ServiceList) ((StandardProcessingExceptionHandler) adapter.getMessageErrorHandler())
+            .getProcessingExceptionService();
+    StandaloneProducer producer = (StandaloneProducer) list.get(0);
+    return (MockMessageProducer) producer.getProducer();
+  }
+
+
   @Override
   protected Object retrieveObjectForSampleConfig() {
     Adapter result = null;
     try {
       DefaultFailedMessageRetrier fmr = new DefaultFailedMessageRetrier();
       FsConsumer consumer = new FsConsumer().withBaseDirectoryUrl("/path/to/retry-directory");
-      StandaloneConsumer c = new StandaloneConsumer();
-      c.setConsumer(consumer);
+      StandaloneConsumer c = new StandaloneConsumer(consumer);
       fmr.setStandaloneConsumer(c);
       result = new Adapter();
       result.setFailedMessageRetrier(fmr);
@@ -65,7 +273,7 @@ public class DefaultFailedMessageRetrierTest
   }
 
   @Override
-  protected FailedMessageRetrier create() {
+  protected DefaultFailedMessageRetrier create() {
     return new DefaultFailedMessageRetrier();
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/EmbeddedJettyHelper.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/EmbeddedJettyHelper.java
@@ -62,9 +62,14 @@ public class EmbeddedJettyHelper {
     jetty = null;
   }
 
+  public String buildUrl(String uri) {
+    String actualUri = uri.startsWith("/") ? uri : "/" + uri;
+    log.trace("Destination is {}{}{}", "http://localhost:", portForServer, actualUri);
+    return "http://localhost:" + portForServer + actualUri;
+  }
+
   public ConfiguredProduceDestination createProduceDestination() {
-    log.trace("Destination is " + "http://localhost:" + portForServer + URL_TO_POST_TO);
-    return new ConfiguredProduceDestination("http://localhost:" + portForServer + URL_TO_POST_TO);
+    return new ConfiguredProduceDestination(buildUrl(URL_TO_POST_TO));
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
@@ -1,0 +1,206 @@
+package com.adaptris.core.http.jetty.retry;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.junit.AfterClass;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.fs.FsHelper;
+import com.adaptris.core.lms.FileBackedMessageFactory;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+
+public class FilesystemRetryStoreTest {
+
+  public static final String TEST_BASE_URL = "retry.baseUrl";
+
+  @AfterClass
+  public static void afterAll() throws Exception {
+    FileUtils.deleteQuietly(FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL)));
+  }
+
+  @Test
+  public void testWrite() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+      store.write(msg);
+      File dir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
+      assertTrue(dir.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY).length >= 1);
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+  @Test
+  public void testWrite_FileBacked() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new FileBackedMessageFactory().newMessage("hello");
+      store.write(msg);
+      File dir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
+      assertTrue(dir.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY).length >= 1);
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+
+  @Test(expected = InterlokException.class)
+  public void testWrite_Exception() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(
+            BaseCase.getConfiguration(TEST_BASE_URL) + "/ spaces / not / valid / in / url");
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+      store.write(msg);
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+  @Test
+  public void testBuildForRetry() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+      store.write(msg);
+      AdaptrisMessage retry = store.buildForRetry(msg.getUniqueId());
+      assertEquals(msg.getUniqueId(), retry.getUniqueId());
+      assertEquals(msg.getMessageHeaders(), retry.getMessageHeaders());
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+  @Test
+  public void testBuildForRetry_FileBacked() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+      store.write(msg);
+      Map<String, String> metadata = store.getMetadata(msg.getUniqueId());
+      AdaptrisMessage retry = store.buildForRetry(msg.getUniqueId(),
+          store.getMetadata(msg.getUniqueId()), new FileBackedMessageFactory());
+      assertEquals(msg.getUniqueId(), retry.getUniqueId());
+      assertEquals(msg.getMessageHeaders(), retry.getMessageHeaders());
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+  @Test(expected = InterlokException.class)
+  public void testBuildForRetry_Exception() throws Exception {
+    FilesystemRetryStore store = new FilesystemRetryStore()
+        .withBaseUrl(
+            BaseCase.getConfiguration(TEST_BASE_URL) + "/ spaces / not / valid / in / url");
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage retry = store.buildForRetry("xxx", Collections.EMPTY_MAP);
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+  @Test
+  public void testGetMetadata() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+      store.write(msg);
+      Map<String, String> metadata = store.getMetadata(msg.getUniqueId());
+      assertEquals(msg.getMessageHeaders(), metadata);
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+  @Test(expected = InterlokException.class)
+  public void testGetMetadata_Exception() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      store.getMetadata("xxx");
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+
+  @Test
+  public void testReport() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+      store.write(msg);
+      assertTrue(store.report().iterator().hasNext());
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+
+  @Test(expected = InterlokException.class)
+  public void testReport_Exception() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(
+            BaseCase.getConfiguration(TEST_BASE_URL) + "/ spaces / not / valid / in / url");
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+      store.report();
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    FilesystemRetryStore store =
+        new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+      store.write(msg);
+      assertTrue(store.delete(msg.getUniqueId()));
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+  @Test(expected = InterlokException.class)
+  public void testDelete_Exception() throws Exception {
+    FilesystemRetryStore store = new FilesystemRetryStore()
+        .withBaseUrl(
+            BaseCase.getConfiguration(TEST_BASE_URL) + "/ spaces / not / valid / in / url");
+    try {
+      LifecycleHelper.initAndStart(store);
+      store.delete("XXXX");
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
@@ -1,0 +1,59 @@
+package com.adaptris.core.http.jetty.retry;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.cloud.RemoteBlob;
+
+// While it's perfectly reasonable to "mock" an in memory one isn't an awful choice for testing.
+// However, it's of *no use in real life*.
+public class InMemoryRetryStore implements RetryStore {
+
+  private static final transient Map<String, AdaptrisMessage> STORE =
+      Collections.synchronizedMap(new HashMap<>());
+
+  @Override
+  public void write(AdaptrisMessage msg) throws InterlokException {
+    STORE.put(msg.getUniqueId(), msg);
+  }
+
+  @Override
+  public AdaptrisMessage buildForRetry(String msgId, Map<String, String> metadata,
+      AdaptrisMessageFactory factory) throws InterlokException {
+    if (STORE.containsKey(msgId)) {
+      return STORE.get(msgId);
+    }
+    throw new InterlokException(msgId + " not found");
+  }
+
+  @Override
+  public Map<String, String> getMetadata(String msgId) throws InterlokException {
+    if (STORE.containsKey(msgId)) {
+      return new HashMap<>(STORE.get(msgId).getMessageHeaders());
+    }
+    throw new InterlokException(msgId + " not found");
+  }
+
+  @Override
+  public boolean delete(String msgId) throws InterlokException {
+    return STORE.remove(msgId) != null;
+  }
+
+  @Override
+  public Iterable<RemoteBlob> report() throws InterlokException {
+    return STORE.entrySet().stream()
+        .map((e) -> new RemoteBlob.Builder().setBucket("bucket")
+            .setLastModified(System.currentTimeMillis()).setName(e.getKey())
+            .setSize(e.getValue().getSize()).build())
+        .collect(Collectors.toList());
+  }
+
+  public static void removeAll() {
+    STORE.clear();
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/ReportBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/ReportBuilderTest.java
@@ -1,0 +1,41 @@
+package com.adaptris.core.http.jetty.retry;
+
+import static org.junit.Assert.assertEquals;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.cloud.RemoteBlob;
+
+public class ReportBuilderTest {
+
+  @Test
+  public void testBuild() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    ReportBuilder builder = new ReportBuilder();
+    try {
+      LifecycleHelper.initAndStart(builder);
+      builder.build(listFiles(10), msg);
+      try (InputStream in = msg.getInputStream()) {
+        List lines = IOUtils.readLines(in, StandardCharsets.UTF_8);
+        assertEquals(10, lines.size());
+      }
+    } finally {
+      LifecycleHelper.stopAndClose(builder);
+    }
+  }
+
+  private Iterable<RemoteBlob> listFiles(int count) {
+    List<RemoteBlob> list = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      list.add(new RemoteBlob.Builder().setBucket("bucket").setName("file" + i).setSize(i)
+          .setLastModified(System.currentTimeMillis()).build());
+    }
+    return list;
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -1,0 +1,286 @@
+package com.adaptris.core.http.jetty.retry;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import com.adaptris.core.Adapter;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ChannelList;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.NullService;
+import com.adaptris.core.StandaloneRequestor;
+import com.adaptris.core.StandardWorkflow;
+import com.adaptris.core.Workflow;
+import com.adaptris.core.http.client.ConfiguredRequestMethodProvider;
+import com.adaptris.core.http.client.RequestMethodProvider;
+import com.adaptris.core.http.client.net.HttpRequestService;
+import com.adaptris.core.http.client.net.StandardHttpProducer;
+import com.adaptris.core.http.jetty.EmbeddedConnection;
+import com.adaptris.core.http.jetty.EmbeddedJettyHelper;
+import com.adaptris.core.services.exception.ConfiguredException;
+import com.adaptris.core.services.exception.ThrowExceptionService;
+import com.adaptris.core.stubs.MockMessageProducer;
+import com.adaptris.core.stubs.StubEventHandler;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.junit.scaffolding.FailedMessageRetrierCase;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
+public class RetryFromJettyTest extends FailedMessageRetrierCase {
+
+  private static EmbeddedJettyHelper jettyHelper = new EmbeddedJettyHelper();
+  private static InMemoryRetryStore retryStore = new InMemoryRetryStore();
+
+  @BeforeClass
+  public static void beforeAll() throws Exception {
+    LifecycleHelper.initAndStart(retryStore);
+    // Seed some messages into the retry store which has a
+    // static map.
+    for (int i = 0; i < 2; i++) {
+      retryStore.write(AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World"));
+    }
+    jettyHelper.startServer();
+  }
+
+  @AfterClass
+  public static void afterAll() throws Exception {
+    LifecycleHelper.stopAndClose(retryStore);
+    InMemoryRetryStore.removeAll();
+    jettyHelper.stopServer();
+  }
+
+
+  @Test
+  public void testReport() throws Exception {
+    RetryFromJetty retrier = create();
+    try {
+      start(retrier);
+      String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_REPORTING_ENDPOINT);
+      HttpRequestService http = new HttpRequestService(url);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      ExampleServiceCase.execute(http, msg);
+      assertEquals(RetryFromJetty.HTTP_OK,
+          msg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+      // We know there should be at least 2 messages seeded...
+      try (InputStream in = msg.getInputStream()) {
+        List lines = IOUtils.readLines(in, StandardCharsets.UTF_8);
+        assertTrue(lines.size() >= 2);
+      }
+    } finally {
+      stop(retrier);
+    }
+  }
+
+  @Test
+  public void testReport_Broken() throws Exception {
+    RetryFromJetty retrier = create();
+    try {
+      retrier.setRetryStore(new BrokenRetryStore());
+      start(retrier);
+      String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_REPORTING_ENDPOINT);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+
+      StandardHttpProducer http = buildProducer(url);
+      http.setIgnoreServerResponseCode(true);
+      http.setMethodProvider(
+          new ConfiguredRequestMethodProvider(RequestMethodProvider.RequestMethod.GET));
+
+      ExampleServiceCase.execute(new StandaloneRequestor(http), msg);
+      assertEquals(RetryFromJetty.HTTP_ERROR,
+          msg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+    } finally {
+      stop(retrier);
+    }
+  }
+
+  @Test
+  public void testRetry() throws Exception {
+    RetryFromJetty retrier = create();
+    StandardWorkflow workflow = createWorkflow();
+    try {
+      MockMessageProducer workflowProducer = (MockMessageProducer) workflow.getProducer();
+      retrier.addWorkflow(workflow);
+      retrier.addWorkflow(createWorkflow());
+      start(workflow, retrier);
+      AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      baseMsg.addMetadata(Workflow.WORKFLOW_ID_KEY, workflow.obtainWorkflowId());
+      retryStore.write(baseMsg);
+      assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+
+      String url =
+          jettyHelper.buildUrl(RetryFromJetty.DEFAULT_ENDPOINT_PREFIX + baseMsg.getUniqueId());
+      StandardHttpProducer http = buildProducer(url);
+      AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+      assertEquals(RetryFromJetty.HTTP_ACCEPTED,
+          triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+
+      // This should trigger the workflow, so we should wait for the message
+      await().atMost(Duration.ofSeconds(1)).with().pollInterval(Duration.ofMillis(100))
+          .until(workflowProducer::messageCount, greaterThanOrEqualTo(1));
+      assertEquals(1, workflowProducer.messageCount());
+
+    } finally {
+      stop(retrier, workflow);
+    }
+  }
+
+  @Test
+  public void testRetry_WrongMethod() throws Exception {
+    RetryFromJetty retrier = create();
+    StandardWorkflow workflow = createWorkflow();
+    try {
+      MockMessageProducer workflowProducer = (MockMessageProducer) workflow.getProducer();
+      retrier.addWorkflow(workflow);
+      retrier.addWorkflow(createWorkflow());
+      start(workflow, retrier);
+      AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      baseMsg.addMetadata(Workflow.WORKFLOW_ID_KEY, workflow.obtainWorkflowId());
+      retryStore.write(baseMsg);
+      assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+
+      // This should result in a route condition that doesn't match POST + the msgId so 400 is
+      // expected
+      String url =
+          jettyHelper.buildUrl(RetryFromJetty.DEFAULT_ENDPOINT_PREFIX + baseMsg.getUniqueId());
+      StandardHttpProducer http = buildProducer(url);
+      http.setIgnoreServerResponseCode(true);
+      http.setMethodProvider(
+          new ConfiguredRequestMethodProvider(RequestMethodProvider.RequestMethod.GET));
+
+
+      AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+      assertEquals(RetryFromJetty.HTTP_BAD,
+          triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+
+    } finally {
+      stop(retrier, workflow);
+    }
+  }
+
+  @Test
+  public void testRetry_NotFound() throws Exception {
+    RetryFromJetty retrier = create();
+    StandardWorkflow workflow = createWorkflow();
+    try {
+      MockMessageProducer workflowProducer = (MockMessageProducer) workflow.getProducer();
+      retrier.addWorkflow(workflow);
+      retrier.addWorkflow(createWorkflow());
+      start(workflow, retrier);
+      AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      baseMsg.addMetadata(Workflow.WORKFLOW_ID_KEY, workflow.obtainWorkflowId());
+      retryStore.write(baseMsg);
+      assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+
+      // This should result in a msgId that isn't found; so we get a 500...
+      AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+      String url =
+          jettyHelper.buildUrl(RetryFromJetty.DEFAULT_ENDPOINT_PREFIX + triggerMsg.getUniqueId());
+      StandardHttpProducer http = buildProducer(url);
+      http.setIgnoreServerResponseCode(true);
+      ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+      assertEquals(RetryFromJetty.HTTP_ERROR,
+          triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+
+    } finally {
+      stop(retrier, workflow);
+    }
+  }
+
+  @Test
+  public void testExecuteQuietly() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    NullService s1 = new NullService();
+    ThrowExceptionService s2 = new ThrowExceptionService(new ConfiguredException("failure"));
+    try {
+      start(s1, s2);
+      RetryFromJetty.executeQuietly(s1, msg);
+      RetryFromJetty.executeQuietly(s2, msg);
+    } finally {
+      stop(s1, s2);
+    }
+  }
+
+  private StandardHttpProducer buildProducer(String url) {
+    StandardHttpProducer producer = new StandardHttpProducer().withURL(url);
+    return producer;
+  }
+
+
+  @Override
+  protected RetryFromJetty create() {
+    return new RetryFromJetty().withRetryStore(new InMemoryRetryStore())
+        .withReportBuilder(new ReportBuilder());
+  }
+
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    Adapter result = null;
+    try {
+      RetryFromJetty fmr = new RetryFromJetty();
+      fmr.setConnection(new EmbeddedConnection());
+      fmr.setRetryStore(new InMemoryRetryStore());
+      result = new Adapter();
+      result.setFailedMessageRetrier(fmr);
+      result.setChannelList(new ChannelList());
+      result.setEventHandler(new StubEventHandler());
+      result.setUniqueId(UUID.randomUUID().toString());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+
+  @Override
+  protected String createBaseFileName(Object object) {
+    return RetryFromJetty.class.getCanonicalName();
+  }
+
+  @Override
+  protected RetryFromJetty createForExamples() {
+    RetryFromJetty fmr = new RetryFromJetty();
+    fmr.setRetryStore(new FilesystemRetryStore().withBaseUrl("file:///path/to/messages"));
+    return fmr;
+  }
+
+  private class BrokenRetryStore implements RetryStore {
+
+    @Override
+    public void write(AdaptrisMessage msg) throws InterlokException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AdaptrisMessage buildForRetry(String msgId, Map<String, String> metadata,
+        AdaptrisMessageFactory factory) throws InterlokException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String> getMetadata(String msgId) throws InterlokException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<RemoteBlob> report() throws InterlokException {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreDeleteTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreDeleteTest.java
@@ -1,0 +1,39 @@
+package com.adaptris.core.http.jetty.retry;
+
+import static com.adaptris.core.http.jetty.retry.FilesystemRetryStoreTest.TEST_BASE_URL;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
+public class RetryStoreDeleteTest extends ExampleServiceCase {
+
+  @Test
+  public void testService() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+    msg.addMessageHeader("deleteMe", "xxx");
+    RetryStoreDeleteService service = new RetryStoreDeleteService()
+        .withMessageId("%message{deleteMe}")
+        .withRetryStore(new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL)));
+    execute(service, msg);
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testService_Exception() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+    msg.addMessageHeader("deleteMe", "xxx");
+    RetryStoreDeleteService service = new RetryStoreDeleteService()
+        .withMessageId("%message{deleteMe}")
+        .withRetryStore(
+            new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL) + "/ invalid"));
+    execute(service, msg);
+  }
+
+  @Override
+  protected RetryStoreDeleteService retrieveObjectForSampleConfig() {
+    return new RetryStoreDeleteService().withMessageId("%message{message-id-to-delete}")
+        .withRetryStore(new FilesystemRetryStore().withBaseUrl("file:///path/to/store"));
+
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreListTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreListTest.java
@@ -1,0 +1,58 @@
+package com.adaptris.core.http.jetty.retry;
+
+import static com.adaptris.core.http.jetty.retry.FilesystemRetryStoreTest.TEST_BASE_URL;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.fs.FsHelper;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
+public class RetryStoreListTest extends ExampleServiceCase {
+
+  private File retryStoreDir;
+
+  @Before
+  public void setUp() throws Exception {
+    retryStoreDir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
+  }
+
+  @Test
+  public void testService() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+    RetryStoreWriteService writer = new RetryStoreWriteService()
+        .withRetryStore(new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL)));
+    RetryStoreListService service = new RetryStoreListService()
+        .withRetryStore(new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL)));
+    execute(writer, msg);
+    execute(service, msg);
+    try (InputStream in = msg.getInputStream()) {
+      List lines = IOUtils.readLines(in, StandardCharsets.UTF_8);
+      assertTrue(lines.size() >= 1);
+    }
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testService_Exception() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+    RetryStoreListService service = new RetryStoreListService()
+        .withRetryStore(
+            new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL) + "/ invalid"));
+    execute(service, msg);
+  }
+
+  @Override
+  protected RetryStoreListService retrieveObjectForSampleConfig() {
+    return new RetryStoreListService()
+        .withRetryStore(new FilesystemRetryStore().withBaseUrl("file:///path/to/store"));
+
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
@@ -1,0 +1,60 @@
+package com.adaptris.core.http.jetty.retry;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.InterlokException;
+
+public class RetryStoreTest implements RetryStore {
+
+  @Before
+  public void setUp() throws Exception {
+    LifecycleHelper.initAndStart(this, false);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    LifecycleHelper.stopAndClose(this, false);
+
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testDefaultDelete() throws Exception {
+    delete("");
+  }
+
+  @Test
+  public void testDefaultBuild() throws Exception {
+    assertNull(buildForRetry(""));
+  }
+
+  @Test
+  public void testDefaultReport() throws Exception {
+    assertFalse(report().iterator().hasNext());
+  }
+
+
+  @Override
+  public void write(AdaptrisMessage msg) throws InterlokException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public AdaptrisMessage buildForRetry(String msgId, Map<String, String> metadata,
+      AdaptrisMessageFactory factory) throws InterlokException {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getMetadata(String msgId) throws InterlokException {
+    return Collections.EMPTY_MAP;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteTest.java
@@ -4,6 +4,7 @@ import static com.adaptris.core.http.jetty.retry.FilesystemRetryStoreTest.TEST_B
 import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileFilter;
+import java.util.Optional;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
@@ -21,7 +22,8 @@ public class RetryStoreWriteTest extends ExampleServiceCase {
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
     RetryStoreWriteService service = new RetryStoreWriteService()
         .withRetryStore(new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL)));
-    int base = retryStoreDir.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY).length;
+    File[] files = retryStoreDir.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY);
+    int base = Optional.ofNullable(files).orElse(new File[0]).length;
     execute(service, msg);
     assertEquals(1,
         retryStoreDir.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY).length - base);
@@ -29,7 +31,6 @@ public class RetryStoreWriteTest extends ExampleServiceCase {
 
   @Test(expected = ServiceException.class)
   public void testService_Exception() throws Exception {
-    File retryStoreDir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
     RetryStoreWriteService service = new RetryStoreWriteService()
         .withRetryStore(

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteTest.java
@@ -1,0 +1,51 @@
+package com.adaptris.core.http.jetty.retry;
+
+import static com.adaptris.core.http.jetty.retry.FilesystemRetryStoreTest.TEST_BASE_URL;
+import static org.junit.Assert.assertEquals;
+import java.io.File;
+import java.io.FileFilter;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.junit.Before;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.fs.FsHelper;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+
+public class RetryStoreWriteTest extends ExampleServiceCase {
+
+  private File retryStoreDir;
+
+  @Before
+  public void setUp() throws Exception {
+    retryStoreDir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
+  }
+
+  @Test
+  public void testService() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+    RetryStoreWriteService service = new RetryStoreWriteService()
+        .withRetryStore(new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL)));
+    int base = retryStoreDir.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY).length;
+    execute(service, msg);
+    assertEquals(1,
+        retryStoreDir.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY).length - base);
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testService_Exception() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+    RetryStoreWriteService service = new RetryStoreWriteService()
+        .withRetryStore(
+            new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL) + "/ invalid"));
+    execute(service, msg);
+  }
+
+  @Override
+  protected RetryStoreWriteService retrieveObjectForSampleConfig() {
+    return new RetryStoreWriteService().withRetryStore(new FilesystemRetryStore().withBaseUrl("file:///path/to/store"));
+
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreWriteTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileFilter;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
-import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
@@ -16,15 +15,9 @@ import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 
 public class RetryStoreWriteTest extends ExampleServiceCase {
 
-  private File retryStoreDir;
-
-  @Before
-  public void setUp() throws Exception {
-    retryStoreDir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
-  }
-
   @Test
   public void testService() throws Exception {
+    File retryStoreDir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
     RetryStoreWriteService service = new RetryStoreWriteService()
         .withRetryStore(new FilesystemRetryStore().withBaseUrl(getConfiguration(TEST_BASE_URL)));
@@ -36,6 +29,7 @@ public class RetryStoreWriteTest extends ExampleServiceCase {
 
   @Test(expected = ServiceException.class)
   public void testService_Exception() throws Exception {
+    File retryStoreDir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
     RetryStoreWriteService service = new RetryStoreWriteService()
         .withRetryStore(

--- a/interlok-core/src/test/java/com/adaptris/core/util/ExceptionHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/ExceptionHelperTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,14 +18,13 @@ package com.adaptris.core.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.InterlokException;
 
 public class ExceptionHelperTest extends ExceptionHelper {
 
@@ -50,7 +49,7 @@ public class ExceptionHelperTest extends ExceptionHelper {
       fail();
     } catch (CoreException e) {
       assertEquals(c2, e);
-    }    
+    }
   }
 
   @Test
@@ -130,6 +129,21 @@ public class ExceptionHelperTest extends ExceptionHelper {
     try {
       throw wrapProduceException(new Exception());
     } catch (ProduceException e) {
+      assertNotNull(e.getCause());
+    }
+  }
+
+  @Test
+  public void testWrapInterlokExceptionThrowable() {
+    InterlokException cause = new InterlokException();
+    try {
+      throw wrapInterlokException(cause);
+    } catch (InterlokException e) {
+      assertEquals(cause, e);
+    }
+    try {
+      throw wrapInterlokException(new Exception());
+    } catch (InterlokException e) {
       assertNotNull(e.getCause());
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/BaseCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/BaseCase.java
@@ -346,4 +346,7 @@ public abstract class BaseCase {
     return name;
   }
 
+  public static String getConfiguration(String key) {
+    return PROPERTIES.getProperty(key);
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/FailedMessageRetrierCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/FailedMessageRetrierCase.java
@@ -16,35 +16,16 @@
 
 package com.adaptris.interlok.junit.scaffolding;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.util.UUID;
 import org.junit.Test;
-import com.adaptris.core.Adapter;
-import com.adaptris.core.AdapterTest;
-import com.adaptris.core.AdaptrisMarshaller;
-import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageConsumer;
-import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.AdaptrisMessageProducer;
 import com.adaptris.core.Channel;
-import com.adaptris.core.ChannelList;
-import com.adaptris.core.CoreConstants;
-import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.FailedMessageRetrier;
-import com.adaptris.core.FailedMessageRetrierImp;
-import com.adaptris.core.ProcessingExceptionHandler;
-import com.adaptris.core.ServiceList;
-import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.StandardProcessingExceptionHandler;
 import com.adaptris.core.StandardWorkflow;
-import com.adaptris.core.Workflow;
-import com.adaptris.core.stubs.FailFirstMockMessageProducer;
 import com.adaptris.core.stubs.MockChannel;
 import com.adaptris.core.stubs.MockMessageConsumer;
 import com.adaptris.core.stubs.MockMessageProducer;
-import com.adaptris.core.stubs.StubEventHandler;
 import com.adaptris.util.GuidGenerator;
 
 @SuppressWarnings("deprecation")
@@ -73,17 +54,6 @@ public abstract class FailedMessageRetrierCase extends ExampleFailedMessageRetri
   }
 
   @Test
-  public void testSetter() throws Exception {
-    FailedMessageRetrierImp retrier = (FailedMessageRetrierImp) create();
-    try {
-      retrier.setStandaloneConsumer(null);
-      fail();
-    }
-    catch (IllegalArgumentException expected) {
-    }
-  }
-
-  @Test
   public void testRegisteredWorkflowIds() throws Exception {
     FailedMessageRetrier retrier = create();
     StandardWorkflow wf1 = createWorkflow();
@@ -104,213 +74,8 @@ public abstract class FailedMessageRetrierCase extends ExampleFailedMessageRetri
     assertEquals(0, retrier.registeredWorkflowIds().size());
   }
 
-  @Test
-  public void testRetry() throws Exception {
-    FailedMessageRetrier retrier = create();
-    StandardWorkflow wf = createWorkflow();
-    try {
-      MockMessageProducer p = (MockMessageProducer) wf.getProducer();
-      retrier.addWorkflow(wf);
-      retrier.addWorkflow(createWorkflow());
-      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
-      msg.addMetadata(Workflow.WORKFLOW_ID_KEY, wf.obtainWorkflowId());
-      start(wf);
-      start(retrier);
-      retrier.onAdaptrisMessage(msg);
-      assertEquals(1, p.getMessages().size());
-    }
-    finally {
-      stop(retrier);
-      stop(wf);
-    }
-  }
-
-  @Test
-  public void testRetryNoWorkflowId() throws Exception {
-    FailedMessageRetrier retrier = create();
-    StandardWorkflow wf = createWorkflow();
-    try {
-      MockMessageProducer p = (MockMessageProducer) wf.getProducer();
-      retrier.addWorkflow(wf);
-      retrier.addWorkflow(createWorkflow());
-      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
-      start(wf);
-      start(retrier);
-      retrier.onAdaptrisMessage(msg);
-      assertFalse(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
-      assertEquals(0, p.getMessages().size());
-    }
-    finally {
-      stop(retrier);
-      stop(wf);
-    }
-  }
-
-  @Test
-  public void testRetryNoMatchForWorkflowId() throws Exception {
-    FailedMessageRetrier retrier = create();
-    StandardWorkflow wf = createWorkflow();
-    try {
-      MockMessageProducer p = (MockMessageProducer) wf.getProducer();
-      retrier.addWorkflow(wf);
-      retrier.addWorkflow(createWorkflow());
-      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
-      msg.addMetadata(Workflow.WORKFLOW_ID_KEY, createWorkflow().obtainWorkflowId());
-      start(retrier);
-      start(wf);
-      retrier.onAdaptrisMessage(msg);
-      assertEquals(0, p.getMessages().size());
-      assertFalse(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
-    }
-    finally {
-      stop(retrier);
-      stop(wf);
-    }
-  }
-
-  @Test
-  public void testRetryInvalidCounter() throws Exception {
-    FailedMessageRetrier retrier = create();
-    StandardWorkflow wf = createWorkflow();
-    try {
-      MockMessageProducer p = (MockMessageProducer) wf.getProducer();
-      retrier.addWorkflow(wf);
-      retrier.addWorkflow(createWorkflow());
-      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
-      msg.addMetadata(Workflow.WORKFLOW_ID_KEY, wf.obtainWorkflowId());
-      msg.addMetadata(CoreConstants.RETRY_COUNT_KEY, "fred");
-      start(retrier);
-      start(wf);
-      retrier.onAdaptrisMessage(msg);
-      assertTrue(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
-      assertEquals("1", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
-
-    }
-    finally {
-      stop(retrier);
-      stop(wf);
-    }
-  }
-
-  @Test
-  public void testMultipleRetries() throws Exception {
-    FailedMessageRetrier retrier = create();
-    StandardWorkflow wf = createWorkflow();
-    try {
-      wf.setProducer(new FailFirstMockMessageProducer());
-      FailFirstMockMessageProducer p = (FailFirstMockMessageProducer) wf.getProducer();
-      retrier.addWorkflow(wf);
-      retrier.addWorkflow(createWorkflow());
-      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
-      msg.addMetadata(Workflow.WORKFLOW_ID_KEY, wf.obtainWorkflowId());
-      start(retrier);
-      start(wf);
-      retrier.onAdaptrisMessage(msg);
-      assertTrue(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
-      assertEquals("1", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
-      retrier.onAdaptrisMessage(msg);
-      assertEquals(1, p.getMessages().size());
-      assertEquals("2", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
-
-    }
-    finally {
-      stop(retrier);
-      stop(wf);
-    }
-  }
-
-  @Test
-  public void testAdapterRetry() throws Exception {
-    FailedMessageRetrier retrier = create();
-    MockMessageProducer errProd = new MockMessageProducer();
-    StandardProcessingExceptionHandler speh = new StandardProcessingExceptionHandler(new StandaloneProducer(errProd));
-    Adapter adapter = createAdapterForRetry(retrier, speh);
-    try {
-      FailFirstMockMessageProducer workflowProducer = (FailFirstMockMessageProducer) adapter.getChannelList().get(0)
-          .getWorkflowList().get(0).getProducer();
-      MockMessageConsumer consumer = (MockMessageConsumer) adapter.getChannelList().get(0).getWorkflowList().get(0).getConsumer();
-      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
-      start(adapter);
-      consumer.submitMessage(msg);
-      // SHould have failed
-      assertEquals(1, errProd.messageCount());
-      retrier.onAdaptrisMessage(errProd.getMessages().get(0));
-      assertTrue(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
-      assertEquals("1", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
-      assertEquals(1, workflowProducer.getMessages().size());
-    }
-    finally {
-      stop(adapter);
-    }
-  }
-
-  @Test
-  public void testRoundTrip_AdapterRetry() throws Exception {
-    AdaptrisMarshaller marshaller = DefaultMarshaller.getDefaultMarshaller();
-    Adapter adapter = (Adapter) marshaller.unmarshal(marshaller.marshal(createAdapterForRetry(create(),
-        new StandardProcessingExceptionHandler(new StandaloneProducer(new MockMessageProducer())))));
-    FailedMessageRetrier retrier = adapter.getFailedMessageRetrier();
-    MockMessageProducer errProd = getErrorHandler(adapter);
-    try {
-      FailFirstMockMessageProducer workflowProducer = (FailFirstMockMessageProducer) adapter.getChannelList().get(0)
-          .getWorkflowList().get(0).getProducer();
-      MockMessageConsumer consumer = (MockMessageConsumer) adapter.getChannelList().get(0).getWorkflowList().get(0).getConsumer();
-      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("ABCDEF");
-      start(adapter);
-      consumer.submitMessage(msg);
-      // SHould have failed
-      assertEquals(1, errProd.messageCount());
-      retrier.onAdaptrisMessage(errProd.getMessages().get(0));
-      assertTrue(msg.containsKey(CoreConstants.RETRY_COUNT_KEY));
-      assertEquals("1", msg.getMetadataValue(CoreConstants.RETRY_COUNT_KEY));
-      assertEquals(1, workflowProducer.getMessages().size());
-    }
-    finally {
-      stop(adapter);
-    }
-  }
-
-  private Adapter createAdapterForRetry(FailedMessageRetrier retrier, ProcessingExceptionHandler errorHandler) throws Exception {
-    Adapter adapter = AdapterTest.createAdapter(getName());
-    adapter.setFailedMessageRetrier(retrier);
-    adapter.setMessageErrorHandler(errorHandler);
-    adapter.getChannelList().clear();
-    Channel c = new Channel();
-    c.setUniqueId(getName());
-    StandardWorkflow wf = new StandardWorkflow();
-    wf.setUniqueId(getName());
-    wf.setConsumer(new MockMessageConsumer());
-    wf.setProducer(new FailFirstMockMessageProducer());
-    c.getWorkflowList().add(wf);
-    adapter.getChannelList().add(c);
-    return adapter;
-  }
-
-  private MockMessageProducer getErrorHandler(Adapter adapter) {
-    ServiceList list = (ServiceList) ((StandardProcessingExceptionHandler) adapter.getMessageErrorHandler())
-        .getProcessingExceptionService();
-    StandaloneProducer producer = (StandaloneProducer) list.get(0);
-    return (MockMessageProducer) producer.getProducer();
-  }
 
   protected abstract FailedMessageRetrier create();
 
   protected abstract FailedMessageRetrier createForExamples();
-
-  @Override
-  protected Object retrieveObjectForSampleConfig() {
-    Adapter result = null;
-    try {
-      FailedMessageRetrier fmr = createForExamples();
-      result = new Adapter();
-      result.setFailedMessageRetrier(fmr);
-      result.setChannelList(new ChannelList());
-      result.setEventHandler(new StubEventHandler());
-      result.setUniqueId(UUID.randomUUID().toString());
-    }
-    catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-    return result;
-  }
 }

--- a/interlok-core/src/test/resources/unit-tests.properties.template
+++ b/interlok-core/src/test/resources/unit-tests.properties.template
@@ -115,8 +115,6 @@ junit.SimpleSequenceNumberTest.basedir=@BUILD_DIR@/junit/SimpleSequenceNumberTes
 junit.jdbc.backreference.url=jdbc:derby:memory:jdbc-backref;create=true
 junit.jdbc.backreference.driver=org.apache.derby.jdbc.EmbeddedDriver
 
-# junit.retry.url=jdbc:derby:memory:jdbc-retry;create=true
-# junit.retry.driver=org.apache.derby.jdbc.EmbeddedDriver
 junit.jdbc.url=jdbc:derby:@BUILD_DIR@/tmp/jdbc/jdbc-tmp;create=true
 junit.jdbc.url.2=jdbc:derby:@BUILD_DIR@/tmp/jdbc/jdbc-failover-tmp
 junit.jdbc.driver=org.apache.derby.jdbc.EmbeddedDriver
@@ -230,3 +228,6 @@ junit.urlhelper.local=file://localhost/@BASE_DIR@/src/test/resources/xstream-sta
 # junit.urlhelper.remote=https://development.adaptris.net/index.html
 junit.urlhelper.remote=https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/master/build.gradle
 junit.urlhelper.classpath=xstream-standard.xml
+
+junit.retry.baseUrl=file://localhost/@BUILD_DIR@/tmp/retry-store
+


### PR DESCRIPTION
## Motivation

This is the changes for : https://github.com/adaptris/interlok/blob/develop/docs/adr/0008-restful-failed-message-retrier.md

## Modification

- Changed FailedMessageRetrier interface so that it no longer extends AdaptrisMessageListener; since there is only a single implementation `DefaultFailedMessageRetrier` across the entire codebase (including optionals) this should be a low-impact change
    - Might have a knock-on effect on the UI, since there is stuff in there explicitly about FailedMessageRetrier
- Added a RetryStore interface with a single public implementation `FilesystemRetryStore` which supports storing messages on the filesystem.
- Added a RetryFromJetty implementation
   - Reports on failed messages via a configurable endpoint (_/api/failed/list_). The default renderer is just a newline separated list of filenames.
   - Supports retrying of failed messages via a configurable endpoint (_/api/retry/'msgId'_)
   - Jetty connection is configurable since it's a normal 'Connection' but is defaulted to be `EmbeddedConnection`
- Add various `RetryStore*` services for completeness.
- __Fixed a long standing "bug" whereby Adapter never called prepare() on its FailedMessageRetrier__
  - By coincidence since everyone only ever uses DefaultFailedMessageRetrier; against the filesystem. It wasn't apparent because FS stuff doesn't need _prepare()_ and it was handling stuff behind the scenes.


The interface definition/behaviour has deviated somewhat from the original ADR which are listed below
- RetryStore defines a `getMetadata(String)` method; which allows us to not read the payload (since this might be large)
- RetryStore defines a `buildForRetry` method which takes a AdaptrisMessageFactory parameter; to avoid yet more AMF configuration.
- RetryFromJetty uses getMetadata() to shortcut checking whether the message has a workflow associated with it.
- RetryFromJetty figures out the workflow, and then gets the MessageFactory associated with that consumer, and uses that to subsequently invoke `buildForRetry()` with metadata + message factory since this means we don't need to care about whether the message is large or not.

## Result

- The com.adaptris.core.http.jetty.retry has 100% coverage for tests.
- RetryFromJetty is now available to configure as the FailedMessageRetrier.
- RetryFromJetty should be used in a conjunction with a `standard-processing-exception-handler` that uses `retry-store-write-service` as part of its exception chain. 

## Testing

How can I test this if I'm reviewing this -> This minimal configuration should allow for testing... (requires interlok-json because...)

```xml
<adapter>
  <unique-id>MyInterlokInstance</unique-id>
  <shared-components>
    <connections>
      <jetty-embedded-connection>
        <unique-id>jetty</unique-id>
      </jetty-embedded-connection>
    </connections>
    <services/>
  </shared-components>
  <message-error-handler class="standard-processing-exception-handler">
    <unique-id>error-handler</unique-id>
    <processing-exception-service class="service-list">
      <unique-id>store-for-retry</unique-id>
      <services>
        <retry-store-write-message>
          <unique-id>store-for-retry</unique-id>
          <retry-store class="retry-store-filesystem">
            <base-url>file:///./fs/retries</base-url>
          </retry-store>
        </retry-store-write-message>
        <exception-report-service>
          <unique-id>generate-json-exception</unique-id>
          <exception-serializer class="exception-as-json"/>
        </exception-report-service>
        <jetty-response-service>
          <unique-id>send-500</unique-id>
          <http-status>500</http-status>
          <content-type>application/json</content-type>
          <response-header-provider class="jetty-no-response-headers"/>
        </jetty-response-service>
      </services>
    </processing-exception-service>
  </message-error-handler>
  <failed-message-retrier class="retry-via-jetty">
    <unique-id>silly-clarke</unique-id>
    <connection class="shared-connection">
      <lookup-name>jetty</lookup-name>
    </connection>
    <report-builder>
      <report-renderer class="remote-blob-list-as-json"/>
      <content-type>application/json</content-type>
    </report-builder>
    <retry-store class="retry-store-filesystem">
      <base-url>file:///./fs/retries</base-url>
    </retry-store>
  </failed-message-retrier>
  <channel-list>
    <channel>
      <consume-connection class="shared-connection">
        <lookup-name>jetty</lookup-name>
      </consume-connection>
      <workflow-list>
        <standard-workflow>
          <consumer class="jetty-message-consumer">
            <unique-id>boring-brattain</unique-id>
            <path>/api/always-fail</path>
          </consumer>
          <service-collection class="service-list">
            <unique-id>pedantic-montalcini</unique-id>
            <services>
              <throw-exception-service>
                <unique-id>always-fail</unique-id>
                <exception-generator class="configured-exception">
                  <message>Always Fails.</message>
                </exception-generator>
              </throw-exception-service>
            </services>
          </service-collection>
          <unique-id>always-fail</unique-id>
        </standard-workflow>
      </workflow-list>
      <unique-id>default-channel</unique-id>
    </channel>
  </channel-list>
</adapter>
```

Gives you 
```console
$ curl -si -XPOST -d"Hello World" http://localhost:8080/api/always-fail
HTTP/1.1 500 Server Error
Content-Type: application/json
Transfer-Encoding: chunked

{
  "exceptionLocation" : "ThrowExceptionService(always-fail)",
  "exceptionMessage" : "Always Fails.",
  "workflow" : "always-fail@default-channel"
}
$ curl -si -XGET http://localhost:8080/api/failed/list
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked

[{"bucket":"./fs/retries","size":128,"name":"ec24c442-e688-45cc-b6db-24bd6893cf4e","lastModified":1603981015000}]
chanl3@lhrm32445 ~
$ curl -si -XPOST http://localhost:8080/api/retry/ec24c442-e688-45cc-b6db-24bd6893cf4e
HTTP/1.1 202 Accepted
Content-Type: text/plain
Transfer-Encoding: chunked


chanl3@lhrm32445 ~
$
```

Of course the logging will still indicate the the workflow "failed" since that's the configured behaviour but you should see : 
```
TRACE [RetryFromJetty::Retry] [c.a.c.h.j.r.RetryFromJetty.onAdaptrisMessage()] [{}] Attempting to retry ec24c442-e688-45cc-b6db-24bd6893cf4e; resubmitting to [always-fail@default-channel]
```
