### PR TITLE
INTERLOK-3501 Add delete functionality

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -398,7 +398,10 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
 
   @NoArgsConstructor
   private class DeleteListener extends ListenerImpl {
+    private transient Object locker = new Object();
+
     @Override
+    @Synchronized(value = "locker")
     public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
         Consumer<AdaptrisMessage> failure) {
       try {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -57,16 +57,22 @@ import lombok.extern.slf4j.Slf4j;
  * into a simpler configuration chain.
  * </p>
  * <p>
- * This jetty implementation allows two modes of operation. Listing the failed messages, and
- * retrying a message.
+ * This jetty implementation allows two modes of operation. Listing the failed messages, retrying a
+ * message, deleting messages from the store.
  * <ul>
  * <li>{@code curl -XGET http://localhost:8080/api/failed/list} gives you a list of message ids that
  * are listed in the store</li>
  * <li>{@code curl -XPOST http://localhost:8080/api/retry/[msgId]} will attempt to resubmit the
  * message to the appropriate workflow; returning a 202 upon success</li>
+ * <li>{@code curl -XDELETE http://localhost:8080/api/failed/delete/[msgId]} will attempt to delete
+ * the message from the store</li>
  * <ul>
- * Note that this implementation expects that you have a separate tooling that allows you to delete
- * failed messages.
+ * </p>
+ * <p>
+ * While DELETE is available, this implementation doesn't make any checks that the messages that you
+ * have retried have been retried successfuly. It is expected that you have separate tooling that
+ * allows you to verify that retried-messages are ultimately sucessfully before triggering the
+ * delete. If you ask for a message to be deleted from the store, then that is what happens.
  * </p>
  *
  * @since 3.11.1
@@ -76,14 +82,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @ComponentProfile(summary = "Listen for HTTP traffic on the specified URI and retry messages",
     recommended = {EmbeddedConnection.class, JettyConnection.class}, since = "3.11.1")
-@DisplayOrder(order = {"retryEndpointPrefix", "reportingEndpoint", "retryHttpMethod", "connection",
-    "retryStore", "reportBuilder"})
+@DisplayOrder(order = {"retryEndpointPrefix", "reportingEndpoint", "deleteEndpointPrefix",
+    "retryHttpMethod", "deleteHttpMethod", "connection", "retryStore", "reportBuilder"})
 @XStreamAlias("retry-via-jetty")
 public class RetryFromJetty extends FailedMessageRetrierImp {
 
   public static final String DEFAULT_ENDPOINT_PREFIX = "/api/retry/";
   public static final String DEFAULT_REPORTING_ENDPOINT = "/api/failed/list";
+  public static final String DEFAULT_DELETE_PREFIX = "/api/failed/delete/";
+
   private static final String HTTP_RETRY_METHOD = "POST";
+  private static final String HTTP_DELETE_METHOD = "DELETE";
+
   private static final TimeInterval DEFAULT_SHUTDOWN_WAIT = new TimeInterval(30L, TimeUnit.SECONDS.name());
 
   public static final String CONTENT_TYPE_METADATA_KEY = "__Content-Type";
@@ -91,12 +101,14 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
 
   private static final String HTTP_STATUS_KEY = "__httpResponseCode";
   private static final String HTTP_STATUS_EXPR = "%message{__httpResponseCode}";
-  private static final String RETRY_MSG_ID_KEY = "__retryMsgId";
+  private static final String MSG_ID_KEY = "__MsgId";
 
   protected static final String HTTP_OK = "" + HttpURLConnection.HTTP_OK;
   protected static final String HTTP_ACCEPTED = "" + HttpURLConnection.HTTP_ACCEPTED;
   protected static final String HTTP_ERROR = "" + HttpURLConnection.HTTP_INTERNAL_ERROR;
   protected static final String HTTP_BAD = "" + HttpURLConnection.HTTP_BAD_REQUEST;
+  protected static final String HTTP_NOT_FOUND = "" + HttpURLConnection.HTTP_NOT_FOUND;
+
 
   /**
    * The retry endpoint.
@@ -121,6 +133,23 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
   @InputFieldDefault(value = DEFAULT_REPORTING_ENDPOINT)
   private String reportingEndpoint;
 
+  /**
+   * The delete endpoint.
+   * <p>
+   * The default if not explicitly specified is {@value DEFAULT_DELETE_PREFIX}, note the trailing
+   * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
+   * form {@code /prefix/'msgId'}
+   * </p>
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = DEFAULT_DELETE_PREFIX)
+  private String deleteEndpointPrefix;
+
+  /**
+   * The underlying Jetty connection.
+   *
+   */
   @Getter
   @Setter
   @NotNull
@@ -156,14 +185,28 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
   @InputFieldDefault(value = HTTP_RETRY_METHOD)
   private String retryHttpMethod;
 
-  private transient String retryServletPath;
-  private transient String retryServletRegexp;
+
+  /**
+   * The HTTP method which is required for deleting messages from the retry store; the default is
+   * DELETE.
+   */
+  @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
+  @InputFieldDefault(value = HTTP_DELETE_METHOD)
+  private String deleteHttpMethod;
+
   private transient StandaloneConsumer reporting;
   private transient StandaloneConsumer retrying;
+  private transient StandaloneConsumer deleting;
+
   private transient ReportListener reporter;
   private transient RetryListener retrier;
+  private transient DeleteListener deleter;
+
   private transient ExecutorService workflowSubmitter;
-  private transient JettyRouteCondition routing;
+  private transient JettyRouteCondition retryRouting;
+  private transient JettyRouteCondition deleteRouting;
   private transient boolean prepared = false;
 
   @Override
@@ -171,22 +214,39 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     if (!prepared) {
       Args.notNull(getReportBuilder(), "report-builder");
       Args.notNull(getRetryStore(), "retry-store");
-      retryServletPath = retryEndpointPrefix() + "*";
-      retryServletRegexp = "^" + retryEndpointPrefix() + "(.*)";
-      routing = new JettyRouteCondition().withUrlPattern(retryServletRegexp)
-          .withMetadataKeys(RETRY_MSG_ID_KEY).withMethod(retryHttpMethod());
+
+      String retryServletPath = retryEndpointPrefix() + "*";
+      String retryServletRegexp = "^" + retryEndpointPrefix() + "(.*)";
+
+      String deleteServletPath = deleteEndpointPrefix() + "*";
+      String deleteServletRegexp = "^" + deleteEndpointPrefix() + "(.*)";
+
+      retryRouting = new JettyRouteCondition().withUrlPattern(retryServletRegexp)
+          .withMetadataKeys(MSG_ID_KEY).withMethod(retryHttpMethod());
+      deleteRouting = new JettyRouteCondition().withUrlPattern(deleteServletRegexp)
+          .withMetadataKeys(MSG_ID_KEY).withMethod(deleteHttpMethod());
+
       reporter = new ReportListener();
       retrier = new RetryListener();
+      deleter = new DeleteListener();
+
       // By not dictating the method in the consumer; we accept all methods in jetty, but we use the
       // jetty route filter to filter it out.
       retrying = new StandaloneConsumer(getConnection(),
           new JettyMessageConsumer().withPath(retryServletPath));
+      deleting = new StandaloneConsumer(getConnection(),
+          new JettyMessageConsumer().withPath(deleteServletPath));
       reporting = new StandaloneConsumer(getConnection(),
           new JettyMessageConsumer().withPath(reportingEndpoint()));
+
       retrying.registerAdaptrisMessageListener(retrier);
       reporting.registerAdaptrisMessageListener(reporter);
-      LifecycleHelper.prepare(routing, getRetryStore(), getReportBuilder(), reporter, retrier,
-          retrying, reporting);
+      deleting.registerAdaptrisMessageListener(deleter);
+
+      LifecycleHelper.prepare(getRetryStore(), getReportBuilder());
+      LifecycleHelper.prepare(deleteRouting, deleter, deleting);
+      LifecycleHelper.prepare(retryRouting, retrier, retrying);
+      LifecycleHelper.prepare(reporter, reporting);
       prepared = true;
     }
   }
@@ -194,27 +254,37 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
   @Override
   public void init() throws CoreException {
     prepare();
-    LifecycleHelper.init(routing, getRetryStore(), getReportBuilder(), reporter, retrier, retrying,
-        reporting);
+    LifecycleHelper.init(getRetryStore(), getReportBuilder());
+    LifecycleHelper.init(deleteRouting, deleter, deleting);
+    LifecycleHelper.init(retryRouting, retrier, retrying);
+    LifecycleHelper.init(reporter, reporting);
+
     workflowSubmitter = Executors.newSingleThreadExecutor();
   }
 
   @Override
   public void start() throws CoreException {
-    LifecycleHelper.start(routing, getRetryStore(), getReportBuilder(), reporter, retrier, retrying,
-        reporting);
+    LifecycleHelper.start(getRetryStore(), getReportBuilder());
+    LifecycleHelper.start(deleteRouting, deleter, deleting);
+    LifecycleHelper.start(retryRouting, retrier, retrying);
+    LifecycleHelper.start(reporter, reporting);
   }
 
   @Override
   public void stop() {
-    LifecycleHelper.stop(routing, retrying, reporting, reporter, retrier, getRetryStore(),
-        getReportBuilder());
+    LifecycleHelper.stop(deleteRouting, deleter, deleting);
+    LifecycleHelper.stop(retryRouting, retrier, retrying);
+    LifecycleHelper.stop(reporter, reporting);
+    LifecycleHelper.stop(getRetryStore(), getReportBuilder());
   }
 
   @Override
   public void close() {
-    LifecycleHelper.close(routing, retrying, reporting, reporter, retrier, getRetryStore(),
-        getReportBuilder());
+    LifecycleHelper.close(deleteRouting, deleter, deleting);
+    LifecycleHelper.close(retryRouting, retrier, retrying);
+    LifecycleHelper.close(reporter, reporting);
+    LifecycleHelper.close(getRetryStore(), getReportBuilder());
+
     ManagedThreadFactory.shutdownQuietly(workflowSubmitter, DEFAULT_SHUTDOWN_WAIT);
   }
 
@@ -236,9 +306,18 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     return StringUtils.defaultIfBlank(getRetryEndpointPrefix(), DEFAULT_REPORTING_ENDPOINT);
   }
 
+  private String deleteEndpointPrefix() {
+    return StringUtils.defaultIfBlank(getDeleteEndpointPrefix(), DEFAULT_DELETE_PREFIX);
+  }
+
   private String retryHttpMethod() {
     return StringUtils.defaultIfBlank(getRetryHttpMethod(), HTTP_RETRY_METHOD);
   }
+
+  private String deleteHttpMethod() {
+    return StringUtils.defaultIfBlank(getDeleteHttpMethod(), HTTP_DELETE_METHOD);
+  }
+
 
   protected static void executeQuietly(Service service, AdaptrisMessage msg) {
     try {
@@ -293,6 +372,7 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     }
   }
 
+
   @NoArgsConstructor
   private class ReportListener extends ListenerImpl {
     @Override
@@ -311,7 +391,41 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
 
     @Override
     public String friendlyName() {
-      return "RetryFromJetty::Reporting";
+      return "RetryFromJetty::Report";
+    }
+  }
+
+
+  @NoArgsConstructor
+  private class DeleteListener extends ListenerImpl {
+    @Override
+    public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
+        Consumer<AdaptrisMessage> failure) {
+      try {
+        JettyRoute route = deleteRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
+            jettyMsg.getMetadataValue(JETTY_URI));
+        if (route.matches()) {
+          String msgId =
+              route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
+                  .findFirst().get().getValue();
+          // If metadata exists, then we can delete...
+          // met
+          Map<String, String> metadata = retryStore.getMetadata(msgId);
+          log.trace("Attempting to delete {}", msgId);
+          getRetryStore().delete(msgId);
+          sendResponse(HTTP_OK, jettyMsg);
+        } else {
+          sendResponse(HTTP_BAD, jettyMsg);
+        }
+      } catch (Exception e) {
+        jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+        sendResponse(HTTP_NOT_FOUND, jettyMsg);
+      }
+    }
+
+    @Override
+    public String friendlyName() {
+      return "RetryFromJetty::Delete";
     }
   }
 
@@ -323,11 +437,11 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
         Consumer<AdaptrisMessage> failure) {
       try {
-        JettyRoute route = routing.build(jettyMsg.getMetadataValue(HTTP_METHOD),
+        JettyRoute route = retryRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
             jettyMsg.getMetadataValue(JETTY_URI));
         if (route.matches()) {
           String msgId =
-              route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(RETRY_MSG_ID_KEY))
+              route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
                   .findFirst().get().getValue();
           // There's a decision point here because we need to decide between
           // large or small message factory.

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
@@ -68,7 +68,8 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
    * This is used to assert that the workflow exists in this instance for that message; there is no
    * point building the whole message only to fail because the workflow doesn't exist.
    * </p>
-   *
+   * 
+   * @throws InterlokException if no metadata could be retrieved (e.g the msgId doesn't exist)
    */
   Map<String, String> getMetadata(String msgId) throws InterlokException;
 


### PR DESCRIPTION
## Motivation

Since https://github.com/adaptris/interlok/pull/556 doesn't expose DELETE functionality; we should add it. Since @mcwarman  was complaining that he had to have additional workflows to support that.

## Modification

- Add a DeleteListener that handles deletes from the store; it works like the retry listener
- Relies on getMetadata() to fail if the message-id is not found.

## Result

New endpoint is available that allows you to do : 

```
curl -XDELETE http://localhost:8080/api/failed/delete/[msgId]
```

## Testing

Configuration as per https://github.com/adaptris/interlok/pull/556. It should now be possible to delete messages from the retry store.

