### PR TITLE
Attempt to retry tests for intermittent failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '6.1.1' apply false
   id "io.freefair.lombok" version "5.3.0" apply false
   // id 'org.kordamp.gradle.jdeps' version '0.12.0' apply false
+  id "org.gradle.test-retry" version "1.2.0" apply false
 }
 
 ext {
@@ -33,19 +34,19 @@ if (JavaVersion.current().isJava8Compatible()) {
   }
 }
 
-ext.jacocoEnabled = { subproject ->
-  return !subproject.name.equals("interlok-core-apt")
-}
+ext.buildDetails = [
+  jacocoEnabled: { subproject ->
+    return !subproject.name.equals("interlok-core-apt")
+  },
 
+  gitBranchNameOrTimestamp: { branchName ->
+    if (branchName.equals("HEAD") || branchName.equals("develop") || branchName.startsWith("release")) {
+      return new Date().format('HH:mm:ss z');
+    }
+    return branchName;
+  },
 
-ext.gitBranchNameOrTimestamp = { branchName ->
-  if (branchName.equals("HEAD") || branchName.equals("develop") || branchName.startsWith("release")) {
-    return new Date().format('HH:mm:ss z');
-  }
-  return branchName;
-}
-
-ext.buildInfo = { ->
+  buildInfo: { ->
    new ByteArrayOutputStream().withStream { os ->
       exec {
         executable = "git"
@@ -53,9 +54,14 @@ ext.buildInfo = { ->
         standardOutput = os
       }
       def branchName = os.toString().replaceAll("\r", "").replaceAll("\n", "").trim();
-      return gitBranchNameOrTimestamp(branchName);
+      return buildDetails.gitBranchNameOrTimestamp(branchName);
     }
-}
+  },
+
+  is_ci_pipeline: { ->
+    return System.getenv().containsKey("CI");
+  }
+]
 
 task clean(type: Delete) {
   delete project.buildDir
@@ -71,8 +77,9 @@ subprojects { subproject ->
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'io.freefair.lombok'
   // apply plugin: 'org.kordamp.gradle.jdeps'
+  apply plugin: 'org.gradle.test-retry'
 
-  if (jacocoEnabled(subproject)) {
+  if (buildDetails.jacocoEnabled(subproject)) {
     apply plugin: "jacoco"
   }
 
@@ -135,7 +142,7 @@ subprojects { subproject ->
   }
 
 
-  if (jacocoEnabled(subproject)) {
+  if (buildDetails.jacocoEnabled(subproject)) {
     jacoco {
       toolVersion="0.8.2"
     }
@@ -166,7 +173,7 @@ subprojects { subproject ->
         entry(key: 'groupId', value: project.group)
         entry(key: 'artifactId', value: project.name)
         entry(key: 'build.date', value: new Date().format('yyyy-MM-dd'))
-        entry(key: 'build.info', value: buildInfo())
+        entry(key: 'build.info', value: buildDetails.buildInfo())
       }
     }
   }

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -308,6 +308,12 @@ test {
       logger.lifecycle("Running: " + descriptor)
      }
   }
+  if (buildDetails.is_ci_pipeline()) {
+    retry {
+      maxRetries = 3
+      maxFailures = 20
+    }
+  }
 }
 
 uploadArchives {


### PR DESCRIPTION
## Motivation

Some junit tests appear to be sensitive in the sense that they cannot be re-created on "real" machines but are intermittently failing when running in virtual environments like the various CI providers we use.

For instance:
- jmx-notifications sometimes fail
- jdbc pooled connections sometimes fail.

What we need to do is to be able to retry tests if they fail, to make sure that they aren't intermittent ones

## Modification

- apply the org.gradle.test-retry plugin
- Configure the retry plugin in interlok-core to only trigger when we are in CI mode (github actions, appveyor, circleci will auto set CI=true as an env-var).
- Encapsulate some existing "functions" into a pseudo module, rather than using `buildInfo()` we use `buildDetails.buildInfo()` etc. It's just for namespacing as our gradle files get more awesome.

## Result

No change for the user running on their desktop/laptop whatever

## Testing

Well, let's check the builds that are triggered as part of this PR.
