### PR TITLE
INTERLOK-3566 Re-add tests and update javadoc

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/util/DestinationHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/DestinationHelper.java
@@ -6,6 +6,9 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageListener;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.util.LoggingHelper.WarningLoggedCallback;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
 
 public class DestinationHelper {
 
@@ -22,9 +25,14 @@ public class DestinationHelper {
    * Helper method so that consume destinations can still be supported in-situ with string based
    * configurations.
    * </p>
+   * <p>
+   * No longer accepts a legacy destination (as they no longer exists), but does perform any
+   * validity checks on {@code configured}.
+   * </p>
    *
-   * @return {@code legacy#getDestination()} if legacy is non-null; {@code configured} otherwise.
+   * @return {@code configured}.
    */
+  @Deprecated
   public static String consumeDestination(final String configured) {
     Object legacy = null;
     return Optional.ofNullable(legacy).map((d) -> d.toString()).orElse(configured);
@@ -37,10 +45,14 @@ public class DestinationHelper {
    * Helper method so that consume destinations can still be supported in-situ with string based
    * configurations.
    * </p>
+   * <p>
+   * No longer accepts a legacy destination (as they no longer exists), but does perform any
+   * validity checks on {@code configured}.
+   * </p>
    *
-   * @return {@code legacy#getFilterExpression()} if legacy is non-null; {@code configured}
-   *         otherwise.
+   * @return {@code configured}.
    */
+  @Deprecated
   public static String filterExpression(final String configured) {
     String legacy = null;
     return Optional.ofNullable(legacy).map((d) -> d.toString()).orElse(configured);
@@ -53,9 +65,13 @@ public class DestinationHelper {
    * Helper method so that consume destinations can still be supported in-situ with string based
    * configurations.
    * </p>
+   * </p>
+   * <p>
+   * No longer accepts a legacy destination (as they no longer exists), but does perform any
+   * validity checks on {@code listener}.
+   * </p>
    *
-   * @return {@code legacy#getDestination()} if legacy is non-null; {@code listener#friendlyName()}
-   *         otherwise.
+   * @return {@code listener#friendlyName()}.
    */
   public static String threadName(final AdaptrisMessageListener listener) {
     // If nothings defined, then just use the current name.
@@ -68,9 +84,12 @@ public class DestinationHelper {
    * Helper method so that consume destinations can still be supported in-situ with string based
    * configurations.
    * </p>
+   * <p>
+   * No longer accepts a legacy destination (as they no longer exists), but does perform any
+   * validity checks on {@code listener}.
+   * </p>
    *
-   * @return {@code legacy#getDestination()} if legacy is non-null; {@code listener#friendlyName()}
-   *         otherwise.
+   * @return {@code listener#friendlyName()}.
    */
   public static String threadName(final AdaptrisMessageListener listener, String defaultName) {
     Object legacy = null;
@@ -88,6 +107,7 @@ public class DestinationHelper {
    * @return {@code legacy.getDestination(msg)} if legacy is non-null;
    *         {@code msg.resolve(configured)} otherwise.
    */
+  @Deprecated
   public static String resolveProduceDestination(String configured, AdaptrisMessage msg) throws ProduceException {
     return msg.resolve(configured);
   }
@@ -105,7 +125,7 @@ public class DestinationHelper {
       WarningLoggedCallback callback,
       String text,
       Object... args) {
-    logWarningIfNotNull(alreadyLogged, callback, null, text, args);
+    logWarningIfNotNull(alreadyLogged, callback, text, args);
   }
 
   /**
@@ -118,12 +138,9 @@ public class DestinationHelper {
    *
    * @see LoggingHelper#logWarning(boolean, WarningLoggedCallback, String, Object...)
    */
+  @Deprecated
   public static void logWarningIfNotNull(boolean alreadyLogged,
-      WarningLoggedCallback callback, Object d, String text, Object... args) {
-    if (d != null) {
-      LoggingHelper.logWarning(alreadyLogged, callback, text, args);
-    } else {
+      WarningLoggedCallback callback, String text, Object... args) {
       callback.warningLogged();
-    }
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/DestinationHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/DestinationHelper.java
@@ -12,6 +12,10 @@ import java.util.Optional;
 
 public class DestinationHelper {
 
+  /** 
+   * @deprecated will be removed w/o warning since it has no meaning since {@code destination} was removed.
+   */
+  @Deprecated
   public static void mustHaveEither(String configured) {
     if (configured == null) {
       throw new IllegalArgumentException("Must have string configuration");
@@ -29,7 +33,7 @@ public class DestinationHelper {
    * No longer accepts a legacy destination (as they no longer exists), but does perform any
    * validity checks on {@code configured}.
    * </p>
-   *
+   * @deprecated will be removed w/o warning since it has no meaning since {@code destination} was removed.
    * @return {@code configured}.
    */
   @Deprecated
@@ -48,7 +52,7 @@ public class DestinationHelper {
    * No longer accepts a legacy destination (as they no longer exists), but does perform any
    * validity checks on {@code configured}.
    * </p>
-   *
+   * @deprecated will be removed w/o warning since it has no meaning since {@code destination} was removed.
    * @return {@code configured}.
    */
   @Deprecated
@@ -100,11 +104,12 @@ public class DestinationHelper {
    * configurations.
    * </p>
    *
-   * @return {@code legacy.getDestination(msg)} if legacy is non-null;
+   * @deprecated just ms msg.resolve() instead.
+    * @return {@code legacy.getDestination(msg)} if legacy is non-null;
    *         {@code msg.resolve(configured)} otherwise.
    */
   @Deprecated
-  public static String resolveProduceDestination(String configured, AdaptrisMessage msg) throws ProduceException {
+  public static String resolveProduceDestination(String configured, AdaptrisMessage msg) {
     return msg.resolve(configured);
   }
 
@@ -112,9 +117,7 @@ public class DestinationHelper {
    * Log a warning if consume destination is not null.
    *
    * @see LoggingHelper#logWarning(boolean, WarningLoggedCallback, String, Object...)
-   * @deprecated use
-   *             {@code logWarningIfNotNull(boolean, WarningLoggedCallback, Object, String, Object...)}
-   *             instead.
+   * @deprecated will be removed w/o warning since it has no meaning since {@code destination} was removed.
    */
   @Deprecated
   public static void logConsumeDestinationWarning(boolean alreadyLogged,

--- a/interlok-core/src/main/java/com/adaptris/core/util/DestinationHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/DestinationHelper.java
@@ -34,8 +34,7 @@ public class DestinationHelper {
    */
   @Deprecated
   public static String consumeDestination(final String configured) {
-    Object legacy = null;
-    return Optional.ofNullable(legacy).map((d) -> d.toString()).orElse(configured);
+    return configured;
   }
 
   /**
@@ -54,8 +53,7 @@ public class DestinationHelper {
    */
   @Deprecated
   public static String filterExpression(final String configured) {
-    String legacy = null;
-    return Optional.ofNullable(legacy).map((d) -> d.toString()).orElse(configured);
+    return configured;
   }
 
 
@@ -92,9 +90,7 @@ public class DestinationHelper {
    * @return {@code listener#friendlyName()}.
    */
   public static String threadName(final AdaptrisMessageListener listener, String defaultName) {
-    Object legacy = null;
-    String threadName = Optional.ofNullable(listener).map((l) -> l.friendlyName()).orElse(defaultName);
-    return Optional.ofNullable(legacy).map((d) -> d.toString()).filter((s) -> StringUtils.isNotEmpty(s)).orElse(threadName);
+    return Optional.ofNullable(listener).map((l) -> l.friendlyName()).orElse(defaultName);
   }
 
   /**
@@ -125,7 +121,7 @@ public class DestinationHelper {
       WarningLoggedCallback callback,
       String text,
       Object... args) {
-    logWarningIfNotNull(alreadyLogged, callback, text, args);
+    logWarningIfNotNull(alreadyLogged, callback, null, text, args);
   }
 
   /**
@@ -140,7 +136,11 @@ public class DestinationHelper {
    */
   @Deprecated
   public static void logWarningIfNotNull(boolean alreadyLogged,
-      WarningLoggedCallback callback, String text, Object... args) {
+      WarningLoggedCallback callback, Object d, String text, Object... args) {
+    if (d != null) {
+      LoggingHelper.logWarning(alreadyLogged, callback, text, args);
+    } else {
       callback.warningLogged();
+    }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/util/DestinationHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/DestinationHelperTest.java
@@ -1,0 +1,56 @@
+package com.adaptris.core.util;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.stubs.MockMessageListener;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class DestinationHelperTest extends DestinationHelper {
+
+  @Test
+  public void testMustHaveEither() {
+    mustHaveEither("x");
+  }
+
+  @Test
+  public void testConsumeDestination() {
+    assertNull(consumeDestination(null));
+  }
+
+  @Test
+  public void testFilterExpression() {
+    assertNull(filterExpression(null));
+    assertEquals("x", filterExpression("x"));
+  }
+
+  @Test
+  public void testThreadNameAdaptrisMessageListenerConsumeDestination() {
+    String currentThreadName = Thread.currentThread().getName();
+    assertEquals(currentThreadName, threadName(null, currentThreadName));
+    assertEquals("MockMessageListener", threadName(new MockMessageListener(), null));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testConsumeDestinationWarning() {
+    logConsumeDestinationWarning(false, () -> { }, "{} warning", "this is a");
+    logConsumeDestinationWarning(false, () -> { }, null, "{} warning", "this is a");
+  }
+
+  @Test
+  public void testLogWarningIfNotNull() {
+    logWarningIfNotNull(false, () -> { }, "{} warning", "this is a");
+    logWarningIfNotNull(false, () -> { }, null, "{} warning", "this is a");
+  }
+
+  @Test
+  public void testProduceDestination() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    assertNull(resolveProduceDestination(null, msg));
+    assertEquals("x", resolveProduceDestination("x", msg));
+  }
+
+}


### PR DESCRIPTION
## Motivation

Re-add tests DestinationHelper

## Modification

Re-add tests DestinationHelper and update JavaDoc, mark the methods as Deprecated.

## Result

There are now unit tests to run and the JavaDoc matches the methods.

## Testing

Tests run as expected.
