### PR TITLE
INTERLOK-3740 JSCH Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,9 @@ subprojects { subproject ->
     all*.exclude group: 'javax.activation', module: 'activation'
     all*.exclude group: 'javax.activation', module: 'javax.activation-api'
 
+    // INTERLOK-3740 switch from jcraft to com.github.mwiede jsch fork.
+    all*.exclude group: 'com.jcraft', module: 'jsch'
+
     // module exclusions for java 11.
     if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
       all*.exclude group: "xml-apis", module: "xml-apis"

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -9,6 +9,7 @@ ext {
   mysqlDriverVersion='8.0.23'
   slf4jVersion = '1.7.30'
   mockitoVersion = '3.8.0'
+  jschVersion = '0.1.62'
 
   verboseTests= project.hasProperty('verboseTests') ? project.getProperty('verboseTests') : "false"
   classesToTest = project.hasProperty("junit.test.classes") ? project.getProperty("junit.test.classes") : "**/*Test*"
@@ -86,7 +87,7 @@ dependencies {
   compile ("com.sun.mail:jakarta.mail:1.6.5")
   compile ("org.glassfish.external:opendmk_jmxremote_optional_jar:1.0-b01-ea")
   compile ("org.glassfish.external:opendmk_jdmkrt_jar:1.0-b01-ea")
-  compile ("com.jcraft:jsch:0.1.55")
+  compile ("com.github.mwiede:jsch:$jschVersion")
   compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.38.v20210224")
   compile ("javax.servlet:javax.servlet-api:4.0.1")
   compile ("net.sf.joost:joost:0.9.1")


### PR DESCRIPTION
## Motivation

Support for JSCH by org.jcraft has discontinued and the last update was compiled for 1.6
Java 11 can only read class files compiled for a minimum Java version of 1.8

## Modification

We're now using com.github.mwiede:jsch:0.1.62, last updated this month.

## Result

We can now run Interlok components that require JSCH in a Java 11 runtime.

## Testing
See the following test project.  It is currently configured in the gradle.build to exclude org.jcraft and include the new replacement.  If you build this project removing the exclude and new include the project will fail to start-up in a Java 11 runtime.

[vcs-git-testing.zip](https://github.com/adaptris/interlok/files/6101760/vcs-git-testing.zip)
