### PR TITLE
INTERLOK-3439 Log a warning when a javascript name is used with a scripting service

### DIFF
--- a/interlok-core/src/test/java/com/adaptris/core/services/EmbeddedScriptingServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/EmbeddedScriptingServiceTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services;
 
@@ -20,21 +20,29 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.BranchingServiceCollection;
 import com.adaptris.core.GeneralServiceExample;
 import com.adaptris.core.MetadataElement;
-import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.metadata.AddMetadataService;
 import com.adaptris.core.util.LifecycleHelper;
 
-@SuppressWarnings("deprecation")
 public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
 
   private static final String MY_METADATA_KEY2 = "MyMetadataKey2";
@@ -52,7 +60,7 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
     EmbeddedScriptingService service = createService(getName());
     assertFalse(service.isBranching());
     execute(service, msg);
-    assertTrue(msg.containsKey(MY_METADATA_KEY));
+    assertTrue(msg.headersContainsKey(MY_METADATA_KEY));
     assertNotSame(MY_METADATA_VALUE, msg.getMetadataValue(MY_METADATA_KEY));
     assertEquals(new StringBuffer(MY_METADATA_VALUE).reverse().toString(), msg.getMetadataValue(MY_METADATA_KEY));
   }
@@ -72,7 +80,7 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
     BranchingServiceCollection bsc = new BranchingServiceCollection();
     bsc.setFirstServiceId(getName());
     bsc.add(createServiceForBranch(getName(), NEXT_SERVICE_ID));
-    AddMetadataService next = new AddMetadataService(new ArrayList<MetadataElement>(Arrays.asList(new MetadataElement(
+    AddMetadataService next = new AddMetadataService(new ArrayList<>(Arrays.asList(new MetadataElement(
         MY_METADATA_KEY2, MY_METADATA_VALUE))));
     next.setUniqueId(NEXT_SERVICE_ID);
     bsc.add(next);
@@ -93,7 +101,7 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     msg.addMetadata(MY_METADATA_KEY, MY_METADATA_VALUE);
     execute(bsc, msg);
-    assertTrue(msg.containsKey(MY_METADATA_KEY));
+    assertTrue(msg.headersContainsKey(MY_METADATA_KEY));
     assertEquals(MY_METADATA_VALUE, msg.getMetadataValue(MY_METADATA_KEY));
     assertEquals(MY_METADATA_VALUE, msg.getMetadataValue(MY_METADATA_KEY3));
   }
@@ -101,23 +109,110 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
   @Test
   public void testInit() throws Exception {
     EmbeddedScriptingService service = new EmbeddedScriptingService();
-    try {
-      LifecycleHelper.init(service);
-      fail("Service initialised w/o a language");
-    }
-    catch (Exception expected) {
-      ;
-    }
+    assertThrows("Service initialised w/o a language", Exception.class, () -> {
+      service.init();
+    });
     service.setLanguage("BLAHBLAHBLAH");
-    try {
+    assertThrows("Service initialised BLAHBLAHBLAH", Exception.class, () -> {
       LifecycleHelper.init(service);
-      fail("Service initialised BLAHBLAHBLAH");
-    }
-    catch (Exception expected) {
-      ;
-    }
+    });
     service.setLanguage("jruby");
     LifecycleHelper.init(service);
+  }
+
+  @Test
+  public void testInitWithJsLanguage() throws Exception {
+    EmbeddedScriptingService service = new EmbeddedScriptingService();
+    service.setScript("// Some script");
+    service.setLanguage("javascript");
+
+    LifecycleHelper.init(service);
+    LifecycleHelper.close(service);
+
+    service.setLanguage("js");
+
+    LifecycleHelper.init(service);
+    LifecycleHelper.close(service);
+
+    service.setLanguage("ecmascript");
+
+    LifecycleHelper.init(service);
+    LifecycleHelper.close(service);
+  }
+
+  @Test
+  public void testLanguageJavascriptEngineNashorn() throws Exception {
+    EmbeddedScriptingService service = new EmbeddedScriptingService();
+    service.setLanguage("javascript");
+
+    ScriptEngineManager engineManager = initEngineManager();
+
+    ScriptEngine scriptEngine = mock(ScriptEngine.class);
+    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
+
+    service.checkEngine(engineManager);
+  }
+
+  @Test
+  public void testLanguageJavascriptEngineGraalJs() throws Exception {
+    EmbeddedScriptingService service = new EmbeddedScriptingService();
+    service.setLanguage("javascript");
+
+    ScriptEngineManager engineManager = initEngineManager();
+
+    ScriptEngine scriptEngine = mock(ScriptEngine.class);
+    when(engineManager.getEngineByName(ScriptingService.GRAAL_JS_ENGINE)).thenReturn(scriptEngine);
+
+    service.checkEngine(engineManager);
+  }
+
+  @Test
+  public void testLanguageJavascriptEngineNoNashorn() throws Exception {
+    EmbeddedScriptingService service = new EmbeddedScriptingService();
+    service.setLanguage("javascript");
+
+    ScriptEngineManager engineManager = initEngineManager();
+
+    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(null);
+
+    service.checkEngine(engineManager);
+  }
+
+  @Test
+  public void testLanguageNashornEngineNashorn() throws Exception {
+    EmbeddedScriptingService service = new EmbeddedScriptingService();
+    service.setLanguage(ScriptingService.NASHORN);
+
+    ScriptEngine scriptEngine = mock(ScriptEngine.class);
+    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
+    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
+
+    service.checkEngine(engineManager);
+  }
+
+  @Test
+  public void testLanguageNashornEngineNashornAndGraalJs() throws Exception {
+    EmbeddedScriptingService service = new EmbeddedScriptingService();
+    service.setLanguage(ScriptingService.NASHORN);
+
+    ScriptEngine scriptEngine = mock(ScriptEngine.class);
+    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
+    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
+    when(engineManager.getEngineByName(ScriptingService.GRAAL_JS_ENGINE)).thenReturn(scriptEngine);
+
+    service.checkEngine(engineManager);
+  }
+
+  @Test
+  public void testLanguageJruby() throws Exception {
+    EmbeddedScriptingService service = new EmbeddedScriptingService();
+    service.setLanguage("jruby");
+
+    ScriptEngine scriptEngine = mock(ScriptEngine.class);
+    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
+    when(engineManager.getEngineByName("jruby")).thenReturn(scriptEngine);
+
+    service.checkEngine(engineManager);
   }
 
   @Test
@@ -135,13 +230,9 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
     EmbeddedScriptingService service = createService(getName());
     service.setScript("This Really Should Fail");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    try {
+    assertThrows("Service failure expected", Exception.class, () -> {
       execute(service, msg);
-      fail("Service failure expected");
-    }
-    catch (ServiceException expected) {
-
-    }
+    });
   }
 
   @Override
@@ -168,7 +259,6 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
     return result;
   }
 
-
   @Override
   protected String getExampleCommentHeader(Object obj) {
     return super.getExampleCommentHeader(obj) + "<!--"
@@ -180,4 +270,18 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
         + "\nlanguage. This isn't something that is easily supported with existing services "
         +"\n(but why would you want to do it?)" + "\n-->\n";
   }
+
+  private ScriptEngineManager initEngineManager() {
+    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
+
+    ScriptEngineFactory graaljsEngineFactory = mock(ScriptEngineFactory.class);
+    when(graaljsEngineFactory.getEngineName()).thenReturn(ScriptingService.GRAAL_JS_ENGINE);
+    ScriptEngineFactory nashornEngineFactory = mock(ScriptEngineFactory.class);
+    when(nashornEngineFactory.getEngineName()).thenReturn(ScriptingService.NASHORN_ENGINE);
+    when(nashornEngineFactory.getNames())
+    .thenReturn(List.of("nashorn", "Nashorn", "js", "JS", "JavaScript", "javascript", "ECMAScript", "ecmascript"));
+    when(engineManager.getEngineFactories()).thenReturn(List.of(graaljsEngineFactory, nashornEngineFactory));
+    return engineManager;
+  }
+
 }


