### PR TITLE
INTERLOK-3567 - Update for new test

### DIFF
--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
@@ -825,7 +825,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
         .when(mockTranslator).translate(any(AdaptrisMessage.class));
     
     String rfc6167 = "jms:queue:" + getName() + "";
-    JmsProducer producer = createProducer(new ConfiguredProduceDestination(rfc6167));
+    JmsProducer producer = createProducer(rfc6167);
     producer.setMessageTranslator(mockTranslator);
     producer.setPerMessageProperties(false);
     StandaloneRequestor serviceList = new StandaloneRequestor(activeMqBroker.getJmsConnection(),


### PR DESCRIPTION
Should have merge develop into feature branch before merging back into develop.

## Motivation

A new test was introduced which used a `ConfiguredProduceDestination`, whereas now the `createProducer()` method just accepts a `String`

## Modification

Update the test to removed the `ConfiguredProduceDestination`

## Result

The unit tests now compile.

## Testing

A simple `gradle build`
