### PR TITLE
Bumping ActiveMQ, apparently 5_16_0 is flagged by dependency checker.…

### DIFF
--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.filters.*
 
 ext {
   componentName='Base Interlok'
-  activeMqVersion='5.16.0'
+  activeMqVersion='5.16.1'
   bouncyCastleVersion='1.68'
   mysqlDriverVersion='8.0.22'
   slf4jVersion = '1.7.30'


### PR DESCRIPTION
…  V3 already taken care of by dependabot.

## Motivation

V3 build failed Friday afternoon because dependency analyzer threw a wobbly over ActiveMQ 5_16_0.  Found a dependabot pr to bump it, so I merged that in.
Now we need to do for v4 branch.
