### PR TITLE
JMS Unit tests - use a static broker

### DIFF
--- a/interlok-core/src/test/java/com/adaptris/core/jms/AutoConvertMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/AutoConvertMessageTranslatorTest.java
@@ -24,7 +24,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
+
 import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
@@ -33,14 +35,18 @@ import javax.jms.MessageEOFException;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
-  
+    
   private static final String ORIGINAL_MESSGAE_TYPE_KEY = "adpmessagetype";
 
   private static final String MAP_MSG_PREFIX = "mapMsg.";
@@ -54,18 +60,25 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
       INTEGER_VALUE, BOOLEAN_VALUE, STRING_VALUE
   };
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Test
   public void testConvertFromConsumeTypeBytes() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setConvertBackToConsumedType(true);
     trans.setRemoveOriginalMessageTypeKey(false);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       BytesMessage jmsMsg = session.createBytesMessage();
@@ -81,22 +94,17 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
 
   @Test
   public void testConvertFromConsumeTypeText() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setConvertBackToConsumedType(true);
     trans.setRemoveOriginalMessageTypeKey(false);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       TextMessage jmsMsg = session.createTextMessage();
@@ -112,17 +120,12 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
   
   @Test
   public void testConvertFromConsumeTypeTextRemoveKeyAfter() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setConvertBackToConsumedType(true);
     trans.setRemoveOriginalMessageTypeKey(true);
@@ -130,8 +133,7 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     assertTrue(trans.getRemoveOriginalMessageTypeKey());
     
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       TextMessage jmsMsg = session.createTextMessage();
@@ -148,24 +150,19 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
 
   @Test
   public void testConvertFromConsumeTypeTextDefaultRemoveKeyAfter() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setConvertBackToConsumedType(true);
     
     assertNull(trans.getRemoveOriginalMessageTypeKey()); // defaults to true if null.
     
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       TextMessage jmsMsg = session.createTextMessage();
@@ -182,23 +179,17 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
   
   @Test
   public void testConvertFromConsumeTypeMap() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setConvertBackToConsumedType(true);
     trans.setRemoveOriginalMessageTypeKey(false);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       MapMessage jmsMsg = session.createMapMessage();
@@ -213,23 +204,17 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
   
   @Test
   public void testConvertFromConsumeTypeObject() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setConvertBackToConsumedType(true);
     trans.setRemoveOriginalMessageTypeKey(false);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       ObjectMessage jmsMsg = session.createObjectMessage();
@@ -246,23 +231,17 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
   
   @Test
   public void testConvertFromConsumeTypeBytesNoMetadataKey() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setConvertBackToConsumedType(true);
     trans.setRemoveOriginalMessageTypeKey(false);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       BytesMessage jmsMsg = session.createBytesMessage();
@@ -279,22 +258,16 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
   
   @Test
   public void testConvertFromConsumeTypeBytesIllegalMetadataKey() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setConvertBackToConsumedType(true);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       BytesMessage jmsMsg = session.createBytesMessage();
@@ -311,21 +284,15 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
   
   @Test
   public void testBytesMessageToAdaptrisMessage() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       BytesMessage jmsMsg = session.createBytesMessage();
@@ -339,21 +306,16 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
 
   @Test
   public void testAdaptrisMessageToBytesMessage() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType(AutoConvertMessageTranslator.SupportedMessageType.Bytes.name());
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -366,19 +328,15 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToTextMessage() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType(AutoConvertMessageTranslator.SupportedMessageType.Text.name());
     try {
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
       addMetadata(msg);
@@ -389,21 +347,15 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
 
     }
   }
 
   @Test
   public void testMapMessageToAdaptrisMessage() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       MapMessage jmsMsg = session.createMapMessage();
@@ -416,20 +368,15 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToMapMessage() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType(AutoConvertMessageTranslator.SupportedMessageType.Map.name());
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
       addMetadata(msg);
@@ -442,20 +389,14 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testObjectMessageToAdaptrisMessage() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       ObjectMessage jmsMsg = session.createObjectMessage();
       Exception e = new Exception("This is an Exception that was serialized");
@@ -470,20 +411,15 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToObjectMessage() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType(AutoConvertMessageTranslator.SupportedMessageType.Object.name());
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
       Exception e = new Exception("This is an Exception that was serialized");
@@ -496,20 +432,14 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
   
   @Test
   public void testMessageToAdaptrisMessageWithFallback() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       Message jmsMsg = session.createMessage();
 
@@ -520,21 +450,15 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
   
   @Test
   public void testAdaptrisMessageToMessageWithFallback() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-
     AutoConvertMessageTranslator trans = new AutoConvertMessageTranslator();
     trans.setJmsOutputType("xxx");
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
       
@@ -543,7 +467,6 @@ public class AutoConvertMessageTranslatorTest extends GenericMessageTypeTranslat
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BasicJavaxJmsMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BasicJavaxJmsMessageTranslatorTest.java
@@ -26,6 +26,9 @@ import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import javax.jms.StreamMessage;
 import javax.jms.TextMessage;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -33,14 +36,23 @@ import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       Message jmsMsg = createMessage(session);
       addProperties(jmsMsg);
       start(trans, session);
@@ -50,18 +62,14 @@ public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTransl
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
@@ -78,18 +86,14 @@ public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTransl
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
   
   @Test
   public void testAdaptrisMessageWithPayloadToMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = this.createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -106,7 +110,6 @@ public class BasicJavaxJmsMessageTranslatorTest extends GenericMessageTypeTransl
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
   

--- a/interlok-core/src/test/java/com/adaptris/core/jms/BytesMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/BytesMessageTranslatorTest.java
@@ -30,6 +30,9 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageEOFException;
 import javax.jms.Session;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
@@ -43,6 +46,18 @@ import com.adaptris.core.stubs.DefectiveMessageFactory;
 @SuppressWarnings("deprecation")
 public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   private static byte[] BYTES = new byte[256]; {
     for(int i=0; i<BYTES.length; i++) {
       BYTES[i] = (byte)i;
@@ -60,12 +75,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   @Override
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       BytesMessage jmsMsg = createMessage(session);
 
       addProperties(jmsMsg);
@@ -78,8 +90,6 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
     finally {
       stop(trans);
-      broker.destroy();
-
     }
   }
 
@@ -88,12 +98,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
   @Override
   @Test
   public void testMoveJmsHeadersJmsMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       BytesMessage jmsMsg = createMessage(session);
       jmsMsg.setJMSCorrelationID("ABC");
       jmsMsg.setJMSDeliveryMode(1);
@@ -118,21 +125,16 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
     finally {
       stop(trans);
-
-      broker.destroy();
     }
   }
 
   @Override
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage_RemoveAllFilter() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     trans.setMetadataFilter(new RemoveAllMetadataFilter());
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       BytesMessage jmsMsg = createMessage(session);
       addProperties(jmsMsg);
       start(trans, session);
@@ -146,22 +148,18 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Override
   @Test
   public void testMoveMetadata_JmsMessageToAdaptrisMessage_WithFilter() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
     regexp.addExcludePattern("IntegerMetadataKey");
     trans.setMetadataFilter(regexp);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       BytesMessage jmsMsg = createMessage(session);
       addProperties(jmsMsg);
       start(trans, session);
@@ -176,19 +174,15 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
 
   @Test
   public void testBytesMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       BytesMessage jmsMsg = session.createBytesMessage();
       jmsMsg.writeBytes(BYTES);
       addProperties(jmsMsg);
@@ -200,18 +194,14 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testBytesMessageToAdaptrisMessage_Alt() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       BytesMessage jmsMsg = session.createBytesMessage();
       jmsMsg.writeBytes(BYTES_ALT);
       addProperties(jmsMsg);
@@ -222,33 +212,28 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
       assertTrue(Arrays.equals(BYTES_ALT, msg.getPayload()));
     } finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
 
   @Test
   public void testBytesMessageToAdaptrisMessage_StreamFailure() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       BytesMessage jmsMsg = createMessage(session);
       jmsMsg.writeBytes(TEXT.getBytes());
       start(trans, session);
       trans.registerMessageFactory(new DefectiveMessageFactory());
       jmsMsg.reset();
       try {
-        AdaptrisMessage msg = trans.translate(jmsMsg);
+        trans.translate(jmsMsg);
         fail();
       } catch (JMSException expected) {
 
       }
     } finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
@@ -268,7 +253,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     try {
       start(trans, session);
       try {
-        AdaptrisMessage msg = trans.translate(jmsMsg);
+        trans.translate(jmsMsg);
         fail();
       } catch (JMSException expected) {
 
@@ -280,12 +265,9 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testAdaptrisMessageToBytesMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
       addMetadata(msg);
@@ -297,14 +279,11 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToBytesMessage_StreamFailure() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     BytesMessageTranslator trans = new BytesMessageTranslator() {
       @Override
       long streamThreshold() {
@@ -312,19 +291,17 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
       }
     };
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = new DefectiveMessageFactory().newMessage(TEXT);
       addMetadata(msg);
       try {
-        Message jmsMsg = trans.translate(msg);
+        trans.translate(msg);
         fail();
       } catch (JMSException expected) {
       }
     } finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
@@ -345,7 +322,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
       try {
-        Message m = trans.translate(msg);
+        trans.translate(msg);
         fail();
       } catch (JMSException expected) {
       }
@@ -358,8 +335,6 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
 
   @Test
   public void testAdaptrisMessageToBytesMessage_ExceedsThreshold() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     BytesMessageTranslator trans = new BytesMessageTranslator() {
 
       @Override
@@ -368,8 +343,7 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
       }
     };
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
       addMetadata(msg);
@@ -381,7 +355,6 @@ public class BytesMessageTranslatorTest extends GenericMessageTypeTranslatorCase
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/ConvertingMetadataConverterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/ConvertingMetadataConverterCase.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.fail;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
@@ -27,34 +30,35 @@ import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public abstract class ConvertingMetadataConverterCase extends MetadataConverterCase {
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testConvertFailure() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
-    try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
-      MetadataCollection metadataCollection = new MetadataCollection();
-      metadataCollection.add(new MetadataElement(HEADER, testName.getMethodName()));
-      Message jmsMsg = session.createMessage();
-      mc.moveMetadata(metadataCollection, jmsMsg);
-      assertEquals(testName.getMethodName(), jmsMsg.getStringProperty(HEADER));
-    }
-    finally {
-      broker.destroy();
-    }
+    Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+    MetadataCollection metadataCollection = new MetadataCollection();
+    metadataCollection.add(new MetadataElement(HEADER, testName.getMethodName()));
+    Message jmsMsg = session.createMessage();
+    mc.moveMetadata(metadataCollection, jmsMsg);
+    assertEquals(testName.getMethodName(), jmsMsg.getStringProperty(HEADER));
   }
 
   @Test
   public void testConvertFailure_Strict() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MetadataConverter mc = createConverter();
     mc.setStrictConversion(true);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       MetadataCollection metadataCollection = new MetadataCollection();
       metadataCollection.add(new MetadataElement(HEADER, testName.getMethodName()));
       Message jmsMsg = session.createMessage();
