### PR TITLE
INTERLOK-3573 XML services should use a restricted instance to mitigate against XXE

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/util/DocumentBuilderFactoryBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/DocumentBuilderFactoryBuilder.java
@@ -13,6 +13,7 @@ import org.xml.sax.EntityResolver;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -24,13 +25,25 @@ import lombok.Setter;
  * Allows simple configuration of a {@link DocumentBuilderFactory}.
  *
  * <p>
- * Note that unless explicitly specified then the corresponding {@link DocumentBuilderFactory} will
- * not have its corresponding setter called.
+ * For security reasons the default behaviour is to mitigate against XXE attacks and the like. It is
+ * still possible to explicitly configure whatever behaviour is required, but we no longer rely on
+ * the underlying {@code DocumentBuilderFactory} defaults. As a result the vanilla configuration for
+ * a {@code DocumentBuilderFactory} that is created by this class will have the following defaults:
+ * <ul>
+ * <li>expandEntityReferences will be set to false if not otherwise specified</li>
+ * <li>The feature {@value #DISABLE_DOCTYP} will be automatically set to true if not otherwise
+ * specified</li>
+ * </ul>
+ * </p>
+ * <p>
+ * Note that the static convenience methods have also been modified to reflect this behaviour. There
+ * are the two new {@link #newLenientInstance()} and
+ * {@link #newLenientInstanceIfNull(DocumentBuilderFactoryBuilder)} methods if the more secure
+ * default is not appropriate.
  * </p>
  *
- * @config xml-document-builder-configuration
- * @author lchan
  *
+ * @config xml-document-builder-configuration
  */
 @XStreamAlias("xml-document-builder-configuration")
 @DisplayOrder(
@@ -47,6 +60,9 @@ public class DocumentBuilderFactoryBuilder {
    * No validation of the features is done and are passed as-is through to the underlying
    * DocumentBuilderFactory.
    * </p>
+   *
+   * @since 4.0 By default the XML Feature {@value #DISABLE_DOCTYP} will be set to true to disable
+   *        doctype declarations.
    */
   @NotNull
   @AutoPopulated
@@ -80,10 +96,13 @@ public class DocumentBuilderFactoryBuilder {
   @Setter
   private Boolean ignoreWhitespace;
   /**
-   * Calls {@link DocumentBuilderFactory#setExpandEntityReferences(boolean)} if non-null
+   * Wraps {@link DocumentBuilderFactory#setExpandEntityReferences(boolean)}.
    *
+   * @since 4.0 If not specified, then the default is 'false' so that we mitigate against XXE
+   *        attacks when parsing XML.
    */
   @AdvancedConfig
+  @InputFieldDefault(value = "false")
   @Getter
   @Setter
   private Boolean expandEntityReferences;
@@ -154,6 +173,9 @@ public class DocumentBuilderFactoryBuilder {
 
       @Override
       void applyConfig(DocumentBuilderFactoryBuilder b, DocumentBuilderFactory f) throws ParserConfigurationException {
+        // INTERLOK-3573
+        // Default expand entity ref to false, and then override.
+        f.setExpandEntityReferences(false);
         if (b.getExpandEntityReferences() != null) {
           f.setExpandEntityReferences(b.getExpandEntityReferences());
         }
@@ -193,6 +215,9 @@ public class DocumentBuilderFactoryBuilder {
 
       @Override
       void applyConfig(DocumentBuilderFactoryBuilder b, DocumentBuilderFactory f) throws ParserConfigurationException {
+        // INTERLOK-3573
+        // Disable DOCTYPS, and then override.
+        f.setFeature(DISABLE_DOCTYP, true);
         for (KeyValuePair entry : b.getFeatures()) {
           f.setFeature(entry.getKey(), BooleanUtils.toBoolean(entry.getValue()));
         }
@@ -208,10 +233,11 @@ public class DocumentBuilderFactoryBuilder {
   /**
    * Create a new instance that is namespace aware.
    *
-   * @return a new instance.
+   *
+   * @return a new instance which is basically the same as {@link #newRestrictedInstance()}.
    */
   public static final DocumentBuilderFactoryBuilder newInstance() {
-    return new DocumentBuilderFactoryBuilder().withNamespaceAware(true);
+    return newRestrictedInstance();
   }
 
   /**
@@ -226,19 +252,65 @@ public class DocumentBuilderFactoryBuilder {
         .addFeature(DISABLE_DOCTYP, Boolean.TRUE);
   }
 
+  /**
+   * Return a DocumentBuilderFactoryBuilder instance that explicitly does not mitigate against XXE
+   * and is also namespace aware.
+   *
+   * <p>
+   * This is included for completeness, it's not expected that you'll want to use this, however if
+   * you were using {@link #newInstance()} and you don't like the new defaults then well, here it
+   * is.
+   * </p>
+   *
+   * @return a new instance
+   */
+  public static final DocumentBuilderFactoryBuilder newLenientInstance() {
+    return new DocumentBuilderFactoryBuilder().withNamespaceAware(true)
+        .withExpandEntityReferences(true).addFeature(DISABLE_DOCTYP, Boolean.FALSE);
+  }
+
+
+  /**
+   * Convenient method to create a new default instance if required.
+   *
+   * @param b an existing configured DocumentBuilderFactoryBuilder, if null, then
+   *        {@link #newInstance()} is used.
+   *
+   * @return a DocumentBuilderFactoryBuilder instance.
+   */
   public static final DocumentBuilderFactoryBuilder newInstanceIfNull(DocumentBuilderFactoryBuilder b) {
     return ObjectUtils.defaultIfNull(b, newInstance());
   }
 
+  /**
+   * Convenient method to create a new default instance if required.
+   *
+   * @param b an existing configured DocumentBuilderFactoryBuilder, if null, then
+   *        {@link #newRestrictedInstance()} is used.
+   *
+   * @return a DocumentBuilderFactoryBuilder instance.
+   */
   public static final DocumentBuilderFactoryBuilder newRestrictedInstanceIfNull(DocumentBuilderFactoryBuilder b) {
     return ObjectUtils.defaultIfNull(b, newRestrictedInstance());
+  }
+
+  /**
+   * Convenient method to create a new default instance if required.
+   *
+   * @param b an existing configured DocumentBuilderFactoryBuilder, if null, then
+   *        {@link #newLenientInstance()()} is used.
+   *
+   * @return a DocumentBuilderFactoryBuilder instance.
+   */
+  public static final DocumentBuilderFactoryBuilder newLenientInstanceIfNull(DocumentBuilderFactoryBuilder b) {
+    return ObjectUtils.defaultIfNull(b, newLenientInstance());
   }
 
   public static final DocumentBuilderFactoryBuilder newInstanceIfNull(DocumentBuilderFactoryBuilder b, NamespaceContext ctx) {
     if (b != null) {
       return b;
     }
-    return ctx == null ? newInstance() : newInstance().withNamespaceAware(true);
+    return ctx == null ? newRestrictedInstance() : newRestrictedInstance().withNamespaceAware(true);
   }
 
 

--- a/interlok-core/src/main/java/com/adaptris/core/util/DocumentBuilderFactoryBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/DocumentBuilderFactoryBuilder.java
@@ -51,7 +51,8 @@ order = {"validating", "namespaceAware", "xincludeAware", "expandEntityReference
     "ignoreWhitespace", "features"})
 public class DocumentBuilderFactoryBuilder {
 
-  public static final String DISABLE_DOCTYP =
+
+  public static final String DISABLE_DOCTYPE =
       "http://apache.org/xml/features/disallow-doctype-decl";
 
   /**
@@ -217,7 +218,7 @@ public class DocumentBuilderFactoryBuilder {
       void applyConfig(DocumentBuilderFactoryBuilder b, DocumentBuilderFactory f) throws ParserConfigurationException {
         // INTERLOK-3573
         // Disable DOCTYPS, and then override.
-        f.setFeature(DISABLE_DOCTYP, true);
+        f.setFeature(DISABLE_DOCTYPE, true);
         for (KeyValuePair entry : b.getFeatures()) {
           f.setFeature(entry.getKey(), BooleanUtils.toBoolean(entry.getValue()));
         }
@@ -249,7 +250,7 @@ public class DocumentBuilderFactoryBuilder {
    */
   public static final DocumentBuilderFactoryBuilder newRestrictedInstance() {
     return new DocumentBuilderFactoryBuilder().withNamespaceAware(true).withExpandEntityReferences(false)
-        .addFeature(DISABLE_DOCTYP, Boolean.TRUE);
+        .addFeature(DISABLE_DOCTYPE, Boolean.TRUE);
   }
 
   /**
@@ -266,7 +267,7 @@ public class DocumentBuilderFactoryBuilder {
    */
   public static final DocumentBuilderFactoryBuilder newLenientInstance() {
     return new DocumentBuilderFactoryBuilder().withNamespaceAware(true)
-        .withExpandEntityReferences(true).addFeature(DISABLE_DOCTYP, Boolean.FALSE);
+        .withExpandEntityReferences(true).addFeature(DISABLE_DOCTYPE, Boolean.FALSE);
   }
 
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/XpathMetadataServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/XpathMetadataServiceTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,10 +28,6 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.common.ConstantDataInputParameter;
-import com.adaptris.core.common.Execution;
-import com.adaptris.core.common.MetadataDataOutputParameter;
-import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.services.metadata.xpath.ConfiguredXpathQuery;
 import com.adaptris.core.services.metadata.xpath.MetadataXpathQuery;
 import com.adaptris.core.services.metadata.xpath.MultiItemConfiguredXpathQuery;
@@ -103,7 +99,7 @@ public class XpathMetadataServiceTest extends MetadataServiceExample {
     assertEquals("partnera", msg.getMetadataValue("source"));
     assertEquals("partnerb", msg.getMetadataValue("destination"));
   }
-  
+
   @Test
   public void testPayloadSingleAttributeValueXPathIntoMetadata() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -114,7 +110,7 @@ public class XpathMetadataServiceTest extends MetadataServiceExample {
     assertEquals("att", msg.getMetadataValue("attribute"));
     assertEquals("two", msg.getMetadataValue("attr"));
   }
-  
+
   @Test
   public void testPayloadMultipleAttributeValuesXPathIntoMetadata() throws Exception {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -149,6 +145,22 @@ public class XpathMetadataServiceTest extends MetadataServiceExample {
     DocumentBuilderFactoryBuilder builder = new DocumentBuilderFactoryBuilder();
     builder.getFeatures().add(new KeyValuePair("http://apache.org/xml/features/disallow-doctype-decl", "true"));
     service.setXmlDocumentFactoryConfig(builder);
+    try {
+      execute(service, msg);
+      fail();
+    } catch (ServiceException expected) {
+      assertTrue(expected.getMessage().contains("DOCTYPE is disallowed"));
+    }
+  }
+
+  @Test
+  public void testDoService_DocType_DefaultBehaviour() throws CoreException {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_WITH_DOCTYPE);
+    // Default document factory should disable doctyps.
+    XpathMetadataService service = new XpathMetadataService();
+    // Shouldn't matter what the query actually is.
+    service.setXpathQueries(new ArrayList<XpathQuery>(Arrays.asList(new ConfiguredXpathQuery("source",
+        "//source-id"), new ConfiguredXpathQuery("destination", "//destination-id"))));
     try {
       execute(service, msg);
       fail();

--- a/interlok-core/src/test/java/com/adaptris/core/util/DocumentBuilderFactoryBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/DocumentBuilderFactoryBuilderTest.java
@@ -16,6 +16,7 @@
 package com.adaptris.core.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -52,18 +53,53 @@ public class DocumentBuilderFactoryBuilderTest {
   public void tearDown() throws Exception {}
 
   @Test
-  public void testNewInstance() {
+  public void testNewLenientInstance() throws Exception {
+    DocumentBuilderFactoryBuilder b = DocumentBuilderFactoryBuilder.newLenientInstance();
+    assertNotNull(b.getFeatures());
+    assertEquals(1, b.getFeatures().size());
+    assertTrue(b.getNamespaceAware());
+    assertTrue(b.getExpandEntityReferences());
+
+    assertEquals(b, DocumentBuilderFactoryBuilder.newLenientInstanceIfNull(b));
+    assertNotSame(b, DocumentBuilderFactoryBuilder.newLenientInstanceIfNull(null));
+
+    DocumentBuilderFactory f = b.build();
+    assertFalse(f.isCoalescing());
+    assertTrue(f.isExpandEntityReferences());
+    assertFalse(f.isIgnoringComments());
+    assertFalse(f.isIgnoringElementContentWhitespace());
+    assertFalse(f.isValidating());
+    assertTrue(f.isNamespaceAware());
+    assertFalse(f.isXIncludeAware());
+    assertFalse(f.getFeature(DISALLOW_DOCTYPE));
+
+  }
+
+
+  @Test
+  public void testNewInstance() throws Exception {
     DocumentBuilderFactoryBuilder b = DocumentBuilderFactoryBuilder.newInstance();
     assertNotNull(b.getFeatures());
-    assertEquals(0, b.getFeatures().size());
+    assertEquals(1, b.getFeatures().size());
     assertEquals(true, b.getNamespaceAware());
+    assertEquals(false, b.getExpandEntityReferences());
 
     assertEquals(b, DocumentBuilderFactoryBuilder.newInstanceIfNull(b));
     assertNotSame(b, DocumentBuilderFactoryBuilder.newInstanceIfNull(null));
+
+    DocumentBuilderFactory f = b.build();
+    assertFalse(f.isCoalescing());
+    assertFalse(f.isExpandEntityReferences());
+    assertFalse(f.isIgnoringComments());
+    assertFalse(f.isIgnoringElementContentWhitespace());
+    assertFalse(f.isValidating());
+    assertTrue(f.isNamespaceAware());
+    assertFalse(f.isXIncludeAware());
+    assertTrue(f.getFeature(DISALLOW_DOCTYPE));
   }
 
   @Test
-  public void testNewRestrictedInstance() {
+  public void testNewRestrictedInstance() throws Exception {
     DocumentBuilderFactoryBuilder b = DocumentBuilderFactoryBuilder.newRestrictedInstance();
     assertNotNull(b.getFeatures());
     assertEquals(1, b.getFeatures().size());
@@ -72,6 +108,16 @@ public class DocumentBuilderFactoryBuilderTest {
     assertEquals(false, b.getExpandEntityReferences());
     assertEquals(b, DocumentBuilderFactoryBuilder.newRestrictedInstanceIfNull(b));
     assertNotSame(b, DocumentBuilderFactoryBuilder.newRestrictedInstanceIfNull(null));
+
+    DocumentBuilderFactory f = b.build();
+    assertFalse(f.isCoalescing());
+    assertFalse(f.isExpandEntityReferences());
+    assertFalse(f.isIgnoringComments());
+    assertFalse(f.isIgnoringElementContentWhitespace());
+    assertFalse(f.isValidating());
+    assertTrue(f.isNamespaceAware());
+    assertFalse(f.isXIncludeAware());
+    assertTrue(f.getFeature(DISALLOW_DOCTYPE));
   }
 
   @Test
@@ -117,12 +163,13 @@ public class DocumentBuilderFactoryBuilderTest {
     assertTrue(DocumentBuilderFactory.class.isAssignableFrom(b.build().getClass()));
     DocumentBuilderFactory f = b.build();
     assertEquals(false, f.isCoalescing());
-    assertEquals(true, f.isExpandEntityReferences());
+    assertEquals(false, f.isExpandEntityReferences());
     assertEquals(false, f.isIgnoringComments());
     assertEquals(false, f.isIgnoringElementContentWhitespace());
     assertEquals(false, f.isValidating());
     assertEquals(true, f.isNamespaceAware());
     assertEquals(false, f.isXIncludeAware());
+    assertEquals(true, f.getFeature(DISALLOW_DOCTYPE));
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/util/DocumentBuilderFactoryBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/DocumentBuilderFactoryBuilderTest.java
@@ -103,7 +103,7 @@ public class DocumentBuilderFactoryBuilderTest {
     DocumentBuilderFactoryBuilder b = DocumentBuilderFactoryBuilder.newRestrictedInstance();
     assertNotNull(b.getFeatures());
     assertEquals(1, b.getFeatures().size());
-    assertNotNull(b.getFeatures().getKeyValuePair(DocumentBuilderFactoryBuilder.DISABLE_DOCTYP));
+    assertNotNull(b.getFeatures().getKeyValuePair(DocumentBuilderFactoryBuilder.DISABLE_DOCTYPE));
     assertEquals(true, b.getNamespaceAware());
     assertEquals(false, b.getExpandEntityReferences());
     assertEquals(b, DocumentBuilderFactoryBuilder.newRestrictedInstanceIfNull(b));


### PR DESCRIPTION
## Motivation

XpathMetadataService is using DocumentBuilderFactoryBuilder.newInstanceIfNull, which relies on the underlying document factory for things like XXE mitigations. It should probably be using newRestrictedInstanceIfNull instead to explicitly disable things like doctype and entity handling.

On the same note, DocumentBuilderFactoryBuilder should be setting those same features to "off" when not configured rather than rely on the default underlying DocumentBuilderFactory configuration.

This change will not break config directly, but it will break currently-working functionality if someone was relying on those featured being defaulted on in some DocumentBuilderFactory implementations.

## Modification

- newInstance() now just delegates to newRestrictedInstance()
- Modify enums so that the new "secure" defaults are applied before any values taken from configuration.
- Add a newLenientInstance/ifNull for completeness.
- Add Tests.


## Result

There is no configuration change for the end-user however there is a massive behaviour change which has knock-on effects.

- expand-entity-references = false by default.
- `http://apache.org/xml/features/disallow-doctype-decl` is set to true as the default feature.
- ALL XML Services are affected that end up having a configurable DocumentBuilderFactoryBuilder (xml-transform / xpath-metadata etc etc).

 
## Testing

Configure an XPathMetadataService that doesn't have a DocumentBuilderFactoryBuilder configured : 

e.g. 
```
<xpath-metadata-service>
   <xpath-query class="configured-xpath-query">
     <metadata-key>adapter_unique_id</metadata-key>
     <xpath-query>/adapter/unique-id</xpath-query>
   </xpath-query>
</xpath-metadata-service>
```

Along with a corresponding input file.

```
<!DOCTYPE adapter [
<!ENTITY MY_ADAPTER_ID 'my-adapter'>

]>

<adapter>
  <unique-id>&MY_ADAPTER_ID;</unique-id>
</adapter>
```

- This PR should fail with an exception containing something like `DOCTYP not allowed`
- The 4.0-SNAPSHOT branch should succeed.

Note that this is very similar to the test contained in XpathMetadataServiceTest#testDoService_DocType_DefaultBehaviour