### PR TITLE
INTERLOK-3497 - Add a system property based file report

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigFileReporter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigFileReporter.java
@@ -1,0 +1,58 @@
+package com.adaptris.core.management.config;
+
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.util.Collection;
+import org.apache.commons.lang3.StringUtils;
+import lombok.NoArgsConstructor;
+
+/**
+ * Reports on deprecated configuration based on a system property.
+ * <p>
+ * Note that this will only emit output if the system property {@value #SYSPROP_FILENAME} is set as
+ * a system property. It is designed to mimic behaviour of the {@code InterlokVerifyReport} process
+ * made available as part of the parent gradle.
+ * </p>
+ */
+@NoArgsConstructor
+public class DeprecatedConfigFileReporter implements ConfigurationReporter {
+
+  public static final String SYSPROP_FILENAME = "interlok.verify.deprecated.filename";
+  public static final String SYSPROP_CATEGORY = "interlok.verify.deprecated.category";
+  public static final String SYSPROP_LEVEL = "interlok.verify.deprecated.level";
+
+  public static final String CATEGORY_DEFAULT = "CODE_SMELL";
+  public static final String LEVEL_DEFAULT = "INFO";
+  private static final String CHECKER_CLASS =
+      DeprecatedConfigurationChecker.class.getCanonicalName();
+
+  @Override
+  public boolean report(Collection<ConfigurationCheckReport> reports) {
+    if (isEnabled()) {
+      emitReport(find(reports));
+    }
+    return true;
+  }
+
+  private static void emitReport(ConfigurationCheckReport report) {
+    String filename = System.getProperty(SYSPROP_FILENAME);
+    String category = System.getProperty(SYSPROP_CATEGORY, CATEGORY_DEFAULT);
+    String level = System.getProperty(SYSPROP_LEVEL, LEVEL_DEFAULT);
+    try (PrintWriter pw = new PrintWriter(new FileWriter(filename))) {
+      for (String s : report.getWarnings()) {
+        pw.println(String.format("%1$s,%2$s,%3$s", category, level, s));
+      }
+    } catch (Exception e) {
+      // eat the exception...
+    }
+  }
+
+  private static ConfigurationCheckReport find(Collection<ConfigurationCheckReport> reports) {
+    return reports.stream().filter((report) -> CHECKER_CLASS.equals(report.getCheckClassName()))
+        .findFirst().orElse(new ConfigurationCheckReport());
+  }
+
+  private static boolean isEnabled() {
+    return StringUtils.isNotBlank(System.getProperty(SYSPROP_FILENAME));
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigurationChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/DeprecatedConfigurationChecker.java
@@ -1,6 +1,9 @@
 package com.adaptris.core.management.config;
 
+import static com.adaptris.core.util.LoggingHelper.filterGuid;
+import static com.adaptris.core.util.LoggingHelper.reflectiveUniqueID;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
@@ -35,8 +38,14 @@ public class DeprecatedConfigurationChecker extends ValidationCheckerImpl {
   private List<String> violationsToWarning(Set<ConstraintViolation<Adapter>> violations) {
     return violations.stream()
         .filter((v) -> !isListImpl(v.getPropertyPath().toString()))
-        .map(v -> String.format("Interlok Deprecation Warning: [%1$s] is deprecated. %2$s", v.getPropertyPath(), v.getMessage()))
+        .map(v -> String.format("Interlok Deprecation Warning: [%1$s][%2$s]: %3$s",
+            v.getPropertyPath(), friendlyName(v.getLeafBean()), v.getMessage()))
         .collect(Collectors.toList());
   }
 
+  public static String friendlyName(Object o) {
+    return Optional.ofNullable(o)
+        .map((obj) -> obj.getClass().getSimpleName() + filterGuid(reflectiveUniqueID(obj)))
+        .orElse("");
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/LoggingHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/LoggingHelper.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,12 +17,9 @@
 package com.adaptris.core.util;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import java.lang.reflect.Method;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.ComponentLifecycle;
 import com.adaptris.core.Service;
 import com.adaptris.core.StateManagedComponent;
@@ -34,21 +31,21 @@ import com.adaptris.core.StateManagedComponent;
  * @author $Author: lchan $
  */
 public abstract class LoggingHelper {
-  
+
   private static final String GUID_PATTERN = "^[0-9a-f]{8}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{12}$";
   private static final Logger log = LoggerFactory.getLogger(LoggingHelper.class);
-  
+
   public static void logDeprecation(boolean alreadyLogged, WarningLoggedCallback callback, String old, String replacement) {
     logWarning(alreadyLogged, callback, "[{}] is deprecated, use [{}] instead", old, replacement);
   }
-  
+
   public static void logWarning(boolean alreadyLogged, WarningLoggedCallback callback, String text, Object...args) {
     if (!alreadyLogged) {
       log.warn(text, args);
       callback.warningLogged();
     }
   }
-  
+
   public static String friendlyName(Service s) {
     if (s == null) {
       return "";
@@ -72,7 +69,7 @@ public abstract class LoggingHelper {
     return comp.getClass().getSimpleName() + filterGuid(reflectiveUniqueID(comp));
   }
 
-  private static String reflectiveUniqueID(ComponentLifecycle comp) {
+  public static String reflectiveUniqueID(Object comp) {
     String result = "";
     try {
       Method m = comp.getClass().getMethod("getUniqueId");
@@ -83,7 +80,7 @@ public abstract class LoggingHelper {
     return result;
   }
 
-  private static String filterGuid(String uid) {
+  public static String filterGuid(String uid) {
     if (isBlank(uid) || uid.matches(GUID_PATTERN)) {
       return "";
     }

--- a/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationReporter
+++ b/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationReporter
@@ -1,1 +1,2 @@
 com.adaptris.core.management.config.ConsoleReporter
+com.adaptris.core.management.config.DeprecatedConfigFileReporter

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigFileReportTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigFileReportTest.java
@@ -1,0 +1,48 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.io.FileReader;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import com.adaptris.core.stubs.TempFileUtils;
+
+public class DeprecatedConfigFileReportTest {
+
+  @Test
+  public void testReport_NoProperty() throws Exception {
+    Object tracker = new Object();
+    File f = TempFileUtils.createTrackedFile(tracker);
+    assertFalse(f.exists());
+    System.setProperty(DeprecatedConfigFileReporter.SYSPROP_FILENAME, "");
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckClassName(DeprecatedConfigurationChecker.class.getCanonicalName());
+    report.setCheckName("blah blah");
+    assertTrue(new DeprecatedConfigFileReporter().report(Arrays.asList(report)));
+    assertFalse(f.exists());
+  }
+
+  @Test
+  public void testReport_Property() throws Exception {
+    Object tracker = new Object();
+    File f = TempFileUtils.createTrackedFile(tracker);
+    assertFalse(f.exists());
+    System.setProperty(DeprecatedConfigFileReporter.SYSPROP_FILENAME, f.getCanonicalPath());
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.getWarnings().add("hello world");
+    report.setCheckClassName(DeprecatedConfigurationChecker.class.getCanonicalName());
+    report.setCheckName("blah blah");
+    assertTrue(new DeprecatedConfigFileReporter().report(Arrays.asList(report)));
+    assertTrue(f.exists());
+    try (FileReader in = new FileReader(f)) {
+      List<String> lines = IOUtils.readLines(in);
+      assertEquals(1, lines.size());
+      assertTrue(lines.get(0).contains("hello world"));
+    }
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
@@ -58,10 +58,8 @@ public class DeprecatedConfigurationCheckerTest {
     assertFalse(report.isCheckPassed());
     // Should be 2 warning, 1 for the deprecated class and 1 for the deprecated member
     assertEquals(2, report.getWarnings().size());
-    assertTrue(report.getWarnings().contains(
-        "Interlok Deprecation Warning: [sharedComponents.services[1]] is deprecated. It will be removed in a future version. No replacement."));
-    assertTrue(report.getWarnings().contains(
-        "Interlok Deprecation Warning: [sharedComponents.services[2].deprecated] is deprecated. It will be removed in a future version. No replacement."));
+    assertTrue(violationsAsExpected(report.getWarnings(), "sharedComponents.services[1]",
+        "sharedComponents.services[2]"));
     assertEquals(0, report.getFailureExceptions().size());
   }
 


### PR DESCRIPTION
## Motivation

To simplify things for the interlok-verify-report out of the parent build.gradle; we need to make the config checker integrate loosely with it.

Since the task works off the back off a file that is emitted via log4j configuration based on the warnings; we can make -configcheck write a file in the same format.

## Modification

- Add a DeprecatedConfigFileReporter that operates based on system properties
- Modify DeprecationConfigChecker so that it includes the unique-id + classname if available.
- Add Tests.

## Result

```
java -Dinterlok.verify.deprecated.filename=./report.txt -jar lib/interlok-boot.jar -configcheck
```

Now emits a report.txt -> if the system property denoting the filename is not present, then no data is written to file.

Available system properties are : 
```
interlok.verify.deprecated.filename
// default is CODE_SMELL
interlok.verify.deprecated.category
// default is INFO
interlok.verify.deprecated.level
```

## Testing

Take this configuration
```xml
<adapter>
  <unique-id>MyInterlokInstance</unique-id>
  <channel-list>
    <channel>
      <workflow-list>
        <standard-workflow>
          <consumer class="null-message-consumer">
            <destination class="configured-consume-destination">
              <destination>/api/base64</destination>
            </destination>
          </consumer>
          <service-collection class="service-list">
            <services>
              <always-fail-service>
               <unique-id>always-fail-cos</unique-id>
              </always-fail-service>
              <service-list>
                <services>
                  <always-fail-service/>
                </services>
              </service-list>
            </services>
          </service-collection>
          <unique-id>clever-edison</unique-id>
        </standard-workflow>
      </workflow-list>
      <unique-id>jovial-feynman</unique-id>
    </channel>
  </channel-list>
</adapter>
```

If you run "gradle check" via the parent gradle system then you get a report.txt file from the parent gradle, this works off the `prepare()` method emitting warnings:

```
$ cat build/reports/interlok/verify/report.txt
CODE_SMELL,INFO,[AlwaysFailService] is deprecated, use [com.adaptris.core.services.exception.ThrowExceptionService] instead
CODE_SMELL,INFO,NullMessageConsumer uses destination, it has no meaning
CODE_SMELL,INFO,[Adapter(MyInterlokInstance)] has a MessageErrorHandler with no behaviour; messages may be discarded upon exception
```

If you build this PR and run it manually : 
```
java -Dinterlok.verify.deprecated.filename=./report.txt -jar lib/interlok-boot.jar -configcheck
```
Then you now get...

```
$ cat ./report.txt
CODE_SMELL,INFO,Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].consumer.destination][NullMessageConsumer]: Is deprecated. It will be removed in 4.0.0
CODE_SMELL,INFO,Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]][AlwaysFailService(always-fail-cos)]: Is deprecated. It will be removed in a future version
CODE_SMELL,INFO,Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[1].services[0]][AlwaysFailService]: Is deprecated. It will be removed in a future version
```