@@ -63,9 +67,6 @@ public abstract class ConvertingMetadataConverterCase extends MetadataConverterC
     }
     catch (JMSException expected) {
 
-    }
-    finally {
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/FailoverJmsConsumerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/FailoverJmsConsumerCase.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.Channel;
@@ -32,15 +35,27 @@ import com.adaptris.core.util.LifecycleHelper;
 public abstract class FailoverJmsConsumerCase
     extends com.adaptris.interlok.junit.scaffolding.jms.JmsConsumerCase {
 
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Test
   public void testBug1012() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     try {
       List<JmsConnection> ptp = new ArrayList<JmsConnection>();
-      ptp.add(broker.getJmsConnection(new BasicActiveMqImplementation(), true));
-      ptp.add(broker.getJmsConnection(new BasicActiveMqImplementation(), false));
+      ptp.add(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true));
+      ptp.add(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), false));
       connection.setConnections(ptp);
       LifecycleHelper.init(connection);
 
@@ -54,8 +69,8 @@ public abstract class FailoverJmsConsumerCase
       connection.setRegisterOwner(true);
       channel.setConsumeConnection(connection);
       ptp = new ArrayList<JmsConnection>();
-      ptp.add(broker.getJmsConnection(new BasicActiveMqImplementation(), true));
-      ptp.add(broker.getJmsConnection(new BasicActiveMqImplementation(), false));
+      ptp.add(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true));
+      ptp.add(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), false));
       connection.setConnections(ptp);
       connection.setConnectionAttempts(1);
       LifecycleHelper.init(connection);
@@ -64,7 +79,6 @@ public abstract class FailoverJmsConsumerCase
     }
     finally {
       LifecycleHelper.close(connection);
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/FailoverJmsProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/FailoverJmsProducerCase.java
@@ -19,13 +19,18 @@ package com.adaptris.core.jms;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.StringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.Channel;
 import com.adaptris.core.CoreException;
@@ -39,46 +44,50 @@ import com.adaptris.util.TimeInterval;
 public abstract class FailoverJmsProducerCase
     extends com.adaptris.interlok.junit.scaffolding.jms.JmsProducerCase {
 
-  private FailoverJmsConnection connection;
+  private static EmbeddedActiveMq activeMqBroker;
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testBug1012() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
-    try {
-      broker.start();
-      List<JmsConnection> ptp = new ArrayList<JmsConnection>();
-      ptp.add(broker.getJmsConnection());
-      ptp.add(broker.getJmsConnection(new BasicActiveMqImplementation(), true));
-      connection.setConnections(ptp);
-      LifecycleHelper.init(connection);
+    List<JmsConnection> ptp = new ArrayList<JmsConnection>();
+    ptp.add(activeMqBroker.getJmsConnection());
+    ptp.add(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true));
+    connection.setConnections(ptp);
+    LifecycleHelper.init(connection);
 
-      assertEquals(1, connection.currentJmsConnection().retrieveExceptionListeners().size());
-      AdaptrisComponent owner = (AdaptrisComponent) connection.currentJmsConnection().retrieveExceptionListeners().toArray()[0];
-      assertTrue("Owner should be failover connection", connection == owner);
-      LifecycleHelper.close(connection);
+    assertEquals(1, connection.currentJmsConnection().retrieveExceptionListeners().size());
+    AdaptrisComponent owner = (AdaptrisComponent) connection.currentJmsConnection().retrieveExceptionListeners().toArray()[0];
+    assertTrue("Owner should be failover connection", connection == owner);
+    LifecycleHelper.close(connection);
 
-      Channel channel = new MockChannel();
-      connection = new FailoverJmsConnection();
-      connection.setRegisterOwner(true);
-      channel.setConsumeConnection(connection);
-      ptp = new ArrayList<JmsConnection>();
-      ptp.add(broker.getJmsConnection());
-      ptp.add(broker.getJmsConnection(new BasicActiveMqImplementation(), true));
-      connection.setConnections(ptp);
-      LifecycleHelper.init(connection);
-      //setting the consume connection no longer sets up the exception handler, so expect 0 here.
-      assertEquals(0, connection.currentJmsConnection().retrieveExceptionListeners().size());
-      LifecycleHelper.close(connection);
+    Channel channel = new MockChannel();
+    connection = new FailoverJmsConnection();
+    connection.setRegisterOwner(true);
+    channel.setConsumeConnection(connection);
+    ptp = new ArrayList<JmsConnection>();
+    ptp.add(activeMqBroker.getJmsConnection());
+    ptp.add(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true));
+    connection.setConnections(ptp);
+    LifecycleHelper.init(connection);
+    //setting the consume connection no longer sets up the exception handler, so expect 0 here.
+    assertEquals(0, connection.currentJmsConnection().retrieveExceptionListeners().size());
+    LifecycleHelper.close(connection);
     }
-    finally {
-      broker.destroy();
-    }
-  }
 
   @Test
   public void testNeverConnects() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     connection.addConnection(new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:123456")));
     connection.addConnection(new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:123456")));
@@ -87,24 +96,21 @@ public abstract class FailoverJmsProducerCase
     connection.addExceptionListener(new StandaloneConsumer());
     connection.setRegisterOwner(true);
     try {
-      broker.start();
       LifecycleHelper.initAndStart(connection);
     }
     catch (CoreException expected) {
 
     }
     finally {
-      broker.destroy();
       LifecycleHelper.stopAndClose(connection);
     }
   }
 
   @Test
   public void testEventuallyConnects() throws Exception {
-    final EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
     connection.addConnection(new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:123456")));
-    connection.addConnection(broker.getJmsConnection(new BasicActiveMqImplementation(), true));
+    connection.addConnection(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true));
     connection.setConnectionRetryInterval(new TimeInterval(250L, TimeUnit.MILLISECONDS));
     connection.addExceptionListener(new StandaloneConsumer());
     connection.setRegisterOwner(true);
@@ -115,7 +121,7 @@ public abstract class FailoverJmsProducerCase
         @Override
         public void run() {
           try {
-            broker.start();
+            activeMqBroker.start();
           }
           catch (Exception e) {
             throw new RuntimeException(e);
@@ -126,7 +132,6 @@ public abstract class FailoverJmsProducerCase
       LifecycleHelper.initAndStart(connection);
     }
     finally {
-      broker.destroy();
       LifecycleHelper.stopAndClose(connection);
       es.shutdownNow();
     }
@@ -134,31 +139,26 @@ public abstract class FailoverJmsProducerCase
 
   @Test
   public void testConnectionEquals() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
-    connection.addConnection(broker.getJmsConnection(new BasicActiveMqImplementation(), true));
-    connection.addConnection(broker.getJmsConnection());
+    connection.addConnection(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true));
+    connection.addConnection(activeMqBroker.getJmsConnection());
     assertEquals(false, connection.connectionEquals(new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:123456"))));
     try {
-      broker.start();
       LifecycleHelper.initAndStart(connection);
       assertNotNull(connection.currentJmsConnection());
-      assertEquals(true, connection.connectionEquals(broker.getJmsConnection(new BasicActiveMqImplementation(), true)));
+      assertEquals(true, connection.connectionEquals(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true)));
     }
     finally {
-      broker.destroy();
       LifecycleHelper.stopAndClose(connection);
     }
   }
 
   @Test
   public void testDelegatedMethods() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     FailoverJmsConnection connection = new FailoverJmsConnection();
-    connection.addConnection(broker.getJmsConnection(new BasicActiveMqImplementation(), true));
-    connection.addConnection(broker.getJmsConnection());
+    connection.addConnection(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true));
+    connection.addConnection(activeMqBroker.getJmsConnection());
     try {
-      broker.start();
       LifecycleHelper.initAndStart(connection);
       assertNotNull(connection.currentJmsConnection());
       assertNotNull(connection.obtainConnectionFactory());
@@ -169,7 +169,6 @@ public abstract class FailoverJmsProducerCase
       assertEquals(BasicActiveMqImplementation.class, connection.configuredVendorImplementation().getClass());
     }
     finally {
-      broker.destroy();
       LifecycleHelper.stopAndClose(connection);
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/GenericMessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/GenericMessageTypeTranslatorCase.java
@@ -17,10 +17,11 @@ package com.adaptris.core.jms;
 
 import javax.jms.Message;
 import javax.jms.Session;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 
 public abstract class GenericMessageTypeTranslatorCase
@@ -30,15 +31,13 @@ public abstract class GenericMessageTypeTranslatorCase
   @Test
   public void testMetadataConverter() throws Exception {
 
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator().withMetadataConverters(
         new StringMetadataConverter(new RegexMetadataFilter().withIncludePatterns(STRING_METADATA)),
         new IntegerMetadataConverter(new RegexMetadataFilter().withIncludePatterns(INTEGER_METADATA)),
         new BooleanMetadataConverter(
             new RegexMetadataFilter().withIncludePatterns(BOOLEAN_METADATA)));
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
       addMetadata(msg);
@@ -46,7 +45,6 @@ public abstract class GenericMessageTypeTranslatorCase
       assertJmsProperties(jmsMsg);
     } finally {
       stop(trans);
-      broker.destroy();
     }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsConnectionTest.java
@@ -18,6 +18,9 @@ package com.adaptris.core.jms;
 
 import static org.junit.Assert.assertNotSame;
 import javax.jms.Session;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -28,13 +31,24 @@ public class JmsConnectionTest {
   @Rule
   public TestName testName = new TestName();
 
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testSession() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       LifecycleHelper.init(conn);
       LifecycleHelper.start(conn);
       Session s1 = conn.createSession(false, AcknowledgeMode.Mode.AUTO_ACKNOWLEDGE.acknowledgeMode());
@@ -43,7 +57,6 @@ public class JmsConnectionTest {
     }
     finally {
       LifecycleHelper.close(conn);
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsTransactedWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsTransactedWorkflowTest.java
@@ -18,13 +18,16 @@ package com.adaptris.core.jms;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
 import com.adaptris.core.Channel;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullProcessingExceptionHandler;
@@ -45,9 +48,20 @@ import com.adaptris.util.TimeInterval;
 public class JmsTransactedWorkflowTest
     extends com.adaptris.interlok.junit.scaffolding.ExampleWorkflowCase {
 
-  private static Log logR = LogFactory.getLog(JmsTransactedWorkflowTest.class);
+  private static EmbeddedActiveMq activeMqBroker;
 
-
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testSetStrict() throws Exception {
     JmsTransactedWorkflow workflow = new JmsTransactedWorkflow();
@@ -65,12 +79,10 @@ public class JmsTransactedWorkflowTest
 
   @Test
   public void testInit_UnsupportedConsumer() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    Channel channel = createStartableChannel(broker);
+    Channel channel = createStartableChannel(activeMqBroker);
     JmsTransactedWorkflow workflow = (JmsTransactedWorkflow) channel.getWorkflowList().get(0);
     workflow.setConsumer(new FsConsumer().withBaseDirectoryUrl("file:////path/to/directory"));
     try {
-      broker.start();
       channel.requestInit();
     }
     catch (CoreException expected) {
@@ -78,7 +90,6 @@ public class JmsTransactedWorkflowTest
     }
     finally {
       channel.requestClose();
-      broker.destroy();
     }
   }
 
@@ -96,12 +107,10 @@ public class JmsTransactedWorkflowTest
 
   @Test
   public void testInit_UnsupportedProduceExceptionHandler() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    Channel channel = createStartableChannel(broker);
+    Channel channel = createStartableChannel(activeMqBroker);
     JmsTransactedWorkflow workflow = (JmsTransactedWorkflow) channel.getWorkflowList().get(0);
     workflow.setProduceExceptionHandler(new RestartProduceExceptionHandler());
     try {
-      broker.start();
       channel.requestInit();
     }
     catch (CoreException expected) {
@@ -110,35 +119,28 @@ public class JmsTransactedWorkflowTest
     }
     finally {
       channel.requestClose();
-      broker.destroy();
     }
   }
 
   @Test
   public void testInit() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    Channel channel = createStartableChannel(broker);
+    Channel channel = createStartableChannel(activeMqBroker);
     try {
-      broker.start();
       channel.requestInit();
     }
     finally {
       channel.requestClose();
-      broker.destroy();
     }
   }
 
   @Test
   public void testStart() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    Channel channel = createStartableChannel(broker);
+    Channel channel = createStartableChannel(activeMqBroker);
     try {
-      broker.start();
       channel.requestStart();
     }
     finally {
       channel.requestClose();
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsUtilsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsUtilsTest.java
@@ -26,200 +26,145 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public class JmsUtilsTest {
 
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testCloseSession() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
-      JmsUtils.closeQuietly(session);
-      JmsUtils.closeQuietly((Session) null);
-      session = (Session) Proxy.newProxyInstance(Session.class.getClassLoader(), new Class[]
-      {
-        Session.class
-      }, new FailingDynamicProxy());
-      JmsUtils.closeQuietly(session);
-    }
-    finally {
-      broker.destroy();
-
-    }
+    Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+    JmsUtils.closeQuietly(session);
+    JmsUtils.closeQuietly((Session) null);
+    session = (Session) Proxy.newProxyInstance(Session.class.getClassLoader(), new Class[]
+    {
+      Session.class
+    }, new FailingDynamicProxy());
+    JmsUtils.closeQuietly(session);
   }
 
   @Test
   public void testCloseConnection() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    try {
-      broker.start();
-      Connection connection = broker.createConnection();
-      JmsUtils.closeQuietly(connection);
-      connection = broker.createConnection();
-      JmsUtils.closeQuietly(connection, true);
-      JmsUtils.closeQuietly((Connection) null);
-      connection = (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]
-      {
-        Connection.class
-      }, new FailingDynamicProxy());
-      JmsUtils.closeQuietly(connection);
-      connection = (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]
-      {
-        Connection.class
-      }, new FailingDynamicProxy());
-      JmsUtils.closeQuietly(connection, true);
-    }
-    finally {
-      broker.destroy();
-
-    }
+    Connection connection = activeMqBroker.createConnection();
+    JmsUtils.closeQuietly(connection);
+    connection = activeMqBroker.createConnection();
+    JmsUtils.closeQuietly(connection, true);
+    JmsUtils.closeQuietly((Connection) null);
+    connection = (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]
+    {
+      Connection.class
+    }, new FailingDynamicProxy());
+    JmsUtils.closeQuietly(connection);
+    connection = (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]
+    {
+      Connection.class
+    }, new FailingDynamicProxy());
+    JmsUtils.closeQuietly(connection, true);
   }
 
   @Test
   public void testStopConnection() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    try {
-      broker.start();
-      Connection connection = broker.createConnection();
-      JmsUtils.stopQuietly(connection);
-      JmsUtils.stopQuietly(null);
-      connection = broker.createConnection();
-      JmsUtils.stopQuietly(connection);
-      connection = (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]
-      {
-        Connection.class
-      }, new FailingDynamicProxy());
-      JmsUtils.stopQuietly(connection);
-    }
-    finally {
-      broker.destroy();
-
-    }
+    Connection connection = activeMqBroker.createConnection();
+    JmsUtils.stopQuietly(connection);
+    JmsUtils.stopQuietly(null);
+    connection = activeMqBroker.createConnection();
+    JmsUtils.stopQuietly(connection);
+    connection = (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class[]
+    {
+      Connection.class
+    }, new FailingDynamicProxy());
+    JmsUtils.stopQuietly(connection);
   }
 
   @Test
   public void testDeleteTemporaryTopic() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
