### PR TITLE
INTERLOK-3580 removed the required annotation from the deprecated field

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/DatabaseConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/DatabaseConnection.java
@@ -46,8 +46,6 @@ import com.adaptris.util.KeyValuePairSet;
  */
 public abstract class DatabaseConnection extends AllowsRetriesConnection {
 
-  @AutoPopulated
-  @NotBlank
   @InputFieldHint(style = "SQL")
   @AdvancedConfig
   @Deprecated
@@ -90,7 +88,6 @@ public abstract class DatabaseConnection extends AllowsRetriesConnection {
    */
   public DatabaseConnection() {
     setDriverImp("com.mysql.jdbc.Driver");
-    setTestStatement("SELECT DATABASE(), VERSION(), NOW(), USER();");
     wrapper = new DataSourceWrapper(this);
     connectionState = ConnectionState.Closed;
   }
@@ -234,14 +231,14 @@ public abstract class DatabaseConnection extends AllowsRetriesConnection {
   /**
    * Set the SQL statement used to test this connection.
    * <p>
-   * The default test statement is <code>SELECT DATABASE(), VERSION(), NOW(), USER()</code> which may not be suitable for your
+   * An example test statement is <code>SELECT DATABASE(), VERSION(), NOW(), USER()</code> which may not be suitable for your
    * database driver. Additionally depending on the JDBC driver implementation certain statements may be 'cached' and might never
    * hit the database, so you need to be aware of that as you will be relying on this test-statement to verify the connection
    * validity.
    * </p>
    * 
    * @see #setAlwaysValidateConnection(Boolean)
-   * @param s the SQL statement used to test this connection; the default is SELECT DATABASE(), VERSION(), NOW(), USER()
+   * @param s the SQL statement used to test this connection
    */
   public void setTestStatement(String s) {
     testStatement = s;


### PR DESCRIPTION
## Motivation

There is an issue with the DatabaseConnection, the field testStatement was marked as Deprecated, but it was left as a required field. 

This means you can not blank this deprecated field. 
This issue is being tracked in 'INTERLOK-3580'.

## Modification

removed the annotation that makes it required; changed the constructor so it doesn't auto populate test statement.

## Result

you should be able to use jdbc connections  and  have blank values in the test statement field

## Testing

use the UI, create config, add connection, create a JdbcPooledConnection using some arbitrary defaults
Save the configuration.

if you re-edit and switch to export mode, you'll see the test statement field, try saving the component with and without a value.
this should work.

You should also get the warning "JdbcPooledConnection has a deprecated member testStatement"


## Also

I've created this pull request to merge with develop, so that the fix will be in the v3 release, (there's no need for this to go near v4 branch as the field is going to be removed in 4)