### PR TITLE
INTERLOK-3508 Add support for multiple reference xpaths

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/config/AdapterConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/AdapterConfigurationChecker.java
@@ -2,7 +2,6 @@ package com.adaptris.core.management.config;
 
 import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
-import com.adaptris.core.config.ConfigPreProcessorLoader;
 import com.adaptris.core.management.BootstrapProperties;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +11,7 @@ public abstract class AdapterConfigurationChecker implements ConfigurationChecke
   @Override
   public ConfigurationCheckReport performConfigCheck(ConfigurationCheckReport report, BootstrapProperties config) {
     try {
-      String xml = ConfigPreProcessorLoader.loadInterlokConfig(config);
+      String xml = CachingConfigLoader.loadInterlokConfig(config);
       Adapter adapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(xml);
       validate(adapter, report);
     } catch (Exception ex) {

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/CachingConfigLoader.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/CachingConfigLoader.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.management.config;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import com.adaptris.core.config.ConfigPreProcessorLoader;
+import com.adaptris.core.config.DefaultPreProcessorLoader;
+import com.adaptris.core.management.BootstrapProperties;
+import lombok.AccessLevel;
+import lombok.Generated;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
+
+/**
+ * Helper to avoid multiple executions of
+ * {@link DefaultPreProcessorLoader#load(BootstrapProperties)}.
+ * <p>
+ * Finds the adapter resource name, that's the key to the cache; and loads the configuration once.
+ * This is purely to avoid multiple executions of the preprocessor when in a configuration check
+ * chain.
+ * </p>
+ *
+ * @since 3.11.1
+ *
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CachingConfigLoader {
+
+  // Artificially small; but since the JVM will terminate we might not care so much.
+  private static final ExpiringMap<String, String> CONFIG_CACHE =
+      ExpiringMap.builder().maxSize(2)
+          .expirationPolicy(ExpirationPolicy.ACCESSED).expiration(10L, TimeUnit.MINUTES).build();
+
+  /**
+   * Helper method to avoid multiple executions of
+   * {@link DefaultPreProcessorLoader#load(BootstrapProperties)}.
+   * <p>
+   * Finds the adapter resource name, that's the key to the cache; and loads the configuration once.
+   * This is purely to avoid multiple executions of the preprocessor when in a configuration check
+   * chain.
+   * </p>
+   */
+  public static String loadInterlokConfig(BootstrapProperties config) {
+    Optional<String> cacheKey = Optional.ofNullable(config.findAdapterResource());
+    return cacheKey.map((key) -> loadOrGet(key, config))
+        .orElseGet(() -> sneakyLoad(config));
+  }
+
+  protected static int cacheSize() {
+    return CONFIG_CACHE.size();
+  }
+
+  @SneakyThrows(Exception.class)
+  @Generated
+  private static String sneakyLoad(BootstrapProperties config) {
+    return ConfigPreProcessorLoader.loadInterlokConfig(config);
+  }
+
+
+  private static synchronized String loadOrGet(String key, BootstrapProperties config) {
+    String xml = "";
+    if (CONFIG_CACHE.containsKey(key)) {
+      xml = CONFIG_CACHE.get(key);
+    } else {
+      xml = sneakyLoad(config);
+      CONFIG_CACHE.put(key, xml);
+    }
+    return xml;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/SharedServiceConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/SharedServiceConfigurationChecker.java
@@ -1,17 +1,24 @@
 package com.adaptris.core.management.config;
 
+import java.util.Arrays;
+
 public class SharedServiceConfigurationChecker extends SharedComponentConfigurationChecker {
 
   private static final String FRIENDLY_NAME = "Shared service check";
 
   private static final String COMPONENT_TYPE = "service";
 
-  private static final String XPATH_AVAILABLE_CONNECTIONS = "//shared-components/services/*/unique-id";
+  private static final String AVAILABLE_SHARED_SERVICES = "//shared-components/services/*/unique-id";
 
-  private static final String XPATH_REFERENCED_CONNECTIONS = "//shared-service/lookup-name";
+  // service-list/shared-service
+  private static final String REFERENCE_ELEMENT_XPATH = "//shared-service/lookup-name";
+
+  // things where a shared-service might be used where <service class="shared-service">
+  private static final String REFERENCE_CLASSNAME_XPATH = "//*[@class='shared-service']/lookup-name";
 
   public SharedServiceConfigurationChecker() {
-    super(COMPONENT_TYPE, XPATH_AVAILABLE_CONNECTIONS, XPATH_REFERENCED_CONNECTIONS);
+    super(COMPONENT_TYPE, Arrays.asList(AVAILABLE_SHARED_SERVICES),
+        Arrays.asList(REFERENCE_ELEMENT_XPATH, REFERENCE_CLASSNAME_XPATH));
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/CachingConfigLoaderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/CachingConfigLoaderTest.java
@@ -1,0 +1,25 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import org.junit.Test;
+import com.adaptris.core.management.BootstrapProperties;
+
+public class CachingConfigLoaderTest {
+
+  @Test
+  public void testLoad_NoKey() throws Exception {
+    BootstrapProperties mockBootProperties = new MockBootProperties("some-data");
+    assertEquals("some-data", CachingConfigLoader.loadInterlokConfig(mockBootProperties));
+  }
+
+  @Test
+  public void testLoad_WithKey() throws Exception {
+    BootstrapProperties mockBootProperties =
+        new MockBootProperties("some-data", Arrays.asList("adapterResourceName"));
+    assertEquals("some-data", CachingConfigLoader.loadInterlokConfig(mockBootProperties));
+    assertEquals(1, CachingConfigLoader.cacheSize());
+    assertEquals("some-data", CachingConfigLoader.loadInterlokConfig(mockBootProperties));
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/MockBootProperties.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/MockBootProperties.java
@@ -3,6 +3,9 @@ package com.adaptris.core.management.config;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.apache.commons.io.input.ReaderInputStream;
 import com.adaptris.core.management.BootstrapProperties;
 
@@ -10,10 +13,16 @@ public class MockBootProperties extends BootstrapProperties {
   private static final long serialVersionUID = 2020080401L;
 
   private transient String xml;
+  private transient List<String> adapterResourceNames = Collections.EMPTY_LIST;
 
   public MockBootProperties(String config) {
     super();
     xml = config;
+  }
+
+  public MockBootProperties(String config, List<String> adapterResources) {
+    this(config);
+    adapterResourceNames = Optional.ofNullable(adapterResources).orElse(Collections.EMPTY_LIST);
   }
 
   @Override
@@ -21,4 +30,8 @@ public class MockBootProperties extends BootstrapProperties {
     return new ReaderInputStream(new StringReader(xml), StandardCharsets.UTF_8);
   }
 
+  @Override
+  public String findAdapterResource() {
+    return adapterResourceNames.stream().findFirst().orElseGet(() -> super.findAdapterResource());
+  }
 }


### PR DESCRIPTION

## Motivation

If you have a shared service defined via its class alias (rather than as an element), then it is ignored by the shared-service checker, which results in a false positive on the warning output when you run -configcheck.

Given this example :
```
<exception-handling-service-wrapper>
  <unique-id>profile-exception-wrapper-in-query</unique-id>
  <service class="service-list">
    <unique-id>do-stuff-that-might-fail</unique-id>
    ....
    ...
    ....
  </service>
  <exception-handling-service class="shared-service">
    <lookup-name>invalid-profile-error</lookup-name>
    <unique-id>product-structure-validation-query</unique-id>
  </exception-handling-service>
  <exception-message-metadata-key>exceptionMessage</exception-message-metadata-key>
</exception-handling-service-wrapper>
```

The shared service `invalid-profile-error` is marked as an _unused shared service_.

## Modification

- Refactor SharedComponentConfigurationChecker to support multiple XPaths for both available component + referenced component.
  - Existing tests pass so no regression expected
  - Add `//*[@class='shared-service']/lookup-name` as a valid ref path
- Add a CachingConfigLoader which caches based on the adapterResourceName to avoid multiple logging and var-subbing; do it once.
  - loadInterlokConfig is only used within the config check chain, so the helper lives there

## Result

Shared services that occur in the configuration as the class alias (`<service class="shared-service">`) should now be reported on appropriately

## Testing

- Minimal XML configuration (this also show-cases the deprecation checker) : 

```xml
<adapter>
  <unique-id>MyInterlokInstance</unique-id>
  <shared-components>
    <services>
      <service-list>
        <unique-id>shared-service-1</unique-id>
      </service-list>
      <service-list>
        <unique-id>shared-service-2</unique-id>
      </service-list>
    </services>
  </shared-components>
  <channel-list>
    <channel>
      <workflow-list>
        <standard-workflow>
          <consumer class="null-message-consumer">
            <destination class="configured-consume-destination">
              <destination>/api/base64</destination>
            </destination>
          </consumer>
          <service-collection class="service-list">
            <services>
              <always-fail-service/>
              <service-list>
                <services>
                  <always-fail-service/>
                </services>
              </service-list>
              <exception-handling-service-wrapper>
                <service class="service-list">
                  <unique-id>do-stuff-that-might-fail</unique-id>
                </service>
                <exception-handling-service class="shared-service">
                  <lookup-name>shared-service-1</lookup-name>
                </exception-handling-service>
                <exception-message-metadata-key>exceptionMessage</exception-message-metadata-key>
              </exception-handling-service-wrapper>
              <shared-service>
                <lookup-name>shared-service-2</lookup-name>
              </shared-service>
            </services>
          </service-collection>
          <unique-id>clever-edison</unique-id>
        </standard-workflow>
      </workflow-list>
      <unique-id>jovial-feynman</unique-id>
    </channel>
  </channel-list>
</adapter>
```

With the current snapshot branch you get 
- `java -jar lib/interlok-boot.jar -configcheck`

```
Configuration loading test:
Passed.

Classpath duplication check:
Warnings found;
Possible duplicates found.  Re-run with '-Dinterlok.bootstrap.debug=true' for more details.

javax.validation checks:
Passed.

Deprecated checks:
Warnings found;
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[1].services[0]] is deprecated. Is deprecated. It will be removed in a future version
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].consumer.destination] is deprecated. Is deprecated. It will be removed in 4.0.0
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]] is deprecated. Is deprecated. It will be removed in a future version

Shared connection check:
Passed.

Shared service check:
Warnings found;
Shared service unused: shared-service-1

Config check only; terminating
```
- __shared-service-1 is marked as being unused__ which is wrong.

- If you have TRACE logging enabled you will also get multiple instances of (obviously need to have some preProcessors configured...). I think the number will 4; 1 via unmarshal, 2 via shared-checker, 1 via deprecation-warning.

```
TRACE [main] [c.a.c.c.DefaultPreProcessorLoader.createInstance()] Loading pre-processor: com.adaptris.core.varsub.VariableSubstitutionPreProcessor
```



Switch to the PR branch with the same configuration you should get 

```

Configuration loading test:
Passed.

Classpath duplication check:
Warnings found;
Possible duplicates found.  Re-run with '-Dinterlok.bootstrap.debug=true' for more details.

javax.validation checks:
Passed.

Deprecated checks:
Warnings found;
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[1].services[0]] is deprecated. Is deprecated. It will be removed in a future version
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]] is deprecated. Is deprecated. It will be removed in a future version
Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].consumer.destination] is deprecated. Is deprecated. It will be removed in 4.0.0

Shared connection check:
Passed.

Shared service check:
Passed.

Config check only; terminating
```

And only 1 logging instance from DefaultPreProcessorLoader rather than 4