-      TemporaryTopic topic = session.createTemporaryTopic();
-      JmsUtils.deleteQuietly(topic);
-      JmsUtils.deleteQuietly((TemporaryTopic) null);
-      topic = (TemporaryTopic) Proxy.newProxyInstance(TemporaryTopic.class.getClassLoader(), new Class[]
-      {
-        TemporaryTopic.class
-      }, new FailingDynamicProxy());
-      JmsUtils.deleteQuietly(topic);
-      JmsUtils.closeQuietly(session);
-
-    }
-    finally {
-      broker.destroy();
-
-    }
+    Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+    TemporaryTopic topic = session.createTemporaryTopic();
+    JmsUtils.deleteQuietly(topic);
+    JmsUtils.deleteQuietly((TemporaryTopic) null);
+    topic = (TemporaryTopic) Proxy.newProxyInstance(TemporaryTopic.class.getClassLoader(), new Class[]
+    {
+      TemporaryTopic.class
+    }, new FailingDynamicProxy());
+    JmsUtils.deleteQuietly(topic);
+    JmsUtils.closeQuietly(session);
   }
 
   @Test
   public void testDeleteTemporaryQueue() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
-      TemporaryQueue queue = session.createTemporaryQueue();
-      JmsUtils.deleteQuietly(queue);
-      JmsUtils.deleteQuietly((TemporaryQueue) null);
-      queue = (TemporaryQueue) Proxy.newProxyInstance(TemporaryQueue.class.getClassLoader(), new Class[]
-      {
-        TemporaryQueue.class
-      }, new FailingDynamicProxy());
-      JmsUtils.deleteQuietly(queue);
-      JmsUtils.closeQuietly(session);
-    }
-    finally {
-      broker.destroy();
-
-    }
+    Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+    TemporaryQueue queue = session.createTemporaryQueue();
+    JmsUtils.deleteQuietly(queue);
+    JmsUtils.deleteQuietly((TemporaryQueue) null);
+    queue = (TemporaryQueue) Proxy.newProxyInstance(TemporaryQueue.class.getClassLoader(), new Class[]
+    {
+      TemporaryQueue.class
+    }, new FailingDynamicProxy());
+    JmsUtils.deleteQuietly(queue);
+    JmsUtils.closeQuietly(session);
   }
 
   @Test
   public void testDeleteTemporaryDestination() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
-      Destination dest = session.createTemporaryQueue();
-      JmsUtils.deleteTemporaryDestination(dest);
-      dest = session.createTemporaryTopic();
-      JmsUtils.deleteTemporaryDestination(dest);
-      JmsUtils.deleteTemporaryDestination(null);
-      dest = (TemporaryQueue) Proxy.newProxyInstance(TemporaryQueue.class.getClassLoader(), new Class[]
-      {
-        TemporaryQueue.class
-      }, new FailingDynamicProxy());
-      JmsUtils.deleteTemporaryDestination(dest);
-      dest = session.createQueue("myQueue");
-      JmsUtils.deleteTemporaryDestination(dest);
-      JmsUtils.closeQuietly(session);
-    }
-    finally {
-      broker.destroy();
-    }
+    Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+    Destination dest = session.createTemporaryQueue();
+    JmsUtils.deleteTemporaryDestination(dest);
+    dest = session.createTemporaryTopic();
+    JmsUtils.deleteTemporaryDestination(dest);
+    JmsUtils.deleteTemporaryDestination(null);
+    dest = (TemporaryQueue) Proxy.newProxyInstance(TemporaryQueue.class.getClassLoader(), new Class[]
+    {
+      TemporaryQueue.class
+    }, new FailingDynamicProxy());
+    JmsUtils.deleteTemporaryDestination(dest);
+    dest = session.createQueue("myQueue");
+    JmsUtils.deleteTemporaryDestination(dest);
+    JmsUtils.closeQuietly(session);
   }
 
   @Test
   public void testCloseProducer() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
-      MessageProducer producer = session.createProducer(session.createTemporaryTopic());
-      JmsUtils.closeQuietly(producer);
-      JmsUtils.closeQuietly((MessageProducer) null);
-      producer = (MessageProducer) Proxy.newProxyInstance(MessageProducer.class.getClassLoader(), new Class[]
-      {
-        MessageProducer.class
-      }, new FailingDynamicProxy());
-      JmsUtils.closeQuietly(producer);
-      JmsUtils.closeQuietly(session);
-    }
-    finally {
-      broker.destroy();
-
-    }
+    Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+    MessageProducer producer = session.createProducer(session.createTemporaryTopic());
+    JmsUtils.closeQuietly(producer);
+    JmsUtils.closeQuietly((MessageProducer) null);
+    producer = (MessageProducer) Proxy.newProxyInstance(MessageProducer.class.getClassLoader(), new Class[]
+    {
+      MessageProducer.class
+    }, new FailingDynamicProxy());
+    JmsUtils.closeQuietly(producer);
+    JmsUtils.closeQuietly(session);
   }
 
   @Test
   public void testCloseConsumer() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