### PR DESCRIPTION
## Motivation

Nashorn script engine is deprecated and will be removed in Java 17 so we need to warn users of ScriptingService and EmbeddedScriptingService and propose an alternative.

## Modification

- When using a scripting service the code now check if the script language is a nashorn supported language("js", "javascript"...)  and log a warning if it is and GraalJS is not in the classpath.
- If the script language is "nashorn" we log a warning regardless if GraalJS is in the classpath or not.
- Added new tests

Graaljs supports the all the javascript names Nashorn supports ("js", "JS", "JavaScript", "javascript", "ECMAScript", "ecmascript") so we don't need to do any translation.

The adapter need to be started with a system property so GraalJS works the same way as Nashorn:
`polyglot.js.nashorn-compat=true`

In the attached project it's set up in the bootsrap.properties.

## Result

- The scripting service still works the same if not using GraalJS but the user will get a warning.
- The scripting service will still works the same if using GraalJS with a javascript language ("javascript", "js", "ecmascript"...).
- JRuby is not affected

## Testing

- Use the attached project [graaljs.zip](https://github.com/adaptris/interlok/files/6065477/graaljs.zip) and build it: `gradlew clean assemble`
- Replace interlok-core.jar with your build from this PR branch.
- Start the adapter `(cd ./build/distribution && java -jar lib/interlok-boot.jar)`

The config has a pulling trigger that create a message every 10s and an EmbeddedScriptingService that add a payload to a message.

- With no change to the project you should not get a any warning.
- If you change the EmbeddedScriptingService  language to "nashorn" and restart the adapter you should get a warning about Nashorn being deprecated. In fact two warnings as there is the warning from Nashorn and the warning from the scripting service.
- If you change back the EmbeddedScriptingService  language to "javascript" and remove the graaljs dependencies graal-sdk.jar, js.jar and js-scriptengine.jar and restart the adapter you should also get the two warnings.



