### PR TITLE
feature/interlok-3551

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/security/password/AesGcmCrypto.java
+++ b/interlok-core/src/main/java/com/adaptris/security/password/AesGcmCrypto.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.security.password;
+
+import com.adaptris.security.exc.PasswordException;
+import com.adaptris.util.text.Base64ByteTranslator;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static com.adaptris.security.password.Password.PORTABLE_PASSWORD_2;
+
+public class AesGcmCrypto extends PasswordImpl {
+
+  private static final String ALGORITHM = "AES";
+  private static final String CIPHER = "AES/GCM/NoPadding";
+  private static final int KEY_LENGTH = 128;
+  private static final int KEY_SIZE = KEY_LENGTH / Byte.SIZE;
+  private static final int TAG_LENGTH = 128;
+  private static final int IV_LENGTH = 12;
+
+  private Base64ByteTranslator base64;
+
+  public AesGcmCrypto() {
+    base64 = new Base64ByteTranslator();
+  }
+
+  public boolean canHandle(String type) {
+    return type != null && type.startsWith(PORTABLE_PASSWORD_2);
+  }
+
+  public String decode(String b64CipherText, String charset) throws PasswordException {
+    if (b64CipherText.startsWith(PORTABLE_PASSWORD_2)) {
+      b64CipherText = b64CipherText.substring(PORTABLE_PASSWORD_2.length());
+    }
+    try {
+      byte[] cipherText = base64.translate(b64CipherText);
+      byte[] iv = Arrays.copyOfRange(cipherText, 0, IV_LENGTH);
+      byte[] key = Arrays.copyOfRange(cipherText, IV_LENGTH, IV_LENGTH + KEY_SIZE);
+      SecretKey secretKey = new SecretKeySpec(key, ALGORITHM);
+      Cipher cipher = Cipher.getInstance(CIPHER);
+      GCMParameterSpec spec = new GCMParameterSpec(TAG_LENGTH, iv);
+      cipher.init(Cipher.DECRYPT_MODE, secretKey, spec);
+      int offset = iv.length + key.length;
+      byte[] plaintext = cipher.doFinal(cipherText, offset, cipherText.length - offset);
+      return new String(plaintext, getEncodingToUse(charset));
+    } catch (Exception e) {
+      throw new PasswordException(e);
+    }
+  }
+
+  public String encode(String plainText, String charset) throws PasswordException {
+    try {
+      KeyGenerator keyGenerator = KeyGenerator.getInstance(ALGORITHM);
+      keyGenerator.init(KEY_LENGTH);
+      SecretKey secretKey = keyGenerator.generateKey();
+      Cipher cipher = Cipher.getInstance(CIPHER);
+      byte[] iv = new byte[IV_LENGTH];
+      (new SecureRandom()).nextBytes(iv);
+      GCMParameterSpec spec = new GCMParameterSpec(TAG_LENGTH, iv);
+      cipher.init(Cipher.ENCRYPT_MODE, secretKey, spec);
+      byte[] bytes = plainText.getBytes(getEncodingToUse(charset));
+      byte[] key = secretKey.getEncoded();
+      byte[] cipherText = new byte[iv.length + key.length + cipher.getOutputSize(bytes.length)];
+      int i = 0;
+      for (byte v : iv) {
+        cipherText[i++] = v;
+      }
+      for (byte k : key) {
+        cipherText[i++] = k;
+      }
+      cipher.doFinal(bytes, 0, bytes.length, cipherText, i);
+      secretKey.getEncoded();
+      return PORTABLE_PASSWORD_2 + base64.translate(cipherText);
+    } catch (Exception e) {
+      throw new PasswordException(e);
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/security/password/Password.java
+++ b/interlok-core/src/main/java/com/adaptris/security/password/Password.java
@@ -57,6 +57,17 @@ public abstract class Password {
    */
   public static final String PORTABLE_PASSWORD = "PW:";
   /**
+   * Standard password style which is portable across environments.
+   * <p>
+   * It uses the Advanced Encryption Standard (AES) algorithm in
+   * Galois/Counter Mode (GCM) to perform the encryption. GCM has the
+   * benefit of providing authenticity (integrity) in addition to
+   * confidentiality.
+   * </p>
+   *
+   */
+  public static final String PORTABLE_PASSWORD_2 = "PW2:";
+  /**
    * Alternative password style which is not portable across environments and machines
    * <p>
    * It is not considered especially secure, but is enough to stop casual interrogation
@@ -73,7 +84,7 @@ public abstract class Password {
 
   private static final String[] STYLES =
   {
-          MSCAPI_STYLE, PORTABLE_PASSWORD
+          MSCAPI_STYLE, PORTABLE_PASSWORD, PORTABLE_PASSWORD_2
   };
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/security/password/Password.java
+++ b/interlok-core/src/main/java/com/adaptris/security/password/Password.java
@@ -66,7 +66,7 @@ public abstract class Password {
    * </p>
    *
    */
-  public static final String PORTABLE_PASSWORD_2 = "PW2:";
+  public static final String PORTABLE_PASSWORD_2 = "AES_GCM:";
   /**
    * Alternative password style which is not portable across environments and machines
    * <p>

--- a/interlok-core/src/main/resources/META-INF/services/com.adaptris.security.password.PasswordCodec
+++ b/interlok-core/src/main/resources/META-INF/services/com.adaptris.security.password.PasswordCodec
@@ -1,3 +1,4 @@
 com.adaptris.security.password.AesCrypto
 com.adaptris.security.password.MicrosoftCrypto
 com.adaptris.security.password.PbeCrypto
+com.adaptris.security.password.AesGcmCrypto

--- a/interlok-core/src/test/java/com/adaptris/security/password/PasswordTest.java
+++ b/interlok-core/src/test/java/com/adaptris/security/password/PasswordTest.java
@@ -58,6 +58,12 @@ public class PasswordTest {
   }
 
   @Test
+  public void testNewPortable() throws Exception {
+    String encoded = Password.encode(TEXT, Password.PORTABLE_PASSWORD_2);
+    assertEquals(TEXT, Password.decode(encoded));
+  }
+
+  @Test
   @SuppressWarnings("deprecation")
   public void testNonPortable() throws Exception {
     String encoded = Password.encode(TEXT, Password.NON_PORTABLE_PASSWORD);


### PR DESCRIPTION
## Motivation

AES/CBC/PKCS5Padding is now considered *weak crypto*, and get flagged up by CWE-327. It looks like it's the PKCS5Padding part that's causing the problem, and one solution is not to use this (or CBC mode) but switch to AES/GCM/NoPadding

## Modification

Add new PasswordImpl class, AesGcmCrypto, which uses AES/GCM/NoPadding instead of AES/CBC/PKCS5Padding.
## Result

The end user now has another implementation of PasswordImpl, that is hopefully more secure. GCM has the benefit of providing authenticity (integrity) in addition to confidentiality.

## Testing

The new implementation should be available as an alternative to the existing implementations.