-      MessageConsumer consumer = session.createConsumer(session.createTemporaryTopic());
-      JmsUtils.closeQuietly(consumer);
-      JmsUtils.closeQuietly((MessageProducer) null);
-      consumer = (MessageConsumer) Proxy.newProxyInstance(MessageConsumer.class.getClassLoader(), new Class[]
-      {
-        MessageConsumer.class
-      }, new FailingDynamicProxy());
-      JmsUtils.closeQuietly(consumer);
-      JmsUtils.closeQuietly(session);
-    }
-    finally {
-      broker.destroy();
-
-    }
+    Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+    MessageConsumer consumer = session.createConsumer(session.createTemporaryTopic());
+    JmsUtils.closeQuietly(consumer);
+    JmsUtils.closeQuietly((MessageProducer) null);
+    consumer = (MessageConsumer) Proxy.newProxyInstance(MessageConsumer.class.getClassLoader(), new Class[]
+    {
+      MessageConsumer.class
+    }, new FailingDynamicProxy());
+    JmsUtils.closeQuietly(consumer);
+    JmsUtils.closeQuietly(session);
   }
 
   private class FailingDynamicProxy implements InvocationHandler {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MapMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MapMessageTranslatorTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertTrue;
 import javax.jms.MapMessage;
 import javax.jms.Message;
 import javax.jms.Session;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -30,6 +33,18 @@ import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
   private static final String BODY_KEY1 = "bodykey1";
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   /**
    * @see com.adaptris.core.jms.MessageTypeTranslatorCase#createMessage(javax.jms.Session)
    */
@@ -50,12 +65,9 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
   @Test
   public void testMapMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       MapMessage jmsMsg = session.createMapMessage();
       jmsMsg.setString(BODY_KEY1, TEXT);
       addProperties(jmsMsg);
@@ -67,18 +79,14 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
     }
     finally {
       stop(t);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToMapMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
 
       addMetadata(msg);
@@ -93,18 +101,14 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
     }
     finally {
       stop(t);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToMapMessageWithMetadataAsPayload() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MapMessageTranslator t = new MapMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
 
       addMetadata(msg);
@@ -122,7 +126,6 @@ public class MapMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
     }
     finally {
       stop(t);
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MessageIdCorrelationIdSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MessageIdCorrelationIdSourceTest.java
@@ -20,7 +20,9 @@ import static org.junit.Assert.assertNotSame;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -32,6 +34,20 @@ import com.adaptris.core.util.LifecycleHelper;
 public class MessageIdCorrelationIdSourceTest {
   @Rule
   public TestName testName = new TestName();
+  
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Before
   public void setUp() throws Exception {
@@ -43,11 +59,8 @@ public class MessageIdCorrelationIdSourceTest {
 
   @Test
   public void testCorrelationIdAdaptrisMessage_ToMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       LifecycleHelper.initAndStart(conn, false);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage("hello");
@@ -58,17 +71,13 @@ public class MessageIdCorrelationIdSourceTest {
       session.close();
     } finally {
       LifecycleHelper.stopAndClose(conn, false);
-      broker.destroy();
     }
   }
 
   @Test
   public void testCorrelationIdMessage_AdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       LifecycleHelper.initAndStart(conn, false);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage("hello");
@@ -83,17 +92,13 @@ public class MessageIdCorrelationIdSourceTest {
       session.close();
     } finally {
       LifecycleHelper.stopAndClose(conn, false);
-      broker.destroy();
     }
   }
 
   @Test
   public void testCorrelationIdMessage_AdaptrisMessage_NoCorrelationId() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       LifecycleHelper.initAndStart(conn, false);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage("hello");
@@ -106,7 +111,6 @@ public class MessageIdCorrelationIdSourceTest {
       session.close();
     } finally {
       LifecycleHelper.stopAndClose(conn, false);
-      broker.destroy();
     }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MetadataCorrelationIdSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MetadataCorrelationIdSourceTest.java
@@ -28,6 +28,8 @@ import javax.jms.TextMessage;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -42,14 +44,24 @@ public class MetadataCorrelationIdSourceTest {
 
   protected transient Log log = LogFactory.getLog(this.getClass());
 
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId() throws Exception {
-
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       start(conn);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -62,17 +74,13 @@ public class MetadataCorrelationIdSourceTest {
     }
     finally {
       stop(conn);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId_NoMetadataKey() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       start(conn);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -85,17 +93,13 @@ public class MetadataCorrelationIdSourceTest {
     }
     finally {
       stop(conn);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId_EmptyValue() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       start(conn);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -108,17 +112,13 @@ public class MetadataCorrelationIdSourceTest {
     }
     finally {
       stop(conn);
-      broker.destroy();
     }
   }
 
   @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       start(conn);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -131,17 +131,13 @@ public class MetadataCorrelationIdSourceTest {
     }
     finally {
       stop(conn);
-      broker.destroy();
     }
   }
 
   @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata_NoMetadataKey() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       start(conn);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -154,17 +150,13 @@ public class MetadataCorrelationIdSourceTest {
     }
     finally {
       stop(conn);
-      broker.destroy();
     }
   }
 
   @Test
   public void testJmsCorrelationIdToAdaptrisMessageMetadata_NoValue() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    JmsConnection conn = broker.getJmsConnection();
+    JmsConnection conn = activeMqBroker.getJmsConnection();
     try {
-      broker.start();
       start(conn);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       AdaptrisMessage adpMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -176,7 +168,6 @@ public class MetadataCorrelationIdSourceTest {
     }
     finally {
       stop(conn);
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/ObjectMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/ObjectMessageTranslatorTest.java
@@ -26,6 +26,9 @@ import java.io.OutputStream;
 import javax.jms.Message;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -33,14 +36,23 @@ import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
 public class ObjectMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testObjectMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = new ObjectMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
 
       ObjectMessage jmsMsg = session.createObjectMessage();
       Exception e = new Exception("This is an Exception that was serialized");
@@ -55,18 +67,14 @@ public class ObjectMessageTranslatorTest extends GenericMessageTypeTranslatorCas
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToObjectMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = new ObjectMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
       Exception e = new Exception("This is an Exception that was serialized");
@@ -79,8 +87,6 @@ public class ObjectMessageTranslatorTest extends GenericMessageTypeTranslatorCas
     }
     finally {
       stop(trans);
-      broker.destroy();
-
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/TextMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/TextMessageTranslatorTest.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertTrue;
 import javax.jms.Message;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -30,15 +33,23 @@ import com.adaptris.core.metadata.RegexMetadataFilter;
 
 public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase {
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Test
   public void testTextMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TextMessageTranslator trans = new TextMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       Message jmsMsg = createMessage(session);
       addProperties(jmsMsg);
       start(trans, session);
@@ -48,18 +59,14 @@ public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase 
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToTextMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TextMessageTranslator trans = new TextMessageTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -71,22 +78,18 @@ public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase 
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testAdaptrisMessageToTextMessageWithMetadataFilter() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     TextMessageTranslator trans = new TextMessageTranslator();
 
     RegexMetadataFilter filter = new RegexMetadataFilter();
     filter.addExcludePattern(INTEGER_METADATA);
     trans.setMetadataFilter(filter);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(TEXT);
@@ -103,7 +106,6 @@ public class TextMessageTranslatorTest extends GenericMessageTypeTranslatorCase 
       assertNull(jmsMsg.getStringProperty(INTEGER_METADATA));
     } finally {
       stop(trans);
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/AdvancedActiveMqProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/AdvancedActiveMqProducerTest.java
@@ -19,6 +19,8 @@ package com.adaptris.core.jms.activemq;
 import static com.adaptris.core.jms.activemq.AdvancedActiveMqImplementationTest.createImpl;
 import org.apache.activemq.ActiveMQPrefetchPolicy;
 import org.apache.activemq.RedeliveryPolicy;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
@@ -31,6 +33,17 @@ import com.adaptris.util.KeyValuePair;
 
 public class AdvancedActiveMqProducerTest extends BasicActiveMqProducerTest {
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Override
   protected String createBaseFileName(Object object) {
@@ -39,50 +52,36 @@ public class AdvancedActiveMqProducerTest extends BasicActiveMqProducerTest {
 
   @Test
   public void testQueueProduceAndConsumeWithRedeliveryPolicy() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
 
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl(
-          createRedelivery(), null)), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl(
+        createRedelivery(), null)), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl(
-              createRedelivery(), null)), new PtpProducer().withQueue((getName())));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl(
+            createRedelivery(), null)), new PtpProducer().withQueue((getName())));
 
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testQueueProduceAndConsumeWithPrefetch() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
 
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl(null,
-          createPrefetch())), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl(null,
+        createPrefetch())), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl(null,
-              createPrefetch())), new PtpProducer().withQueue((getName())));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl(null,
+            createPrefetch())), new PtpProducer().withQueue((getName())));
 
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqConsumerTest.java
@@ -22,6 +22,9 @@ import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
 import static com.adaptris.interlok.junit.scaffolding.jms.JmsProducerCase.assertMessages;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisConnection;
@@ -71,6 +74,19 @@ public class BasicActiveMqConsumerTest
     }
   }
 
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Override
   protected String createBaseFileName(Object object) {
@@ -98,77 +114,54 @@ public class BasicActiveMqConsumerTest
 
   @Test
   public void testTopicProduceAndConsume() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
+    PasConsumer consumer = new PasConsumer().withTopic(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-      PasConsumer consumer = new PasConsumer().withTopic(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PasProducer().withTopic(getName()));
-      // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
-      LifecycleHelper.prepare(standaloneConsumer);
-      LifecycleHelper.prepare(standaloneProducer);
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-      AdaptrisMessage consumed = jms.getMessages().get(0);
-      // Since it's not a workflow; this will be false.
-      assertFalse(consumed.headersContainsKey(CoreConstants.MESSAGE_CONSUME_LOCATION));
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
-
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PasProducer().withTopic(getName()));
+    // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
+    LifecycleHelper.prepare(standaloneConsumer);
+    LifecycleHelper.prepare(standaloneProducer);
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
+    AdaptrisMessage consumed = jms.getMessages().get(0);
+    // Since it's not a workflow; this will be false.
+    assertFalse(consumed.headersContainsKey(CoreConstants.MESSAGE_CONSUME_LOCATION));
   }
 
   @Test
   public void testTopicProduceAndConsumeWithImplicitFallbackMessageTranslation() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PasConsumer consumer = new PasConsumer().withTopic(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    PasConsumer consumer = new PasConsumer().withTopic(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-      DefinedJmsProducer producer = new PasProducer().withTopic(getName());
-      producer.setMessageTranslator(new BytesMessageTranslator());
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
+    DefinedJmsProducer producer = new PasProducer().withTopic(getName());
+    producer.setMessageTranslator(new BytesMessageTranslator());
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testTopicProduceAndConsumeWithExplicitFallbackMessageTranslation() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PasConsumer consumer = new PasConsumer().withTopic(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new AutoConvertMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    PasConsumer consumer = new PasConsumer().withTopic(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new AutoConvertMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-      DefinedJmsProducer producer = new PasProducer().withTopic(getName());
-      producer.setMessageTranslator(new BytesMessageTranslator());
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
+    DefinedJmsProducer producer = new PasProducer().withTopic(getName());
+    producer.setMessageTranslator(new BytesMessageTranslator());
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
   private Channel createChannel(AdaptrisConnection cc, Workflow wf) throws Exception {
@@ -188,7 +181,6 @@ public class BasicActiveMqConsumerTest
 
   @Test
   public void testQueue_ProduceWhenConsumerStopped() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     PtpConsumer consumer = new PtpConsumer().withQueue(getName());
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
     StandardWorkflow workflow = new StandardWorkflow();
@@ -198,8 +190,6 @@ public class BasicActiveMqConsumerTest
     Channel channel = createChannel(activeMqBroker.getJmsConnection(createVendorImpl()), workflow);
 
     try {
-      activeMqBroker.start();
-
       StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
               new PtpProducer().withQueue((getName())));
 
@@ -215,13 +205,11 @@ public class BasicActiveMqConsumerTest
     }
     finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testTopic_ProduceWhenConsumerStopped() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     PasConsumer consumer = new PasConsumer().withTopic(getName());
     consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
     StandardWorkflow workflow = new StandardWorkflow();
@@ -231,8 +219,6 @@ public class BasicActiveMqConsumerTest
     Channel channel = createChannel(activeMqBroker.getJmsConnection(createVendorImpl()), workflow);
 
     try {
-      activeMqBroker.start();
-
       StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
               new PasProducer().withTopic(getName()));
 
@@ -248,80 +234,57 @@ public class BasicActiveMqConsumerTest
     }
     finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testQueueProduceAndConsume() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
 
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PtpProducer().withQueue((getName())));
-      // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
-      LifecycleHelper.prepare(standaloneConsumer);
-      LifecycleHelper.prepare(standaloneProducer);
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PtpProducer().withQueue((getName())));
+    // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
+    LifecycleHelper.prepare(standaloneConsumer);
+    LifecycleHelper.prepare(standaloneProducer);
 
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testQueueProduceAndConsumeWithImplicitFallbackMessageTranslation() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-      DefinedJmsProducer producer = new PtpProducer().withQueue((getName()));
-      producer.setMessageTranslator(new BytesMessageTranslator());
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
+    DefinedJmsProducer producer = new PtpProducer().withQueue((getName()));
+    producer.setMessageTranslator(new BytesMessageTranslator());
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testQueueProduceAndConsumeWithExplicitFallbackMessageTranslation() throws Exception {
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new AutoConvertMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new AutoConvertMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-      DefinedJmsProducer producer = new PtpProducer().withQueue((getName()));
-      producer.setMessageTranslator(new BytesMessageTranslator());
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
+    DefinedJmsProducer producer = new PtpProducer().withQueue((getName()));
+    producer.setMessageTranslator(new BytesMessageTranslator());
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
@@ -330,26 +293,20 @@ public class BasicActiveMqConsumerTest
       log.debug("Blob Server not available; skipping test");
       return;
     }
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new BlobMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      PtpProducer producer = new PtpProducer().withQueue((getName()));
-      producer.setMessageTranslator(new BlobMessageTranslator("blobUrl"));
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new BlobMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      execute(standaloneConsumer, standaloneProducer, addBlobUrlRef(createMessage(null), "blobUrl"), jms);
-      assertMessages(jms, 1, false);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    PtpProducer producer = new PtpProducer().withQueue((getName()));
+    producer.setMessageTranslator(new BlobMessageTranslator("blobUrl"));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+
+    execute(standaloneConsumer, standaloneProducer, addBlobUrlRef(createMessage(null), "blobUrl"), jms);
+    assertMessages(jms, 1, false);
   }
 
   @Test
