### PR TITLE
INTERLOK-218 Remove references/usages of testConnection

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/AdvancedJdbcPooledConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/AdvancedJdbcPooledConnection.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,10 +15,6 @@
  */
 package com.adaptris.core.jdbc;
 
-import java.sql.SQLException;
-import javax.validation.Valid;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -27,10 +23,15 @@ import com.adaptris.security.password.Password;
 import com.adaptris.util.KeyValuePairSet;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.validation.Valid;
+import java.sql.SQLException;
 
 /**
  * A {@link DatabaseConnection} instance that provides connection pooling via c3p0.
- * 
+ *
  * @author amcgrath
  * @see PooledConnectionProperties
  */
@@ -40,15 +41,15 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
     tag = "connections,jdbc")
 @DisplayOrder(order = {"username", "password", "driverImp", "connectUrl", "connectionPoolProperties", "connectionProperties"})
 public class AdvancedJdbcPooledConnection extends JdbcPooledConnectionImpl {
-  
+
   @Valid
   private KeyValuePairSet connectionPoolProperties;
 
   public AdvancedJdbcPooledConnection() {
     super();
   }
-  
-  
+
+
   @Override
   protected C3P0PooledDataSource createPool() throws Exception {
     ComboPooledDataSource pool = new ComboPooledDataSource();
@@ -69,21 +70,20 @@ public class AdvancedJdbcPooledConnection extends JdbcPooledConnectionImpl {
 
   @Override
   public boolean equals(Object ajpc) {
-    if (ajpc == null) 
+    if (ajpc == null)
       return false;
-    
-    if (ajpc == this) 
+
+    if (ajpc == this)
       return true;
-    
+
     if (ajpc instanceof AdvancedJdbcPooledConnection) {
       AdvancedJdbcPooledConnection conn = (AdvancedJdbcPooledConnection) ajpc;
-      
+
       return new EqualsBuilder()
           .append(conn.getConnectUrl(), this.getConnectUrl())
           .append(conn.getDriverImp(), this.getDriverImp())
           .append(conn.getAlwaysValidateConnection(), this.getAlwaysValidateConnection())
           .append(conn.getDebugMode(), this.getDebugMode())
-          .append(conn.getTestStatement(), this.getTestStatement())
           .append(conn.getAutoCommit(), this.getAutoCommit())
           .append(conn.getConnectionProperties(), this.getConnectionProperties())
           .append(conn.getConnectionPoolProperties(), this.getConnectionPoolProperties())
@@ -99,7 +99,6 @@ public class AdvancedJdbcPooledConnection extends JdbcPooledConnectionImpl {
         .append(getDriverImp())
         .append(this.getAlwaysValidateConnection())
         .append(getDebugMode())
-        .append(getTestStatement())
         .append(getAutoCommit())
         .append(this.getConnectionProperties())
         .append(getConnectionPoolProperties())

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/DatabaseConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/DatabaseConnection.java
@@ -16,13 +16,6 @@
 
 package com.adaptris.core.jdbc;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Properties;
-import javax.sql.DataSource;
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -34,6 +27,14 @@ import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.security.exc.PasswordException;
 import com.adaptris.util.KeyValuePairBag;
 import com.adaptris.util.KeyValuePairSet;
+import org.apache.commons.lang3.BooleanUtils;
+
+import javax.sql.DataSource;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * <p>
@@ -44,11 +45,8 @@ import com.adaptris.util.KeyValuePairSet;
  */
 public abstract class DatabaseConnection extends AllowsRetriesConnection {
 
-  @AutoPopulated
-  @NotBlank
-  @InputFieldHint(style = "SQL")
-  @AdvancedConfig
-  private String testStatement;
+  public static final int NUM_SECONDS_TIMEOUT_CONN_VALIDATE = 5;
+
   @NotBlank
   @AutoPopulated
   private String driverImp;
@@ -84,7 +82,6 @@ public abstract class DatabaseConnection extends AllowsRetriesConnection {
    */
   public DatabaseConnection() {
     setDriverImp("com.mysql.jdbc.Driver");
-    setTestStatement("SELECT DATABASE(), VERSION(), NOW(), USER();");
     wrapper = new DataSourceWrapper(this);
     connectionState = ConnectionState.Closed;
   }
@@ -223,33 +220,6 @@ public abstract class DatabaseConnection extends AllowsRetriesConnection {
 
   public boolean debugMode() {
     return BooleanUtils.toBooleanDefaultIfNull(getDebugMode(), false);
-  }
-
-  /**
-   * Set the SQL statement used to test this connection.
-   * <p>
-   * The default test statement is <code>SELECT DATABASE(), VERSION(), NOW(), USER()</code> which may not be suitable for your
-   * database driver. Additionally depending on the JDBC driver implementation certain statements may be 'cached' and might never
-   * hit the database, so you need to be aware of that as you will be relying on this test-statement to verify the connection
-   * validity.
-   * </p>
-   * 
-   * @see #setAlwaysValidateConnection(Boolean)
-   * @param s the SQL statement used to test this connection; the default is SELECT DATABASE(), VERSION(), NOW(), USER()
-   */
-  public void setTestStatement(String s) {
-    testStatement = s;
-  }
-
-  /**
-   * <p>
-   * Returns the SQL statement used to test this connection.
-   * </p>
-   * 
-   * @return the SQL statement used to test this connection
-   */
-  public String getTestStatement() {
-    return testStatement;
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/FailoverJdbcConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/FailoverJdbcConnection.java
@@ -16,16 +16,6 @@
 
 package com.adaptris.core.jdbc;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.validation.constraints.NotNull;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
@@ -36,6 +26,14 @@ import com.adaptris.jdbc.connection.FailoverConfig;
 import com.adaptris.jdbc.connection.FailoverConnection;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.validation.constraints.NotNull;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * <p>
@@ -127,7 +125,6 @@ public class FailoverJdbcConnection extends DatabaseConnection {
       config.setAutoCommit(autoCommit());
       config.setDatabaseDriver(getDriverImp());
       config.setDebugMode(debugMode());
-      config.setTestStatement(getTestStatement());
       config.setAlwaysValidateConnection(alwaysValidateConnection());
       config.setConnectionProperties(connectionProperties());
       failover = new FailoverConnection(config);
@@ -181,7 +178,6 @@ public class FailoverJdbcConnection extends DatabaseConnection {
           .append(c.getDriverImp(), this.getDriverImp())
           .append(c.getAlwaysValidateConnection(), this.getAlwaysValidateConnection())
           .append(c.getDebugMode(), this.getDebugMode())
-          .append(c.getTestStatement(), this.getTestStatement())
           .append(c.getAutoCommit(), this.getAutoCommit())
           .append(c.getConnectionProperties(), this.getConnectionProperties())
           .isEquals();
@@ -197,7 +193,6 @@ public class FailoverJdbcConnection extends DatabaseConnection {
         .append(getDriverImp())
         .append(this.getAlwaysValidateConnection())
         .append(getDebugMode())
-        .append(getTestStatement())
         .append(getAutoCommit())
         .append(this.getConnectionProperties())
         .toHashCode();

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcConnection.java
@@ -16,14 +16,6 @@
 
 package com.adaptris.core.jdbc;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.Properties;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -31,6 +23,13 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.util.JdbcUtil;
 import com.adaptris.security.exc.PasswordException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * <p>
@@ -46,8 +45,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @DisplayOrder(order = {"username", "password", "driverImp", "connectUrl"})
 public class JdbcConnection extends DatabaseConnection {
 
-  private static final int NUM_SECONDS_TIMEOUT_CONN_VALIDATE = 5;
-  
+
   private String connectUrl;
   private transient Connection sqlConnection;
 
@@ -147,7 +145,7 @@ public class JdbcConnection extends DatabaseConnection {
       return new EqualsBuilder().append(getConnectUrl(), rhs.getConnectUrl())
           .append(getAlwaysValidateConnection(), rhs.getAlwaysValidateConnection()).append(getAutoCommit(), rhs.getAutoCommit())
           .append(getDebugMode(), rhs.getDebugMode()).append(getDriverImp(), rhs.getDriverImp())
-          .append(getTestStatement(), rhs.getTestStatement()).isEquals();
+          .isEquals();
     }
     return false;
   }
@@ -155,7 +153,7 @@ public class JdbcConnection extends DatabaseConnection {
   @Override
   public int hashCode() {
     return new HashCodeBuilder(11, 17).append(getConnectUrl()).append(getAlwaysValidateConnection()).append(getAutoCommit())
-        .append(getDebugMode()).append(getDriverImp()).append(getTestStatement()).toHashCode();
+        .append(getDebugMode()).append(getDriverImp()).toHashCode();
   }
 
   /** @see com.adaptris.core.jdbc.DatabaseConnection#getConnectionName() */
@@ -188,15 +186,6 @@ public class JdbcConnection extends DatabaseConnection {
         log.error("Couldn't decode password for database");
         throw new SQLException(e);
       }
-    }
-    try {
-      if (alwaysValidateConnection()) {
-        JdbcUtil.testConnection(sqlConnection, getTestStatement(), debugMode());
-      }
-    }
-    catch (SQLException e) {
-      sqlConnection = null;
-      throw e;
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcPooledConnectionImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcPooledConnectionImpl.java
@@ -15,15 +15,15 @@
 */
 package com.adaptris.core.jdbc;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import javax.sql.DataSource;
-import javax.validation.constraints.NotBlank;
-import org.apache.commons.io.IOUtils;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.core.util.JdbcUtil;
+import org.apache.commons.io.IOUtils;
+
+import javax.sql.DataSource;
+import javax.validation.constraints.NotBlank;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 public abstract class JdbcPooledConnectionImpl extends DatabaseConnection {
   @NotBlank
@@ -92,10 +92,12 @@ public abstract class JdbcPooledConnectionImpl extends DatabaseConnection {
    * @throws SQLException if the statement could not be performed.
    */
   private Connection testConnection(Connection sqlConnection) throws SQLException {
-    if (!alwaysValidateConnection()) {
-      return sqlConnection;
+    if (alwaysValidateConnection()) {
+      if (!sqlConnection.isValid(NUM_SECONDS_TIMEOUT_CONN_VALIDATE)) {
+        throw new SQLException("Connection is not valid");
+      }
     }
-    return JdbcUtil.testConnection(sqlConnection, getTestStatement(), debugMode());
+    return sqlConnection;
   }
 
   public String getConnectUrl() {

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/PluggableJdbcPooledConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/PluggableJdbcPooledConnection.java
@@ -1,9 +1,5 @@
 package com.adaptris.core.jdbc;
 
-import javax.validation.Valid;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
@@ -12,6 +8,11 @@ import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.util.Args;
 import com.adaptris.util.KeyValuePairSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.validation.Valid;
 
 /**
  * Concrete {@link JdbcPooledConnectionImpl} that allows you to plug in connection pool
@@ -61,7 +62,7 @@ public class PluggableJdbcPooledConnection extends JdbcPooledConnectionImpl {
 
       return new EqualsBuilder().append(conn.getConnectUrl(), getConnectUrl()).append(conn.getDriverImp(), getDriverImp())
           .append(conn.getAlwaysValidateConnection(), getAlwaysValidateConnection())
-          .append(conn.getDebugMode(), getDebugMode()).append(conn.getTestStatement(), getTestStatement())
+          .append(conn.getDebugMode(), getDebugMode())
           .append(conn.getAutoCommit(), getAutoCommit()).append(conn.getConnectionProperties(), getConnectionProperties())
           .append(conn.getBuilder(), getBuilder()).append(conn.getPoolProperties(), getPoolProperties()).isEquals();
     }
@@ -71,7 +72,7 @@ public class PluggableJdbcPooledConnection extends JdbcPooledConnectionImpl {
   @Override
   public int hashCode() {
     return new HashCodeBuilder(19, 37).append(getConnectUrl()).append(getDriverImp())
-        .append(getAlwaysValidateConnection()).append(getDebugMode()).append(getTestStatement()).append(getAutoCommit())
+        .append(getAlwaysValidateConnection()).append(getDebugMode()).append(getAutoCommit())
         .append(getConnectionProperties()).append(getBuilder()).append(getPoolProperties()).toHashCode();
   }
 

--- a/interlok-core/src/main/java/com/adaptris/jdbc/connection/FailoverConfig.java
+++ b/interlok-core/src/main/java/com/adaptris/jdbc/connection/FailoverConfig.java
@@ -42,7 +42,6 @@ public final class FailoverConfig implements Cloneable {
   private boolean verbose;
   private List<String> connectionUrls;
   private String databaseDriver;
-  private String testStatement;
   private boolean autoCommit;
   private boolean alwaysValidateConnection;
   private String username;
@@ -56,12 +55,6 @@ public final class FailoverConfig implements Cloneable {
    * resource key for driver classname
    */
   public static final String JDBC_DRIVER = "jdbc.driver.classname";
-
-  /**
-   * Resource key for testing a connection.
-   *
-   */
-  public static final String JDBC_TEST_STATEMENT = "jdbc.driver.test";
 
   /**
    * resource key for driver url
@@ -102,7 +95,6 @@ public final class FailoverConfig implements Cloneable {
   public FailoverConfig() {
     setConnectionUrls(new ArrayList<String>());
     setDatabaseDriver(MYSQL_DRIVER);
-    setTestStatement(MYSQL_TEST_STMT);
     setAutoCommit(true);
     setAlwaysValidateConnection(true);
     setConnectionProperties(new Properties());
@@ -201,25 +193,6 @@ public final class FailoverConfig implements Cloneable {
   }
 
   /**
-   * Get the statement that will test the connection.
-   *
-   * @return the statement
-   */
-  public String getTestStatement() {
-    return testStatement;
-  }
-
-  /**
-   * Set the statement that will test the connection.
-   *
-   * @param string the statement
-   * @throws IllegalArgumentException if the statement is null.
-   */
-  public void setTestStatement(String string) throws IllegalArgumentException {
-    testStatement = Args.notNull(string, "testStatement");
-  }
-
-  /**
    * @see java.lang.Object#equals(java.lang.Object)
    */
   @Override
@@ -232,7 +205,7 @@ public final class FailoverConfig implements Cloneable {
     }
     if (o instanceof FailoverConfig) {
       FailoverConfig rhs = (FailoverConfig) o;
-      return new EqualsBuilder().append(getTestStatement(), rhs.getTestStatement())
+      return new EqualsBuilder()
           .append(getDebugMode(), rhs.getDebugMode())
           .append(getDatabaseDriver(), rhs.getDatabaseDriver()).append(getAutoCommit(), rhs.getAutoCommit())
           .append(getAlwaysValidateConnection(), rhs.getAlwaysValidateConnection())
@@ -246,7 +219,7 @@ public final class FailoverConfig implements Cloneable {
    */
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(31, 17).append(getTestStatement()).append(getDatabaseDriver())
+    return new HashCodeBuilder(31, 17).append(getDatabaseDriver())
         .append(getAutoCommit()).append(getAlwaysValidateConnection()).append(getConnectionUrls())
         .append(getDebugMode())
         .toHashCode();
@@ -256,7 +229,6 @@ public final class FailoverConfig implements Cloneable {
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("driver", getDatabaseDriver())
         .append("connectionUrls", getConnectionUrls())
-        .append("testStatement", getTestStatement())
         .append("debugMode", getDebugMode())
         .append("autoCommit", getAutoCommit())
         .append("alwaysValidate", getAlwaysValidateConnection())
@@ -329,7 +301,6 @@ public final class FailoverConfig implements Cloneable {
     // }
     // }
     setConnectionUrls(connectionUrls);
-    setTestStatement(p.getProperty(JDBC_TEST_STATEMENT, MYSQL_TEST_STMT));
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/jdbc/connection/FailoverConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/jdbc/connection/FailoverConnection.java
@@ -21,6 +21,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
 
+import com.adaptris.core.jdbc.DatabaseConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,7 +147,9 @@ public final class FailoverConnection {
         this.createConnection();
       }
       if (config.getAlwaysValidateConnection()) {
-        JdbcUtil.testConnection(sqlConnection, config.getTestStatement(), config.getDebugMode());
+        if (!sqlConnection.isValid(DatabaseConnection.NUM_SECONDS_TIMEOUT_CONN_VALIDATE)) {
+          throw new SQLException();
+        }
       }
     }
     catch (SQLException e) {

--- a/interlok-core/src/main/java/com/adaptris/jdbc/connection/FailoverDataSource.java
+++ b/interlok-core/src/main/java/com/adaptris/jdbc/connection/FailoverDataSource.java
@@ -68,8 +68,7 @@ public class FailoverDataSource implements DataSource {
 
   private static final String[] REQUIRED_PROPERTIES =
   {
-      FailoverConfig.JDBC_DRIVER, FailoverConfig.JDBC_AUTO_COMMIT,
-      FailoverConfig.JDBC_TEST_STATEMENT
+      FailoverConfig.JDBC_DRIVER, FailoverConfig.JDBC_AUTO_COMMIT
   };
 
   /**

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/FailoverJdbcConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/FailoverJdbcConnectionTest.java
@@ -15,35 +15,17 @@
  */
 
 package com.adaptris.core.jdbc;
-import static org.junit.Assert.fail;
+
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.TimeInterval;
+import org.junit.Test;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
-import com.adaptris.core.util.LifecycleHelper;
-import com.adaptris.util.TimeInterval;
 
 public class FailoverJdbcConnectionTest
     extends com.adaptris.interlok.junit.scaffolding.DatabaseConnectionCase<FailoverJdbcConnection> {
-
-
-  public FailoverJdbcConnectionTest() {
-
-  }
-
-
-  @Test
-  public void testBug2082() throws Exception {
-    FailoverJdbcConnection conn = configure(createConnection());
-    conn.setTestStatement("SELECT 1;");
-    try {
-      LifecycleHelper.init(conn);
-      conn.connect();
-      fail("Expected exception");
-    } catch (Exception expected) {
-      ;
-    }
-  }
 
   @Test
   public void testInitialUrlConnectFailure() throws Exception {
@@ -60,19 +42,6 @@ public class FailoverJdbcConnectionTest
     conn.setAlwaysValidateConnection(false);
     List<String> urls = conn.getConnectUrls();
     conn.setConnectUrls(Arrays.asList(new String[] {PROPERTIES.getProperty("jdbc.url") + nameGen.create(this), urls.get(0)}));
-
-    LifecycleHelper.init(conn);
-    conn.connect();
-  }
-
-  @Test
-  public void testTestStatementEmptyString() throws Exception {
-    FailoverJdbcConnection conn = configure(createConnection());
-    conn.setAlwaysValidateConnection(true);
-    conn.setTestStatement("");
-    List<String> urls = conn.getConnectUrls();
-    conn.setConnectUrls(Arrays.asList(new String[] {PROPERTIES.getProperty("jdbc.url") + nameGen.create(this), urls.get(0)}));
-
     LifecycleHelper.init(conn);
     conn.connect();
   }
@@ -87,7 +56,6 @@ public class FailoverJdbcConnectionTest
     String url = initialiseDatabase();
     conn1.addConnectUrl(url);
     conn1.setDriverImp(DRIVER_IMP);
-    conn1.setTestStatement(DEFAULT_TEST_STATEMENT);
     conn1.setDebugMode(true);
     conn1.setConnectionAttempts(1);
     conn1.setConnectionRetryInterval(new TimeInterval(10L, TimeUnit.MILLISECONDS.name()));

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/FailoverPasswordProtectedDatabaseConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/FailoverPasswordProtectedDatabaseConnectionTest.java
@@ -15,13 +15,16 @@
 */
 
 package com.adaptris.core.jdbc;
-import static org.junit.Assert.fail;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.concurrent.TimeUnit;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.TimeInterval;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
 
 public class FailoverPasswordProtectedDatabaseConnectionTest extends PasswordProtectedDatabaseConnectionTest {
 
@@ -36,7 +39,6 @@ public class FailoverPasswordProtectedDatabaseConnectionTest extends PasswordPro
     conn1.setPassword(PROPERTIES.getProperty(KEY_JDBC_PASSWORD));
     conn1.setConnectionAttempts(1);
     conn1.setConnectionRetryInterval(new TimeInterval(10L, TimeUnit.MILLISECONDS.name()));
-    conn1.setTestStatement(PROPERTIES.getProperty(KEY_JDBC_TEST_STATEMENT));
     conn1.setDebugMode(true);
     
     return conn1;

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcPooledConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcPooledConnectionTest.java
@@ -15,18 +15,7 @@
 */
 
 package com.adaptris.core.jdbc;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-import org.awaitility.Awaitility;
-import org.junit.Test;
+
 import com.adaptris.core.ClosedState;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.StartedState;
@@ -35,6 +24,20 @@ import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.TimeInterval;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
+import org.awaitility.Awaitility;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class JdbcPooledConnectionTest
     extends com.adaptris.interlok.junit.scaffolding.DatabaseConnectionCase<JdbcPooledConnection> {
@@ -133,7 +136,6 @@ public class JdbcPooledConnectionTest
     Thread.currentThread().setName("testConnectionDataSource_Poolsize");
 
     JdbcPooledConnection con = configure(createConnection());
-    con.setTestStatement("");
     con.setConnectUrl("jdbc:derby:memory:" + GUID.safeUUID() + ";create=true");
     con.setDriverImp("org.apache.derby.jdbc.EmbeddedDriver");
     con.setMinimumPoolSize(1);

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/DatabaseConnectionCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/DatabaseConnectionCase.java
@@ -36,8 +36,6 @@ import com.adaptris.util.TimeInterval;
 public abstract class DatabaseConnectionCase<T extends DatabaseConnection> extends BaseCase {
   protected static final String DRIVER_IMP = "org.apache.derby.jdbc.EmbeddedDriver";
 
-  protected static final String DEFAULT_TEST_STATEMENT = "SELECT seq_number from sequences where id='id'";
-
   protected static GuidGenerator nameGen = new GuidGenerator();
 
   public DatabaseConnectionCase() {
@@ -85,21 +83,6 @@ public abstract class DatabaseConnectionCase<T extends DatabaseConnection> exten
   }
 
   @Test
-  public void testInvalidSelectStatement() throws Exception {
-    DatabaseConnection conn = configure(createConnection());
-    conn.setTestStatement("What Ho");
-    conn.setAlwaysValidateConnection(true);
-    try {
-      LifecycleHelper.init(conn);
-      conn.connect();
-      fail("Expected exception");
-    }
-    catch (Exception expected) {
-      ;
-    }
-  }
-
-  @Test
   public void testConnectionWhenNotInitialised() throws Exception {
     DatabaseConnection con = configure(createConnection());
     try {
@@ -114,7 +97,6 @@ public abstract class DatabaseConnectionCase<T extends DatabaseConnection> exten
   @Test
   public void testConnectWithoutDebugMode() throws Exception {
     DatabaseConnection conn = configure(createConnection());
-    conn.setTestStatement(DEFAULT_TEST_STATEMENT);
     conn.setDebugMode(false);
     LifecycleHelper.init(conn);
     conn.connect();
@@ -124,7 +106,6 @@ public abstract class DatabaseConnectionCase<T extends DatabaseConnection> exten
   public void testConnectWithDebugMode() throws Exception {
     DatabaseConnection conn = configure(createConnection());
     conn.setDebugMode(true);
-    conn.setTestStatement(DEFAULT_TEST_STATEMENT);
     LifecycleHelper.init(conn);
     conn.connect();
   }
@@ -133,7 +114,6 @@ public abstract class DatabaseConnectionCase<T extends DatabaseConnection> exten
   public void testConnectWithAlwaysValidate() throws Exception {
     DatabaseConnection conn = configure(createConnection());
     conn.setAlwaysValidateConnection(true);
-    conn.setTestStatement(DEFAULT_TEST_STATEMENT);
     LifecycleHelper.init(conn);
     conn.connect();
   }
@@ -142,7 +122,6 @@ public abstract class DatabaseConnectionCase<T extends DatabaseConnection> exten
   public void testConnectWithoutAlwaysValidate() throws Exception {
     DatabaseConnection conn = configure(createConnection());
     conn.setAlwaysValidateConnection(false);
-    conn.setTestStatement(DEFAULT_TEST_STATEMENT);
     LifecycleHelper.init(conn);
     conn.connect();
   }
@@ -152,7 +131,6 @@ public abstract class DatabaseConnectionCase<T extends DatabaseConnection> exten
     DatabaseConnection conn = configure(createConnection());
     conn.setDebugMode(true);
     conn.setAlwaysValidateConnection(true);
-    conn.setTestStatement(DEFAULT_TEST_STATEMENT);
     LifecycleHelper.init(conn);
     conn.connect();
   }

--- a/interlok-core/src/test/java/com/adaptris/jdbc/connection/FailoverConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/jdbc/connection/FailoverConnectionTest.java
@@ -16,12 +16,21 @@
 
 package com.adaptris.jdbc.connection;
 
+import com.adaptris.core.util.JdbcUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_ALWAYS_VERIFY;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_AUTO_COMMIT;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_DEBUG;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_DRIVER;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_PASSWORD;
-import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_TEST_STATEMENT;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_URL_ROOT;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_USERNAME;
 import static org.junit.Assert.assertEquals;
@@ -29,14 +38,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Properties;
-import org.junit.Before;
-import org.junit.Test;
-import com.adaptris.core.util.JdbcUtil;
 
 /**
  *
@@ -61,13 +62,6 @@ public class FailoverConnectionTest extends com.adaptris.interlok.junit.scaffold
     }
     try {
       fc1.addConnectionUrl(null);
-      fail("Expected IllegalArgumentException");
-    }
-    catch (IllegalArgumentException expected) {
-
-    }
-    try {
-      fc1.setTestStatement(null);
       fail("Expected IllegalArgumentException");
     }
     catch (IllegalArgumentException expected) {
@@ -217,7 +211,6 @@ public class FailoverConnectionTest extends com.adaptris.interlok.junit.scaffold
     fc.setAlwaysValidateConnection(true);
     fc.setAutoCommit(true);
     fc.setDatabaseDriver(PROPERTIES.getProperty("jdbc.driver"));
-    fc.setTestStatement("SELECT seq_number from sequences where id='id'");
     fc.setDebugMode(true);
     return fc;
   }
@@ -228,7 +221,6 @@ public class FailoverConnectionTest extends com.adaptris.interlok.junit.scaffold
     p.setProperty(JDBC_AUTO_COMMIT, "true");
     p.setProperty(JDBC_DEBUG, "true");
     p.setProperty(JDBC_ALWAYS_VERIFY, "true");
-    p.setProperty(JDBC_TEST_STATEMENT, "SELECT seq_number from sequences where id='id'");
     p.setProperty(JDBC_URL_ROOT + ".1", PROPERTIES.getProperty("jdbc.url"));
     p.setProperty(JDBC_URL_ROOT + ".2", PROPERTIES.getProperty("jdbc.url.2"));
     return p;

--- a/interlok-core/src/test/java/com/adaptris/jdbc/connection/FailoverDatasourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/jdbc/connection/FailoverDatasourceTest.java
@@ -19,7 +19,6 @@ import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_ALWAYS_VERIFY;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_AUTO_COMMIT;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_DEBUG;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_DRIVER;
-import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_TEST_STATEMENT;
 import static com.adaptris.jdbc.connection.FailoverConfig.JDBC_URL_ROOT;
 import static com.adaptris.jdbc.connection.FailoverConnectionTest.createTables;
 import static org.junit.Assert.assertEquals;
@@ -508,7 +507,6 @@ public class FailoverDatasourceTest extends FailoverDataSource {
     p.setProperty(JDBC_AUTO_COMMIT, "true");
     p.setProperty(JDBC_DEBUG, "true");
     p.setProperty(JDBC_ALWAYS_VERIFY, "true");
-    p.setProperty(JDBC_TEST_STATEMENT, "VALUES CURRENT_TIMESTAMP");
     p.setProperty(JDBC_URL_ROOT + ".1", "jdbc:derby:memory:jdbc-failover-ds-1;create=true");
     p.setProperty(JDBC_URL_ROOT + ".2", "jdbc:derby:memory:jdbc-failover-ds-2;create=true");
     return p;


### PR DESCRIPTION
## Motivation

We are using JDK1.8 and going for 11; a java.sql.Connection#isValid(int) method which should be used to check the validity of the connection has been available since 1.6

Surely by now, all the JDBC drivers will be JDBC4 compatible (we would need to re-visit this if they aren't).

## Modification

Remove all uses of DatabaseConnection member testConnection.

## Result

There is no need for the end user to set a test connection SQL statement.

## Testing

There should no longer be the testConnection field in the UI. The unit tests should still execute as expected. DB connections should still work as expected.
