### PR TITLE
feature/INTERLOK-2873

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ComparatorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ComparatorImpl.java
@@ -28,11 +28,11 @@ public abstract class ComparatorImpl implements MetadataComparator {
   @AutoPopulated
   @Getter
   @Setter
-  protected String resultKey;
+  private String resultKey;
 
   @Getter
   @Setter
-  protected String value;
+  private String value;
 
   public ComparatorImpl() {
     setResultKey(getClass().getCanonicalName());

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ComparatorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ComparatorImpl.java
@@ -22,8 +22,6 @@ import com.adaptris.core.AdaptrisMessage;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-
 public abstract class ComparatorImpl implements MetadataComparator {
 
   @AffectsMetadata

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ComparatorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ComparatorImpl.java
@@ -16,32 +16,34 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import javax.validation.constraints.NotBlank;
 import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.core.AdaptrisMessage;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
 
 public abstract class ComparatorImpl implements MetadataComparator {
-  
+
   @AffectsMetadata
   @AutoPopulated
-  @NotBlank
-  private String resultKey;
-  
+  @Getter
+  @Setter
+  protected String resultKey;
+
+  @Getter
+  @Setter
+  protected String value;
+
   public ComparatorImpl() {
     setResultKey(getClass().getCanonicalName());
   }
 
-  public String getResultKey() {
-    return resultKey;
-  }
+  protected abstract boolean compare(String a, String b);
 
-  /**
-   * Set the key where we store the result.
-   * 
-   * @param rk the key, default is the classname
-   */
-  public void setResultKey(String rk) {
-    this.resultKey = rk;
+  @Override
+  public boolean apply(AdaptrisMessage message, String object) {
+    return compare(message.resolve(value), message.resolve(object));
   }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/CompareTimestamps.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/CompareTimestamps.java
@@ -16,17 +16,19 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * 
@@ -42,6 +44,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-compare-timestamps")
+@AdapterComponent
+@ComponentProfile(summary = "Compares a configured metadata timestamp value against teh supplied value.", tag = "operator,comparator,metadata")
 public class CompareTimestamps extends ComparatorImpl {
 
   private static final String DEFAULT_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
@@ -68,10 +72,7 @@ public class CompareTimestamps extends ComparatorImpl {
     MetadataElement result = new MetadataElement();
     result.setKey(getResultKey());
     try {
-      SimpleDateFormat sdf = new SimpleDateFormat(dateFormat());
-      Date firstDate = sdf.parse(firstItem.getValue());
-      Date secondDate = sdf.parse(secondItem.getValue());
-      result.setValue(String.valueOf(firstDate.compareTo(secondDate)));
+      result.setValue(String.valueOf(compareFormattedDates(firstItem.getValue(), secondItem.getValue())));
     } catch (ParseException e) {
       throw ExceptionHelper.wrapServiceException(e);
     }
@@ -95,5 +96,21 @@ public class CompareTimestamps extends ComparatorImpl {
    */
   public void setDateFormat(String f) {
     this.dateFormat = f;
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    try {
+      return compareFormattedDates(a, b) == 0;
+    } catch (ParseException e) {
+      return false;
+    }
+  }
+
+  private int compareFormattedDates(String a, String b) throws ParseException {
+    SimpleDateFormat sdf = new SimpleDateFormat(dateFormat());
+    Date firstDate = sdf.parse(a);
+    Date secondDate = sdf.parse(b);
+    return firstDate.compareTo(secondDate);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/CompareTimestamps.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/CompareTimestamps.java
@@ -45,7 +45,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
  */
 @XStreamAlias("metadata-compare-timestamps")
 @AdapterComponent
-@ComponentProfile(summary = "Compares a configured metadata timestamp value against teh supplied value.", tag = "operator,comparator,metadata")
+@ComponentProfile(summary = "Compares a configured metadata timestamp value against the supplied value.", tag = "operator,comparator,metadata")
 public class CompareTimestamps extends ComparatorImpl {
 
   private static final String DEFAULT_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/Contains.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/Contains.java
@@ -18,8 +18,12 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -34,6 +38,11 @@ import org.apache.commons.lang3.StringUtils;
 @AdapterComponent
 @ComponentProfile(summary = "Tests that a configured metadata value contains the supplied value.", tag = "operator,comparator,metadata")
 public class Contains extends ComparatorImpl {
+
+  @InputFieldDefault("false")
+  @Getter
+  @Setter
+  private Boolean ignoreCase;
 
   public Contains() {
     super();
@@ -50,7 +59,14 @@ public class Contains extends ComparatorImpl {
   }
 
   @Override
-  protected boolean compare(String a, String b) {
-    return StringUtils.contains(a, b);
+  protected boolean compare(String haystack, String needle) {
+    if (ignoreCase()) {
+      return StringUtils.containsIgnoreCase(haystack, needle);
+    }
+    return StringUtils.contains(haystack, needle);
+  }
+
+  private boolean ignoreCase() {
+    return BooleanUtils.toBooleanDefaultIfNull(ignoreCase, false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/Contains.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/Contains.java
@@ -16,10 +16,11 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -30,6 +31,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-contains")
+@AdapterComponent
+@ComponentProfile(summary = "Tests that a configured metadata value contains the supplied value.", tag = "operator,comparator,metadata")
 public class Contains extends ComparatorImpl {
 
   public Contains() {
@@ -43,7 +46,11 @@ public class Contains extends ComparatorImpl {
 
   @Override
   public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(StringUtils.contains(firstItem.getValue(),
-        secondItem.getValue())));
+    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    return StringUtils.contains(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ContainsIgnoreCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ContainsIgnoreCase.java
@@ -16,10 +16,11 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -30,6 +31,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-contains-ignore-case")
+@AdapterComponent
+@ComponentProfile(summary = "Tests that a configured metadata value contains the supplied value, ignoring case.", tag = "operator,comparator,metadata")
 public class ContainsIgnoreCase extends ComparatorImpl {
 
   public ContainsIgnoreCase() {
@@ -43,7 +46,11 @@ public class ContainsIgnoreCase extends ComparatorImpl {
 
   @Override
   public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(StringUtils.containsIgnoreCase(firstItem.getValue(),
-        secondItem.getValue())));
+    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    return StringUtils.containsIgnoreCase(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ContainsIgnoreCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/ContainsIgnoreCase.java
@@ -18,9 +18,7 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -33,24 +31,15 @@ import org.apache.commons.lang3.StringUtils;
 @XStreamAlias("metadata-contains-ignore-case")
 @AdapterComponent
 @ComponentProfile(summary = "Tests that a configured metadata value contains the supplied value, ignoring case.", tag = "operator,comparator,metadata")
-public class ContainsIgnoreCase extends ComparatorImpl {
+public class ContainsIgnoreCase extends Contains {
 
   public ContainsIgnoreCase() {
     super();
+    setIgnoreCase(true);
   }
 
   public ContainsIgnoreCase(String result) {
     this();
     setResultKey(result);
-  }
-
-  @Override
-  public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
-  }
-
-  @Override
-  protected boolean compare(String a, String b) {
-    return StringUtils.containsIgnoreCase(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EndsWith.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EndsWith.java
@@ -18,8 +18,12 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -34,6 +38,11 @@ import org.apache.commons.lang3.StringUtils;
 @AdapterComponent
 @ComponentProfile(summary = "Tests that a configured metadata value ends with the supplied value.", tag = "operator,comparator,metadata")
 public class EndsWith extends ComparatorImpl {
+
+  @InputFieldDefault("false")
+  @Getter
+  @Setter
+  private Boolean ignoreCase;
 
   public EndsWith() {
     super();
@@ -50,7 +59,14 @@ public class EndsWith extends ComparatorImpl {
   }
 
   @Override
-  protected boolean compare(String a, String b) {
-    return StringUtils.endsWith(a, b);
+  protected boolean compare(String string, String suffix) {
+    if (ignoreCase()) {
+      return StringUtils.endsWithIgnoreCase(string, suffix);
+    }
+    return StringUtils.endsWith(string, suffix);
+  }
+
+  private boolean ignoreCase() {
+    return BooleanUtils.toBooleanDefaultIfNull(ignoreCase, false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EndsWith.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EndsWith.java
@@ -16,10 +16,11 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -30,6 +31,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-ends-with")
+@AdapterComponent
+@ComponentProfile(summary = "Tests that a configured metadata value ends with the supplied value.", tag = "operator,comparator,metadata")
 public class EndsWith extends ComparatorImpl {
 
   public EndsWith() {
@@ -43,7 +46,11 @@ public class EndsWith extends ComparatorImpl {
 
   @Override
   public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(StringUtils.endsWith(firstItem.getValue(),
-        secondItem.getValue())));
+    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    return StringUtils.endsWith(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EndsWithIgnoreCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EndsWithIgnoreCase.java
@@ -16,10 +16,11 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -30,6 +31,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-ends-with-ignore-case")
+@AdapterComponent
+@ComponentProfile(summary = "Tests that a configured metadata value ends with the supplied value, ignoring case.", tag = "operator,comparator,metadata")
 public class EndsWithIgnoreCase extends ComparatorImpl {
 
   public EndsWithIgnoreCase() {
@@ -43,7 +46,11 @@ public class EndsWithIgnoreCase extends ComparatorImpl {
 
   @Override
   public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(StringUtils.endsWithIgnoreCase(firstItem.getValue(),
-        secondItem.getValue())));
+    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    return StringUtils.endsWithIgnoreCase(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EndsWithIgnoreCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EndsWithIgnoreCase.java
@@ -18,9 +18,7 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -33,24 +31,15 @@ import org.apache.commons.lang3.StringUtils;
 @XStreamAlias("metadata-ends-with-ignore-case")
 @AdapterComponent
 @ComponentProfile(summary = "Tests that a configured metadata value ends with the supplied value, ignoring case.", tag = "operator,comparator,metadata")
-public class EndsWithIgnoreCase extends ComparatorImpl {
+public class EndsWithIgnoreCase extends EndsWith {
 
   public EndsWithIgnoreCase() {
     super();
+    setIgnoreCase(true);
   }
 
   public EndsWithIgnoreCase(String result) {
     this();
     setResultKey(result);
-  }
-
-  @Override
-  public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
-  }
-
-  @Override
-  protected boolean compare(String a, String b) {
-    return StringUtils.endsWithIgnoreCase(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/Equals.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/Equals.java
@@ -18,8 +18,12 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -33,6 +37,11 @@ import org.apache.commons.lang3.StringUtils;
 @AdapterComponent
 @ComponentProfile(summary = "Tests that a configured metadata value equals the supplied value.", tag = "operator,comparator,metadata")
 public class Equals extends ComparatorImpl {
+
+  @InputFieldDefault("false")
+  @Getter
+  @Setter
+  private Boolean ignoreCase;
 
   public Equals() {
     super();
@@ -49,7 +58,14 @@ public class Equals extends ComparatorImpl {
   }
 
   @Override
-  protected boolean compare(String a, String b) {
-    return StringUtils.equals(a, b);
+  protected boolean compare(String value, String wanted) {
+    if (ignoreCase()) {
+      return StringUtils.equalsAnyIgnoreCase(value, wanted);
+    }
+    return StringUtils.equals(value, wanted);
+  }
+
+  private boolean ignoreCase() {
+    return BooleanUtils.toBooleanDefaultIfNull(ignoreCase, false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/Equals.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/Equals.java
@@ -16,10 +16,11 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Used with {@link MetadataComparisonService}.
@@ -29,6 +30,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-equals")
+@AdapterComponent
+@ComponentProfile(summary = "Tests that a configured metadata value equals the supplied value.", tag = "operator,comparator,metadata")
 public class Equals extends ComparatorImpl {
 
   public Equals() {
@@ -42,6 +45,11 @@ public class Equals extends ComparatorImpl {
 
   @Override
   public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(StringUtils.equals(firstItem.getValue(), secondItem.getValue())));
+    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    return StringUtils.equals(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EqualsIgnoreCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EqualsIgnoreCase.java
@@ -18,9 +18,7 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -33,24 +31,15 @@ import org.apache.commons.lang3.StringUtils;
 @XStreamAlias("metadata-equals-ignore-case")
 @AdapterComponent
 @ComponentProfile(summary = "Tests that a configured metadata value equals the supplied value, ignoring case.", tag = "operator,comparator,metadata")
-public class EqualsIgnoreCase extends ComparatorImpl {
+public class EqualsIgnoreCase extends Equals {
 
   public EqualsIgnoreCase() {
     super();
+    setIgnoreCase(true);
   }
 
   public EqualsIgnoreCase(String result) {
     this();
     setResultKey(result);
-  }
-
-  @Override
-  public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
-  }
-
-  @Override
-  protected boolean compare(String a, String b) {
-    return StringUtils.equalsIgnoreCase(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EqualsIgnoreCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/EqualsIgnoreCase.java
@@ -16,10 +16,11 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -30,6 +31,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-equals-ignore-case")
+@AdapterComponent
+@ComponentProfile(summary = "Tests that a configured metadata value equals the supplied value, ignoring case.", tag = "operator,comparator,metadata")
 public class EqualsIgnoreCase extends ComparatorImpl {
 
   public EqualsIgnoreCase() {
@@ -43,7 +46,11 @@ public class EqualsIgnoreCase extends ComparatorImpl {
 
   @Override
   public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(StringUtils.equalsIgnoreCase(firstItem.getValue(),
-        secondItem.getValue())));
+    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    return StringUtils.equalsIgnoreCase(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/MetadataComparator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/MetadataComparator.java
@@ -18,13 +18,14 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.conditional.Operator;
 
 /** Compare two items of metadata returning the result of the comparison.
  * 
  * @author lchan
  *
  */
-public interface MetadataComparator {
+public interface MetadataComparator extends Operator {
 
   MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) throws ServiceException;
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/MetadataComparisonService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/MetadataComparisonService.java
@@ -16,9 +16,6 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -29,6 +26,10 @@ import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 /**
  * Implementation of {@link com.adaptris.core.Service} that compares two items of metadata.

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/StartsWith.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/StartsWith.java
@@ -18,8 +18,12 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -34,6 +38,11 @@ import org.apache.commons.lang3.StringUtils;
 @AdapterComponent
 @ComponentProfile(summary = "Tests that a configured metadata value starts with the supplied value.", tag = "operator,comparator,metadata")
 public class StartsWith extends ComparatorImpl {
+
+  @InputFieldDefault("false")
+  @Getter
+  @Setter
+  private Boolean ignoreCase;
 
   public StartsWith() {
     super();
@@ -50,7 +59,14 @@ public class StartsWith extends ComparatorImpl {
   }
 
   @Override
-  protected boolean compare(String a, String b) {
-    return StringUtils.startsWith(a, b);
+  protected boolean compare(String string, String prefix) {
+    if (ignoreCase()) {
+      return StringUtils.startsWithIgnoreCase(string, prefix);
+    }
+    return StringUtils.startsWith(string, prefix);
+  }
+
+  private boolean ignoreCase() {
+    return BooleanUtils.toBooleanDefaultIfNull(ignoreCase, false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/StartsWith.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/StartsWith.java
@@ -16,10 +16,11 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -30,6 +31,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-starts-with")
+@AdapterComponent
+@ComponentProfile(summary = "Tests that a configured metadata value starts with the supplied value.", tag = "operator,comparator,metadata")
 public class StartsWith extends ComparatorImpl {
 
   public StartsWith() {
@@ -43,7 +46,11 @@ public class StartsWith extends ComparatorImpl {
 
   @Override
   public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(StringUtils.startsWith(firstItem.getValue(),
-        secondItem.getValue())));
+    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    return StringUtils.startsWith(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/StartsWithIgnoreCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/StartsWithIgnoreCase.java
@@ -18,9 +18,7 @@ package com.adaptris.core.services.metadata.compare;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -33,24 +31,15 @@ import org.apache.commons.lang3.StringUtils;
 @XStreamAlias("metadata-starts-with-ignore-case")
 @AdapterComponent
 @ComponentProfile(summary = "Tests that a configured metadata value starts with the supplied value, ignoring case.", tag = "operator,comparator,metadata")
-public class StartsWithIgnoreCase extends ComparatorImpl {
+public class StartsWithIgnoreCase extends StartsWith {
 
   public StartsWithIgnoreCase() {
     super();
+    setIgnoreCase(true);
   }
 
   public StartsWithIgnoreCase(String result) {
     this();
     setResultKey(result);
-  }
-
-  @Override
-  public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
-  }
-
-  @Override
-  protected boolean compare(String a, String b) {
-    return StringUtils.startsWithIgnoreCase(a, b);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/StartsWithIgnoreCase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/StartsWithIgnoreCase.java
@@ -16,10 +16,11 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 
@@ -30,6 +31,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * 
  */
 @XStreamAlias("metadata-starts-with-ignore-case")
+@AdapterComponent
+@ComponentProfile(summary = "Tests that a configured metadata value starts with the supplied value, ignoring case.", tag = "operator,comparator,metadata")
 public class StartsWithIgnoreCase extends ComparatorImpl {
 
   public StartsWithIgnoreCase() {
@@ -43,7 +46,11 @@ public class StartsWithIgnoreCase extends ComparatorImpl {
 
   @Override
   public MetadataElement compare(MetadataElement firstItem, MetadataElement secondItem) {
-    return new MetadataElement(getResultKey(), String.valueOf(StringUtils.startsWithIgnoreCase(firstItem.getValue(),
-        secondItem.getValue())));
+    return new MetadataElement(getResultKey(), String.valueOf(compare(firstItem.getValue(), secondItem.getValue())));
+  }
+
+  @Override
+  protected boolean compare(String a, String b) {
+    return StringUtils.startsWithIgnoreCase(a, b);
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/CompareTimestampsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/CompareTimestampsTest.java
@@ -1,0 +1,52 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CompareTimestampsTest {
+
+  private CompareTimestamps operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new CompareTimestamps();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("2020-12-03T10:11:29+0000");
+
+    assertTrue(operator.apply(message, "2020-12-03T11:11:29+0100"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-equals-test");
+
+    assertFalse(operator.apply(message, "2020-12-03T11:11:29+0000"));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/ContainsIgnoreCaseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/ContainsIgnoreCaseTest.java
@@ -1,0 +1,53 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ContainsIgnoreCaseTest
+{
+
+  private ContainsIgnoreCase operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new ContainsIgnoreCase();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("metadata-equals-test");
+
+    assertTrue(operator.apply(message, "EQUALS"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-equals-test");
+
+    assertFalse(operator.apply(message, "xxxx"));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/ContainsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/ContainsTest.java
@@ -1,0 +1,52 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ContainsTest {
+
+  private Contains operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new Contains();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("metadata-equals-test");
+
+    assertTrue(operator.apply(message, "equals"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-equals-test");
+
+    assertFalse(operator.apply(message, "EQUALS"));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/EndsWithIgnoreCaseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/EndsWithIgnoreCaseTest.java
@@ -1,0 +1,52 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EndsWithIgnoreCaseTest {
+
+  private EndsWithIgnoreCase operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new EndsWithIgnoreCase();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("metadata-starts-with-test");
+
+    assertTrue(operator.apply(message, "TEST"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-starts-with-test");
+
+    assertFalse(operator.apply(message, "xxxx"));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/EndsWithTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/EndsWithTest.java
@@ -1,0 +1,52 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EndsWithTest {
+
+  private EndsWith operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new EndsWith();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("metadata-starts-with-test");
+
+    assertTrue(operator.apply(message, "test"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-starts-with-test");
+
+    assertFalse(operator.apply(message, "TEST"));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/EqualsIgnoreCaseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/EqualsIgnoreCaseTest.java
@@ -1,0 +1,52 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EqualsIgnoreCaseTest {
+
+  private EqualsIgnoreCase operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new EqualsIgnoreCase();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("metadata-equals-test");
+
+    assertTrue(operator.apply(message, "METADATA-EQUALS-TEST"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-equals-test");
+
+    assertFalse(operator.apply(message, "xxxx"));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/EqualsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/EqualsTest.java
@@ -1,0 +1,52 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EqualsTest {
+
+  private Equals operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new Equals();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("metadata-equals-test");
+
+    assertTrue(operator.apply(message, "metadata-equals-test"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-equals-test");
+
+    assertFalse(operator.apply(message, "METADATA-EQUALS-TEST"));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/MetadataComparisonServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/MetadataComparisonServiceTest.java
@@ -16,14 +16,6 @@
 
 package com.adaptris.core.services.metadata.compare;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
@@ -31,6 +23,16 @@ import com.adaptris.core.Service;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.metadata.MetadataServiceExample;
 import com.adaptris.core.util.LifecycleHelper;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 public class MetadataComparisonServiceTest extends MetadataServiceExample {
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/StartsWithIgnoreCaseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/StartsWithIgnoreCaseTest.java
@@ -1,0 +1,52 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StartsWithIgnoreCaseTest {
+
+  private StartsWithIgnoreCase operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new StartsWithIgnoreCase();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("metadata-starts-with-test");
+
+    assertTrue(operator.apply(message, "METADATA"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-starts-with-test");
+
+    assertFalse(operator.apply(message, "xxxx"));
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/StartsWithTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/compare/StartsWithTest.java
@@ -1,0 +1,52 @@
+/*
+    Copyright Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.core.services.metadata.compare;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StartsWithTest {
+
+  private StartsWith operator;
+
+  private AdaptrisMessage message;
+
+  @Before
+  public void setUp() throws Exception {
+    operator = new StartsWith();
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+  }
+
+  @Test
+  public void testTrue() {
+    operator.setValue("metadata-starts-with-test");
+
+    assertTrue(operator.apply(message, "metadata"));
+  }
+
+  @Test
+  public void testFalse() {
+    operator.setValue("metadata-starts-with-test");
+
+    assertFalse(operator.apply(message, "METADATA"));
+  }
+}


### PR DESCRIPTION
## Motivation

The metadata comparisons should be usable as operators by ConditionWithOperator classes.

## Modification

The metadata comparators now implement operator, and can be used as such. 

## Result

The users gets some new operators (particularly StartsWith, EndsWith, and Contains, as they already have Equals). They can be used by classes which extend ConditionWithOperator, whilst not breaking backwards compatibility with the MetadataComparisonService.

## Testing

There are new unit tests (that are copied from the original operators) that confirm the new functionality whilst keepin the old. They should now also appear in the UI whenever a ConditionWithOperator wants an operator.