@@ -358,54 +315,40 @@ public class BasicActiveMqConsumerTest
       log.debug("Blob Server not available; skipping test");
       return;
     }
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new BlobMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new BlobMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      PtpProducer producer = new PtpProducer().withQueue((getName()));
-      producer.setMessageTranslator(new BlobMessageTranslator("blobUrl"));
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    PtpProducer producer = new PtpProducer().withQueue((getName()));
+    producer.setMessageTranslator(new BlobMessageTranslator("blobUrl"));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
 
-      execute(standaloneConsumer, standaloneProducer, addBlobUrlRef(createMessage(new FileBackedMessageFactory()), "blobUrl"), jms);
-      assertMessages(jms, 1, false);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, addBlobUrlRef(createMessage(new FileBackedMessageFactory()), "blobUrl"), jms);
+    assertMessages(jms, 1, false);
   }
 
   @Test
   public void testStartWithDurableSubscribers_WithNonBlockingChannelStrategy() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      Adapter adapter = createDurableSubsAdapter(getName(), activeMqBroker);
-      adapter.requestStart();
-      assertEquals(StartedState.getInstance(), adapter.retrieveComponentState());
-      adapter.requestClose();
-      assertEquals(ClosedState.getInstance(), adapter.retrieveComponentState());
-      adapter.getChannelList().setLifecycleStrategy(new NonBlockingChannelStartStrategy());
-      adapter.requestStart();
-      // Thread.sleep(1000);
-      Channel c = adapter.getChannelList().getChannel(0);
-      int maxAttempts = 100;
-      int attempts = 0;
-      while (attempts < maxAttempts && c.retrieveComponentState() != StartedState.getInstance()) {
-        Thread.sleep(500);
-        attempts++;
-      }
-      assertEquals(StartedState.getInstance(), c.retrieveComponentState());
-      adapter.requestClose();
+    Adapter adapter = createDurableSubsAdapter(getName(), activeMqBroker);
+    adapter.requestStart();
+    assertEquals(StartedState.getInstance(), adapter.retrieveComponentState());
+    adapter.requestClose();
+    assertEquals(ClosedState.getInstance(), adapter.retrieveComponentState());
+    adapter.getChannelList().setLifecycleStrategy(new NonBlockingChannelStartStrategy());
+    adapter.requestStart();
+    // Thread.sleep(1000);
+    Channel c = adapter.getChannelList().getChannel(0);
+    int maxAttempts = 100;
+    int attempts = 0;
+    while (attempts < maxAttempts && c.retrieveComponentState() != StartedState.getInstance()) {
+      Thread.sleep(500);
+      attempts++;
     }
-    finally {
-      activeMqBroker.destroy();
-    }
+    assertEquals(StartedState.getInstance(), c.retrieveComponentState());
+    adapter.requestClose();
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BasicActiveMqProducerTest.java
@@ -37,6 +37,8 @@ import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQQueueSender;
 import org.apache.activemq.ActiveMQSession;
 import org.apache.activemq.ActiveMQTopicPublisher;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MimeEncoder;
@@ -69,6 +71,20 @@ public class BasicActiveMqProducerTest
   private static final String MY_CLIENT_ID;
   private static final String MY_SUBSCRIPTION_ID;
 
+  protected static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   static {
     try {
       GuidGenerator guid = new GuidGenerator();
@@ -106,10 +122,8 @@ public class BasicActiveMqProducerTest
 
   @Test
   public void testTopicRequestReply() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
-      activeMqBroker.start();
       echo.start();
       StandaloneRequestor standaloneProducer = new StandaloneRequestor(activeMqBroker.getJmsConnection(createVendorImpl()),
               new PasProducer().withTopic(getName()));
@@ -122,20 +136,17 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testTopicRequestReplyWithMessageWrongType() throws Exception {
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
-    TopicLoopback echo = new TopicLoopback(broker, getName(), false);
+    TopicLoopback echo = new TopicLoopback(activeMqBroker, getName(), false);
     try {
-      broker.start();
       echo.start();
       PasProducer producer = new PasProducer().withTopic(getName());
       producer.setMessageTranslator(new BytesMessageTranslator());
-      StandaloneRequestor req = new StandaloneRequestor(broker.getJmsConnection(createVendorImpl()), producer);
+      StandaloneRequestor req = new StandaloneRequestor(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
       AdaptrisMessage msg = createMessage();
       ExampleServiceCase.execute(req, msg);
       echo.waitFor(DEFAULT_TIMEOUT);
@@ -144,16 +155,13 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      broker.destroy();
     }
   }
 
   @Test
   public void testQueueRequestReply() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     QueueLoopback echo = new QueueLoopback(activeMqBroker, getName());
     try {
-      activeMqBroker.start();
       echo.start();
       StandaloneRequestor standaloneProducer = new StandaloneRequestor(activeMqBroker.getJmsConnection(createVendorImpl()),
               new PtpProducer().withQueue((getName())));
@@ -166,16 +174,13 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testQueueRequestReplyWithMessageWrongType() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     QueueLoopback echo = new QueueLoopback(activeMqBroker, getName(), false);
     try {
-      activeMqBroker.start();
       echo.start();
       PtpProducer producer = new PtpProducer().withQueue((getName()));
       producer.setMessageTranslator(new BytesMessageTranslator());
@@ -190,16 +195,13 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testTopicProduce_WithStaticReplyTo() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
-      activeMqBroker.start();
       echo.start();
       StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
               new PasProducer().withTopic(getName()));
@@ -213,16 +215,13 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testQueueProduce_WithStaticReplyTo() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     QueueLoopback echo = new QueueLoopback(activeMqBroker, getName());
     try {
-      activeMqBroker.start();
       echo.start();
       StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
               new PtpProducer().withQueue(getName()));
@@ -236,16 +235,13 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testTopicProduceWithPerMessagePropertiesDisabled() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
-      activeMqBroker.start();
       echo.start();
       PasProducer pasProducer = new PasProducer().withTopic(getName());
       pasProducer.setDeliveryMode(String.valueOf(DeliveryMode.PERSISTENT));
@@ -262,16 +258,13 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testTopicProduceWithPerMessageProperties() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
-      activeMqBroker.start();
       echo.start();
       PasProducer pasProducer = new PasProducer().withTopic(getName());
       pasProducer.setDeliveryMode(String.valueOf(DeliveryMode.PERSISTENT));
@@ -288,232 +281,168 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testTopicProduceAndConsume() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PasConsumer consumer = new PasConsumer().withTopic(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    PasConsumer consumer = new PasConsumer().withTopic(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PasProducer().withTopic(getName()));
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PasProducer().withTopic(getName()));
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testTopicProduceAndConsume_CustomMessageFactory() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PasConsumer consumer = new PasConsumer().withTopic(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageFactory(new StubMessageFactory());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    PasConsumer consumer = new PasConsumer().withTopic(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageFactory(new StubMessageFactory());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PasProducer().withTopic(getName()));
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-      assertEquals(AdaptrisMessageStub.class, jms.getMessages().get(0).getClass());
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PasProducer().withTopic(getName()));
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
+    assertEquals(AdaptrisMessageStub.class, jms.getMessages().get(0).getClass());
   }
 
   @Test
   public void testTopicProduceAndConsume_WithEncoder() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PasConsumer consumer = new PasConsumer().withTopic(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setEncoder(new MimeEncoder());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    PasConsumer consumer = new PasConsumer().withTopic(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setEncoder(new MimeEncoder());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
-      PasProducer producer = new PasProducer().withTopic(getName());
-      producer.setEncoder(new MimeEncoder());
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
+    PasProducer producer = new PasProducer().withTopic(getName());
+    producer.setEncoder(new MimeEncoder());
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testTopicProduceAndConsume_DurableSubscriber() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PasConsumer consumer = new PasConsumer().withTopic(getName());
-      consumer.setDurable(true);
-      consumer.setSubscriptionId(MY_SUBSCRIPTION_ID);
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      JmsConnection conn = activeMqBroker.getJmsConnection(createVendorImpl(), true);
-      conn.setClientId(MY_CLIENT_ID);
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(conn, consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    PasConsumer consumer = new PasConsumer().withTopic(getName());
+    consumer.setDurable(true);
+    consumer.setSubscriptionId(MY_SUBSCRIPTION_ID);
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    JmsConnection conn = activeMqBroker.getJmsConnection(createVendorImpl(), true);
+    conn.setClientId(MY_CLIENT_ID);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(conn, consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      // Start it once to get some durable Action.
-      start(standaloneConsumer);
-      stop(standaloneConsumer);
+    // Start it once to get some durable Action.
+    start(standaloneConsumer);
+    stop(standaloneConsumer);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PasProducer().withTopic(getName()));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PasProducer().withTopic(getName()));
 
-      int count = 10;
-      for (int i = 0; i < count; i++) {
-        ExampleServiceCase.execute(standaloneProducer, createMessage());
-      }
-
-      start(standaloneConsumer);
-      waitForMessages(jms, count);
-      assertMessages(jms, 10);
+    int count = 10;
+    for (int i = 0; i < count; i++) {
+      ExampleServiceCase.execute(standaloneProducer, createMessage());
     }
-    finally {
-      activeMqBroker.destroy();
-    }
+
+    start(standaloneConsumer);
+    waitForMessages(jms, count);
+    assertMessages(jms, 10);
   }
 
   @Test
   public void testTopicProduceAndConsumeWrongType() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PasConsumer consumer = new PasConsumer().withTopic(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new BytesMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    PasConsumer consumer = new PasConsumer().withTopic(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new BytesMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
 
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PasProducer().withTopic(getName()));
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PasProducer().withTopic(getName()));
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testQueueProduceAndConsume() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
 
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PtpProducer().withQueue((getName())));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PtpProducer().withQueue((getName())));
 
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testQueueProduceAndConsume_CustomMessageFactory() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageFactory(new StubMessageFactory());
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageFactory(new StubMessageFactory());
 
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PtpProducer().withQueue((getName())));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PtpProducer().withQueue((getName())));
 
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-      assertEquals(AdaptrisMessageStub.class, jms.getMessages().get(0).getClass());
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
+    assertEquals(AdaptrisMessageStub.class, jms.getMessages().get(0).getClass());
   }
 
   @Test
   public void testQueueProduceAndConsume_WithEncoder() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setEncoder(new MimeEncoder());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setEncoder(new MimeEncoder());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
 
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      PtpProducer producer = new PtpProducer().withQueue((getName()));
-      producer.setEncoder(new MimeEncoder());
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    PtpProducer producer = new PtpProducer().withQueue((getName()));
+    producer.setEncoder(new MimeEncoder());
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
 
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
   public void testQueueProduceAndConsumeWrongType() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new BytesMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new BytesMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
