### PR TITLE
INTERLOK-3537 JMS durable subscriber is not durable with just subscription-id

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConsumer.java
@@ -18,9 +18,7 @@ package com.adaptris.core.jms;
 
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
-
 import org.apache.commons.lang3.BooleanUtils;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -29,8 +27,8 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.CoreException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -71,6 +69,7 @@ recommended = {JmsConnection.class})
 @DisplayOrder(
     order = {"endpoint", "messageSelector", "destination", "acknowledgeMode",
     "messageTranslator"})
+@NoArgsConstructor
 public class JmsConsumer extends JmsConsumerImpl {
 
   /**
@@ -96,14 +95,6 @@ public class JmsConsumer extends JmsConsumerImpl {
   @Setter
   // Needs to be @NotBlank when destination is removed.
   private String endpoint;
-
-  public JmsConsumer() {
-  }
-
-  // Here for test purposes.
-  JmsConsumer(boolean transacted) {
-    super(transacted);
-  }
 
   public JmsConsumer withEndpoint(String s) {
     setEndpoint(s);

--- a/interlok-core/src/main/java/com/adaptris/core/jms/PasConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/PasConsumer.java
@@ -30,8 +30,8 @@ import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.util.Args;
 import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -48,6 +48,7 @@ import lombok.Setter;
 recommended = {JmsConnection.class})
 @DisplayOrder(order = {"topic", "messageSelector", "destination", "durable",
     "subscriptionId", "acknowledgeMode", "messageTranslator"})
+@NoArgsConstructor
 public class PasConsumer extends JmsConsumerImpl {
 
   /**
@@ -83,13 +84,6 @@ public class PasConsumer extends JmsConsumerImpl {
 
   private transient boolean durableWarningLogged = false;
 
-  public PasConsumer() {
-    super();
-  }
-
-  PasConsumer(boolean b) {
-    super(b);
-  }
 
   protected String subscriptionId() {
     if (durable()) {

--- a/interlok-core/src/main/java/com/adaptris/core/jms/PasConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/PasConsumer.java
@@ -18,9 +18,8 @@ package com.adaptris.core.jms;
 
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
-
 import org.apache.commons.lang3.BooleanUtils;
-
+import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -98,7 +97,7 @@ public class PasConsumer extends JmsConsumerImpl {
     super.prepare();
     if (getDurable() != null) {
       LoggingHelper.logWarning(durableWarningLogged, () -> durableWarningLogged = true,
-          "{} uses 'durable', this will be implied if subscrption-id is not blank",
+          "{} uses 'durable', this will be implied if subscription-id is not blank",
           LoggingHelper.friendlyName(this));
 
     }
@@ -123,6 +122,9 @@ public class PasConsumer extends JmsConsumerImpl {
   }
 
   boolean durable() {
-    return BooleanUtils.toBooleanDefaultIfNull(getDurable(), false);
+    return BooleanUtils.or(new boolean[] {
+        BooleanUtils.toBooleanDefaultIfNull(getDurable(), false),
+        !StringUtils.isBlank(getSubscriptionId())
+    });
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/PtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/PtpConsumer.java
@@ -24,6 +24,7 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.CoreException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -41,6 +42,7 @@ import lombok.Setter;
 @DisplayOrder(
     order = {"queue", "messageSelector", "destination", "acknowledgeMode",
     "messageTranslator"})
+@NoArgsConstructor
 public class PtpConsumer extends JmsConsumerImpl {
 
   /**
@@ -51,15 +53,6 @@ public class PtpConsumer extends JmsConsumerImpl {
   @Setter
   // Needs to be @NotBlank when destination is removed.
   private String queue;
-
-  public PtpConsumer() {
-    super();
-  }
-
-  PtpConsumer(boolean b) {
-    super(b);
-  }
-
 
   @Override
   protected String configuredEndpoint() {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasConsumerTest.java
@@ -16,6 +16,9 @@
 
 package com.adaptris.core.jms;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
 
@@ -50,5 +53,26 @@ public class PasConsumerTest extends com.adaptris.interlok.junit.scaffolding.jms
     result.setConsumer(pc);
 
     return result;
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testDurable_Deprecated() throws Exception {
+    JmsConnection c = new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:16161"));
+    PasConsumer pas = new PasConsumer();
+    pas.setTopic("destination");
+    assertFalse(pas.durable());
+    pas.setDurable(Boolean.TRUE);
+    assertTrue(pas.durable());
+  }
+
+  @Test
+  public void testDurable_WithSubscriptionId() throws Exception {
+    JmsConnection c = new JmsConnection(new BasicActiveMqImplementation("tcp://localhost:16161"));
+    PasConsumer pas = new PasConsumer();
+    pas.setTopic("destination");
+    assertFalse(pas.durable());
+    pas.setSubscriptionId("MySubscriptionId");
+    assertTrue(pas.durable());
   }
 }


### PR DESCRIPTION
## Motivation

Even though durable is deprecated, this is still required as configuration otherwise everything is a non-durable subscriber

In order for the subscriber to be durable, you still need `durable=true`. This was a regression introduced into PasConsumer by the changes for 3.11.0.

## Modification

Change durable() method to be 

```
  boolean durable() {
    return BooleanUtils.or(new boolean[] {
        BooleanUtils.toBooleanDefaultIfNull(getDurable(), false),
        !StringUtils.isBlank(getSubscriptionId())
    });
  }
```

## Result

Regression is fixed from 3.11.0

## Testing

Confirm the bug  in 3.11.x

- Start your JMS Broker of choice.
- 3.11.1 -> Create a PasConsumer with a subscriptionId but no "durable flag".
- Produce some messages to the topic and confirm they are consumed.
- Kill the consumer channel.
- Produce some more messages, and then restart the consumer workflow...
    - These messages are never consumed, so the consumer was never durable.

Redo the test with this PR branch; the 2nd lot of messages should be consumed, which proves that the subscriber is durable; or you can just trust the test `BasicActiveMqProducerTest#testTopicProduceAndConsume_DurableSubscriber`

