### PR TITLE
updated the ConfigDeprecated/Removal annotations; from 3.12 to 4

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
@@ -27,7 +27,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @deprecated since 3.10.2
  */
 @Deprecated
-@ConfigDeprecated(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "3.12.0", groups = Deprecated.class)
+@ConfigDeprecated(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "4.0.0", groups = Deprecated.class)
 @XStreamAlias("restart-produce-exception-handler")
 public class RestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyRouteSpec.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyRouteSpec.java
@@ -69,15 +69,15 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 public class JettyRouteSpec implements ComponentLifecycle {
 
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a condition instead", groups = Deprecated.class)
   private String urlPattern;
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a condition instead", groups = Deprecated.class)
   private String method;
   @XStreamImplicit(itemFieldName = "metadata-key")
   @AffectsMetadata
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a condition instead", groups = Deprecated.class)
   private List<String> metadataKeys;
   @NotBlank
   private String serviceId;
@@ -125,7 +125,7 @@ public class JettyRouteSpec implements ComponentLifecycle {
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a condition instead", groups = Deprecated.class)
   public String getUrlPattern() {
     return urlPattern;
   }
@@ -137,7 +137,7 @@ public class JettyRouteSpec implements ComponentLifecycle {
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @Removal(version = "4.0.0", message = "Use a condition instead")
   public void setUrlPattern(String urlPattern) {
     this.urlPattern = Args.notBlank(urlPattern, "urlPattern");
   }
@@ -151,7 +151,7 @@ public class JettyRouteSpec implements ComponentLifecycle {
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a condition instead", groups = Deprecated.class)
   public String getMethod() {
     return method;
   }
@@ -162,7 +162,7 @@ public class JettyRouteSpec implements ComponentLifecycle {
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @Removal(version = "4.0.0", message = "Use a condition instead")
   public void setMethod(String method) {
     this.method = method;
   }
@@ -172,7 +172,7 @@ public class JettyRouteSpec implements ComponentLifecycle {
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a condition instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a condition instead", groups = Deprecated.class)
   public List<String> getMetadataKeys() {
     return metadataKeys;
   }
@@ -191,7 +191,7 @@ public class JettyRouteSpec implements ComponentLifecycle {
    * @deprecated since 3.9.0 use a condition instead
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a condition instead")
+  @Removal(version = "4.0.0", message = "Use a condition instead")
   public void setMetadataKeys(List<String> s) {
     metadataKeys = s;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/http/oauth/GetOauthToken.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/oauth/GetOauthToken.java
@@ -36,17 +36,17 @@ public class GetOauthToken extends OauthTokenGetter {
   @AffectsMetadata
   @InputFieldDefault(value = "Authorization")
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   private String tokenKey;
   @AffectsMetadata
   @AdvancedConfig
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   private String tokenExpiryKey;
   @AffectsMetadata
   @AdvancedConfig
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   private String refreshTokenKey;
 
   private transient boolean warningLogged = false;
@@ -84,7 +84,7 @@ public class GetOauthToken extends OauthTokenGetter {
 
 
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   public String getTokenKey() {
     return tokenKey;
   }
@@ -95,21 +95,21 @@ public class GetOauthToken extends OauthTokenGetter {
    * @param key the key.
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
+  @Removal(version = "4.0.0", message = "Use a access-token-writer instead")
   public void setTokenKey(String key) {
     tokenKey = Args.notBlank(key, "tokenMetadataKey");
   }
 
 
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
+  @Removal(version = "4.0.0", message = "Use a access-token-writer instead")
   public GetOauthToken withTokenExpiryKey(String b) {
     setTokenExpiryKey(b);
     return this;
   }
 
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a access-token-writer instead", groups = Deprecated.class)
   public String getTokenExpiryKey() {
     return tokenExpiryKey;
   }
@@ -123,20 +123,20 @@ public class GetOauthToken extends OauthTokenGetter {
    * @param key key.
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-writer instead")
+  @Removal(version = "4.0.0", message = "Use a access-token-writer instead")
   public void setTokenExpiryKey(String key) {
     tokenExpiryKey = Args.notBlank(key, "tokenExpiryKey");
   }
 
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-write instead")
+  @Removal(version = "4.0.0", message = "Use a access-token-write instead")
   public GetOauthToken withRefreshTokenKey(String refreshMetadataKey) {
     setRefreshTokenKey(refreshMetadataKey);
     return this;
   }
 
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use a access-token-write instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use a access-token-write instead", groups = Deprecated.class)
   public String getRefreshTokenKey() {
     return refreshTokenKey;
   }
@@ -150,7 +150,7 @@ public class GetOauthToken extends OauthTokenGetter {
    * @param key key.
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use a access-token-write instead")
+  @Removal(version = "4.0.0", message = "Use a access-token-write instead")
   public void setRefreshTokenKey(String key) {
     refreshTokenKey = key;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadFromMetadataService.java
@@ -56,7 +56,7 @@ public class PayloadFromMetadataService extends PayloadFromTemplateService {
   @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "true")
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "use quote-replacement instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "use quote-replacement instead", groups = Deprecated.class)
   private Boolean escapeBackslash;
 
   private transient boolean warningLogged = false;
@@ -85,7 +85,7 @@ public class PayloadFromMetadataService extends PayloadFromTemplateService {
    * @deprecated since 3.10.0, use {@link #setQuoteReplacement(Boolean)} instead.
    */
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "use quote-replacement instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "use quote-replacement instead", groups = Deprecated.class)
   public Boolean getEscapeBackslash() {
     return escapeBackslash;
   }
@@ -101,7 +101,7 @@ public class PayloadFromMetadataService extends PayloadFromTemplateService {
    * @param b the value to set
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "use quote-replacement instead")
+  @Removal(version = "4.0.0", message = "use quote-replacement instead")
   public void setEscapeBackslash(Boolean b) {
     escapeBackslash = b;
   }
@@ -111,7 +111,7 @@ public class PayloadFromMetadataService extends PayloadFromTemplateService {
    * @deprecated since 3.10.0, use {@link #setQuoteReplacement(Boolean)} instead.
    */
   @Deprecated
-  @Removal(version = "3.12.0", message = "use quote-replacement instead")
+  @Removal(version = "4.0.0", message = "use quote-replacement instead")
   public PayloadFromMetadataService withEscapeBackslash(Boolean b) {
     setEscapeBackslash(b);
     return this;

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlSchemaValidator.java
@@ -79,7 +79,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
     CacheConnection.class
 })
 @Deprecated
-@ConfigDeprecated(removalVersion = "3.12.0", message="Use basic-xml-schema-validator or extended-xml-schema-validator instead", groups = Deprecated.class)
+@ConfigDeprecated(removalVersion = "4.0.0", message="Use basic-xml-schema-validator or extended-xml-schema-validator instead", groups = Deprecated.class)
 public class XmlSchemaValidator extends MessageValidatorImpl {
 
   private static final int DEFAULT_CACHE_SIZE = 16;

--- a/interlok-core/src/main/java/com/adaptris/core/util/CloseableIterable.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/CloseableIterable.java
@@ -27,14 +27,14 @@ import com.adaptris.validation.constraints.ConfigDeprecated;
  * @deprecated since 3.10.2 moved to com.adaptris.interlok.util package.
  */
 @Deprecated
-@ConfigDeprecated(removalVersion = "3.12.0", groups = Deprecated.class)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public interface CloseableIterable<E> extends com.adaptris.interlok.util.CloseableIterable<E> {
 
   /**
    * @deprecated since 3.10.2 use {@link com.adaptris.interlok.util.CloseableIterable#ensureCloseable(Iterable)} instead.
    */
   @Deprecated
-  @Removal(version="3.12.0")
+  @Removal(version="4.0.0")
   static <E> CloseableIterable<E> ensureCloseable(final Iterable<E> iter) {
     if (iter instanceof CloseableIterable) {
       return (CloseableIterable<E>) iter;


### PR DESCRIPTION
## Motivation

Config components are marked as being removed in 3.12.0 but these changes are now being delayed until 4.0.0

## Modification

updated the ConfigDeprecated/Removal annotations

## Result

any warnings generated from config checker / ui will be correct

## Testing

just eyeball the changes and make sure nothing stupid was done