-              new PtpProducer().withQueue((getName())));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()),
+            new PtpProducer().withQueue((getName())));
 
-      execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(), jms);
+    assertMessages(jms, 1);
   }
 
   @Test
@@ -578,26 +507,19 @@ public class BasicActiveMqProducerTest
 
   @Test
   public void testBlobConsumeWithNonBlob() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new BlobMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new BlobMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      PtpProducer producer = new PtpProducer().withQueue((getName()));
-      producer.setMessageTranslator(new TextMessageTranslator());
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    PtpProducer producer = new PtpProducer().withQueue((getName()));
+    producer.setMessageTranslator(new TextMessageTranslator());
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
 
-      execute(standaloneConsumer, standaloneProducer, EmbeddedActiveMq.createMessage(null), jms);
-      assertMessages(jms, 1, true);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, EmbeddedActiveMq.createMessage(null), jms);
+    assertMessages(jms, 1, true);
   }
 
   @Test
@@ -606,26 +528,19 @@ public class BasicActiveMqProducerTest
       log.debug("Blob Server not available; skipping test");
       return;
     }
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new BlobMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new BlobMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      PtpProducer producer = new PtpProducer().withQueue((getName()));
-      producer.setMessageTranslator(new BlobMessageTranslator("blobUrl"));
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    PtpProducer producer = new PtpProducer().withQueue((getName()));
+    producer.setMessageTranslator(new BlobMessageTranslator("blobUrl"));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
 
-      execute(standaloneConsumer, standaloneProducer, addBlobUrlRef(EmbeddedActiveMq.createMessage(null), "blobUrl"), jms);
-      assertMessages(jms, 1, false);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, addBlobUrlRef(EmbeddedActiveMq.createMessage(null), "blobUrl"), jms);
+    assertMessages(jms, 1, false);
   }
 
   @Test
