### PR TITLE
INTERLOK-3706 Add exclusion specific for java11+eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,14 @@ subprojects { subproject ->
     all*.exclude group: 'javax.validation', module: 'validation-api'
     all*.exclude group: 'javax.activation', module: 'activation'
     all*.exclude group: 'javax.activation', module: 'javax.activation-api'
+
+    // module exclusions for java 11.
+    if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
+      all*.exclude group: "xml-apis", module: "xml-apis"
+      all*.exclude group: "stax", module: "stax-api"
+      all*.exclude group: "org.apache.geronimo.specs", module: "geronimo-jta_1.1_spec"
+    }
+
   }
 
   dependencies {


### PR DESCRIPTION
## Motivation

If you import the project into eclipse; it doesn't work and comes up with hundreds of errors along the lines of "package X is accessible from multiple modules 'un-named' && java something"

This is a side effect of the JPMS system, which has always existed but is now being enforced by Eclipse on Java11+ projects (or something).

## Modification

If our java build is > 1.9 then we exclude jars that might be included by transitive dependences that don't play nice with JPMS.

## Result

- Eclipse should now work
- `./gradlew test` should still work, since the java runtime is "less strict that eclipse".

## Testing

- Withouht this branch import the current develop branch into eclipse (you'll need to have made eclipse Java11 aware).
- It should have a bunch of errors and won't build.
- Switch to this branch, it should build.

Note that this build.gradle change might need to be applied to a lot of sub-projects.
