### PR TITLE
Remove java9 deprecated constructors

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/EventFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/EventFactory.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ public abstract class EventFactory {
    */
   public static Event create(String name) throws CoreException {
     try {
-      Event result = (Event) Class.forName(name).newInstance();
+      Event result = (Event) Class.forName(name).getDeclaredConstructor().newInstance();
       result.setUniqueId(uidGenerator.create(result));
       result.setCreationTime(System.currentTimeMillis());
       return result;
@@ -65,7 +65,7 @@ public abstract class EventFactory {
   public static <T> T create(Class<T> name) throws CoreException {
     T result;
     try {
-      result = (T) Class.forName(name.getName()).newInstance();
+      result = (T) Class.forName(name.getName()).getDeclaredConstructor().newInstance();
       ((Event)result).setUniqueId(uidGenerator.create(result));
       ((Event)result).setCreationTime(System.currentTimeMillis());
     }

--- a/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
@@ -291,7 +291,9 @@ public class BootstrapProperties extends Properties {
   public synchronized AdapterConfigManager getConfigManager() throws Exception {
     if (configManager == null) {
       configManager = (AdapterConfigManager) Class
-          .forName(PropertyHelper.getPropertyIgnoringCase(this, CFG_KEY_CONFIG_MANAGER, DEFAULT_CONFIG_MANAGER)).newInstance();
+          .forName(PropertyHelper.getPropertyIgnoringCase(this, CFG_KEY_CONFIG_MANAGER,
+              DEFAULT_CONFIG_MANAGER))
+          .getDeclaredConstructor().newInstance();
       configManager.configure(this);
     }
     return configManager;

--- a/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponentFactory.java
@@ -19,7 +19,6 @@ package com.adaptris.core.management;
 import static com.adaptris.core.management.Constants.CFG_KEY_MANAGEMENT_COMPONENT;
 import static com.adaptris.core.util.PropertyHelper.getPropertyIgnoringCase;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -28,10 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.ClosedState;
 import com.adaptris.core.management.classloader.ClassLoaderFactory;
 
@@ -51,7 +48,7 @@ public class ManagementComponentFactory {
   private static final ManagementComponentFactory INSTANCE = new ManagementComponentFactory();
 
   private final Map<Properties, List<ManagementComponentInfo>> managementComponents = new HashMap<>();
-  
+
   private ManagementComponentFactory() {
   }
 
@@ -122,13 +119,13 @@ public class ManagementComponentFactory {
       final String components[] = componentList.split(COMPONENT_SEPARATOR);
       for (final String componentName : components) {
         ManagementComponent resolvedComponent = resolve(componentName, bootstropProperties);
-        
+
         ManagementComponentInfo mcInfo = new ManagementComponentInfo();
         mcInfo.setClassName(resolvedComponent.getClass().getName());
         mcInfo.setState(ClosedState.getInstance());
         mcInfo.setName(componentName);
         mcInfo.setInstance(resolvedComponent);
-        
+
         result.add(mcInfo);
       }
     }
@@ -152,13 +149,15 @@ public class ManagementComponentFactory {
           classLoader = classLoaderFactory.create(classLoader);
           Thread.currentThread().setContextClassLoader(classLoader);
         }
-        final ManagementComponent component = (ManagementComponent) Class.forName(p.getProperty(PROPERTY_KEY), true, classLoader).newInstance();
+        final ManagementComponent component =
+            (ManagementComponent) Class.forName(p.getProperty(PROPERTY_KEY), true, classLoader)
+                .getDeclaredConstructor().newInstance();
         if (classloaderProperty != null) {
           component.setClassLoader(classLoader);
         }
         return component;
       }
-      return (ManagementComponent) Class.forName(name).newInstance();
+      return (ManagementComponent) Class.forName(name).getDeclaredConstructor().newInstance();
     } finally {
       Thread.currentThread().setContextClassLoader(originalContectClassLoader);
     }

--- a/interlok-core/src/main/java/com/adaptris/core/management/properties/PropertyResolver.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/properties/PropertyResolver.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,6 @@
 package com.adaptris.core.management.properties;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -26,10 +25,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.util.PropertyHelper;
 
 /**
@@ -63,7 +60,7 @@ public abstract class PropertyResolver {
 
   /**
    * Convenience method to get a default instance of the PropertyResolver.
-   * 
+   *
    * @return an already initialised default instance.
    * @throws Exception on exception
    */
@@ -84,7 +81,7 @@ public abstract class PropertyResolver {
   /**
    * If the property needs decoding, then this method returns the decoded property. If the property is not encoded, then it simply
    * returns the same value.
-   * 
+   *
    * @param s - The current value for the property.
    * @return The decoded property.
    * @throws Exception
@@ -127,7 +124,7 @@ public abstract class PropertyResolver {
       for (Iterator i = p.keySet().iterator(); i.hasNext();) {
         String key = (String) i.next();
         String clazz = p.getProperty(key);
-        schemes.put(key, (Decoder) Class.forName(clazz).newInstance());
+        schemes.put(key, (Decoder) Class.forName(clazz).getDeclaredConstructor().newInstance());
       }
     }
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/vcs/RuntimeVersionControlLoader.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/vcs/RuntimeVersionControlLoader.java
@@ -61,10 +61,10 @@ public class RuntimeVersionControlLoader {
     RuntimeVersionControl result = vcs;
     try {
       if (result != null) {
-        result = result.getClass().newInstance();
+        result = result.getClass().getDeclaredConstructor().newInstance();
       }
     }
-    catch (InstantiationException | IllegalAccessException e) {
+    catch (Exception e) {
     }
     return result;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/DoubleColumnTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/DoubleColumnTranslator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,17 +18,16 @@ package com.adaptris.core.services.jdbc.types;
 
 import java.io.IOException;
 import java.sql.SQLException;
-
 import com.adaptris.jdbc.JdbcResultRow;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Column Translator implementation for handling double types
- * 
+ *
  * @config jdbc-type-double-column-translator
- * 
+ *
  * @author lchan
- * 
+ *
  */
 @XStreamAlias("jdbc-type-double-column-translator")
 public class DoubleColumnTranslator extends FormattableColumnTranslator {
@@ -45,18 +44,18 @@ public class DoubleColumnTranslator extends FormattableColumnTranslator {
   public String translate(JdbcResultRow rs, int column) throws SQLException, IOException {
     Object doubleObject = rs.getFieldValue(column);
     if(doubleObject instanceof Double)
-      return toString((Double) rs.getFieldValue(column));
+      return toString(rs.getFieldValue(column));
     else
-      return toString(new Double(rs.getFieldValue(column).toString()));
+      return toString(Double.valueOf(rs.getFieldValue(column).toString()));
   }
 
   @Override
   public String translate(JdbcResultRow rs, String column) throws SQLException, IOException {
     Object doubleObject = rs.getFieldValue(column);
     if(doubleObject instanceof Double)
-      return toString((Double) rs.getFieldValue(column));
+      return toString(rs.getFieldValue(column));
     else
-      return toString(new Double(rs.getFieldValue(column).toString()));
+      return toString(Double.valueOf(rs.getFieldValue(column).toString()));
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/FloatColumnTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/FloatColumnTranslator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,17 +18,16 @@ package com.adaptris.core.services.jdbc.types;
 
 import java.io.IOException;
 import java.sql.SQLException;
-
 import com.adaptris.jdbc.JdbcResultRow;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Column Translator implementation for handling float types
- * 
+ *
  * @config jdbc-type-float-column-translator
- * 
+ *
  * @author lchan
- * 
+ *
  */
 @XStreamAlias("jdbc-type-float-column-translator")
 public class FloatColumnTranslator extends FormattableColumnTranslator {
@@ -45,18 +44,18 @@ public class FloatColumnTranslator extends FormattableColumnTranslator {
   public String translate(JdbcResultRow rs, int column) throws SQLException, IOException {
     Object doubleObject = rs.getFieldValue(column);
     if(doubleObject instanceof Float)
-      return toString((Float) rs.getFieldValue(column));
+      return toString(rs.getFieldValue(column));
     else
-      return toString(new Float(rs.getFieldValue(column).toString()));
+      return toString(Float.valueOf(rs.getFieldValue(column).toString()));
   }
 
   @Override
   public String translate(JdbcResultRow rs, String column) throws SQLException, IOException {
     Object doubleObject = rs.getFieldValue(column);
     if(doubleObject instanceof Float)
-      return toString((Float) rs.getFieldValue(column));
+      return toString(rs.getFieldValue(column));
     else
-      return toString(new Float(rs.getFieldValue(column).toString()));
+      return toString(Float.valueOf(rs.getFieldValue(column).toString()));
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/IntegerColumnTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/IntegerColumnTranslator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,18 +18,17 @@ package com.adaptris.core.services.jdbc.types;
 
 import java.io.IOException;
 import java.sql.SQLException;
-
 import com.adaptris.jdbc.JdbcResultRow;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Column Translator implementation for handling integer types
- * 
+ *
  * @config jdbc-type-integer-column-translator
- * 
- * 
+ *
+ *
  * @author lchan
- * 
+ *
  */
 @XStreamAlias("jdbc-type-integer-column-translator")
 public class IntegerColumnTranslator extends FormattableColumnTranslator {
@@ -41,18 +40,18 @@ public class IntegerColumnTranslator extends FormattableColumnTranslator {
   public String translate(JdbcResultRow rs, int column) throws SQLException, IOException {
     Object integerObject = rs.getFieldValue(column);
     if(integerObject instanceof Integer)
-      return toString((Integer) rs.getFieldValue(column));
+      return toString(rs.getFieldValue(column));
     else
-      return toString(new Integer(rs.getFieldValue(column).toString()));
+      return toString(Integer.valueOf(rs.getFieldValue(column).toString()));
   }
 
   @Override
   public String translate(JdbcResultRow rs, String column) throws SQLException, IOException {
     Object integerObject = rs.getFieldValue(column);
     if(integerObject instanceof Integer)
-      return toString((Integer) rs.getFieldValue(column));
+      return toString(rs.getFieldValue(column));
     else
-      return toString(new Integer(rs.getFieldValue(column).toString()));
+      return toString(Integer.valueOf(rs.getFieldValue(column).toString()));
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/security/certificate/X509Builder.java
+++ b/interlok-core/src/main/java/com/adaptris/security/certificate/X509Builder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,6 @@ import java.security.cert.X509Certificate;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
-
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
@@ -40,7 +39,6 @@ import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-
 import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.adaptris.security.exc.CertException;
 import com.adaptris.security.util.SecurityUtil;
@@ -63,6 +61,7 @@ final class X509Builder implements CertificateBuilder {
   /**
    * @see CertificateBuilder#setCertificateParameters(CertificateParameter)
    */
+  @Override
   public void setCertificateParameters(CertificateParameter cm) {
     certificateParm = cm;
   }
@@ -70,6 +69,7 @@ final class X509Builder implements CertificateBuilder {
   /**
    * @see CertificateBuilder#getPrivateKey()
    */
+  @Override
   public PrivateKey getPrivateKey() {
     return privateKey;
   }
@@ -77,6 +77,7 @@ final class X509Builder implements CertificateBuilder {
   /**
    * @see CertificateBuilder#getPublicKey()
    */
+  @Override
   public PublicKey getPublicKey() {
     return publicKey;
   }
@@ -84,6 +85,7 @@ final class X509Builder implements CertificateBuilder {
   /**
    * @see CertificateBuilder#reset()
    */
+  @Override
   public void reset() {
     certificate = null;
     publicKey = null;
@@ -93,6 +95,7 @@ final class X509Builder implements CertificateBuilder {
   /**
    * @see CertificateBuilder#createSelfSignedCertificate()
    */
+  @Override
   public Certificate createSelfSignedCertificate()
       throws AdaptrisSecurityException {
     try {
@@ -109,6 +112,7 @@ final class X509Builder implements CertificateBuilder {
   /**
    * @see CertificateBuilder#createSelfSignedCertificate(OutputStream)
    */
+  @Override
   public void createSelfSignedCertificate(OutputStream output)
       throws AdaptrisSecurityException {
     try {
@@ -138,7 +142,7 @@ final class X509Builder implements CertificateBuilder {
       throws NoSuchAlgorithmException, CertificateException, OperatorCreationException {
     X509Certificate result = null;
     if (privateKey == null) {
-      this.createKeyPair();
+      createKeyPair();
     }
 
     // The certificate is self-signed, so use the current
@@ -147,7 +151,8 @@ final class X509Builder implements CertificateBuilder {
 
     // The certificate is self-signed, do we exactly care what
     // the serial number that uniquely identifies is
-    BigInteger serial = BigInteger.valueOf(new Integer(SecurityUtil.getSecureRandom().nextInt(10000)).longValue());
+    BigInteger serial = BigInteger
+        .valueOf(Integer.valueOf(SecurityUtil.getSecureRandom().nextInt(10000)).longValue());
 
     GregorianCalendar valid = new GregorianCalendar();
     Date notBefore = valid.getTime();
@@ -159,7 +164,7 @@ final class X509Builder implements CertificateBuilder {
     X509v3CertificateBuilder certGen = new X509v3CertificateBuilder(name, serial, notBefore, notAfter, name, pubKeyInfo);
     String alg = certificateParm.getSignatureAlgorithm();
     JcaContentSignerBuilder builder = new JcaContentSignerBuilder(alg);
- 
+
     // build and sign the certificate
     X509CertificateHolder certHolder = certGen.build(builder.build(privateKey));
 

--- a/interlok-core/src/main/java/com/adaptris/security/keystore/KeystoreFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/security/keystore/KeystoreFactory.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,10 +23,8 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.adaptris.security.exc.KeystoreException;
 import com.adaptris.security.util.Constants;
@@ -103,7 +101,8 @@ public abstract class KeystoreFactory {
       if (System.getProperties().containsKey(KEYSTORE_FACTORY_CLASS)) {
         String cls = System.getProperty(KEYSTORE_FACTORY_CLASS);
         try {
-          defaultFactory = (KeystoreFactory) Class.forName(cls).newInstance();
+          defaultFactory =
+              (KeystoreFactory) Class.forName(cls).getDeclaredConstructor().newInstance();
         }
         catch (Exception e) {
           logR.warn("Failed to create custom keystore factory " + cls
@@ -260,7 +259,7 @@ public abstract class KeystoreFactory {
       }
       else {
         try {
-          kp = (KeystoreProxy) clazz.newInstance();
+          kp = (KeystoreProxy) clazz.getDeclaredConstructor().newInstance();
           kp.setKeystoreLocation(ksl);
         }
         catch (Exception e) {

--- a/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
+++ b/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -165,7 +165,7 @@ public class SftpClient extends FileTransferClientImp {
 
 
   /**
-   * 
+   *
    * @see FileTransferClient#connect(java.lang.String, java.lang.String)
    */
   @Override
@@ -208,7 +208,7 @@ public class SftpClient extends FileTransferClientImp {
       sftpSession.setDaemonThread(true);
       sftpSession.setUserInfo(ui);
       sftpSession.connect(timeout);
-      sftpSession.setServerAliveInterval(new Long(getKeepAliveTimeout()).intValue());
+      sftpSession.setServerAliveInterval(Long.valueOf(getKeepAliveTimeout()).intValue());
       log("OPEN {}:{}", sshHost, sshPort);
       Channel c = sftpSession.openChannel("sftp");
       c.connect(timeout);
@@ -233,7 +233,7 @@ public class SftpClient extends FileTransferClientImp {
   }
 
   /**
-   * 
+   *
    * @see FileTransferClient#dir(java.lang.String, boolean)
    */
   @Override

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XPath.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XPath.java
@@ -285,7 +285,7 @@ public class XPath {
   static XPathFactory build(boolean useSaxon) {
     try {
       if (useSaxon && SAXON_XPATH_FACTORY.isPresent()) {
-        return (XPathFactory) SAXON_XPATH_FACTORY.get().newInstance();
+        return (XPathFactory) SAXON_XPATH_FACTORY.get().getDeclaredConstructor().newInstance();
       }
     } catch (Exception e) {
 

--- a/interlok-core/src/test/java/com/adaptris/core/CoreExceptionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/CoreExceptionTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,11 +57,11 @@ public class CoreExceptionTest {
   public void testConstructor() throws Exception {
     for (String s : EXCEPTION_NAMES) {
       try {
-        Exception e = (Exception) Class.forName(s).newInstance();
+        Exception e = (Exception) Class.forName(s).getDeclaredConstructor().newInstance();
         assertNull(e.getCause());
         assertNull(e.getMessage());
       }
-      catch (InstantiationException sometimes) {
+      catch (InstantiationException | NoSuchMethodException sometimes) {
 
       }
     }

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcObjectMetadataParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcObjectMetadataParameterTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,23 +24,23 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 
 public class JdbcObjectMetadataParameterTest extends NullableParameterCase {
-  
-  private static final Integer METADATA_VALUE = new Integer(999);
+
+  private static final Integer METADATA_VALUE = Integer.valueOf(999);
   private static final String METADATA_KEY = "PARAM_METADATA_KEY";
   private AdaptrisMessage message;
-  
+
   @Before
-  public void setUp() throws Exception {    
+  public void setUp() throws Exception {
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
   }
-  
+
   @Override
   protected JdbcObjectMetadataParameter createParameter() {
     return new JdbcObjectMetadataParameter();
   }
 
   @Test
-  public void testNoMetadataKeyForInputParam() throws Exception {    
+  public void testNoMetadataKeyForInputParam() throws Exception {
     JdbcObjectMetadataParameter param = new JdbcObjectMetadataParameter();
     try {
       param.applyInputParam(message);
@@ -50,7 +50,7 @@ public class JdbcObjectMetadataParameterTest extends NullableParameterCase {
   }
 
   @Test
-  public void testNoMetadataKeyForOutputParam() throws Exception {    
+  public void testNoMetadataKeyForOutputParam() throws Exception {
     JdbcObjectMetadataParameter param = new JdbcObjectMetadataParameter();
     try {
       param.applyOutputParam(null, message);
@@ -82,33 +82,33 @@ public class JdbcObjectMetadataParameterTest extends NullableParameterCase {
   public void testMetadataAlreadyExistsOutputParam() throws Exception {
     message.addObjectHeader(METADATA_KEY, METADATA_VALUE);
     assertEquals(message.getObjectHeaders().get(METADATA_KEY), METADATA_VALUE);
-    
+
     JdbcObjectMetadataParameter param = new JdbcObjectMetadataParameter();
     param.setMetadataKey(METADATA_KEY);
-    
+
     param.applyOutputParam("NEW_PARAM_METADATA_VALUE", message);
-    
+
     assertEquals(message.getObjectHeaders().get(METADATA_KEY), "NEW_PARAM_METADATA_VALUE");
   }
 
   @Test
   public void testMetadataAppliedInputParam() throws Exception {
     message.addObjectHeader(METADATA_KEY, METADATA_VALUE);
-    
+
     JdbcObjectMetadataParameter param = new JdbcObjectMetadataParameter();
     param.setMetadataKey(METADATA_KEY);
     Object appliedInputParam = param.applyInputParam(message);
-    
+
     assertEquals(appliedInputParam, METADATA_VALUE);
   }
 
   @Test
-  public void testMetadataAppliedOutputParam() throws Exception {    
+  public void testMetadataAppliedOutputParam() throws Exception {
     JdbcObjectMetadataParameter param = new JdbcObjectMetadataParameter();
     param.setMetadataKey(METADATA_KEY);
-    
+
     param.applyOutputParam(METADATA_VALUE, message);
-    
+
     assertTrue(message.getObjectHeaders().containsKey(METADATA_KEY));
     assertEquals(message.getObjectHeaders().get(METADATA_KEY), METADATA_VALUE);
   }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsTransactedWorkflowTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsTransactedWorkflowTest.java
@@ -18,16 +18,13 @@ package com.adaptris.core.jms;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import com.adaptris.core.Channel;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.NullProcessingExceptionHandler;
@@ -45,6 +42,7 @@ import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.TimeInterval;
 
+@SuppressWarnings("deprecation")
 public class JmsTransactedWorkflowTest
     extends com.adaptris.interlok.junit.scaffolding.ExampleWorkflowCase {
 
@@ -55,13 +53,13 @@ public class JmsTransactedWorkflowTest
     activeMqBroker = new EmbeddedActiveMq();
     activeMqBroker.start();
   }
-  
+
   @AfterClass
   public static void tearDownAll() throws Exception {
     if(activeMqBroker != null)
       activeMqBroker.destroy();
   }
-  
+
   @Test
   public void testSetStrict() throws Exception {
     JmsTransactedWorkflow workflow = new JmsTransactedWorkflow();

--- a/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPasPollingConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/activemq/ActiveMqPasPollingConsumerTest.java
@@ -16,16 +16,15 @@
 
 package com.adaptris.core.jms.activemq;
 
-import static com.adaptris.core.BaseCase.start;
-import static com.adaptris.core.BaseCase.stop;
-import static com.adaptris.core.BaseCase.waitForMessages;
-import static com.adaptris.core.jms.JmsProducerCase.assertMessages;
-import static com.adaptris.core.jms.JmsProducerCase.createMessage;
+import static com.adaptris.interlok.junit.scaffolding.BaseCase.start;
+import static com.adaptris.interlok.junit.scaffolding.BaseCase.stop;
+import static com.adaptris.interlok.junit.scaffolding.BaseCase.waitForMessages;
+import static com.adaptris.interlok.junit.scaffolding.jms.JmsProducerCase.assertMessages;
+import static com.adaptris.interlok.junit.scaffolding.jms.JmsProducerCase.createMessage;
 import static org.junit.Assert.fail;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -53,7 +52,7 @@ public class ActiveMqPasPollingConsumerTest {
 
   @Rule
   public TestName testName = new TestName();
-  
+
   private static EmbeddedActiveMq activeMqBroker;
 
   @BeforeClass
@@ -61,7 +60,7 @@ public class ActiveMqPasPollingConsumerTest {
     activeMqBroker = new EmbeddedActiveMq();
     activeMqBroker.start();
   }
-  
+
   @AfterClass
   public static void tearDownAll() throws Exception {
     if(activeMqBroker != null)
@@ -166,7 +165,8 @@ public class ActiveMqPasPollingConsumerTest {
     consumer.setSubscriptionId(MY_SUBSCRIPTION_ID);
     consumer.setReacquireLockBetweenMessages(true);
     consumer.setAdditionalDebug(true);
-    consumer.setReceiveTimeout(new TimeInterval(new Integer(new Random().nextInt(100) + 100).longValue(), TimeUnit.MILLISECONDS));
+    consumer.setReceiveTimeout(new TimeInterval(
+        Integer.valueOf(new Random().nextInt(100) + 100).longValue(), TimeUnit.MILLISECONDS));
     StandaloneConsumer sc = new StandaloneConsumer(consumer);
     return sc;
   }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/ForEachTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/ForEachTest.java
@@ -7,15 +7,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.DefaultMessageFactory;
@@ -45,12 +42,12 @@ public class ForEachTest extends ConditionalServiceExample
 	public void setUp() throws Exception
 	{
 		MockitoAnnotations.openMocks(this);
-		
+
 		when(mock.retrieveComponentState())
             .thenReturn(StartedState.getInstance());
 		when(mock.createName())
 		    .thenReturn(mock.getClass().getName());
-		
+
 		forEach = new ForEach();
 		then = new ThenService();
 		then.setService(mock);
@@ -63,7 +60,7 @@ public class ForEachTest extends ConditionalServiceExample
 	public void testForEach() throws Exception
 	{
 		forEach.doService(message);
-		assertEquals(new Integer(1), forEach.getThreadCount());
+    assertEquals(Integer.valueOf(1), forEach.getThreadCount());
 		verify(mock, times(2)).doService(any(AdaptrisMessage.class));
 	}
 
@@ -79,7 +76,7 @@ public class ForEachTest extends ConditionalServiceExample
 	public void testParallelForEach() throws Exception
 	{
 		forEach.setThreadCount(0);
-		assertEquals(new Integer(0), forEach.getThreadCount());
+    assertEquals(Integer.valueOf(0), forEach.getThreadCount());
 		forEach.doService(message);
 		verify(mock, times(2)).doService(any(AdaptrisMessage.class));
 	}
@@ -88,7 +85,7 @@ public class ForEachTest extends ConditionalServiceExample
 	public void testBadThreadCount()
 	{
 		forEach.setThreadCount(-1);
-		assertEquals(new Integer(0), forEach.getThreadCount());
+    assertEquals(Integer.valueOf(0), forEach.getThreadCount());
 	}
 
 	@Test
@@ -98,7 +95,7 @@ public class ForEachTest extends ConditionalServiceExample
 		forEach.doService(message);
 		verify(mock, times(2)).doService(any(AdaptrisMessage.class));
 	}
-	
+
 	@Test
   @SuppressWarnings("serial")
 	public void testNonCloneableMessage() throws Exception

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/BooleanColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/BooleanColumnTranslatorTest.java
@@ -16,12 +16,9 @@
 
 package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
-
 import java.sql.Types;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class BooleanColumnTranslatorTest {
@@ -66,7 +63,7 @@ public class BooleanColumnTranslatorTest {
   @Test
   public void testFalseBoolean() throws Exception {
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Boolean("false"), Types.BOOLEAN);
+    row.setFieldValue("testField", Boolean.valueOf("false"), Types.BOOLEAN);
 
     String translated = translator.translate(row, 0);
 
@@ -76,7 +73,7 @@ public class BooleanColumnTranslatorTest {
   @Test
   public void testTrueBoolean() throws Exception {
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Boolean("true"), Types.BOOLEAN);
+    row.setFieldValue("testField", Boolean.valueOf("true"), Types.BOOLEAN);
 
     String translated = translator.translate(row, 0);
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/DoubleColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/DoubleColumnTranslatorTest.java
@@ -17,12 +17,9 @@
 package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import java.sql.Types;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class DoubleColumnTranslatorTest {
@@ -38,7 +35,7 @@ public class DoubleColumnTranslatorTest {
   @Test
   public void testFormattedFloat() throws Exception {
     translator.setFormat("%f");
-    Float floatVal = new Float("123");
+    Float floatVal = Float.valueOf("123");
 
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", floatVal, Types.DOUBLE);
@@ -56,7 +53,7 @@ public class DoubleColumnTranslatorTest {
   @Test
   public void testFormattedDouble() throws Exception {
     translator.setFormat("%f");
-    Double floatVal = new Double("123");
+    Double floatVal = Double.valueOf("123");
 
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", floatVal, Types.DOUBLE);
@@ -74,7 +71,7 @@ public class DoubleColumnTranslatorTest {
   @Test
   public void testFormattedInteger() throws Exception {
     translator.setFormat("%f");
-    Integer floatVal = new Integer("123");
+    Integer floatVal = Integer.valueOf("123");
 
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", floatVal, Types.DOUBLE);

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/FloatColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/FloatColumnTranslatorTest.java
@@ -18,12 +18,9 @@ package com.adaptris.core.services.jdbc.types;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import java.sql.Types;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class FloatColumnTranslatorTest {
@@ -39,7 +36,7 @@ public class FloatColumnTranslatorTest {
   @Test
   public void testFormattedFloat() throws Exception {
     translator.setFormat("%f");
-    Float floatVal = new Float("123");
+    Float floatVal = Float.valueOf("123");
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", floatVal, Types.FLOAT);
     {
@@ -55,7 +52,7 @@ public class FloatColumnTranslatorTest {
   @Test
   public void testFormattedDouble() throws Exception {
     translator.setFormat("%f");
-    Double floatVal = new Double("123");
+    Double floatVal = Double.valueOf("123");
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", floatVal, Types.FLOAT);
     {
@@ -71,7 +68,7 @@ public class FloatColumnTranslatorTest {
   @Test
   public void testFormattedInteger() throws Exception {
     translator.setFormat("%f");
-    Integer floatVal = new Integer("123");
+    Integer floatVal = Integer.valueOf("123");
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", floatVal, Types.FLOAT);
     {

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/IntegerColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/IntegerColumnTranslatorTest.java
@@ -17,12 +17,9 @@
 package com.adaptris.core.services.jdbc.types;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import java.sql.Types;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.jdbc.JdbcResultRow;
 
 public class IntegerColumnTranslatorTest {
@@ -38,7 +35,7 @@ public class IntegerColumnTranslatorTest {
   @Test
   public void testFormattedFloat() throws Exception {
     translator.setFormat("%05d");
-    Float intVal = new Float("123");
+    Float intVal = Float.valueOf("123");
 
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", intVal, Types.INTEGER);
@@ -59,7 +56,7 @@ public class IntegerColumnTranslatorTest {
   @Test
   public void testFormattedDouble() throws Exception {
     translator.setFormat("%05d");
-    Double doubleVal = new Double("123");
+    Double doubleVal = Double.valueOf("123");
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", doubleVal, Types.INTEGER);
     try {
@@ -79,7 +76,7 @@ public class IntegerColumnTranslatorTest {
   @Test
   public void testFormattedInteger() throws Exception {
     translator.setFormat("%05d");
-    Integer intVal = new Integer("123");
+    Integer intVal = Integer.valueOf("123");
 
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", intVal, Types.INTEGER);
@@ -96,7 +93,7 @@ public class IntegerColumnTranslatorTest {
   @Test
   public void testFormattedString() throws Exception {
     translator.setFormat("%05d");
-    String stringVal = new String("123");
+    String stringVal = "123";
 
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", stringVal, Types.INTEGER);
@@ -113,7 +110,7 @@ public class IntegerColumnTranslatorTest {
   @Test
   public void testIllegalFormat() throws Exception {
     translator.setFormat("%zZX");
-    Integer intVal = new Integer("123");
+    Integer intVal = Integer.valueOf("123");
 
     JdbcResultRow row = new JdbcResultRow();
     row.setFieldValue("testField", intVal, Types.INTEGER);

--- a/interlok-core/src/test/java/com/adaptris/core/services/jmx/MetadataValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jmx/MetadataValueTranslatorTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,35 +28,35 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 
 public class MetadataValueTranslatorTest {
-  
+
   private MetadataValueTranslator metadataValueTranslator;
-  
+
   private AdaptrisMessage message;
-  
+
   @Before
   public void setUp() throws Exception {
     metadataValueTranslator = new MetadataValueTranslator();
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
   }
-  
+
 
   @Test
   public void testSetValue() throws Exception {
     String newMetadataKey = "NewMetadataKey";
     String newValue = "NewValue";
-    
+
     metadataValueTranslator.setMetadataKey(newMetadataKey);
     metadataValueTranslator.setType("java.lang.String");
-    
+
     metadataValueTranslator.setValue(message, newValue);
-    
+
     assertEquals(newValue, message.getMetadataValue(newMetadataKey));
   }
 
   @Test
   public void testSetValueNoMetadataKey() throws Exception {
     String newValue = "NewValue";
-    
+
     metadataValueTranslator.setType("java.lang.String");
     // no error, just warning log
     metadataValueTranslator.setValue(message, newValue);
@@ -65,37 +65,37 @@ public class MetadataValueTranslatorTest {
   @Test
   public void testGetValueNoMetadataKey() throws Exception {
     String newValue = "NewValue";
-        
+
     metadataValueTranslator.setValue(message, newValue);
-    
+
     assertNull(newValue, metadataValueTranslator.getValue(message));
   }
 
   @Test
   public void testSetValueWithIntegerType() throws Exception {
     String newMetadataKey = "NewMetadataKey";
-    Integer newValue = new Integer(1);
-    
+    Integer newValue = Integer.valueOf(1);
+
     metadataValueTranslator.setMetadataKey(newMetadataKey);
     metadataValueTranslator.setType("java.lang.Integer");
-    
+
     metadataValueTranslator.setValue(message, newValue);
-    
+
     Object value = metadataValueTranslator.getValue(message);
-    
+
     assertTrue(value instanceof Integer);
-    assertEquals(new Integer(1), newValue);
+    assertEquals(Integer.valueOf(1), newValue);
   }
 
   @Test
   public void testGetValueDefaultType() throws Exception {
     String newMetadataKey = "NewMetadataKey";
     String newValue = "NewValue";
-    
+
     metadataValueTranslator.setMetadataKey(newMetadataKey);
-    
+
     metadataValueTranslator.setValue(message, newValue);
-    
+
     assertEquals(newValue, metadataValueTranslator.getValue(message));
   }
 
@@ -103,12 +103,12 @@ public class MetadataValueTranslatorTest {
   public void testGetValueDateType() throws Exception {
     String newMetadataKey = "NewMetadataKey";
     Date todaysDate = new Date();
-    
+
     metadataValueTranslator.setMetadataKey(newMetadataKey);
     metadataValueTranslator.setType(Date.class.getName());
-    
+
     metadataValueTranslator.setValue(message, todaysDate);
-    
+
     Object value = metadataValueTranslator.getValue(message);
     assertTrue(value instanceof Date);
     assertEquals(todaysDate, value);
@@ -118,12 +118,12 @@ public class MetadataValueTranslatorTest {
   public void testGetValueInvalidType() throws Exception {
     String newMetadataKey = "NewMetadataKey";
     String newValue = "1";
-    
+
     metadataValueTranslator.setMetadataKey(newMetadataKey);
     metadataValueTranslator.setType("MyInvalidType");
-    
+
     metadataValueTranslator.setValue(message, newValue);
-    
+
     try {
       metadataValueTranslator.getValue(message);
       fail("Should fail with a core exception");

--- a/interlok-core/src/test/java/com/adaptris/core/services/jmx/ObjectMetadataValueTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jmx/ObjectMetadataValueTranslatorTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,17 +26,17 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 
 public class ObjectMetadataValueTranslatorTest {
-  
+
   private ObjectMetadataValueTranslator objectMetadataValueTranslator;
-  
+
   private AdaptrisMessage message;
-  
+
   @Before
   public void setUp() throws Exception {
     objectMetadataValueTranslator = new ObjectMetadataValueTranslator();
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
   }
-  
+
   public void tearDown() throws Exception {
   }
 
@@ -44,21 +44,21 @@ public class ObjectMetadataValueTranslatorTest {
   public void testSetValue() throws Exception {
     String newMetadataKey = "NewMetadataKey";
     String expectedValue = "NewValue";
-    
+
     objectMetadataValueTranslator.setMetadataKey(newMetadataKey);
     objectMetadataValueTranslator.setType("java.lang.String");
-    
+
     objectMetadataValueTranslator.setValue(message, expectedValue);
-    
+
     String newValue = (String) objectMetadataValueTranslator.getValue(message);
-    
+
     assertEquals(expectedValue, newValue);
   }
 
   @Test
   public void testSetValueNoMetadataKey() throws Exception {
     String newValue = "NewValue";
-    
+
     objectMetadataValueTranslator.setType("java.lang.String");
     // no error, just warning log
     objectMetadataValueTranslator.setValue(message, newValue);
@@ -67,37 +67,37 @@ public class ObjectMetadataValueTranslatorTest {
   @Test
   public void testGetValueNoMetadataKey() throws Exception {
     String newValue = "NewValue";
-        
+
     objectMetadataValueTranslator.setValue(message, newValue);
-    
+
     assertNull(newValue, objectMetadataValueTranslator.getValue(message));
   }
 
   @Test
   public void testSetValueWithIntegerType() throws Exception {
     String newMetadataKey = "NewMetadataKey";
-    Integer newValue = new Integer(1);
-    
+    Integer newValue = Integer.valueOf(1);
+
     objectMetadataValueTranslator.setMetadataKey(newMetadataKey);
     objectMetadataValueTranslator.setType("java.lang.Integer");
-    
+
     objectMetadataValueTranslator.setValue(message, newValue);
-    
+
     Object value = objectMetadataValueTranslator.getValue(message);
-    
+
     assertTrue(value instanceof Integer);
-    assertEquals(new Integer(1), newValue);
+    assertEquals(Integer.valueOf(1), newValue);
   }
 
   @Test
   public void testGetValueDefaultType() throws Exception {
     String newMetadataKey = "NewMetadataKey";
     String newValue = "NewValue";
-    
+
     objectMetadataValueTranslator.setMetadataKey(newMetadataKey);
-    
+
     objectMetadataValueTranslator.setValue(message, newValue);
-    
+
     assertEquals(newValue, objectMetadataValueTranslator.getValue(message));
   }
 
@@ -105,12 +105,12 @@ public class ObjectMetadataValueTranslatorTest {
   public void testGetValueDateType() throws Exception {
     String newMetadataKey = "NewMetadataKey";
     Date todaysDate = new Date();
-    
+
     objectMetadataValueTranslator.setMetadataKey(newMetadataKey);
     objectMetadataValueTranslator.setType(Date.class.getName());
-    
+
     objectMetadataValueTranslator.setValue(message, todaysDate);
-    
+
     Object value = objectMetadataValueTranslator.getValue(message);
     assertTrue(value instanceof Date);
     assertEquals(todaysDate, value);

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/ServiceExceptionHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/ServiceExceptionHandlerTest.java
@@ -46,6 +46,7 @@ public class ServiceExceptionHandlerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testThrowFirst_NoExceptions() throws Exception {
     ServiceExceptionHandler handler = new ServiceExceptionHandler();
     handler.throwFirstException();
@@ -53,6 +54,7 @@ public class ServiceExceptionHandlerTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testThrowFirst() throws Exception {
     ServiceExceptionHandler handler = new ServiceExceptionHandler();
     handler.uncaughtException(Thread.currentThread(), new ServiceException("first"));

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/ServiceWorkerPoolTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/ServiceWorkerPoolTest.java
@@ -32,6 +32,7 @@ import com.adaptris.core.NullService;
 import com.adaptris.core.stubs.MockService;
 import com.adaptris.core.stubs.MockService.FailureCondition;
 import com.adaptris.core.util.ManagedThreadFactory;
+import com.adaptris.interlok.util.Closer;
 import com.adaptris.util.TimeInterval;
 
 public class ServiceWorkerPoolTest extends ServiceWorkerPool {
@@ -106,7 +107,7 @@ public class ServiceWorkerPoolTest extends ServiceWorkerPool {
     GenericObjectPool<ServiceWorkerPool.Worker> objPool = createCommonsObjectPool();
     warmup(objPool);
     assertEquals(10, objPool.getNumIdle());
-    closeQuietly(objPool);
+    Closer.closeQuietly(objPool);
   }
 
   @Test
@@ -120,7 +121,7 @@ public class ServiceWorkerPoolTest extends ServiceWorkerPool {
     } catch (CoreException expected) {
 
     } finally {
-      closeQuietly(objPool);
+      Closer.closeQuietly(objPool);
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/util/DestinationHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/DestinationHelperTest.java
@@ -1,13 +1,13 @@
 package com.adaptris.core.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.stubs.MockMessageListener;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
+@SuppressWarnings("deprecation")
 public class DestinationHelperTest extends DestinationHelper {
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/security/AdaptrisSecurityExceptionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/security/AdaptrisSecurityExceptionTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +17,10 @@ package com.adaptris.security;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
 import java.lang.reflect.Constructor;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.adaptris.security.exc.CertException;
 import com.adaptris.security.exc.DecryptException;
@@ -54,10 +51,10 @@ public class AdaptrisSecurityExceptionTest {
   @Test
   public void testConstructor() throws Exception {
     for (String s : EXCEPTION_NAMES) {
-      Exception e = (Exception) Class.forName(s).newInstance();
+      Exception e = (Exception) Class.forName(s).getDeclaredConstructor().newInstance();
       assertNull(e.getCause());
       assertNull(e.getMessage());
-    }   
+    }
   }
 
   @Test
@@ -70,7 +67,7 @@ public class AdaptrisSecurityExceptionTest {
       Exception e = ((Exception) cnst.newInstance(args));
       assertEquals(cause, e.getCause());
       assertEquals(Exception.class.getName(), e.getMessage());
-    }     
+    }
   }
 
   @Test
@@ -82,7 +79,7 @@ public class AdaptrisSecurityExceptionTest {
       Exception e = ((Exception) cnst.newInstance(args));
       assertNull(e.getCause());
       assertEquals("hello", e.getMessage());
-    }      
+    }
   }
 
   @Test
@@ -95,7 +92,7 @@ public class AdaptrisSecurityExceptionTest {
       Exception e = ((Exception) cnst.newInstance(args));
       assertEquals(cause, e.getCause());
       assertEquals("hello", e.getMessage());
-    }  
+    }
   }
 
 }


### PR DESCRIPTION
## Motivation

Java 9+ has deprecated a bunch of constructors; so this is a fairly non-contentious change to make sure we aren't burned later on.

## Modification

- new Integer -> Integer.valueOf() (and so forth for the number types).
- Class.forName().newInstance() -> Class.forName().getDeclaredConstructor().newInstance() 
    - Since getDeclaredConstructor() can throw NoSuchMethodException some tests had to have their exception handling widened.
- Add SuppressWarnings annotation where appropriate

## Result

Fewer deprecation warnings; no change for the user.

## Testing

The tests still pass.