@@ -634,35 +549,27 @@ public class BasicActiveMqProducerTest
       log.debug("Blob Server not available; skipping test");
       return;
     }
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      PtpConsumer consumer = new PtpConsumer().withQueue(getName());
-      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-      consumer.setMessageTranslator(new BlobMessageTranslator());
-      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
-      MockMessageListener jms = new MockMessageListener();
-      standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      PtpProducer producer = new PtpProducer().withQueue((getName()));
-      producer.setMessageTranslator(new BlobMessageTranslator("blobUrl"));
-      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+    PtpConsumer consumer = new PtpConsumer().withQueue(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    consumer.setMessageTranslator(new BlobMessageTranslator());
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(createVendorImpl()), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
 
-      execute(standaloneConsumer, standaloneProducer,
-          addBlobUrlRef(EmbeddedActiveMq.createMessage(new FileBackedMessageFactory()), "blobUrl"), jms);
-      assertMessages(jms, 1, false);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    PtpProducer producer = new PtpProducer().withQueue((getName()));
+    producer.setMessageTranslator(new BlobMessageTranslator("blobUrl"));
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(createVendorImpl()), producer);
+
+    execute(standaloneConsumer, standaloneProducer,
+        addBlobUrlRef(EmbeddedActiveMq.createMessage(new FileBackedMessageFactory()), "blobUrl"), jms);
+    assertMessages(jms, 1, false);
   }
 
   @Test
   public void testTopicRequestReply_Bug2277() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     TopicLoopback echo = new TopicLoopback(activeMqBroker, getName());
     try {
-      activeMqBroker.start();
       echo.start();
       StandaloneRequestor standaloneProducer = new StandaloneRequestor(activeMqBroker.getJmsConnection(createVendorImpl()),
               new PasProducer().withTopic(getName()));
@@ -676,16 +583,13 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testQueueRequestReply_Bug2277() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     QueueLoopback echo = new QueueLoopback(activeMqBroker, getName());
     try {
-      activeMqBroker.start();
       echo.start();
       StandaloneRequestor standaloneProducer = new StandaloneRequestor(activeMqBroker.getJmsConnection(createVendorImpl()),
               new PtpProducer().withQueue((getName())));
@@ -699,7 +603,6 @@ public class BasicActiveMqProducerTest
     }
     finally {
       echo.stop();
-      activeMqBroker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BlobMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/BlobMessageTranslatorTest.java
@@ -16,21 +16,25 @@
 
 package com.adaptris.core.jms.activemq;
 
-import static com.adaptris.core.jms.MessageTypeTranslatorCase.addMetadata;
-import static com.adaptris.core.jms.MessageTypeTranslatorCase.addProperties;
-import static com.adaptris.core.jms.MessageTypeTranslatorCase.assertJmsProperties;
-import static com.adaptris.core.jms.MessageTypeTranslatorCase.assertMetadata;
+import static com.adaptris.interlok.junit.scaffolding.jms.MessageTypeTranslatorCase.addMetadata;
+import static com.adaptris.interlok.junit.scaffolding.jms.MessageTypeTranslatorCase.addProperties;
+import static com.adaptris.interlok.junit.scaffolding.jms.MessageTypeTranslatorCase.assertJmsProperties;
+import static com.adaptris.interlok.junit.scaffolding.jms.MessageTypeTranslatorCase.assertMetadata;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.jms.Message;
 import javax.jms.Session;
+
 import org.apache.activemq.ActiveMQSession;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.DefaultMessageFactory;
@@ -45,11 +49,22 @@ import com.adaptris.core.jms.MessageTypeTranslatorImp;
 public class BlobMessageTranslatorTest
     extends com.adaptris.interlok.junit.scaffolding.jms.JmsProducerExample {
 
-  private transient Log log = LogFactory.getLog(this.getClass());
-
   private static final String INPUT = "Quick zephyrs blow, vexing daft Jim";
 
+  private static EmbeddedActiveMq activeMqBroker;
 
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   private Message createMessage(Session session) throws Exception {
     return ((ActiveMQSession) session).createBlobMessage(new ByteArrayInputStream(INPUT.getBytes()));
   }
@@ -57,10 +72,8 @@ public class BlobMessageTranslatorTest
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage() throws Exception {
     MessageTypeTranslatorImp trans = new BlobMessageTranslator();
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConnection conn = null;
     try {
-      activeMqBroker.start();
       conn = activeMqBroker.getJmsConnection(new BasicActiveMqImplementation());
       start(conn);
       Session session = conn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
@@ -77,17 +90,14 @@ public class BlobMessageTranslatorTest
     finally {
       stop(trans);
       stop(conn);
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testMoveJmsHeadersJmsMessageToAdaptrisMessage() throws Exception {
     MessageTypeTranslatorImp trans = new BlobMessageTranslator();
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConnection conn = null;
     try {
-      activeMqBroker.start();
       conn = activeMqBroker.getJmsConnection(new BasicActiveMqImplementation());
       start(conn);
 
@@ -115,7 +125,6 @@ public class BlobMessageTranslatorTest
     finally {
       stop(trans);
       stop(conn);
-      activeMqBroker.destroy();
     }
 
   }
@@ -123,10 +132,8 @@ public class BlobMessageTranslatorTest
   @Test
   public void testMoveMetadataAdaptrisMessageToJmsMessage() throws Exception {
     MessageTypeTranslatorImp trans = new BlobMessageTranslator();
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConnection conn = null;
     try {
-      activeMqBroker.start();
       conn = activeMqBroker.getJmsConnection(new BasicActiveMqImplementation());
       start(conn);
 
@@ -144,7 +151,6 @@ public class BlobMessageTranslatorTest
     finally {
       stop(trans);
       stop(conn);
-      activeMqBroker.destroy();
     }
 
   }
@@ -152,10 +158,8 @@ public class BlobMessageTranslatorTest
   @Test
   public void testBug895() throws Exception {
     MessageTypeTranslatorImp trans = new BlobMessageTranslator();
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     JmsConnection conn = null;
     try {
-      activeMqBroker.start();
       conn = activeMqBroker.getJmsConnection(new BasicActiveMqImplementation());
       start(conn);
 
@@ -177,7 +181,6 @@ public class BlobMessageTranslatorTest
     finally {
       stop(trans);
       stop(conn);
-      activeMqBroker.destroy();
     }
 
   }
@@ -194,8 +197,8 @@ public class BlobMessageTranslatorTest
   }
 
   @Override
-  protected List retrieveObjectsForSampleConfig() {
-    ArrayList result = new ArrayList();
+  protected List<StandaloneProducer> retrieveObjectsForSampleConfig() {
+    ArrayList<StandaloneProducer> result = new ArrayList<>();
     result.add(buildStandaloneProducer(new JmsConnection(), new JmsProducer()));
     return result;
   }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/FailoverPasProducerTest.java
@@ -19,6 +19,9 @@ package com.adaptris.core.jms.activemq;
 import static com.adaptris.core.BaseCase.execute;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -32,27 +35,33 @@ public class FailoverPasProducerTest {
 
   @Rule
   public TestName testName = new TestName();
+  
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Test
   public void testProduceAndConsume() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     StandaloneConsumer standaloneConsumer =
-        new StandaloneConsumer(broker.getFailoverJmsConnection(false),
+        new StandaloneConsumer(activeMqBroker.getFailoverJmsConnection(false),
             new PasConsumer().withTopic(testName.getMethodName()));
     MockMessageListener jms = new MockMessageListener();
     standaloneConsumer.registerAdaptrisMessageListener(jms);
     StandaloneProducer standaloneProducer =
-        new StandaloneProducer(broker.getFailoverJmsConnection(false),
+        new StandaloneProducer(activeMqBroker.getFailoverJmsConnection(false),
             new PasProducer().withTopic(testName.getMethodName()));
-    try {
-      broker.start();
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms, 1);
-    }
-    finally {
-      broker.destroy();
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms, 1);
   }
 
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsConnectionErrorHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsConnectionErrorHandlerTest.java
@@ -22,6 +22,9 @@ import static com.adaptris.interlok.junit.scaffolding.BaseCase.MAX_WAIT;
 import static com.adaptris.interlok.junit.scaffolding.BaseCase.waitForMessages;
 import static org.junit.Assert.assertEquals;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -57,15 +60,26 @@ public class JmsConnectionErrorHandlerTest {
   private Logger log = LoggerFactory.getLogger(this.getClass());
   @Rule
   public TestName testName = new TestName();
+  
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Test
   public void testConnectionErrorHandler() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName(), new JmsConnectionErrorHandler());
     try {
-      activeMqBroker.start();
       channel.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       activeMqBroker.stop();
@@ -79,15 +93,12 @@ public class JmsConnectionErrorHandlerTest {
     }
     finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   // Tests INTERLOK-2063
   @Test
   public void testConnectionErrorHandler_WithRuntimeException() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker,
         new JmsConnectionCloseWithRuntimeException(activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true)),
         testName.getMethodName(), new JmsConnectionErrorHandler() {
@@ -97,7 +108,6 @@ public class JmsConnectionErrorHandlerTest {
           }
         });
     try {
-      activeMqBroker.start();
       channel.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       activeMqBroker.stop();
@@ -110,20 +120,16 @@ public class JmsConnectionErrorHandlerTest {
 
     } finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testConnectionErrorHandler_WithInitialiseException() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = new MockChannelFail(createChannel(activeMqBroker,
         activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName(), new JmsConnectionErrorHandler()),
         MockChannelFail.WhenToFail.INIT_AFTER_CLOSE);
     try {
-      activeMqBroker.start();
       channel.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       activeMqBroker.stop();
@@ -139,20 +145,16 @@ public class JmsConnectionErrorHandlerTest {
 
     } finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testConnectionErrorHandler_WithStartException() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = new MockChannelFail(createChannel(activeMqBroker,
         activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName(), new JmsConnectionErrorHandler()),
         MockChannelFail.WhenToFail.START_AFTER_CLOSE);
     try {
-      activeMqBroker.start();
       channel.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       activeMqBroker.stop();
@@ -166,18 +168,14 @@ public class JmsConnectionErrorHandlerTest {
 
     } finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testConnectionErrorHandler_NotSingleExecution() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName(), new JmsConnectionErrorHandler(false));
     try {
-      activeMqBroker.start();
       channel.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       activeMqBroker.stop();
@@ -191,19 +189,15 @@ public class JmsConnectionErrorHandlerTest {
     }
     finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testConnectionErrorHandlerWithUnamedChannel() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(null, activeMqBroker,
         activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName());
     try {
-      activeMqBroker.start();
       channel.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       activeMqBroker.stop();
@@ -217,21 +211,17 @@ public class JmsConnectionErrorHandlerTest {
     }
     finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testConnectionErrorHandlerWithJndi() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     MockChannel channel = createChannel(activeMqBroker,
         activeMqBroker.getJndiPasConnection(new StandardJndiImplementation(), false, queueName, topicName), topicName,
         new JmsConnectionErrorHandler());
     try {
-      activeMqBroker.start();
       channel.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       activeMqBroker.stop();
@@ -245,18 +235,14 @@ public class JmsConnectionErrorHandlerTest {
     }
     finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testBug1926() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     MockChannel channel = createChannel(activeMqBroker, activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true),
         testName.getMethodName(), new JmsConnectionErrorHandler());
     try {
-      activeMqBroker.start();
       channel.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       activeMqBroker.stop();
@@ -270,14 +256,11 @@ public class JmsConnectionErrorHandlerTest {
     }
     finally {
       channel.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testRestartSharedConnection() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     Adapter adapter = new Adapter();
     adapter.setUniqueId(testName.getMethodName());
     JmsConnection connection = activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true);
@@ -291,7 +274,6 @@ public class JmsConnectionErrorHandlerTest {
     MockMessageProducer producer = (MockMessageProducer) channel.getWorkflowList().get(0).getProducer();
     adapter.getChannelList().add(channel);
     try {
-      activeMqBroker.start();
       adapter.requestStart();
       assertEquals(StartedState.getInstance(), channel.retrieveComponentState());
       // Now try and send a message
@@ -322,14 +304,11 @@ public class JmsConnectionErrorHandlerTest {
     }
     finally {
       adapter.requestClose();
-      activeMqBroker.destroy();
     }
   }
 
   @Test
   public void testRestartSharedConnection_ChannelNotStarted() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     Adapter adapter = new Adapter();
     adapter.setUniqueId(testName.getMethodName());
     JmsConnection connection = activeMqBroker.getJmsConnection(new BasicActiveMqImplementation(), true);
@@ -347,7 +326,6 @@ public class JmsConnectionErrorHandlerTest {
     adapter.getChannelList().add(started);
     adapter.getChannelList().add(neverStarted);
     try {
-      activeMqBroker.start();
       adapter.requestStart();
       assertEquals(StartedState.getInstance(), started.retrieveComponentState());
       assertEquals(ClosedState.getInstance(), neverStarted.retrieveComponentState());
@@ -379,7 +357,6 @@ public class JmsConnectionErrorHandlerTest {
     }
     finally {
       adapter.requestClose();
-      activeMqBroker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsReplyToDestinationTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JmsReplyToDestinationTest.java
@@ -24,6 +24,8 @@ import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQSession;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -38,6 +40,19 @@ public class JmsReplyToDestinationTest
   private static final String ANY_OLD_KEY = "ANY_OLD_KEY";
   protected static Log log = LogFactory.getLog(JmsReplyToDestinationTest.class);
 
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   private AdaptrisMessage createMessage(Destination d) throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("xxx");
@@ -55,65 +70,37 @@ public class JmsReplyToDestinationTest
 
   @Test
   public void testRetrieveDestination() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      Queue tempQueue = createTempQueue(activeMqBroker);
-      AdaptrisMessage msg = createMessage(tempQueue);
-      JmsReplyToDestination d = new JmsReplyToDestination();
-      assertEquals("Queues", tempQueue, d.retrieveJmsDestination(msg));
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    Queue tempQueue = createTempQueue(activeMqBroker);
+    AdaptrisMessage msg = createMessage(tempQueue);
+    JmsReplyToDestination d = new JmsReplyToDestination();
+    assertEquals("Queues", tempQueue, d.retrieveJmsDestination(msg));
   }
 
   @Test
   public void testRetrieveDestination_ByName() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      Queue tempQueue = createTempQueue(activeMqBroker);
-      AdaptrisMessage msg = createMessage(tempQueue);
-      JmsReplyToDestination d = new JmsReplyToDestination();
-      d.setObjectMetadataKey(ANY_OLD_KEY);
-      assertEquals("Queues", tempQueue, d.retrieveJmsDestination(msg));
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    Queue tempQueue = createTempQueue(activeMqBroker);
+    AdaptrisMessage msg = createMessage(tempQueue);
+    JmsReplyToDestination d = new JmsReplyToDestination();
+    d.setObjectMetadataKey(ANY_OLD_KEY);
+    assertEquals("Queues", tempQueue, d.retrieveJmsDestination(msg));
   }
 
   @Test
   public void testGetDestination() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      Queue tempQueue = createTempQueue(activeMqBroker);
-      AdaptrisMessage msg = createMessage(tempQueue);
-      JmsReplyToDestination d = new JmsReplyToDestination();
-      assertEquals(tempQueue.toString(), d.getDestination(msg));
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    Queue tempQueue = createTempQueue(activeMqBroker);
+    AdaptrisMessage msg = createMessage(tempQueue);
+    JmsReplyToDestination d = new JmsReplyToDestination();
+    assertEquals(tempQueue.toString(), d.getDestination(msg));
   }
 
   @Test
   public void testGetDestination_MetadataDoesNotExist() throws Exception {
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
-    try {
-      activeMqBroker.start();
-      Queue tempQueue = createTempQueue(activeMqBroker);
-      AdaptrisMessage msg = createMessage(tempQueue);
-      msg.getObjectHeaders().clear();
-      JmsReplyToDestination d = new JmsReplyToDestination();
-      d.setObjectMetadataKey(ANY_OLD_KEY);
-      assertNull(d.getDestination(msg));
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+    Queue tempQueue = createTempQueue(activeMqBroker);
+    AdaptrisMessage msg = createMessage(tempQueue);
+    msg.getObjectHeaders().clear();
+    JmsReplyToDestination d = new JmsReplyToDestination();
+    d.setObjectMetadataKey(ANY_OLD_KEY);
+    assertNull(d.getDestination(msg));
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPtpProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/JndiPtpProducerCase.java
@@ -22,6 +22,9 @@ import static com.adaptris.core.BaseCase.stop;
 import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
 import static com.adaptris.core.jms.activemq.EmbeddedActiveMq.createMessage;
 import static org.junit.Assert.fail;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -43,10 +46,22 @@ public abstract class JndiPtpProducerCase {
 
   protected abstract StandardJndiImplementation createVendorImplementation();
 
+  protected static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
   @Test
   public void testProduceAndConsume() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
     String queueName = testName.getMethodName() + "_queue";
@@ -57,14 +72,9 @@ public abstract class JndiPtpProducerCase {
     standaloneConsumer.registerAdaptrisMessageListener(jms);
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJndiPtpConnection(sendVendorImp, false,
             queueName, topicName), new PtpProducer().withQueue((queueName)));
-    try {
-      activeMqBroker.start();
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms);
   }
 
   @Test
@@ -77,7 +87,7 @@ public abstract class JndiPtpProducerCase {
     sfc.setProperties(kvps);
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
+
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
     sendVendorImp.setExtraFactoryConfiguration(sfc);
@@ -87,54 +97,37 @@ public abstract class JndiPtpProducerCase {
     standaloneConsumer.registerAdaptrisMessageListener(jms);
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJndiPtpConnection(sendVendorImp, false,
             queueName, topicName), new PtpProducer().withQueue((queueName)));
-    try {
-      activeMqBroker.start();
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms);
-    }
-    finally {
-      activeMqBroker.destroy();
-    }
+
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms);
   }
 
   @Test
   public void testProduceAndConsumeUsingJndiOnly() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     StandardJndiImplementation recvVendorImp = createVendorImplementation();
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
 
-    PtpConsumer consumer = new PtpConsumer().withQueue(queueName);
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJndiPtpConnection(recvVendorImp, true,
             queueName, topicName), new PtpConsumer().withQueue(queueName));
     MockMessageListener jms = new MockMessageListener();
     standaloneConsumer.registerAdaptrisMessageListener(jms);
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJndiPtpConnection(sendVendorImp, true,
             queueName, topicName), new PtpProducer().withQueue((queueName)));
-    try {
-      activeMqBroker.start();
-      execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
-      assertMessages(jms);
-    }
-    finally {
-      activeMqBroker.destroy();
 
-    }
+    execute(standaloneConsumer, standaloneProducer, createMessage(null), jms);
+    assertMessages(jms);
   }
 
   @Test
   public void testProduceJndiOnlyObjectNotFound() throws Exception {
-
-    EmbeddedActiveMq activeMqBroker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     StandardJndiImplementation sendVendorImp = createVendorImplementation();
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJndiPtpConnection(sendVendorImp, true,
             queueName, topicName), new PtpProducer().withQueue((this.getClass().getSimpleName())));
     try {
-      activeMqBroker.start();
       start(standaloneProducer);
       standaloneProducer.produce(createMessage(null));
       fail("Expected ProduceException");
@@ -143,7 +136,6 @@ public abstract class JndiPtpProducerCase {
     }
     finally {
       stop(standaloneProducer);
-      activeMqBroker.destroy();
     }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/jms/JndiImplementationCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/jms/JndiImplementationCase.java
@@ -22,17 +22,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.JmsConnectionConfig;
 import com.adaptris.core.jms.PasProducer;
 import com.adaptris.core.jms.VendorImplementation;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
-import com.adaptris.core.jms.activemq.EmbeddedArtemis;
 import com.adaptris.core.jms.activemq.RequiresCredentialsBroker;
 import com.adaptris.core.jms.jndi.BaseJndiImplementation;
 import com.adaptris.core.jms.jndi.NoOpFactoryConfiguration;
@@ -50,6 +54,20 @@ public abstract class JndiImplementationCase {
 
   @Rule
   public TestName testName = new TestName();
+  
+  private static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   @Test
   public void testSetEnableJndiForQueues() throws Exception {
@@ -161,44 +179,36 @@ public abstract class JndiImplementationCase {
 
   @Test
   public void testInitialiseDefaultArtemisBroker() throws Exception {
-
-    EmbeddedArtemis broker = new EmbeddedArtemis();
     String topicName = testName.getMethodName() + "_topic";
 
     PasProducer producer = new PasProducer().withTopic(topicName);
-    JmsConnection c = broker.getJmsConnection();
+    JmsConnection c = activeMqBroker.getJmsConnection();
     StandaloneProducer standaloneProducer = new StandaloneProducer(c, producer);
 
     try {
-      broker.start();
       LifecycleHelper.init(standaloneProducer);
     }
     finally {
       LifecycleHelper.close(standaloneProducer);
-      broker.destroy();
     }
   }
 
   @Test
   public void testInitialiseWithCredentials() throws Exception {
-
-    RequiresCredentialsBroker broker = new RequiresCredentialsBroker();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     PasProducer producer = new PasProducer().withTopic(topicName);;
     StandardJndiImplementation jv = createVendorImplementation();
-    JmsConnection c = broker.getJndiPasConnection(jv, false, queueName, topicName);
+    JmsConnection c = activeMqBroker.getJndiPasConnection(jv, false, queueName, topicName);
 
     jv.getJndiParams().addKeyValuePair(new KeyValuePair("UserName", RequiresCredentialsBroker.DEFAULT_USERNAME));
     jv.getJndiParams().addKeyValuePair(new KeyValuePair("Password", RequiresCredentialsBroker.DEFAULT_PASSWORD));
     StandaloneProducer standaloneProducer = new StandaloneProducer(c, producer);
     try {
-      broker.start();
       LifecycleHelper.init(standaloneProducer);
     }
     finally {
       LifecycleHelper.close(standaloneProducer);
-      broker.destroy();
     }
   }
 
@@ -281,53 +291,41 @@ public abstract class JndiImplementationCase {
 
   @Test
   public void testInitialiseWithTopicConnectionFactoryNotFound() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     PasProducer producer = new PasProducer().withTopic(queueName);
     StandardJndiImplementation jv = createVendorImplementation();
-    JmsConnection c = broker.getJndiPasConnection(jv, false, queueName, topicName);
+    JmsConnection c = activeMqBroker.getJndiPasConnection(jv, false, queueName, topicName);
     c.setConnectionAttempts(1);
     c.setConnectionRetryInterval(new TimeInterval(100L, TimeUnit.MILLISECONDS.name()));
     jv.setJndiName("testInitialiseWithTopicConnectionFactoryNotFound");
     StandaloneProducer standaloneProducer = new StandaloneProducer(c, producer);
     try {
-      broker.start();
       LifecycleHelper.init(standaloneProducer);
       fail("Should Fail to lookup 'testInitialiseWithTopicConnectionFactoryNotFound'");
     }
     catch (Exception e) {
       // expected
     }
-    finally {
-      broker.destroy();
-    }
   }
 
   @Test
   public void testInitialiseWithQueueConnectionFactoryNotFound() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     String queueName = testName.getMethodName() + "_queue";
     String topicName = testName.getMethodName() + "_topic";
     PasProducer producer = new PasProducer().withTopic((topicName));
     StandardJndiImplementation jv = createVendorImplementation();
-    JmsConnection c = broker.getJndiPtpConnection(jv, false, queueName, topicName);
+    JmsConnection c = activeMqBroker.getJndiPtpConnection(jv, false, queueName, topicName);
     c.setConnectionAttempts(1);
     c.setConnectionRetryInterval(new TimeInterval(100L, TimeUnit.MILLISECONDS));
     jv.setJndiName("testInitialiseWithQueueConnectionFactoryNotFound");
     StandaloneProducer standaloneProducer = new StandaloneProducer(c, producer);
     try {
-      broker.start();
       LifecycleHelper.init(standaloneProducer);
       fail("Should Fail to lookup 'testInitialiseWithQueueConnectionFactoryNotFound'");
     }
     catch (Exception e) {
       // expected
-    }
-    finally {
-      broker.destroy();
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/jms/MessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/jms/MessageTypeTranslatorCase.java
@@ -37,6 +37,8 @@ import javax.jms.Message;
 import javax.jms.Session;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -78,6 +80,20 @@ public abstract class MessageTypeTranslatorCase {
   protected transient Log log = LogFactory.getLog(this.getClass());
   @Rule
   public TestName testName = new TestName();
+  
+  protected static EmbeddedActiveMq activeMqBroker;
+
+  @BeforeClass
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterClass
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
 
   protected abstract MessageTypeTranslatorImp createTranslator() throws Exception;
 
@@ -151,12 +167,9 @@ public abstract class MessageTypeTranslatorCase {
 
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       Message jmsMsg = createMessage(session);
       addProperties(jmsMsg);
       start(trans, session);
@@ -165,20 +178,16 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
 
   @Test
   public void testMoveMetadataJmsMessageToAdaptrisMessage_RemoveAllFilter() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     trans.setMetadataFilter(new RemoveAllMetadataFilter());
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       Message jmsMsg = createMessage(session);
       addProperties(jmsMsg);
       start(trans, session);
@@ -189,21 +198,17 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testMoveMetadata_JmsMessageToAdaptrisMessage_WithFilter() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
     regexp.addExcludePattern("IntegerMetadataKey");
     trans.setMetadataFilter(regexp);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       Message jmsMsg = createMessage(session);
       addProperties(jmsMsg);
       start(trans, session);
@@ -214,18 +219,15 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
 
   @Test
   public void testMoveJmsHeadersJmsMessageToAdaptrisMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       Message jmsMsg = createMessage(session);
       jmsMsg.setJMSCorrelationID("ABC");
       jmsMsg.setJMSDeliveryMode(1);
@@ -246,19 +248,15 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
 
   @Test
   public void testMoveJmsHeadersAdaptrisMessageToJmsMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator().withMoveJmsHeaders(true);
     try {
-      broker.start();
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
 
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
       addMetadata(msg);
@@ -278,22 +276,18 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
 
   }
 
   @Test
   public void testMoveMetadataAdaptrisMessageToJmsMessage() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
 
       addMetadata(msg);
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       Message jmsMsg = trans.translate(msg);
@@ -301,23 +295,19 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
 
     }
   }
 
   @Test
   public void testMoveMetadata_AdaptrisMessageToJmsMessage_RemoveAll() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans =
         createTranslator().withMetadataFilter(new RemoveAllMetadataFilter());
     try {
-      broker.start();
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
 
       addMetadata(msg);
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
 
       Message jmsMsg = trans.translate(msg);
@@ -327,24 +317,20 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
 
     }
   }
 
   @Test
   public void testMoveMetadata_AdaptrisMessageToJmsMessage_WithFilter() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     RegexMetadataFilter regexp = new RegexMetadataFilter();
     regexp.addExcludePattern("IntegerMetadataKey");
     trans.setMetadataFilter(regexp);
     try {
-      broker.start();
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
       addMetadata(msg);
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       start(trans, session);
       Message jmsMsg = trans.translate(msg);
       assertEquals(STRING_VALUE, jmsMsg.getStringProperty(STRING_METADATA));
@@ -354,22 +340,18 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
     }
   }
 
   @Test
   public void testBug895() throws Exception {
-
-    EmbeddedActiveMq broker = new EmbeddedActiveMq();
     MessageTypeTranslatorImp trans = createTranslator();
     try {
-      broker.start();
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
 
       msg.addMetadata(JmsConstants.JMS_PRIORITY, "9");
       msg.addMetadata(JmsConstants.JMS_TYPE, "idaho");
-      Session session = broker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
       trans.setMoveJmsHeaders(true);
       start(trans, session);
 
@@ -380,8 +362,6 @@ public abstract class MessageTypeTranslatorCase {
     }
     finally {
       stop(trans);
-      broker.destroy();
-
     }
   }
 


### PR DESCRIPTION
## Motivation

Each and every unit-test would construct it's own instance of a broker, which seems like a waste of resource and time.
So now we want to create one instance per class of unit tests and let each test simply refer to that instance.

## Modification

Each unit test class creates it's own broker in the on BeforeClass phase and each test refers to it.

## Result

Slightly faster build times and less resource usage.
