### PR TITLE
INTERLOK-3561 ThreadContextWorkflow

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,24 +16,17 @@
 
 package com.adaptris.core;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import org.apache.commons.lang3.Range;
-import org.apache.commons.pool2.PooledObject;
-import org.apache.commons.pool2.PooledObjectFactory;
-import org.apache.commons.pool2.impl.DefaultPooledObject;
-import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.ObjectPool;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -46,6 +39,8 @@ import com.adaptris.util.FifoMutexLock;
 import com.adaptris.util.NumberUtils;
 import com.adaptris.util.TimeInterval;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * A Workflow that pools ServiceCollections.
@@ -70,10 +65,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <code>AdaptrisMessageConsumer</code> is succesfully stopped will be treated as <b>bad</b> messages and sent directly to the
  * configured {@link com.adaptris.core.ProcessingExceptionHandler}.
  * </p>
- * 
+ *
  * @config pooling-workflow
- * 
- * 
+ *
+ *
  * @author lchan
  * @author $Author: lchan $
  * @see ProcessingExceptionHandler
@@ -82,22 +77,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Workflow with a thread pool handling the service chain", tag = "workflow,base")
 @DisplayOrder(order = {"poolSize", "minIdle", "maxIdle", "threadPriority", "disableDefaultMessageCount"})
-public class PoolingWorkflow extends WorkflowImp {
+public class PoolingWorkflow extends WorkflowWithObjectPool {
 
-  /**
-   * The default maximum pool size.
-   *
-   */
-  public static final int DEFAULT_MAX_POOLSIZE = 10;
-  /**
-   * the default minimum idle size.
-   *
-   */
-  public static final int DEFAULT_MIN_IDLE = 1;
-  /**
-   * The default max idle size.
-   */
-  public static final int DEFAULT_MAX_IDLE = DEFAULT_MAX_POOLSIZE;
 
   /**
    * The default thread lifetime.
@@ -109,37 +90,49 @@ public class PoolingWorkflow extends WorkflowImp {
    *
    */
   private static final TimeInterval DEFAULT_SHUTDOWN_WAIT = new TimeInterval(1L, TimeUnit.MINUTES.name());
-  /**
-   * The default wait time for pool initialisation
-   *
-   */
-  private static final TimeInterval DEFAULT_INIT_WAIT = new TimeInterval(1L, TimeUnit.MINUTES.name());
+
 
   private static final Range PRIORITY_RANGE =
       Range.between(Thread.MIN_PRIORITY, Thread.MAX_PRIORITY);
 
   private transient boolean priorityWarningLogged = false;
 
-  @InputFieldDefault(value = "10")
-  private Integer poolSize;
-  @InputFieldDefault(value = "1")
-  private Integer minIdle;
-  @InputFieldDefault(value = "10")
-  private Integer maxIdle;
-
+  /**
+   * Set the lifetime for threads in the pool.
+   * <p>
+   * Threads that have been dormant for the specified interval are discarded.
+   * </p>
+   */
   @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "1 minute")
   @Valid
+  @Getter
+  @Setter
   private TimeInterval threadKeepAlive;
+  /**
+   * Set the shutdown wait timeout for the pool.
+   * <p>
+   * When <code>stop()</code> is invoked, this causes a emptying and shutdown of the pool. The
+   * specified value is the amount of time to wait for a clean shutdown. If this timeout is exceeded
+   * then a forced shutdown ensues, which may mean messages are in an inconsistent state.
+   * </p>
+   *
+   *
+   */
   @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "1 minute")
   @Valid
+  @Getter
+  @Setter
   private TimeInterval shutdownWaitTime;
-  @AdvancedConfig(rare = true)
-  @InputFieldDefault(value = "1 minute")
-  @Valid
-  private TimeInterval initWaitTime;
 
+
+  /**
+   * The priority for threads created to handle messages.
+   *
+   */
+  @Getter
+  @Setter
   @AdvancedConfig
   @InputFieldDefault(value = "5")
   @Min(Thread.MIN_PRIORITY)
