### PR TITLE
Interlok 3527

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamOutputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MetadataStreamOutputParameter.java
@@ -55,11 +55,13 @@ public class MetadataStreamOutputParameter extends MetadataStreamParameter
   public void insert(InputStreamWithEncoding data, InterlokMessage message) throws InterlokException {
     try {
       StringBuilder builder = new StringBuilder();
-      try (
-          Reader in = new InputStreamReader(data.inputStream,
-              charset(defaultIfEmpty(getContentEncoding(), data.encoding)));
-          StringBuilderWriter out = new StringBuilderWriter(builder)) {
-        IOUtils.copy(in, out);
+      if(data.inputStream != null) {
+        try (
+            Reader in = new InputStreamReader(data.inputStream,
+                charset(defaultIfEmpty(getContentEncoding(), data.encoding)));
+            StringBuilderWriter out = new StringBuilderWriter(builder)) {
+          IOUtils.copy(in, out);
+        }
       }
       message.addMessageHeader(getMetadataKey(), builder.toString());
     } catch (IOException e) {

--- a/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataOutputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataOutputParameterTest.java
@@ -74,6 +74,14 @@ public class MetadataStreamDataOutputParameterTest {
     assertNotSame(TEXT, msg.getContent());
     assertEquals(TEXT, msg.getMetadataValue(DEFAULT_METADATA_KEY));
   }
+  
+  @Test
+  public void testInsert_NullStream() throws Exception {
+    MetadataStreamOutputParameter p = new MetadataStreamOutputParameter(DEFAULT_METADATA_KEY);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    p.insert(new InputStreamWithEncoding(null, null), msg);
+    assertEquals("", msg.getMetadataValue(DEFAULT_METADATA_KEY));
+  }
 
   @Test
   public void testInsert_Encoding() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataOutputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/MetadataStreamDataOutputParameterTest.java
@@ -75,8 +75,10 @@ public class MetadataStreamDataOutputParameterTest {
     assertEquals(TEXT, msg.getMetadataValue(DEFAULT_METADATA_KEY));
   }
   
+  
   @Test
   public void testInsert_NullStream() throws Exception {
+    // INTERLOK-3527
     MetadataStreamOutputParameter p = new MetadataStreamOutputParameter(DEFAULT_METADATA_KEY);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     p.insert(new InputStreamWithEncoding(null, null), msg);


### PR DESCRIPTION
## Motivation

A report suggested in certain situations our StandardHttpProducer's request method can throw an NPE.  It requires a response code <= 200 and >= 400 where the error response stream is null.

Turns out this is caused by configuring a MetadataStreamOutputParameter as the response handler.

## Modification

PayloadStreamOutputParameter checks for null streams in the IOUtils.copy(), the metadata version does this also but first creates a reader object with the input stream, this causes an NPE.

We now check for a null stream and only perform the copy if the stream is not null.  In either case the metadata item is still  created.

## Result

NPE will no longer be thrown by the MetadataStreamOutputParameter if the stream is null.

## Testing

Check the new unit test in the StandardHttpProducerTest class, this shows how to configure the StandardHttpProducer and the required response that would create an NPE.
