### PR TITLE
INTERLOK-3463 Make the HikariPoolBuilder "lazier"

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/C3P0PooledDataSource.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/C3P0PooledDataSource.java
@@ -4,18 +4,21 @@ import java.io.IOException;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
 public class C3P0PooledDataSource extends PooledDataSourceImpl<ComboPooledDataSource> {
+  private ComboPooledDataSource wrapped = null;
 
   public C3P0PooledDataSource(ComboPooledDataSource wrapped) {
-    super(wrapped);
+    super();
+    this.wrapped = wrapped;
   }
 
+  @Override
   public ComboPooledDataSource wrapped() {
     return wrapped;
   }
 
   @Override
   public void close() throws IOException {
-    wrapped.close();
+    wrapped().close();
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/PluggableJdbcPooledConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/PluggableJdbcPooledConnection.java
@@ -1,7 +1,6 @@
 package com.adaptris.core.jdbc;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -34,7 +33,6 @@ public class PluggableJdbcPooledConnection extends JdbcPooledConnectionImpl {
   @Valid
   @InputFieldDefault(value = "default-jdbc-pool-factory")
   @AutoPopulated
-  @NotNull
   private ConnectionPoolBuilder builder;
   @Valid
   private KeyValuePairSet poolProperties;
@@ -61,20 +59,20 @@ public class PluggableJdbcPooledConnection extends JdbcPooledConnectionImpl {
     if (other instanceof PluggableJdbcPooledConnection) {
       PluggableJdbcPooledConnection conn = (PluggableJdbcPooledConnection) other;
 
-      return new EqualsBuilder().append(conn.getConnectUrl(), this.getConnectUrl()).append(conn.getDriverImp(), this.getDriverImp())
-          .append(conn.getAlwaysValidateConnection(), this.getAlwaysValidateConnection())
-          .append(conn.getDebugMode(), this.getDebugMode()).append(conn.getTestStatement(), this.getTestStatement())
-          .append(conn.getAutoCommit(), this.getAutoCommit()).append(conn.getConnectionProperties(), this.getConnectionProperties())
-          .append(conn.getBuilder(), this.getBuilder()).append(conn.getPoolProperties(), this.getPoolProperties()).isEquals();
+      return new EqualsBuilder().append(conn.getConnectUrl(), getConnectUrl()).append(conn.getDriverImp(), getDriverImp())
+          .append(conn.getAlwaysValidateConnection(), getAlwaysValidateConnection())
+          .append(conn.getDebugMode(), getDebugMode()).append(conn.getTestStatement(), getTestStatement())
+          .append(conn.getAutoCommit(), getAutoCommit()).append(conn.getConnectionProperties(), getConnectionProperties())
+          .append(conn.getBuilder(), getBuilder()).append(conn.getPoolProperties(), getPoolProperties()).isEquals();
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(19, 37).append(this.getConnectUrl()).append(getDriverImp())
-        .append(this.getAlwaysValidateConnection()).append(getDebugMode()).append(getTestStatement()).append(getAutoCommit())
-        .append(this.getConnectionProperties()).append(getBuilder()).append(getPoolProperties()).toHashCode();
+    return new HashCodeBuilder(19, 37).append(getConnectUrl()).append(getDriverImp())
+        .append(getAlwaysValidateConnection()).append(getDebugMode()).append(getTestStatement()).append(getAutoCommit())
+        .append(getConnectionProperties()).append(getBuilder()).append(getPoolProperties()).toHashCode();
   }
 
 
@@ -115,7 +113,7 @@ public class PluggableJdbcPooledConnection extends JdbcPooledConnectionImpl {
    * @param kvps the connection pool properties.
    */
   public void setPoolProperties(KeyValuePairSet kvps) {
-    this.poolProperties = kvps;
+    poolProperties = kvps;
   }
 
   public KeyValuePairSet poolProperties() {

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/PooledDataSourceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/PooledDataSourceImpl.java
@@ -6,58 +6,56 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 public abstract class PooledDataSourceImpl<T extends DataSource> implements PooledDataSource {
-
-  protected transient T wrapped;
-
-  public PooledDataSourceImpl(T wrapped) {
-    this.wrapped = wrapped;
-  }
 
   @Override
   public Connection getConnection() throws SQLException {
-    return wrapped.getConnection();
+    return wrapped().getConnection();
   }
 
   @Override
   public Connection getConnection(String username, String password) throws SQLException {
-    return wrapped.getConnection(username, password);
+    return wrapped().getConnection(username, password);
   }
 
   @Override
   public PrintWriter getLogWriter() throws SQLException {
-    return wrapped.getLogWriter();
+    return wrapped().getLogWriter();
   }
 
   @Override
   public void setLogWriter(PrintWriter out) throws SQLException {
-    wrapped.setLogWriter(out);
+    wrapped().setLogWriter(out);
   }
 
   @Override
   public void setLoginTimeout(int seconds) throws SQLException {
-    wrapped.setLoginTimeout(seconds);
+    wrapped().setLoginTimeout(seconds);
   }
 
   @Override
   public int getLoginTimeout() throws SQLException {
-    return wrapped.getLoginTimeout();
+    return wrapped().getLoginTimeout();
   }
 
   @Override
   public Logger getParentLogger() throws SQLFeatureNotSupportedException {
-    return wrapped.getParentLogger();
+    return wrapped().getParentLogger();
   }
 
   @Override
   public <S> S unwrap(Class<S> iface) throws SQLException {
-    return wrapped.unwrap(iface);
+    return wrapped().unwrap(iface);
   }
 
   @Override
   public boolean isWrapperFor(Class<?> iface) throws SQLException {
-    return wrapped.isWrapperFor(iface);
+    return wrapped().isWrapperFor(iface);
   }
+
+  protected abstract T wrapped();
 
 }


### PR DESCRIPTION
## Motivation

If you use the Hikari connection pool via pluggable-jdbc-connnection-pool; and the database is not available, then 
`java -jar lib/interlok-boot.jar -configcheck` doesn't work.

So, if you have this simple configuration, and you don't have a mariaDB instance on localhost running, then -configcheck will fail.

```xml
<adapter>
  <unique-id>MyInterlokInstance</unique-id>
  <shared-components>
    <connections>
      <pluggable-jdbc-pooled-connection>
        <unique-id>jdbc-pooled-connection</unique-id>
        <test-statement>SELECT DATABASE(), VERSION(), NOW(), USER();</test-statement>
        <driver-imp>com.mysql.jdbc.Driver</driver-imp>
        <always-validate-connection>true</always-validate-connection>
        <username>root</username>
        <password>root</password>
        <connect-url>jdbc:mysql://localhost:3306/mysql?autoReconnect=true</connect-url>
        <builder class="jdbc-hikari-pool-builder"/>
      </pluggable-jdbc-pooled-connection>

    </connections>
    <services/>
  </shared-components>
</adapter>
```

## Modification

- We delay the construction of the HikariDataSource until we actually need to use it (i.e. when a real datasource
method is called). This means that configuration checks which call prepare() don't break if there's no database.
- Refactor PooledDataSourceImpl so that the underlying datasource is provided by the concrete classes.
- Remove the NonNull annotation from PluggableJdbcConnection for the build since it has a sensible default.

## Result

- configcheck now works again with Hikari connection pool

## Testing

- use nightly build, run -configcheck with the above configuration.: __FAILS__
- use nightly build, change the builder element to be jdbc-default-pool-factory : __SUCCESS__
- use nightly build, remove the builder element; run configcheck again : __FAIL__
- checkout the PR, run -configcheck with the above configuration: __SUCCESS__
- checkout the PR, remove the builder element; run configcheck : __SUCCESS__

