### PR TITLE
INTERLOK-3497 shared components in report

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/config/WarningsToFile.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/WarningsToFile.java
@@ -1,13 +1,18 @@
 package com.adaptris.core.management.config;
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import lombok.NoArgsConstructor;
 
 /**
- * Reports on deprecated configuration based on a system property.
+ * Reports on warnings from various ConfigurationChecks based on a system property.
  * <p>
  * Note that this will only emit output if the system property {@value #SYSPROP_FILENAME} is set as
  * a system property. It is designed to mimic behaviour of the {@code InterlokVerifyReport} process
@@ -15,21 +20,26 @@ import lombok.NoArgsConstructor;
  * </p>
  */
 @NoArgsConstructor
-public class DeprecatedConfigFileReporter implements ConfigurationReporter {
+public class WarningsToFile implements ConfigurationReporter {
 
-  public static final String SYSPROP_FILENAME = "interlok.verify.deprecated.filename";
-  public static final String SYSPROP_CATEGORY = "interlok.verify.deprecated.category";
-  public static final String SYSPROP_LEVEL = "interlok.verify.deprecated.level";
+  public static final String SYSPROP_FILENAME = "interlok.verify.warning.filename";
+  public static final String SYSPROP_CATEGORY = "interlok.verify.warning.category";
+  public static final String SYSPROP_LEVEL = "interlok.verify.warning.level";
 
   public static final String CATEGORY_DEFAULT = "CODE_SMELL";
   public static final String LEVEL_DEFAULT = "INFO";
-  private static final String CHECKER_CLASS =
-      DeprecatedConfigurationChecker.class.getCanonicalName();
+
+
+  private static final List<String> SUPPORTED_CHECKERS =
+      Arrays.asList(DeprecatedConfigurationChecker.class.getCanonicalName(),
+          SharedConnectionConfigurationChecker.class.getCanonicalName(),
+          SharedServiceConfigurationChecker.class.getCanonicalName());
 
   @Override
   public boolean report(Collection<ConfigurationCheckReport> reports) {
     if (isEnabled()) {
-      emitReport(find(reports));
+      FileUtils.deleteQuietly(new File(System.getProperty(SYSPROP_FILENAME)));
+      find(reports).forEach((r) -> emitReport(r));
     }
     return true;
   }
@@ -38,7 +48,7 @@ public class DeprecatedConfigFileReporter implements ConfigurationReporter {
     String filename = System.getProperty(SYSPROP_FILENAME);
     String category = System.getProperty(SYSPROP_CATEGORY, CATEGORY_DEFAULT);
     String level = System.getProperty(SYSPROP_LEVEL, LEVEL_DEFAULT);
-    try (PrintWriter pw = new PrintWriter(new FileWriter(filename))) {
+    try (PrintWriter pw = new PrintWriter(new FileWriter(filename, true))) {
       for (String s : report.getWarnings()) {
         pw.println(String.format("%1$s,%2$s,%3$s", category, level, s));
       }
@@ -47,9 +57,10 @@ public class DeprecatedConfigFileReporter implements ConfigurationReporter {
     }
   }
 
-  private static ConfigurationCheckReport find(Collection<ConfigurationCheckReport> reports) {
-    return reports.stream().filter((report) -> CHECKER_CLASS.equals(report.getCheckClassName()))
-        .findFirst().orElse(new ConfigurationCheckReport());
+  private static List<ConfigurationCheckReport> find(Collection<ConfigurationCheckReport> reports) {
+    return reports.stream()
+        .filter((report) -> SUPPORTED_CHECKERS.contains(report.getCheckClassName()))
+        .collect(Collectors.toList());
   }
 
   private static boolean isEnabled() {

--- a/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationReporter
+++ b/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationReporter
@@ -1,2 +1,2 @@
 com.adaptris.core.management.config.ConsoleReporter
-com.adaptris.core.management.config.DeprecatedConfigFileReporter
+com.adaptris.core.management.config.WarningsToFile

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigFileReportTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigFileReportTest.java
@@ -18,11 +18,11 @@ public class DeprecatedConfigFileReportTest {
     Object tracker = new Object();
     File f = TempFileUtils.createTrackedFile(tracker);
     assertFalse(f.exists());
-    System.setProperty(DeprecatedConfigFileReporter.SYSPROP_FILENAME, "");
+    System.setProperty(WarningsToFile.SYSPROP_FILENAME, "");
     ConfigurationCheckReport report = new ConfigurationCheckReport();
     report.setCheckClassName(DeprecatedConfigurationChecker.class.getCanonicalName());
     report.setCheckName("blah blah");
-    assertTrue(new DeprecatedConfigFileReporter().report(Arrays.asList(report)));
+    assertTrue(new WarningsToFile().report(Arrays.asList(report)));
     assertFalse(f.exists());
   }
 
@@ -31,12 +31,12 @@ public class DeprecatedConfigFileReportTest {
     Object tracker = new Object();
     File f = TempFileUtils.createTrackedFile(tracker);
     assertFalse(f.exists());
-    System.setProperty(DeprecatedConfigFileReporter.SYSPROP_FILENAME, f.getCanonicalPath());
+    System.setProperty(WarningsToFile.SYSPROP_FILENAME, f.getCanonicalPath());
     ConfigurationCheckReport report = new ConfigurationCheckReport();
     report.getWarnings().add("hello world");
     report.setCheckClassName(DeprecatedConfigurationChecker.class.getCanonicalName());
     report.setCheckName("blah blah");
-    assertTrue(new DeprecatedConfigFileReporter().report(Arrays.asList(report)));
+    assertTrue(new WarningsToFile().report(Arrays.asList(report)));
     assertTrue(f.exists());
     try (FileReader in = new FileReader(f)) {
       List<String> lines = IOUtils.readLines(in);


### PR DESCRIPTION
## Motivation

https://github.com/adaptris/interlok/pull/579 was limited in scope since it only checked the deprecation warnings.
However, since this is a configuration reporter; we can actually report on all warnings.

## Modification

- Rename DeprecatedConfigChecker to be WarningsToFile
- Add support for the shared-component checkers.

## Result

The properties change to (which is OK, since it only breaks snapshot).

```
interlok.verify.warning.filename
// default is CODE_SMELL
interlok.verify.warning.category
// default is INFO
interlok.verify.warning.level
```
## Testing

Take the configuration from https://github.com/adaptris/interlok/pull/579 and add in some shared components.

```
  <shared-components>
    <connections>
      <null-connection>
        <unique-id>unused-null-connection</unique-id>
      </null-connection>
    </connections>
    <services>
      <service-list>
        <unique-id>shared-service-1</unique-id>
      </service-list>
      <service-list>
        <unique-id>shared-service-2</unique-id>
      </service-list>
      <service-list>
        <unique-id>shared-service-3</unique-id>
      </service-list>
    </services>
  </shared-components>
```

```
$ (cd build/distribution && java -Dinterlok.verify.warning.filename=./report.txt -jar lib/interlok-boot.jar -configcheck
...
$ cat build/distribution/report.txt
CODE_SMELL,INFO,Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].consumer.destination][NullMessageConsumer]: Is deprecated. It will be removed in 4.0.0
CODE_SMELL,INFO,Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[1].services[0]][AlwaysFailService]: Is deprecated. It will be removed in a future version
CODE_SMELL,INFO,Interlok Deprecation Warning: [channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]][AlwaysFailService(always-fail-cos)]: Is deprecated. It will be removed in a future version
CODE_SMELL,INFO,Shared connection unused: unused-null-connection
CODE_SMELL,INFO,Shared service unused: shared-service-1
CODE_SMELL,INFO,Shared service unused: shared-service-2
CODE_SMELL,INFO,Shared service unused: shared-service-3
```
