### PR TITLE
INTERLOK-3491 Use regexp to filter out duplicates

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigurationChecker.java
@@ -2,22 +2,29 @@ package com.adaptris.core.management.config;
 
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
-
+import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.core.Adapter;
 
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
 public class DeprecatedConfigurationChecker extends AdapterConfigurationChecker {
 
+  private static final String PATTERN_WORKFLOW_LIST_ARRAY = ".*workflowList\\[[0-9+]\\].*";
+  private static final String PATTERN_CHANNEL_LIST_ARRAY = ".*channelList\\[[0-9+]\\].*";
   private static final String FRIENDLY_NAME = "Deprecated checks";
   private static final ValidatorFactory JAVAX_VALIDATOR_FACTORY = Validation.buildDefaultValidatorFactory();
+
+  private transient Pattern isWorkflowListArray;
+  private transient Pattern isChannelListArray;
+
+  public DeprecatedConfigurationChecker() {
+    isWorkflowListArray = Pattern.compile(PATTERN_WORKFLOW_LIST_ARRAY);
+    isChannelListArray = Pattern.compile(PATTERN_CHANNEL_LIST_ARRAY);
+  }
 
   @Override
   protected void validate(Adapter adapter, ConfigurationCheckReport report) {
@@ -36,8 +43,18 @@ public class DeprecatedConfigurationChecker extends AdapterConfigurationChecker 
 
   private List<String> violationsToWarning(Set<ConstraintViolation<Adapter>> violations) {
     return violations.stream()
+        .filter((v) -> !isListImpl(v.getPropertyPath().toString()))
         .map(v -> String.format("Interlok Deprecation Warning: [%1$s] is deprecated. %2$s", v.getPropertyPath(), v.getMessage()))
         .collect(Collectors.toList());
   }
 
+  // Since ChannelList & workflowList implements collection, we have
+  // the weird situation where a single "issue" can trigger 4 separate warnings.
+  private boolean isListImpl(String path) {
+    return BooleanUtils.or(new boolean[] {
+        isChannelListArray.matcher(path).matches(),
+        isWorkflowListArray.matcher(path).matches()
+    });
+
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigurationChecker.java
@@ -2,29 +2,20 @@ package com.adaptris.core.management.config;
 
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
-import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.core.Adapter;
+import lombok.NoArgsConstructor;
 
-public class DeprecatedConfigurationChecker extends AdapterConfigurationChecker {
+@NoArgsConstructor
+public class DeprecatedConfigurationChecker extends ValidationCheckerImpl {
 
-  private static final String PATTERN_WORKFLOW_LIST_ARRAY = ".*workflowList\\[[0-9+]\\].*";
-  private static final String PATTERN_CHANNEL_LIST_ARRAY = ".*channelList\\[[0-9+]\\].*";
   private static final String FRIENDLY_NAME = "Deprecated checks";
   private static final ValidatorFactory JAVAX_VALIDATOR_FACTORY = Validation.buildDefaultValidatorFactory();
 
-  private transient Pattern isWorkflowListArray;
-  private transient Pattern isChannelListArray;
-
-  public DeprecatedConfigurationChecker() {
-    isWorkflowListArray = Pattern.compile(PATTERN_WORKFLOW_LIST_ARRAY);
-    isChannelListArray = Pattern.compile(PATTERN_CHANNEL_LIST_ARRAY);
-  }
 
   @Override
   protected void validate(Adapter adapter, ConfigurationCheckReport report) {
@@ -48,13 +39,4 @@ public class DeprecatedConfigurationChecker extends AdapterConfigurationChecker 
         .collect(Collectors.toList());
   }
 
-  // Since ChannelList & workflowList implements collection, we have
-  // the weird situation where a single "issue" can trigger 4 separate warnings.
-  private boolean isListImpl(String path) {
-    return BooleanUtils.or(new boolean[] {
-        isChannelListArray.matcher(path).matches(),
-        isWorkflowListArray.matcher(path).matches()
-    });
-
-  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/JavaxValidationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/JavaxValidationChecker.java
@@ -3,19 +3,16 @@ package com.adaptris.core.management.config;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
-
 import com.adaptris.core.Adapter;
 import com.adaptris.core.CoreException;
-
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class JavaxValidationChecker extends AdapterConfigurationChecker {
+public class JavaxValidationChecker extends ValidationCheckerImpl {
 
   private static final String FRIENDLY_NAME = "javax.validation checks";
   private static final ValidatorFactory JAVAX_VALIDATOR_FACTORY = Validation.buildDefaultValidatorFactory();
@@ -37,7 +34,8 @@ public class JavaxValidationChecker extends AdapterConfigurationChecker {
   }
 
   private List<Exception> violationsToException(Set<ConstraintViolation<Adapter>> violations) {
-    return violations.stream().map(v -> new CoreException(
+    return violations.stream().filter((v) -> !isListImpl(v.getPropertyPath().toString()))
+        .map(v -> new CoreException(
         String.format("Interlok Validation Error: [%1$s]=[%2$s]", v.getPropertyPath(), v.getMessage())))
         .collect(Collectors.toList());
   }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ValidationCheckerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ValidationCheckerImpl.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.management.config;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.IterableUtils;
+import lombok.NoArgsConstructor;
+
+/**
+ * Provides some utilities for javax validation style checking.
+ *
+ */
+@NoArgsConstructor
+public abstract class ValidationCheckerImpl extends AdapterConfigurationChecker {
+  private static final String PATTERN_SERVICE_COLL_ARRAY = ".*serviceCollection\\[[0-9+]\\].*";
+  private static final String PATTERN_WORKFLOW_LIST_ARRAY = ".*workflowList\\[[0-9+]\\].*";
+  private static final String PATTERN_CHANNEL_LIST_ARRAY = ".*channelList\\[[0-9+]\\].*";
+
+
+  private static final List<Pattern> ARRAY_PATTERNS =
+      Collections.unmodifiableList(Arrays.asList(Pattern.compile(PATTERN_CHANNEL_LIST_ARRAY),
+          Pattern.compile(PATTERN_WORKFLOW_LIST_ARRAY),
+          Pattern.compile(PATTERN_SERVICE_COLL_ARRAY)));
+
+  // Since ChannelList & workflowList implements collection, we have
+  // the weird situation where a single "issue" can trigger 4 separate warnings.
+  protected boolean isListImpl(String path) {
+    List<Matcher> matcherList =
+        ARRAY_PATTERNS.stream().map((p) -> p.matcher(path)).collect(Collectors.toList());
+    return IterableUtils.matchesAny(matcherList, (matcher) -> matcher.matches());
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
@@ -74,11 +74,13 @@ public class DeprecatedConfigurationCheckerTest {
     checker.validate(createAdapterConfig(false, true), report);
 
     assertFalse(report.isCheckPassed());
-    // Should be 3 warnings,
-    // deprecated class, deprecated member, consumer destination.
-    assertEquals(3, report.getWarnings().size());
+    // Should be 4 warnings,
+    // deprecated class, deprecated member, consumer destination, deprecated service inside a
+    // service list.
+    assertEquals(4, report.getWarnings().size());
     assertTrue(violationsAsExpected(report.getWarnings(), "sharedComponents.services[1]",
         "sharedComponents.services[2]",
+        "channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]",
         "channelList.channels[0].workflowList.workflows[0].consumer.destination"));
     assertEquals(0, report.getFailureExceptions().size());
   }
@@ -136,6 +138,7 @@ public class DeprecatedConfigurationCheckerTest {
         NullMessageConsumer consumer = new NullMessageConsumer();
         consumer.setDestination(new ConfiguredConsumeDestination("dest"));
         w.setConsumer(consumer);
+        w.getServiceCollection().add(new DeprecatedService());
       }
       c.getWorkflowList().add(w);
       adapter.getChannelList().add(c);

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
@@ -3,7 +3,9 @@ package com.adaptris.core.management.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.collections4.IterableUtils;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisMessage;
@@ -96,16 +98,10 @@ public class DeprecatedConfigurationCheckerTest {
     return DefaultMarshaller.getDefaultMarshaller().marshal(adapter);
   }
 
-  // Probably has to be a better way than nested for loops...
   private boolean violationsAsExpected(List<String> violations, String... txt) {
+    List<String> expected = Arrays.asList(txt);
     for (String v : violations) {
-      int matches = 0;
-      for (String s : txt) {
-        if (v.contains(s)) {
-          matches++;
-        }
-      }
-      if (matches == 0) {
+      if (!IterableUtils.matchesAny(expected, (match) -> v.contains(match))) {
         return false;
       }
     }


### PR DESCRIPTION
## Motivation

If you have a consumer (the only consumer in the only workflow in the only channel)

```xml
          <consumer class="jetty-message-consumer">
            <unique-id>csv-receive</unique-id>
            <destination class="configured-consume-destination">
              <destination>/api/csv</destination>
            </destination>
            <parameter-handler class="jetty-http-ignore-parameters"/>
            <header-handler class="jetty-http-headers-as-metadata"/>
          </consumer>
```

And you run `gradle check` in a parent gradle style project then you get 4 deprecation warnings; they all refer to the same element, but manifest themselves because `channelList` implements List and has a `Valid` annotation, ditto `workflowList`

```
Deprecated checks:
Warnings found;
Interlok Deprecation Warning: [channelList.channels[0].workflowList[0].consumer.destination] is deprecated. Use 'path' instead
Interlok Deprecation Warning: [channelList[0].workflowList[0].consumer.destination] is deprecated. Use 'path' instead
Interlok Deprecation Warning: [channelList[0].workflowList.workflows[0].consumer.destination] is deprecated. Use 'path' instead
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].consumer.destination] is deprecated. Use 'path' instead
```
## Modification

Add 2x regular expressions to filter out possible duplicates. i.e. remove the ones that treat channelList/workflowList as a list rather than a simple bean.

## Result

Only 1 message : 
```
Deprecated checks:
Warnings found;
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].consumer.destination] is deprecated. Use 'path' instead
```

## Testing

Create configuration as above; run with the snapshot build, and run with this branch.