@@ -147,44 +140,18 @@ public class PoolingWorkflow extends WorkflowImp {
   private Integer threadPriority;
 
   private transient ExecutorService threadPool;
-  private transient GenericObjectPool<Worker> objectPool;
+  private transient ObjectPool<Worker> objectPool;
   private transient FifoMutexLock poolLock;
-  private transient AdaptrisMarshaller serviceListMarshaller;
   private transient String currentThreadName;
-  private transient ServiceCollection marshalledServiceCollection;
 
   public PoolingWorkflow() {
     super();
     poolLock = new FifoMutexLock();
-    serviceListMarshaller = DefaultMarshaller.getDefaultMarshaller();
   }
 
   public PoolingWorkflow(String uniqueId) throws CoreException {
     this();
     setUniqueId(uniqueId);
-  }
-
-  /**
-   * Set the size of the pool.
-   *
-   * @param i the size of the pool
-   */
-  public void setPoolSize(Integer i) {
-    poolSize = i;
-  }
-
-  /**
-   * Get the size of the pool.
-   *
-   * @return the size.
-   * @see #setPoolSize(Integer)
-   */
-  public Integer getPoolSize() {
-    return poolSize;
-  }
-
-  public int poolSize() {
-    return NumberUtils.toIntDefaultIfNull(getPoolSize(), DEFAULT_MAX_POOLSIZE);
   }
 
   public long threadLifetimeMs() {
@@ -195,41 +162,6 @@ public class PoolingWorkflow extends WorkflowImp {
     return TimeInterval.toMillisecondsDefaultIfNull(getShutdownWaitTime(), DEFAULT_SHUTDOWN_WAIT);
   }
 
-  public TimeInterval getThreadKeepAlive() {
-    return threadKeepAlive;
-  }
-
-  /**
-   * Set the lifetime for threads in the pool.
-   * <p>
-   * Threads that have been dormant for the specified interval are discarded.
-   * </p>
-   *
-   * @param interval the lifetime (default is 60 seconds)
-   */
-  public void setThreadKeepAlive(TimeInterval interval) {
-    threadKeepAlive = interval;
-  }
-
-  public TimeInterval getShutdownWaitTime() {
-    return shutdownWaitTime;
-  }
-
-  /**
-   * Set the shutdown wait timeout for the pool.
-   * <p>
-   * When <code>stop()</code> is invoked, this causes a emptying and shutdown of the pool. The specified value is the amount of time
-   * to wait for a clean shutdown. If this timeout is exceeded then a forced shutdown ensues, which may mean messages are in an
-   * inconsistent state.
-   * </p>
-   *
-   * @param interval the shutdown time (default is 60 seconds)
-   * @see #stop()
-   */
-  public void setShutdownWaitTime(TimeInterval interval) {
-    shutdownWaitTime = interval;
-  }
-
   /**
    * Initialise the workflow.
    *
@@ -238,21 +170,12 @@ public class PoolingWorkflow extends WorkflowImp {
    */
   @Override
   protected void initialiseWorkflow() throws CoreException {
-
-    if (maxIdle() > poolSize()) {
-      log.warn("Maximum number of idle workers > pool-size, re-sizing max-idle");
-      setMaxIdle(poolSize());
-    }
-    if (minIdle() > poolSize()) {
-      log.warn("Minimum number of idle workers > pool-size, re-sizing min-idle");
-      setMinIdle(poolSize());
-    }
-    if (minIdle() > maxIdle()) {
-      log.warn("Minimum number of idle workers > max-idle, max-idle modified");
-      setMaxIdle(minIdle());
-    }
-    marshalledServiceCollection = cloneServiceCollection(getServiceCollection());
-    LifecycleHelper.prepare(marshalledServiceCollection);
+    checkPoolConfig();
+    // simply checks that the service collection is ready for work so call prepare()
+    // to check any licensing restrictions.
+    // init() is done during start.
+    ServiceCollection prepareCheck = cloneServiceCollection(getServiceCollection());
+    LifecycleHelper.prepare(prepareCheck);
     LifecycleHelper.init(getProducer());
     getConsumer().registerAdaptrisMessageListener(this);
     LifecycleHelper.init(getConsumer());
@@ -268,7 +191,7 @@ public class PoolingWorkflow extends WorkflowImp {
     LifecycleHelper.start(getProducer());
     objectPool = createObjectPool();
     threadPool = createExecutor();
-    populatePool();
+    populatePool(objectPool);
     LifecycleHelper.start(getConsumer());
   }
 
@@ -293,38 +216,8 @@ public class PoolingWorkflow extends WorkflowImp {
     LifecycleHelper.stop(getProducer());
   }
 
-  /**
-   * Process a message from the <code>MessageConsumer</code>
-   * <p>
-   * If <code>stop()</code> is invoked then any messages that are currently being processed will be allowed to finish, however any
-   * new messages that enter the workflow via <code>onAdaptrisMessage(AdaptrisMessage)</code> will be treated as BAD messages and
-   * sent directly to the configured MessageErrorHandler.
-   * </p>
-   *
-   * @see WorkflowImp#handleBadMessage(AdaptrisMessage)
-   *
-   */
   @Override
-  public void onAdaptrisMessage(final AdaptrisMessage msg, Consumer<AdaptrisMessage> success, Consumer<AdaptrisMessage> failure) {
-    ListenerCallbackHelper.prepare(msg, success, failure);
-    if (!obtainChannel().isAvailable()) {
-      handleChannelUnavailable(msg);
-    }
-    else {
-      onMessage(msg);
-    }
-  }
-  
-  /**
-   *
-   * @see WorkflowImp#resubmitMessage(com.adaptris.core.AdaptrisMessage)
-   */
-  @Override
-  protected void resubmitMessage(AdaptrisMessage msg) {
-    onMessage(msg);
-  }
-
-  private void onMessage(AdaptrisMessage msg) {
+  protected void onMessage(AdaptrisMessage msg) {
     try {
       addConsumeLocation(msg);
       currentThreadName = Thread.currentThread().getName();
@@ -392,20 +285,6 @@ public class PoolingWorkflow extends WorkflowImp {
     super.sendMessageLifecycleEvent(msg);
   }
 
-  private GenericObjectPool<Worker> createObjectPool() {
-    GenericObjectPool<Worker> pool = new GenericObjectPool<>(new WorkerFactory());
-    long lifetime = threadLifetimeMs();
-    pool.setMaxTotal(poolSize());
-    pool.setMinIdle(minIdle());
-    pool.setMaxIdle(maxIdle());
-    pool.setMaxWaitMillis(-1L);
-    pool.setBlockWhenExhausted(true);
-    pool.setSoftMinEvictableIdleTimeMillis(lifetime);
-    pool.setTimeBetweenEvictionRunsMillis(
-        lifetime + ThreadLocalRandom.current().nextLong(lifetime));
-    return pool;
-  }
-
   private ExecutorService createExecutor() {
     ExecutorService es = Executors.newCachedThreadPool(new WorkerThreadFactory());
     if (es instanceof ThreadPoolExecutor) {
@@ -414,39 +293,6 @@ public class PoolingWorkflow extends WorkflowImp {
     return es;
   }
 
-  private void populatePool() throws CoreException {
-    int size = minIdle();
-    ExecutorService populator = Executors.newCachedThreadPool();
-    try {
-      final CyclicBarrier barrier = new CyclicBarrier(size + 1);
-      log.trace("Need more ({}) children as soon as possible to handle work. Get to it", size);
-      final List<Worker> workers = new ArrayList<>(size);
-      for (int i = 0; i < size; i++) {
-        populator.execute(new Runnable() {
-          @Override
-          public void run() {
-            try {
-              Worker w = objectPool.borrowObject();
-              workers.add(w);
-              barrier.await(initWaitTimeMs(), TimeUnit.MILLISECONDS);
-            }
-            catch (Exception e) {
-              barrier.reset();
-            }
-          }
-        });
-      }
-      barrier.await(initWaitTimeMs(), TimeUnit.MILLISECONDS);
-      for (Worker worker : workers) {
-        objectPool.returnObject(worker);
-      }
-    }
-    catch (Exception e) {
-      throw new CoreException(e);
-    } finally {
-      populator.shutdownNow();
-    }
-  }
 
   private void shutdownPool() {
     try {
@@ -469,68 +315,6 @@ public class PoolingWorkflow extends WorkflowImp {
     poolLock.release();
   }
 
-  public Integer getThreadPriority() {
-    return threadPriority;
-  }
-
-  public void setThreadPriority(Integer i) {
-    threadPriority = i;
-  }
-
-  /**
-   * Return the minimum idle objects in the pool.
-   *
-   * @return the minimum idle number
-   */
-  public Integer getMinIdle() {
-    return minIdle;
-  }
-
-  /**
-   * Set the minimum number of idle objects in the pool.
-   *
-   * @param i the minIdle to set
-   */
-  public void setMinIdle(Integer i) {
-    minIdle = i;
-  }
-
-  /**
-   * Return the maximum idle objects in the pool.
-   *
-   * @return the maximum idle number
-   */
-  public int minIdle() {
-    return NumberUtils.toIntDefaultIfNull(getMinIdle(), DEFAULT_MIN_IDLE);
-  }
-
-  /**
-   * Return the maximum idle objects in the pool.
-   *
-   * @return the maximum idle number
-   */
-  public Integer getMaxIdle() {
-    return maxIdle;
-  }
-
-  /**
-   * Set the maximum number of idle objects in the pool.
-   *
-   * @param i the maxIdle to set (default 10)
-   */
-  public void setMaxIdle(Integer i) {
-    maxIdle = i;
-  }
-
-  /**
-   * Return the maximum idle objects in the pool.
-   *
-   * @return the maximum idle number
-   */
-  public int maxIdle() {
-    return NumberUtils.toIntDefaultIfNull(getMaxIdle(), DEFAULT_MAX_IDLE);
-  }
-
   public int threadPriority() {
     int priority = NumberUtils.toIntDefaultIfNull(getThreadPriority(), Thread.NORM_PRIORITY);
     if (!PRIORITY_RANGE.contains(priority)) {
@@ -541,30 +325,6 @@ public class PoolingWorkflow extends WorkflowImp {
       priority = Thread.NORM_PRIORITY;
     }
     return priority;
-  }
-
-
-  /**
-   * @return the initWaitTime
-   */
-  public TimeInterval getInitWaitTime() {
-    return initWaitTime;
-  }
-
-  /**
-   * Set the amount of time to wait for object pool population.
-   * <p>
-   * Upon start the object pool is populated with the {@link #minIdle()} number of workers.
-   * </p>
-   * 
-   * @param t the initWaitTime to set, default if not specified is 1 minute
-   */
-  public void setInitWaitTime(TimeInterval t) {
-    initWaitTime = t;
-  }
-
-  public long initWaitTimeMs() {
-    return TimeInterval.toMillisecondsDefaultIfNull(getInitWaitTime(), DEFAULT_INIT_WAIT);
   }
 
   /**
@@ -595,13 +355,6 @@ public class PoolingWorkflow extends WorkflowImp {
     return objectPool.getNumIdle();
   }
 
-  private ServiceCollection cloneServiceCollection(ServiceCollection original) throws CoreException {
-    ServiceCollection result = null;
-    result = (ServiceCollection) serviceListMarshaller.unmarshal(serviceListMarshaller.marshal(original));
-    LifecycleHelper.registerEventHandler(result, eventHandler);
-    return result;
-  }
-
   /**
    * Return the current number of active threads in the thread pool. This number is just a snaphot, and may change immediately upon
    * returning
@@ -611,10 +364,6 @@ public class PoolingWorkflow extends WorkflowImp {
   public int currentThreadPoolCount() {
     return ((ThreadPoolExecutor) threadPool).getPoolSize();
   }
-
-  @Override
-  protected void prepareWorkflow() throws CoreException {}
-
 
   private class WorkerThreadFactory extends ManagedThreadFactory {
 
@@ -635,50 +384,6 @@ public class PoolingWorkflow extends WorkflowImp {
 
   }
 
-  /**
-   * The Manager private class. This is responsible for creating objects when requested by the object pool
-   */
-  private class WorkerFactory implements PooledObjectFactory<Worker> {
-
-    WorkerFactory() {
-    }
-
-
-    @Override
-    public PooledObject<Worker> makeObject() throws Exception {
-      Worker w = null;
-      try {
-        w = new Worker();
-        w.start();
-      }
-      catch (Exception e) {
-        log.error("Error creating object for pool", e);
-        throw e;
-      }
-      return new DefaultPooledObject<>(w);
-    }
-
-
-    @Override
-    public void destroyObject(PooledObject<Worker> arg0) throws Exception {
-      arg0.getObject().stop();
-    }
-
-    @Override
-    public boolean validateObject(PooledObject<Worker> arg0) {
-      return arg0.getObject().isValid();
-    }
-
-
-    @Override
-    public void activateObject(PooledObject<Worker> arg0) throws Exception {
-    }
-
-    @Override
-    public void passivateObject(PooledObject<Worker> arg0) throws Exception {
-    }
-
-  }
 
   private class CallableWorker implements Callable<AdaptrisMessage> {
     private AdaptrisMessage message;
@@ -718,64 +423,6 @@ public class PoolingWorkflow extends WorkflowImp {
       }
       Thread.currentThread().setName(oldName);
       return result;
-    }
-  }
-
-
-  class Worker {
-
-    private ServiceCollection sc;
-
-    Worker() throws CoreException {
-      try {
-        sc = cloneServiceCollection(marshalledServiceCollection);
-      }
-      catch (Exception e) {
-        throw new CoreException(e);
-      }
-    }
-
-    public void start() throws CoreException {
-      LifecycleHelper.initAndStart(sc, false);
-    }
-
-    public void stop() throws CoreException {
-      LifecycleHelper.stopAndClose(sc, false);
-    }
-
-    public boolean isValid() {
-      return true;
-    }
-
-    public AdaptrisMessage handleMessage(AdaptrisMessage msg) {
-      AdaptrisMessage wip = null;
-      try {
-        long start = System.currentTimeMillis();
-        log.debug("start processing msg [{}]", messageLogger().toString(msg));
-        wip = (AdaptrisMessage) msg.clone();
-        // Set the channel id and workflow id on the message lifecycle.
-        wip.getMessageLifecycleEvent().setChannelId(obtainChannel().getUniqueId());
-        wip.getMessageLifecycleEvent().setWorkflowId(obtainWorkflowId());
-        wip.addEvent(getConsumer(), true);
-        sc.doService(wip);
-        doProduce(wip);
-        // handle success callback here.
-        // failure callback will be handled by the message-error-handler that's configured...
-        ListenerCallbackHelper.handleSuccessCallback(wip);
-        logSuccess(wip, start);
-      }
-      catch (ProduceException e) {
-        wip.addEvent(getProducer(), false);
-        handleBadMessage("Exception producing message", e, copyExceptionHeaders(wip, msg));
-        handleProduceException();
-      }
-      catch (Exception e) {
-        handleBadMessage("Exception processing message", e, copyExceptionHeaders(wip, msg));
-      }
-      finally {
-        sendMessageLifecycleEvent(wip);
-      }
-      return wip;
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/PoolingWorkflow.java
@@ -216,7 +216,7 @@ public class PoolingWorkflow extends WorkflowWithObjectPool {
   protected void onMessage(AdaptrisMessage msg) {
     try {
       addConsumeLocation(msg);
-      currentThreadName = Thread.currentThread().getName();
+      currentThreadName = friendlyName();
       if (poolLock.permitAvailable()) {
         workflowStart(msg);
         // workflowCompletion.add(msg, threadPool.submit(new CallableWorker(msg)));

--- a/interlok-core/src/main/java/com/adaptris/core/ThreadContextWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ThreadContextWorkflow.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core;
+
+import org.apache.commons.pool2.ObjectPool;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.util.Closer;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Workflow that executes services in the current thread.
+ *
+ * <p>
+ * This is different to {@link StandardWorkflow} in the sense that it does not synchronize on the
+ * {@code onAdaptrisMessage()} method and processes the message in the same thread as the caller.
+ * This is useful if you have a consumer that may be triggered by multiple threads (e.g. Jetty or
+ * JMS) but you don't want to use {@link PoolingWorkflow}. It is probably of little or no benefit
+ * where the consumer is a polling implementation.
+ * </p>
+ * <p>
+ * Since services cannot be guaranteed to be thread-safe; it maintains an internal object pool that
+ * is independently sizeable.
+ * </p>
+ *
+ * @config thread-context-workflow
+ */
+@XStreamAlias("thread-context-workflow")
+@ComponentProfile(summary = "Workflow that executes within the current thread context.",
+    tag = "workflow",
+    since = "3.12.0")
+@DisplayOrder(order =
+{
+    "poolSize", "minIdle", "maxIdle", "disableDefaultMessageCount"
+})
+@NoArgsConstructor
+public class ThreadContextWorkflow extends WorkflowWithObjectPool {
+
+  @Getter(AccessLevel.PACKAGE)
+  private transient ObjectPool<Worker> objectPool;
+
+  @Override
+  protected void onMessage(AdaptrisMessage msg) {
+    Worker worker = null;
+    try {
+      workflowStart(msg);
+      processingStart(msg);
+      addConsumeLocation(msg);
+      worker = objectPool.borrowObject();
+      AdaptrisMessage result = worker.handleMessage(msg);
+      workflowEnd(msg, result);
+      returnObject(objectPool, worker);
+    } catch (Exception e) {
+      msg.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, e);
+      handleBadMessage(msg);
+    }
+  }
+
+  @Override
+  protected void initialiseWorkflow() throws CoreException {
+    preFlightServiceCheck();
+    LifecycleHelper.init(getProducer());
+    getConsumer().registerAdaptrisMessageListener(this);
+    LifecycleHelper.init(getConsumer());
+  }
+
+  @Override
+  protected void startWorkflow() throws CoreException {
+    LifecycleHelper.start(getProducer());
+    objectPool = populatePool(createObjectPool());
+    LifecycleHelper.start(getConsumer());
+  }
+
+  @Override
+  protected void stopWorkflow() {
+    LifecycleHelper.stop(getConsumer());
+    Closer.closeQuietly(objectPool);
+    LifecycleHelper.stop(getProducer());
+  }
+
+  @Override
+  protected void closeWorkflow() {
+    LifecycleHelper.close(getConsumer());
+    LifecycleHelper.close(getProducer());
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/ThreadContextWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ThreadContextWorkflow.java
@@ -129,12 +129,12 @@ public class ThreadContextWorkflow extends WorkflowWithObjectPool {
   //
   @Override
   public String friendlyName() {
-    return obtainWorkflowId() + "(" + threadName() + ")";
+    return super.friendlyName() + threadName();
   }
 
   private String threadName() {
     return BooleanUtils.toBooleanDefaultIfNull(getAddCurrentThreadName(), true)
-        ? Thread.currentThread().getName()
+        ? "(" + Thread.currentThread().getName() + ")"
         : "";
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowWithObjectPool.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowWithObjectPool.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2021 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.adaptris.core;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import javax.validation.Valid;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.NumberUtils;
+import com.adaptris.util.TimeInterval;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A Workflow that has a object pool of ServiceCollections
+ *
+ */
+public abstract class WorkflowWithObjectPool extends WorkflowImp {
+
+  /**
+   * The default maximum pool size.
+   *
+   */
+  public static final int DEFAULT_MAX_POOLSIZE = 10;
+  /**
+   * the default minimum idle size.
+   *
+   */
+  public static final int DEFAULT_MIN_IDLE = 1;
+  /**
+   * The default max idle size.
+   */
+  public static final int DEFAULT_MAX_IDLE = DEFAULT_MAX_POOLSIZE;
+
+
+  /**
+   * The default wait time for pool initialisation
+   *
+   */
+  private static final TimeInterval DEFAULT_INIT_WAIT = new TimeInterval(1L, TimeUnit.MINUTES.name());
+
+  /**
+   * The max size of the pool
+   *
+   */
+  @InputFieldDefault(value = "10")
+  @Getter
+  @Setter
+  private Integer poolSize;
+  /**
+   * The minimum number of idle objects in the pool.
+   *
+   */
+  @InputFieldDefault(value = "1")
+  @Getter
+  @Setter
+  private Integer minIdle;
+  /**
+   * The maximum number of idle objects in the pool.
+   *
+   */
+  @InputFieldDefault(value = "10")
+  @Getter
+  @Setter
+  private Integer maxIdle;
+
+  /**
+   * Set the amount of time to wait for object pool population.
+   * <p>
+   * Upon start the object pool is populated with the {@link #minIdle()} number of workers.
+   * </p>
+   */
+  @AdvancedConfig(rare = true)
+  @InputFieldDefault(value = "1 minute")
+  @Valid
+  @Getter
+  @Setter
+  private TimeInterval initWaitTime;
+
+  public WorkflowWithObjectPool() {
+    super();
+  }
+
+  public WorkflowWithObjectPool(String uniqueId) throws CoreException {
+    this();
+    setUniqueId(uniqueId);
+  }
+
+  /**
+   * Process a message from the <code>MessageConsumer</code>
+   *
+   * @see WorkflowImp#handleBadMessage(AdaptrisMessage)
+   *
+   */
+  @Override
+  public void onAdaptrisMessage(final AdaptrisMessage msg, Consumer<AdaptrisMessage> success,
+      Consumer<AdaptrisMessage> failure) {
+    ListenerCallbackHelper.prepare(msg, success, failure);
+    if (!obtainChannel().isAvailable()) {
+      handleChannelUnavailable(msg);
+    } else {
+      onMessage(msg);
+    }
+  }
+
+  protected abstract void onMessage(AdaptrisMessage msg);
+
+  @Override
+  protected void resubmitMessage(AdaptrisMessage msg) {
+    onMessage(msg);
+  }
+
+  public int poolSize() {
+    return NumberUtils.toIntDefaultIfNull(getPoolSize(), DEFAULT_MAX_POOLSIZE);
+  }
+
+  /**
+   * Check the object pool such that it isn't going to cause issues.
+   *
+   */
+  protected void checkPoolConfig() {
+    if (maxIdle() > poolSize()) {
+      log.warn("Maximum number of idle workers > pool-size, re-sizing max-idle");
+      setMaxIdle(poolSize());
+    }
+    if (minIdle() > poolSize()) {
+      log.warn("Minimum number of idle workers > pool-size, re-sizing min-idle");
+      setMinIdle(poolSize());
+    }
+    if (minIdle() > maxIdle()) {
+      log.warn("Minimum number of idle workers > max-idle, max-idle modified");
+      setMaxIdle(minIdle());
+    }
+  }
+
+  protected ObjectPool<Worker> createObjectPool() throws CoreException {
+    checkPoolConfig();
+    ServiceCollection workerServiceCollection = cloneServiceCollection(getServiceCollection());
+    GenericObjectPool<Worker> pool =
+        new GenericObjectPool<>(new WorkerFactory(workerServiceCollection));
+    long lifetime = DEFAULT_INIT_WAIT.toMilliseconds();
+    pool.setMaxTotal(poolSize());
+    pool.setMinIdle(minIdle());
+    pool.setMaxIdle(maxIdle());
+    pool.setMaxWaitMillis(-1L);
+    pool.setBlockWhenExhausted(true);
+    pool.setSoftMinEvictableIdleTimeMillis(lifetime);
+    pool.setTimeBetweenEvictionRunsMillis(
+        lifetime + ThreadLocalRandom.current().nextLong(lifetime));
+    return pool;
+  }
+
+  protected void populatePool(ObjectPool<Worker> objectPool) throws CoreException {
+    int size = minIdle();
+    ExecutorService populator = Executors.newCachedThreadPool();
+    try {
+      final CyclicBarrier barrier = new CyclicBarrier(size + 1);
+      log.trace("Need more ({}) children as soon as possible to handle work. Get to it", size);
+      for (int i = 0; i < size; i++) {
+        populator.execute(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              objectPool.addObject();
+              barrier.await(initWaitTimeMs(), TimeUnit.MILLISECONDS);
+            }
+            catch (Exception e) {
+              barrier.reset();
+            }
+          }
+        });
+      }
+      barrier.await(initWaitTimeMs(), TimeUnit.MILLISECONDS);
+    }
+    catch (Exception e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    } finally {
+      populator.shutdownNow();
+    }
+  }
+
+  /**
+   * Return the maximum idle objects in the pool.
+   *
+   * @return the maximum idle number
+   */
+  public int minIdle() {
+    return NumberUtils.toIntDefaultIfNull(getMinIdle(), DEFAULT_MIN_IDLE);
+  }
+
+  /**
+   * Return the maximum idle objects in the pool.
+   *
+   * @return the maximum idle number
+   */
+  public int maxIdle() {
+    return NumberUtils.toIntDefaultIfNull(getMaxIdle(), DEFAULT_MAX_IDLE);
+  }
+
+  public long initWaitTimeMs() {
+    return TimeInterval.toMillisecondsDefaultIfNull(getInitWaitTime(), DEFAULT_INIT_WAIT);
+  }
+
+
+  protected ServiceCollection cloneServiceCollection(ServiceCollection original)
+      throws CoreException {
+    ServiceCollection result = DefaultMarshaller.roundTrip(original);
+    LifecycleHelper.registerEventHandler(result, eventHandler);
+    return result;
+  }
+
+  @Override
+  protected void prepareWorkflow() throws CoreException {}
+
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  protected class WorkerFactory implements PooledObjectFactory<Worker> {
+
+    private transient ServiceCollection baseCollection;
+
+    @Override
+    public PooledObject<Worker> makeObject() throws Exception {
+      Worker w = null;
+      try {
+        w = new Worker(cloneServiceCollection(baseCollection));
+        w.start();
+      }
+      catch (Exception e) {
+        log.error("Error creating object for pool", e);
+        throw e;
+      }
+      return new DefaultPooledObject<>(w);
+    }
+
+
+    @Override
+    public void destroyObject(PooledObject<Worker> arg0) throws Exception {
+      arg0.getObject().stop();
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<Worker> arg0) {
+      return arg0.getObject().isValid();
+    }
+
+
+    @Override
+    public void activateObject(PooledObject<Worker> arg0) throws Exception {
+    }
+
+    @Override
+    public void passivateObject(PooledObject<Worker> arg0) throws Exception {
+    }
+
+  }
+
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  protected class Worker {
+
+    private ServiceCollection sc;
+
+    public void start() throws CoreException {
+      LifecycleHelper.initAndStart(sc, false);
+    }
+
+    public void stop() {
+      LifecycleHelper.stopAndClose(sc, false);
+    }
+
+    public boolean isValid() {
+      return true;
+    }
+
+    public AdaptrisMessage handleMessage(AdaptrisMessage msg) {
+      AdaptrisMessage wip = null;
+      try {
+        long start = System.currentTimeMillis();
+        log.debug("start processing msg [{}]", messageLogger().toString(msg));
+        wip = (AdaptrisMessage) msg.clone();
+        // Set the channel id and workflow id on the message lifecycle.
+        wip.getMessageLifecycleEvent().setChannelId(obtainChannel().getUniqueId());
+        wip.getMessageLifecycleEvent().setWorkflowId(obtainWorkflowId());
+        wip.addEvent(getConsumer(), true);
+        sc.doService(wip);
+        doProduce(wip);
+        // handle success callback here.
+        // failure callback will be handled by the message-error-handler that's configured...
+        ListenerCallbackHelper.handleSuccessCallback(wip);
+        logSuccess(wip, start);
+      }
+      catch (ProduceException e) {
+        wip.addEvent(getProducer(), false);
+        handleBadMessage("Exception producing message", e, copyExceptionHeaders(wip, msg));
+        handleProduceException();
+      }
+      catch (Exception e) {
+        handleBadMessage("Exception processing message", e, copyExceptionHeaders(wip, msg));
+      }
+      finally {
+        sendMessageLifecycleEvent(wip);
+      }
+      return wip;
+    }
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowWithObjectPool.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowWithObjectPool.java
@@ -107,11 +107,6 @@ public abstract class WorkflowWithObjectPool extends WorkflowImp {
     super();
   }
 
-  public WorkflowWithObjectPool(String uniqueId) throws CoreException {
-    this();
-    setUniqueId(uniqueId);
-  }
-
   /**
    * Process a message from the <code>MessageConsumer</code>
    *

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyNoBacklogInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyNoBacklogInterceptor.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,13 +20,10 @@ import static com.adaptris.core.CoreConstants.KEY_WORKFLOW_SKIP_PRODUCER;
 import static com.adaptris.core.CoreConstants.STOP_PROCESSING_KEY;
 import static com.adaptris.core.CoreConstants.STOP_PROCESSING_VALUE;
 import static com.adaptris.core.http.jetty.JettyWorkflowInterceptorImpl.messageComplete;
-
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.servlet.http.HttpServletResponse;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.AdaptrisMessage;
@@ -34,13 +31,14 @@ import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.PoolingWorkflow;
 import com.adaptris.core.Workflow;
+import com.adaptris.core.WorkflowWithObjectPool;
 import com.adaptris.core.interceptor.WorkflowInterceptorImpl;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * WorkflowInterceptor that automatically returns a 503 if it knows there is nothing available to handle the inbound message in the
  * parent workflow.
- * 
+ *
  * <p>
  * Note that this interceptor only works with {@link PoolingWorkflow}; results are undefined when used with other workflows. What
  * actually happens is that if the current message (during workflowStart()) increases the count of messages in flight over the
@@ -49,7 +47,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * workflow to skip processing the message (effectively the message will be discarded); you will see logging to that effect at
  * TRACE/DEBUG level.
  * </p>
- * 
+ *
  * @config jetty-no-backlog-interceptor
  * @since 3.7.3
  */
@@ -69,8 +67,8 @@ public class JettyNoBacklogInterceptor extends WorkflowInterceptorImpl {
   @Override
   public void init() throws CoreException {
     Workflow w = parentWorkflow();
-    if (PoolingWorkflow.class.isAssignableFrom(w.getClass())) {
-      maxWorkers = ((PoolingWorkflow) w).poolSize();
+    if (WorkflowWithObjectPool.class.isAssignableFrom(w.getClass())) {
+      maxWorkers = ((WorkflowWithObjectPool) w).poolSize();
     }
     log.trace("503 Server Error will be sent when there are {} messages in flight", maxWorkers);
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyNoBacklogInterceptor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/JettyNoBacklogInterceptor.java
@@ -31,7 +31,6 @@ import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.PoolingWorkflow;
 import com.adaptris.core.Workflow;
-import com.adaptris.core.WorkflowWithObjectPool;
 import com.adaptris.core.interceptor.WorkflowInterceptorImpl;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -67,8 +66,8 @@ public class JettyNoBacklogInterceptor extends WorkflowInterceptorImpl {
   @Override
   public void init() throws CoreException {
     Workflow w = parentWorkflow();
-    if (WorkflowWithObjectPool.class.isAssignableFrom(w.getClass())) {
-      maxWorkers = ((WorkflowWithObjectPool) w).poolSize();
+    if (PoolingWorkflow.class.isAssignableFrom(w.getClass())) {
+      maxWorkers = ((PoolingWorkflow) w).poolSize();
     }
     log.trace("503 Server Error will be sent when there are {} messages in flight", maxWorkers);
 

--- a/interlok-core/src/test/java/com/adaptris/core/ThreadContextWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ThreadContextWorkflowTest.java
@@ -1,0 +1,625 @@
+/*
+ * Copyright 2021 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.adaptris.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.awaitility.Awaitility;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.adaptris.core.services.exception.ConfiguredException;
+import com.adaptris.core.services.exception.ThrowExceptionService;
+import com.adaptris.core.services.metadata.AddMetadataService;
+import com.adaptris.core.services.metadata.PayloadFromTemplateService;
+import com.adaptris.core.stubs.FailFirstMockMessageProducer;
+import com.adaptris.core.stubs.MockChannel;
+import com.adaptris.core.stubs.MockMessageProducer;
+import com.adaptris.core.stubs.MockSkipProducerService;
+import com.adaptris.core.stubs.MockWorkflowInterceptor;
+import com.adaptris.core.stubs.StaticMockMessageProducer;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.MinimalMessageLogger;
+import com.adaptris.util.TimeInterval;
+
+public class ThreadContextWorkflowTest
+    extends com.adaptris.interlok.junit.scaffolding.ExampleWorkflowCase {
+
+  private static final Logger log = LoggerFactory.getLogger(ThreadContextWorkflowTest.class);
+
+  protected static final String METADATA_KEY = "key1";
+  protected static final String METADATA_VALUE = "value";
+
+  @Test
+  public void testOnMessageWithSendEvents() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    MockMessageProducer eventProd = new MockMessageProducer();
+    DefaultEventHandler evtHandler = new DefaultEventHandler(eventProd);
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[]
+    {
+        new AddMetadataService(Arrays.asList(new MetadataElement[]
+        {
+          new MetadataElement(METADATA_KEY, METADATA_VALUE)
+        })), new PayloadFromTemplateService().withTemplate(PAYLOAD_2)
+    }));
+    try {
+      channel.setEventHandler(evtHandler);
+      ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      workflow.setSendEvents(true);
+      channel.prepare();
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+      assertEquals("Make sure all produced", 1, producer.getMessages().size());
+      for (Iterator i = producer.getMessages().iterator(); i.hasNext();) {
+        AdaptrisMessage m = (AdaptrisMessage) i.next();
+        assertEquals(PAYLOAD_2, m.getContent());
+        assertTrue("Contains correct metadata key", m.headersContainsKey(METADATA_KEY));
+        assertEquals(METADATA_VALUE, m.getMetadataValue(METADATA_KEY));
+      }
+      waitForMessages(eventProd, 1);
+      assertEquals(1, eventProd.messageCount());
+    }
+    finally {
+      stop(channel);
+      stop(evtHandler);
+    }
+  }
+
+  @Test
+  public void testOnMessageWithoutEvents() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    MockMessageProducer eventProd = new MockMessageProducer();
+    DefaultEventHandler evtHandler = new DefaultEventHandler(eventProd);
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[]
+    {
+        new AddMetadataService(Arrays.asList(new MetadataElement[]
+        {
+          new MetadataElement(METADATA_KEY, METADATA_VALUE)
+        })), new PayloadFromTemplateService().withTemplate(PAYLOAD_2)
+    }));
+    try {
+      channel.setEventHandler(evtHandler);
+      ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      workflow.setSendEvents(false);
+      channel.prepare();
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+      assertEquals("Make sure all produced", 1, producer.getMessages().size());
+      for (Iterator i = producer.getMessages().iterator(); i.hasNext();) {
+        AdaptrisMessage m = (AdaptrisMessage) i.next();
+        assertEquals(PAYLOAD_2, m.getContent());
+        assertTrue("Contains correct metadata key", m.headersContainsKey(METADATA_KEY));
+        assertEquals(METADATA_VALUE, m.getMetadataValue(METADATA_KEY));
+      }
+      waitForMessages(eventProd, 0);
+      assertEquals(0, eventProd.messageCount());
+    }
+    finally {
+      stop(channel);
+      stop(evtHandler);
+    }
+  }
+
+  @Test
+  public void testOnMessageWithInterceptors() throws Exception {
+    MockWorkflowInterceptor interceptor = new MockWorkflowInterceptor();
+    MockMessageProducer producer = new MockMessageProducer();
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[]
+    {
+        new AddMetadataService(Arrays.asList(new MetadataElement[]
+        {
+          new MetadataElement(METADATA_KEY, METADATA_VALUE)
+        })), new PayloadFromTemplateService().withTemplate(PAYLOAD_2)
+    }));
+    int count = 10;
+    try {
+      ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      workflow.addInterceptor(interceptor);
+      channel.prepare();
+      start(channel);
+      for (int i = 0; i < count; i++) {
+        AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+        workflow.onAdaptrisMessage(msg);
+      }
+      assertEquals("Make sure all produced", count, producer.messageCount());
+      assertEquals("Make sure all intercepted", count, interceptor.messageCount());
+      for (AdaptrisMessage m : producer.getMessages()) {
+        assertEquals(PAYLOAD_2, m.getContent());
+        assertTrue("Contains correct metadata key", m.headersContainsKey(METADATA_KEY));
+        assertEquals(METADATA_VALUE, m.getMetadataValue(METADATA_KEY));
+      }
+    }
+    finally {
+      stop(channel);
+    }
+
+  }
+
+  @Test
+  public void testHandleChannelUnavailable() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    final MockChannel channel = createChannel(producer, Arrays.asList(new Service[]
+    {
+        new AddMetadataService(Arrays.asList(new MetadataElement[]
+        {
+          new MetadataElement(METADATA_KEY, METADATA_VALUE)
+        })), new PayloadFromTemplateService().withTemplate(PAYLOAD_2)
+    }));
+    try {
+      ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      workflow.setChannelUnavailableWaitInterval(new TimeInterval(1200L, TimeUnit.MILLISECONDS));
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+      channel.prepare();
+      start(channel);
+      channel.toggleAvailability(false);
+      Timer t = new Timer(true);
+      t.schedule(new TimerTask() {
+        @Override
+        public void run() {
+          channel.toggleAvailability(true);
+        }
+
+      }, 500);
+      workflow.onAdaptrisMessage(msg);
+
+      assertEquals("Make sure all produced", 1, producer.getMessages().size());
+      for (Iterator i = producer.getMessages().iterator(); i.hasNext();) {
+        AdaptrisMessage m = (AdaptrisMessage) i.next();
+        assertEquals(PAYLOAD_2, m.getContent());
+        assertTrue("Contains correct metadata key", m.headersContainsKey(METADATA_KEY));
+        assertEquals(METADATA_VALUE, m.getMetadataValue(METADATA_KEY));
+      }
+    }
+    finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testServiceException() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    MockMessageProducer meh = new MockMessageProducer();
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[]
+    {
+      new ThrowExceptionService(new ConfiguredException("Fail"))
+    }));
+    try {
+      ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      channel.setMessageErrorHandler(new StandardProcessingExceptionHandler(
+    		  new ServiceList(new ArrayList<Service>(Arrays.asList(new Service[]
+    	    	      {
+    	    	        new StandaloneProducer(meh)
+    	    	      })))));
+      channel.prepare();
+
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+
+      assertEquals("Make none produced", 0, producer.getMessages().size());
+      assertEquals(1, meh.getMessages().size());
+      for (Iterator i = meh.getMessages().iterator(); i.hasNext();) {
+        AdaptrisMessage m = (AdaptrisMessage) i.next();
+        assertEquals(PAYLOAD_1, m.getContent());
+        assertFalse("Does not contains correct metadata key", m.headersContainsKey(METADATA_KEY));
+        assertNotNull(m.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION));
+        assertNotNull(m.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION_CAUSE));
+        assertEquals(ThrowExceptionService.class.getSimpleName(),
+            m.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION_CAUSE));
+      }
+    }
+    finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testBrokenPool() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    MockMessageProducer eventProd = new MockMessageProducer();
+    DefaultEventHandler evtHandler = new DefaultEventHandler(eventProd);
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[]
+    {
+        new AddMetadataService(Arrays.asList(new MetadataElement[]
+        {
+          new MetadataElement(METADATA_KEY, METADATA_VALUE)
+        })), new PayloadFromTemplateService().withTemplate(PAYLOAD_2)
+    }));
+    MockMessageProducer meh = new MockMessageProducer();
+    try {
+      ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      channel.setMessageErrorHandler(new StandardProcessingExceptionHandler(
+          new ServiceList(
+              new ArrayList<Service>(Arrays.asList(new Service[] {new StandaloneProducer(meh)})))));
+      channel.prepare();
+
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+      start(channel);
+      // close the pool which should cause an IllegalStateException
+      workflow.getObjectPool().close();
+      workflow.onAdaptrisMessage(msg);
+
+      assertEquals("Make none produced", 0, producer.getMessages().size());
+      assertEquals(1, meh.getMessages().size());
+      for (Iterator i = meh.getMessages().iterator(); i.hasNext();) {
+        AdaptrisMessage m = (AdaptrisMessage) i.next();
+        assertEquals(PAYLOAD_1, m.getContent());
+        assertFalse("Does not contains correct metadata key", m.headersContainsKey(METADATA_KEY));
+      }
+    } finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testProduceException() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer() {
+      @Override
+      protected void doProduce(AdaptrisMessage msg, String endpoint) throws ProduceException {
+        throw new ProduceException();
+      }
+    };
+    MockMessageProducer meh = new MockMessageProducer();
+    MockChannel channel = createChannel(producer,
+        Arrays.asList(new Service[] {new ThrowExceptionService(new ConfiguredException("Fail"))}));
+    try {
+      ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      channel.setMessageErrorHandler(new StandardProcessingExceptionHandler(
+    		  new ServiceList(new ArrayList<Service>(Arrays.asList(new Service[]
+    	    	      {
+    	    	        new StandaloneProducer(meh)
+    	    	      })))));
+      channel.prepare();
+
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+
+      assertEquals("Make none produced", 0, producer.getMessages().size());
+      assertEquals(1, meh.getMessages().size());
+      for (Iterator i = meh.getMessages().iterator(); i.hasNext();) {
+        AdaptrisMessage m = (AdaptrisMessage) i.next();
+        assertEquals(PAYLOAD_1, m.getContent());
+        assertFalse("Does not contains correct metadata key", m.headersContainsKey(METADATA_KEY));
+      }
+    }
+    finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testRuntimeException() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer() {
+      @Override
+      protected void doProduce(AdaptrisMessage msg, String endpoint) throws ProduceException {
+        throw new RuntimeException();
+      }
+    };
+    MockMessageProducer meh = new MockMessageProducer();
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[]
+    {
+        new AddMetadataService(Arrays.asList(new MetadataElement[]
+        {
+          new MetadataElement(METADATA_KEY, METADATA_VALUE)
+        })), new PayloadFromTemplateService().withTemplate(PAYLOAD_2)
+    }));
+    try {
+      ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      channel.setMessageErrorHandler(new StandardProcessingExceptionHandler(
+    		  new ServiceList(new ArrayList<Service>(Arrays.asList(new Service[]
+    	    	      {
+    	    	        new StandaloneProducer(meh)
+    	    	      })))));
+      channel.prepare();
+
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+
+      assertEquals("Make none produced", 0, producer.getMessages().size());
+      assertEquals(1, meh.getMessages().size());
+      for (Iterator i = meh.getMessages().iterator(); i.hasNext();) {
+        AdaptrisMessage m = (AdaptrisMessage) i.next();
+        assertEquals(PAYLOAD_1, m.getContent());
+        assertFalse("Does not contains correct metadata key", m.headersContainsKey(METADATA_KEY));
+      }
+    }
+    finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testOnMessage_SkipProducer() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    StaticMockMessageProducer serviceProducer = new StaticMockMessageProducer();
+    MockChannel channel = createChannel(producer, Arrays.asList(
+        new Service[] {new StandaloneProducer(serviceProducer), new MockSkipProducerService()}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+      assertEquals(1, serviceProducer.messageCount());
+      assertEquals(0, producer.messageCount());
+    } finally {
+      stop(channel);
+    }
+  }
+
+
+  @Test
+  public void testOnMessage_MessageLogger() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[] {new NullService()}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    workflow.setMessageLogger(new MinimalMessageLogger());
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+      assertEquals(1, producer.messageCount());
+    } finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testOnMessage_withConsumeLocation() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[] {new NullService()}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    msg.addMessageHeader(getName(), "hello world");
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    workflow.setConsumer(new ConsumerWithLocation(getName()));
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+      AdaptrisMessage consumed = producer.getMessages().get(0);
+      assertTrue(consumed.headersContainsKey(CoreConstants.MESSAGE_CONSUME_LOCATION));
+      assertEquals("hello world",
+          consumed.getMetadataValue(CoreConstants.MESSAGE_CONSUME_LOCATION));
+    } finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testOnMessage_withConsumeLocation_NoMatch() throws Exception {
+    MockMessageProducer producer = new MockMessageProducer();
+    MockChannel channel = createChannel(producer, Arrays.asList(new Service[] {new NullService()}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    workflow.setConsumer(new ConsumerWithLocation(getName()));
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg);
+      AdaptrisMessage consumed = producer.getMessages().get(0);
+      assertFalse(consumed.headersContainsKey(CoreConstants.MESSAGE_CONSUME_LOCATION));
+    } finally {
+      stop(channel);
+    }
+  }
+
+
+  @Test
+  public void testOnMessage_SuccessCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new MockMessageProducer(), Arrays.asList(new Service[] {new NullService()}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg, (m) -> {
+        onSuccess.set(true);
+      });
+      assertTrue(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+
+  }
+
+  @Test
+  public void testOnMessage_ServiceFailsFailureCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new MockMessageProducer(), Arrays.asList(new Service[] {new ThrowExceptionService(new ConfiguredException("expected"))}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg,
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+
+      assertFalse(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testOnMessage_ServiceFailsWithRetryHandlerFailureCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new MockMessageProducer(), Arrays.asList(new Service[] {new ThrowExceptionService(new ConfiguredException("expected"))}));
+
+    channel.setMessageErrorHandler(new RetryMessageErrorHandler(3, new TimeInterval(100l, TimeUnit.MILLISECONDS), new NullService()));
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg,
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+
+      assertFalse(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testOnMessage_ProducerFailsFailureCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new FailFirstMockMessageProducer(1), Arrays.asList(new Service[] {new NullService()}));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg,
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+
+      assertFalse(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testOnMessage_ProducerFailsWithRetryHandlerSuccessCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new FailFirstMockMessageProducer(1), Arrays.asList(new Service[] {new NullService()}));
+
+    channel.setMessageErrorHandler(new RetryMessageErrorHandler(2, new TimeInterval(100l, TimeUnit.MILLISECONDS), new NullService()));
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg,
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+
+      Awaitility.await()
+        .atMost(Duration.ofSeconds(2))
+      .with()
+        .pollInterval(Duration.ofMillis(100))
+        .until(onSuccess::get);
+
+      assertTrue(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+
+  @Test
+  public void testOnMessage_ProducerFailsWithRetryHandlerFailureCallback() throws Exception {
+    AtomicBoolean onSuccess = new AtomicBoolean(false);
+    MockChannel channel = createChannel(new FailFirstMockMessageProducer(5), Arrays.asList(new Service[] {new NullService()}));
+
+    channel.setMessageErrorHandler(new RetryMessageErrorHandler(4, new TimeInterval(100l, TimeUnit.MILLISECONDS), new NullService()));
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    try {
+      start(channel);
+      workflow.onAdaptrisMessage(msg,
+          (m) -> {
+            onSuccess.set(true);
+          },
+          (m) -> {
+            onSuccess.set(false);
+          });
+
+      assertFalse(onSuccess.get());
+    } finally {
+      stop(channel);
+    }
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    Channel c = new Channel();
+    c.setUniqueId(UUID.randomUUID().toString());
+    ThreadContextWorkflow wf1 = createWorkflowForExampleConfig();
+    wf1.setUniqueId("Unthrottled-Workflow");
+    c.getWorkflowList().add(wf1);
+    return c;
+  }
+
+
+  protected MockChannel createChannel(AdaptrisMessageProducer producer, List<Service> services) throws Exception {
+    MockChannel channel = new MockChannel();
+    ThreadContextWorkflow workflow = createWorkflowForGenericTests();
+    workflow.setProducer(producer);
+    workflow.getServiceCollection().addAll(services);
+    channel.getWorkflowList().add(workflow);
+    return channel;
+  }
+
+  @Override
+  protected String createBaseFileName(Object object) {
+    return ThreadContextWorkflow.class.getName();
+  }
+
+  @Override
+  protected ThreadContextWorkflow createWorkflowForGenericTests() {
+    return new ThreadContextWorkflow();
+  }
+
+  private ThreadContextWorkflow createWorkflowForExampleConfig() {
+    ThreadContextWorkflow wf = new ThreadContextWorkflow();
+    NullMessageConsumer consumer = new NullMessageConsumer();
+    wf.setConsumer(consumer);
+    wf.setProducer(new NullMessageProducer());
+    return wf;
+  }
+
+  private class ConsumerWithLocation extends NullMessageConsumer {
+    private String metadataKey;
+
+    public ConsumerWithLocation(String key) {
+      metadataKey = Args.notBlank(key, "metadataKey");
+    }
+
+    @Override
+    public String consumeLocationKey() {
+      return metadataKey;
+    }
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/ThreadContextWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ThreadContextWorkflowTest.java
@@ -574,6 +574,27 @@ public class ThreadContextWorkflowTest
     }
   }
 
+  @Test
+  public void testFriendlyName() throws Exception {
+    String oldName = Thread.currentThread().getName();
+    MockChannel channel =
+        createChannel(new MockMessageProducer(), Arrays.asList(new Service[] {new NullService()}));
+    Thread.currentThread().setName(getName());
+    channel.setUniqueId("channel");
+    ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+    workflow.setUniqueId("workflow");
+    try {
+      start(channel);
+      assertTrue(workflow.friendlyName().contains(getName()));
+      workflow.setAddCurrentThreadName(Boolean.FALSE);
+      assertFalse(workflow.friendlyName().contains(getName()));
+    } finally {
+      Thread.currentThread().setName(oldName);
+      stop(channel);
+    }
+  }
+
+
   @Override
   protected Object retrieveObjectForSampleConfig() {
     Channel c = new Channel();

--- a/interlok-core/src/test/java/com/adaptris/core/ThreadContextWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ThreadContextWorkflowTest.java
@@ -361,6 +361,7 @@ public class ThreadContextWorkflowTest
   public void testOnMessage_SkipProducer() throws Exception {
     MockMessageProducer producer = new MockMessageProducer();
     StaticMockMessageProducer serviceProducer = new StaticMockMessageProducer();
+    serviceProducer.getMessages().clear();
     MockChannel channel = createChannel(producer, Arrays.asList(
         new Service[] {new StandaloneProducer(serviceProducer), new MockSkipProducerService()}));
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD_1);

--- a/interlok-core/src/test/java/com/adaptris/core/ThreadContextWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ThreadContextWorkflowTest.java
@@ -140,6 +140,7 @@ public class ThreadContextWorkflowTest
     int count = 10;
     try {
       ThreadContextWorkflow workflow = (ThreadContextWorkflow) channel.getWorkflowList().get(0);
+      workflow.setAdditionalDebug(Boolean.TRUE);
       workflow.addInterceptor(interceptor);
       channel.prepare();
       start(channel);

--- a/interlok-core/src/test/java/com/adaptris/core/WorkflowWithObjectPoolTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/WorkflowWithObjectPoolTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.adaptris.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.adaptris.core.stubs.MockService;
+import com.adaptris.interlok.util.Closer;
+import com.adaptris.util.TimeInterval;
+import lombok.NoArgsConstructor;
+
+// Should actually test more, but this tests all the edge cases that
+// aren't tested via PoolingWorkflow etc.
+@NoArgsConstructor
+public class WorkflowWithObjectPoolTest extends WorkflowWithObjectPool {
+
+  private static final Logger log = LoggerFactory.getLogger(WorkflowWithObjectPoolTest.class);
+
+  @Override
+  protected void onMessage(AdaptrisMessage msg) {
+
+  }
+
+  @Override
+  protected void initialiseWorkflow() throws CoreException {
+  }
+
+  @Override
+  protected void startWorkflow() throws CoreException {
+  }
+
+  @Override
+  protected void stopWorkflow() {
+  }
+
+  @Override
+  protected void closeWorkflow() {
+  }
+
+  @Test
+  public void testWorkerFactory() throws Exception {
+    WorkerFactory factory = new WorkerFactory(new ServiceList());
+    PooledObject<Worker> obj = factory.makeObject();
+    factory.activateObject(obj);
+    factory.passivateObject(obj);
+    assertTrue(factory.validateObject(obj));
+    factory.destroyObject(obj);
+
+  }
+
+  @Test(expected = CoreException.class)
+  public void testWorkerFactory_Uncloneable() throws Exception {
+    WorkerFactory factory = new WorkerFactory(new ServiceList(new UnserializableService("")));
+    PooledObject<Worker> obj = factory.makeObject();
+  }
+
+  @Test
+  public void testPopulatePool() throws Exception {
+    setMinIdle(10);
+    setInitWaitTime(new TimeInterval(1L, TimeUnit.SECONDS));
+    GenericObjectPool<Worker> pool = (GenericObjectPool<Worker>) createObjectPool();
+    try {
+      populatePool(pool);
+    } finally {
+      Closer.closeQuietly(pool);
+    }
+  }
+
+  @Test(expected = CoreException.class)
+  public void testPopulatePool_FailToInit() throws Exception {
+    setMinIdle(10);
+    setServiceCollection(new ServiceList(new MockService(MockService.FailureCondition.Lifecycle)));
+    setInitWaitTime(new TimeInterval(1L, TimeUnit.SECONDS));
+    GenericObjectPool<Worker> pool = (GenericObjectPool<Worker>) createObjectPool();
+    try {
+      populatePool(pool);
+    } finally {
+      Closer.closeQuietly(pool);
+    }
+  }
+
+  @Test
+  public void testReturnObject() throws Exception {
+    setMinIdle(1);
+    GenericObjectPool<Worker> pool = (GenericObjectPool<Worker>) createObjectPool();
+    Worker worker = pool.borrowObject();
+    returnObject(pool, worker);
+    assertEquals(1, pool.getNumIdle());
+  }
+
+  @Test
+  public void testReturnObject_InvalidObject() throws Exception {
+    setMinIdle(1);
+    GenericObjectPool<Worker> pool = dummyPool();
+    Worker invalidWorker = new DummyWorker();
+    // worker that isn't associated, should ultimately throu
+    // an IllegalStateException...
+    returnObject(pool, invalidWorker);
+
+  }
+
+  @Test
+  public void testReturnObject_FailureToReturn() throws Exception {
+    setMinIdle(1);
+    GenericObjectPool<Worker> pool = dummyPool();
+    Worker worker = pool.borrowObject();
+    returnObject(pool, worker);
+    // On the 2nd return it should cause an IllegalState since it can't deallocate it?
+    // But the object itself can be destroyed/invalidated.
+    returnObject(pool, worker);
+  }
+
+  private GenericObjectPool<Worker> dummyPool() {
+    GenericObjectPool<Worker> pool =
+        new GenericObjectPool<>(new DummyFactory());
+    pool.setMaxTotal(poolSize());
+    pool.setMinIdle(minIdle());
+    pool.setMaxIdle(maxIdle());
+    pool.setMaxWaitMillis(-1L);
+    pool.setBlockWhenExhausted(true);
+    return pool;
+  }
+
+  public class UnserializableService extends NullService {
+    // no parameter less constructor breaks XStream.
+    public UnserializableService(String x) {
+      super();
+    }
+  }
+
+  public class DummyFactory extends WorkerFactory {
+
+    public DummyFactory() {
+      super(new ServiceList());
+    }
+
+    @Override
+    public PooledObject<Worker> makeObject() throws Exception {
+      return new DefaultPooledObject<>(new DummyWorker());
+    }
+
+  }
+
+  public class DummyWorker extends Worker {
+
+    public DummyWorker() {
+      super(new ServiceList());
+    }
+  }
+
+}


### PR DESCRIPTION
## Motivation

From @gerco 

>When running a bunch of PoolingWorkflows with an embedded Jetty connection, I'm noticing various performance issues depending on configuration:
>
>If the jetty executor is set to some number threads and each pooling workflow is set to fewer threads, a situation can occur where one PoolingWorkflow is swamped with work and has dozens of Jetty threads waiting for an available thread in the PoolingWorkflow.
>
>If the Jetty executor is set to the some number of threads and each pooling workflow is set to the same number, we are running many more threads than we ideally would. This is causing issues with dynamic-shared-services caching since these caches can be very large and per-thread so we run out of memory.
>
>Is there a way to run workflows directly on the Jetty threads rather than have a PoolingWorkflow in between, introducing a layer of complexity we don't need?


## Modification

- Refactor a shared hierarchy out of PoolingWorkflow into a "WorkflowWithObjectPool"
- Added a new ThreadContextWorkflow that extends WorkflowWithObjectPool
    - Not synchronized and maintains a configurable object pool to avoid non-thread safe service lists.
- Modify JettyNoBacklogInterceptor to use WorkflowWithObjectPool as its decision point where it previously used PoolingWorkflow.

## Result

A new workflow `ThreadContextWorkflow` is now available to configure.

## Testing

- Have a jetty workflow that contains a standard workflow; the service should just be WaitService (default 20 seconds is fine, but you'll get bored) : `/api/standard-sleep`
- Have a jetty workflow that contains a pooling workflow; the service should be exactly the same as above : `/api/pooled-sleep`
- Test them both with 3 (or more)  simultaneous curl requests and check that behaviour is as expected.
    - the pooled version will all finish in ~20 seconds.
    - The standard version will finish in ~60 seconds (or more), since standardworkflow is synchronized.

- Create a new thread-context-workflow that has the same configuration : `/api/sleep`
    - additional-debug (expert mode) : true (for extra logging).
    - use-current-thread-name : true (this is the default).
- Test the new workflow using simultaneous curl requests...

- This will finish in ~20 seconds proving that we're handling the requests in a threaded fashion that is unrelated to any internal thread pools that we have.

You should have logging that looks something like this, the __qtp*__ is the internal jetty thread pool thread.

```
TRACE [sad-hugle@default-channel(qtp674484384-35)] [c.a.c.ThreadContextWorkflow.logPoolState()] [{}] Current Pool after [Borrow]: Idle [0], Active [1], Max [10]
DEBUG [sad-hugle@default-channel(qtp674484384-35)] [c.a.c.ThreadContextWorkflow.handleMessage()] [{}] start processing msg...
DEBUG [sad-hugle@default-channel(qtp674484384-35)] [c.a.c.ServiceList.applyServices()] [{}] Executing doService on [WaitService(loving-dijkstra)]
TRACE [sad-hugle@default-channel(qtp674484384-37)] [c.a.c.ThreadContextWorkflow.logPoolState()] [{}] Current Pool after [Borrow]: Idle [0], Active [2], Max [10]
DEBUG [sad-hugle@default-channel(qtp674484384-37)] [c.a.c.ThreadContextWorkflow.handleMessage()] [{}] start processing msg...
DEBUG [sad-hugle@default-channel(qtp674484384-37)] [c.a.c.ServiceList.applyServices()] [{}] Executing doService on [WaitService(loving-dijkstra)]
TRACE [sad-hugle@default-channel(qtp674484384-41)] [c.a.c.ThreadContextWorkflow.logPoolState()] [{}] Current Pool after [Borrow]: Idle [0], Active [3], Max [10]
DEBUG [sad-hugle@default-channel(qtp674484384-41)] [c.a.c.ThreadContextWorkflow.handleMessage()] [{}] start processing msg...
DEBUG [sad-hugle@default-channel(qtp674484384-41)] [c.a.c.ServiceList.applyServices()] [{}] Executing doService on [WaitService(loving-dijkstra)]

...
TRACE [sad-hugle@default-channel(qtp674484384-35)] [c.a.c.ThreadContextWorkflow.logPoolState()] [{}] Current Pool after [Return]: Idle [1], Active [2], Max [10]
TRACE [sad-hugle@default-channel(qtp674484384-37)] [c.a.c.ThreadContextWorkflow.logPoolState()] [{}] Current Pool after [Return]: Idle [2], Active [1], Max [10]
TRACE [sad-hugle@default-channel(qtp674484384-41)] [c.a.c.ThreadContextWorkflow.logPoolState()] [{}] Current Pool after [Return]: Idle [3], Active [0], Max [10]
```