### PR TITLE
INTERLOK-2963 #comment Upgrade Derby DB to 10.15.2.0

### DIFF
--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -96,7 +96,8 @@ dependencies {
   compile ("net.sf.saxon:Saxon-HE:10.3")
   compile ("xerces:xercesImpl:2.12.1")
   compile ("com.mchange:c3p0:0.9.5.5")
-  compile ("org.apache.derby:derby:10.14.2.0")
+  compile ("org.apache.derby:derby:10.15.2.0")
+  compile ("org.apache.derby:derbytools:10.15.2.0")
   compile ("org.apache-extras.beanshell:bsh:2.0b6")
   compile ("javax:javaee-api:8.0.1")
 


### PR DESCRIPTION
## Motivation

Use the latest derby version that integrates better with java11

## Modification

Upgrade derby to 10.15.2.0

## Result

Nothing should change on how Interlok works

## Testing

Tests should pass
