### PR TITLE
INTERLOK-3711 stacktrace as part of retry-store

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/util/MessageHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/MessageHelper.java
@@ -6,9 +6,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.lms.FileBackedMessage;
 import lombok.AccessLevel;
@@ -79,4 +81,19 @@ public class MessageHelper {
     return msg;
   }
 
+
+  /**
+   * Get a stacktrace from the message if available.
+   *
+   * @param msg the message
+   * @return An optional wrapping {@code ExceptionUtils#getStackTrace(Throwable)}.
+   */
+  public static Optional<String> stackTraceAsString(AdaptrisMessage msg) {
+    Map hdrs = msg.getObjectHeaders();
+    if (hdrs.containsKey(OBJ_METADATA_EXCEPTION)) {
+      return Optional
+          .ofNullable(ExceptionUtils.getStackTrace((Throwable) hdrs.get(OBJ_METADATA_EXCEPTION)));
+    }
+    return Optional.empty();
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/util/MessageHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/MessageHelperTest.java
@@ -82,4 +82,11 @@ public class MessageHelperTest {
     assertEquals("ISO-8859-2", msg.getContentEncoding());
   }
 
+  @Test
+  public void testStackTraceToString() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    assertFalse(MessageHelper.stackTraceAsString(msg).isPresent());
+    msg.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, new Exception());
+    assertTrue(MessageHelper.stackTraceAsString(msg).isPresent());
+  }
 }


### PR DESCRIPTION
## Motivation

When using jetty-retry-store currently we don't write the stacktrace out anywhere, so you can't easily investigate the problem.

The stacktrace itself isn't "required to build up what needs to be retried", but could be useful information regardless.

## Modification

- Add a method to `MessageHelper` to return an Optional wrapping the stack trace.
- If the stacktrace exists then it is written to the msgDir as _stacktrace.txt_ which means that it's available for further investigations as required.

## Result

If using the filesystem-retry-store then an extra file is present.
- No change for optional component implementations (such as AWS) at this time; the MessageHelper helper is propbably useful to make that work.

## Testing

Use the configuration from https://github.com/adaptris/interlok/pull/556 ; however check that the files written to the filesystem store contains a stacktrace.txt
