### PR TITLE
Correct dotAll usage for regex in resolve method

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
@@ -473,9 +473,9 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
     }
     target = super.resolve(target, dotAll);
     // resolve any %payload{id:...}'s or %payload_id{...}'s before attempting any %message{...}'s
-    Pattern pattern = dotAll ? normalPayloadResolver2 : dotAllPayloadResolver2;
+    Pattern pattern = dotAll ? dotAllPayloadResolver2 : normalPayloadResolver2;
     target = resolve(target, pattern, false);
-    pattern = dotAll ? normalPayloadResolver : dotAllPayloadResolver;
+    pattern = dotAll ? dotAllPayloadResolver : normalPayloadResolver;
     return resolve(target, pattern, true);
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadMessageFactoryTest.java
@@ -220,6 +220,12 @@ public class MultiPayloadMessageFactoryTest extends AdaptrisMessageFactoryImplCa
     assertEquals(new String(PAYLOAD), message.resolve("%payload_id{cake}"));
     assertNull(message.resolve(null));
     assertEquals("VALUE", message.resolve("%message{KEY}"));
+
+    message = (MultiPayloadAdaptrisMessage)messageFactory.newMessage("bacon", CONTENT, ENCODING);
+    message.addContent("joke", "The other day I was listening to a song about superglue, it’s been stuck in my head ever since.");
+    message.switchPayload("bacon");
+    String s = message.resolve("Thank you for your message.\n\nHere's a random joke: %payload_id{joke}.\n\n-- \n\nSomething interesting...\n");
+
     try {
       message.resolve("%payload_id{fail}");
       fail();


### PR DESCRIPTION
## Motivation

Discovered that the ternary operator was incorrect when testing the MS Azure/Graph mail consumer/producer.

## Modification

Flipped the results of the ternary operator.

## Result

The resolve now works correctly.

## Testing

I added to the resolve test case my originally non-working example, which now works as expected.
