### PR TITLE
INTERLOK-3528 xpath Class.forName()

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/util/XmlUtils.java
+++ b/interlok-core/src/main/java/com/adaptris/util/XmlUtils.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,12 +17,10 @@
 package com.adaptris.util;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
-
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -35,21 +33,20 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.Text;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
-
+import com.adaptris.annotation.Removal;
 import com.adaptris.util.text.xml.Resolver;
 import com.adaptris.util.text.xml.Validator;
 import com.adaptris.util.text.xml.XPath;
 
 /**
  * Class which provides convenience methods for various aspects of XML usage.
- * 
+ *
  * @author Stuart Ellidge
  */
 public class XmlUtils {
@@ -91,6 +88,7 @@ public class XmlUtils {
    * @deprecated URIResolver does nothing so use {@link #XmlUtils(EntityResolver)} instead.
    */
   @Deprecated
+  @Removal(version = "4.0.0")
   public XmlUtils(EntityResolver er, URIResolver ur) {
     this(er);
   }
@@ -100,6 +98,7 @@ public class XmlUtils {
    *             instead.
    */
   @Deprecated
+  @Removal(version = "4.0.0")
   public XmlUtils(EntityResolver er, URIResolver ur, NamespaceContext ctx) {
     this(er, ctx, DocumentBuilderFactory.newInstance());
   }
@@ -109,6 +108,7 @@ public class XmlUtils {
    *             instead.
    */
   @Deprecated
+  @Removal(version = "4.0.0")
   public XmlUtils(EntityResolver er, URIResolver ur, NamespaceContext ctx, DocumentBuilderFactory dbf) {
     this(er, ctx, dbf);
   }
@@ -503,9 +503,9 @@ public class XmlUtils {
   /**
    * Convenience method which enables a new Node to be added to a parent at a specified position, by specifying the Node to insert
    * before. Here is a sample of how to use:
-   * 
+   *
    * <pre>
-  *  {@code 
+  *  {@code
    *
    *   // Example of how to insert a Node as the 3rd child of a parent
    *   Node p  = xmlUtils.getSingleNode("/mydoc/parent");
@@ -515,7 +515,7 @@ public class XmlUtils {
    *
    * }
    * </pre>
-   * 
+   *
    * @param newNode the Node to be added
    * @param existingNode the Node to insert before
    * @param parent the parent Node

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/Validator.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/Validator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,6 @@ package com.adaptris.util.text.xml;
 
 import java.io.InputStream;
 import java.io.Reader;
-
 import org.apache.xerces.parsers.DOMParser;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
@@ -29,15 +28,17 @@ import org.xml.sax.SAXParseException;
 
 /**
  * @author Stuart Ellidge
- * 
+ *
  * Convenience class which validates an XML document against a specified schema
  */
 public class Validator {
+
+
   private DOMParser parser = null;
 
   /**
    * Constructor that creates a new Validator object
-   * 
+   *
    * @param schema a valid url to the schema to process
    * @throws Exception if a parse error is encountered
    */
@@ -47,7 +48,7 @@ public class Validator {
 
   /**
    * Constructor that creates a new Validator object
-   * 
+   *
    * @param schema a valid url to the schema to process
    * @param resolver an EntityResolver to use to retrieve included / imported
    *          documents
@@ -61,10 +62,12 @@ public class Validator {
   private DOMParser createParser(String schema) throws Exception {
     DOMParser result = new DOMParser();
 
-    Class poolClass = Class.forName("org.apache.xerces.util.XMLGrammarPoolImpl");
-    Object grammarPool = poolClass.newInstance();
-    result.setProperty("http://apache.org/xml/properties/internal/grammar-pool", grammarPool);
-
+    // pointless class.forName() here, since we can't do any validation
+    // if xerces isn't available
+    // Class poolClass = Class.forName("org.apache.xerces.util.XMLGrammarPoolImpl");
+    // Object grammarPool = poolClass.newInstance();
+    result.setProperty("http://apache.org/xml/properties/internal/grammar-pool",
+        new org.apache.xerces.util.XMLGrammarPoolImpl());
     result.setFeature("http://xml.org/sax/features/validation", true);
     result.setFeature("http://apache.org/xml/features/validation/schema", true);
     result.setProperty("http://apache.org/xml/properties/schema/external-noNamespaceSchemaLocation", schema);
@@ -75,7 +78,7 @@ public class Validator {
   /**
    * method which parses an xml document from an input stream, validates it and
    * returns the subsequent Document object.
-   * 
+   *
    * @param xml the xml document as input stream
    * @return the resultant Document (if parsing successful)
    * @throws Exception if the document fails to be validated
@@ -87,7 +90,7 @@ public class Validator {
   /**
    * method which parses an xml document from a Reader, validates it and returns
    * the subsequent Document object.
-   * 
+   *
    * @param xml the xml document as reader
    * @return the resultant Document (if parsing successful)
    * @throws Exception if the document fails to be validated
@@ -99,7 +102,7 @@ public class Validator {
   /**
    * method which parses an xml document from an input source, validates it and
    * returns the subsequent Document object.
-   * 
+   *
    * @param xml the xml document as input source
    * @return the resultant Document (if parsing successful)
    * @throws Exception if the document fails to be validated


### PR DESCRIPTION
## Motivation

At the moment whenever you call `new com.adaptris.util.xml.XPath()` there is a call to Class.forName() to figure out which XpathFactory that it really wants to use (this is because Saxon is no longer available via XPathFactory.newInstance()) so we have to figure out which one to use.

The naiive use of Class.forName() can end up blocking Threads, most of the time it doesn't but high thread count + lots of XPaths...
 
```
java.lang.Thread.State: BLOCKED (on object monitor)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:398)
  - waiting to lock <0x00000006c03be418> (a java.lang.Object)
  at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:92)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
  at java.lang.Class.forName0(Native Method)
  at java.lang.Class.forName(Class.java:264)
  at com.adaptris.util.text.xml.XPath.build(XPath.java:290)
```


## Modification

- Add a static method that does the `Class.forName` once, and then re-use that class instance to create the appropriate XPathFactory if saxon is selected.
- Make the existing "unbounded" map that XmlTransform uses to cache things, a bounded ExpiringMap impl since lets just say that if we're hitting this edge case with XPath, then transforms may well being used as well.
- Remove use of Class.forName() in XmlValidator (used during schema validation) for the same reason... There was never a need to reflectively construct the xerces grammar pool since we'd always fail if it didn't exist; so that's a hard dependency we can't get rid of.

## Result

No visible impact other than the high-thread / xpath use-case.

## Testing

No tests change, no test failures, so no regressions


