### PR TITLE
feature/interlok-3588 - FtpConsumer - Add the posibility to consume files from subfolders

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
@@ -16,12 +16,6 @@
 
 package com.adaptris.core.ftp;
 
-import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import java.io.File;
-import java.io.FileFilter;
-import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -33,6 +27,16 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.io.FileFilter;
+
+import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
+import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * FTP implementation of the AdaptrisMessageConsumer interface.
@@ -59,7 +63,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *
  * @see FtpConnection
  * @see FileTransferConnection
- * @see com.adaptris.core.ConsumeDestination
  * @author lchan
  */
 @XStreamAlias("ftp-consumer")
@@ -75,13 +78,20 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 public class FtpConsumer extends FtpConsumerImpl {
   private static final String DEFAULT_WIP_SUFFIX = "_wip";
 
-
   @NotNull
   @AutoPopulated
+  @Getter
+  @Setter
   private String workDirectory = "/work";
+
   @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
   private String procDirectory;
+
   @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
   private String wipSuffix;
 
   public FtpConsumer() {
@@ -190,61 +200,6 @@ public class FtpConsumer extends FtpConsumerImpl {
   }
 
   /**
-   * Get the "proc" directory.
-   *
-   * @return the configured directory.
-   */
-  public String getProcDirectory() {
-    return procDirectory;
-  }
-
-  /**
-   * Get the work directory.
-   *
-   * @return the work directory.
-   */
-  public String getWorkDirectory() {
-    return workDirectory;
-  }
-
-  /**
-   * Set the directory where files are placed after processing.
-   * <p>
-   * If set, then after downloading the file, it is renamed to this directory, otherwise it is deleted.
-   * </p>
-   * <p>
-   * If the ConsumeDestination specifies a URL, then it is assumed be a sub-directory of the path specified by the URL. If the
-   * ConsumeDestination does not specify a URL, then it is an absolute path.
-   * </p>
-   *
-   * @param s the directory
-   */
-  public void setProcDirectory(String s) {
-    procDirectory = s;
-  }
-
-  /**
-   * Set the work directory.
-   * <p>
-   * If the ConsumeDestination specifies a URL, then it is assumed be a sub-directory of the path specified by the URL. If the
-   * ConsumeDestination does not specify a URL, then it is an absolute path.
-   * </p>
-   *
-   * @see com.adaptris.core.ConsumeDestination
-   * @param s the directory.
-   */
-  public void setWorkDirectory(String s) {
-    workDirectory = s;
-  }
-
-  /**
-   * @return Returns the wipSuffix.
-   */
-  public String getWipSuffix() {
-    return wipSuffix;
-  }
-
-  /**
    * Return the wip Suffix with null protection.
    *
    * @return the suffix, default is "_wip" if not configured.
@@ -252,21 +207,4 @@ public class FtpConsumer extends FtpConsumerImpl {
   String wipSuffix() {
     return getWipSuffix() != null ? getWipSuffix() : DEFAULT_WIP_SUFFIX;
   }
-
-  /**
-   * Set the suffix of the file to indicate it is being processed.
-   *
-   * <p>
-   * The first action performed by the consumer is to attempt to rename any file that it is attempting to process to mark it as
-   * being processed. This will allow multiple consumers to poll the same directory, and also isolate the consumer from anything
-   * that attempts to write to the file concurrently.
-   * </p>
-   *
-   * @param s The wipSuffix to set, default is "_wip" if not specified.
-   */
-  public void setWipSuffix(String s) {
-    wipSuffix = s;
-  }
-
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumer.java
@@ -41,22 +41,29 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 /**
  * FTP implementation of the AdaptrisMessageConsumer interface.
  * <p>
- * The connection type for this consumer should always be a concrete implementation of {@link FileTransferConnection}.
+ * The connection type for this consumer should always be a concrete
+ * implementation of {@link FileTransferConnection}.
  * </p>
  * <p>
- * The destination returned by the ConsumeDestination implementation should be in the form in the URL form dictated by the
- * <code>FileTransferConnection</code> flavour or simply the IP Address / DNS name of the target Server. If the URL form is used,
- * then it is possible to override the username, password, and port settings of the server, in all other cases the configuration
- * specified in the <code>FileTransferConnection</code> object will be used.
+ * The destination should be in the form in the URL form dictated by the
+ * <code>FileTransferConnection</code> flavour or simply the IP
+ * Address/DNS name of the target Server. If the URL form is used, then
+ * it is possible to override the username, password, and port settings
+ * of the server, in all other cases the configuration specified in the
+ * <code>FileTransferConnection</code> object will be used.
  * </p>
  * <p>
- * In the event the proc-directory is not configured, then after processing the file, it is deleted. If proc-directory is
- * configured, then the remote file will be renamed to this directory
+ * In the event the proc-directory is not configured, then after
+ * processing the file, it is deleted. If proc-directory is configured,
+ * then the remote file will be renamed to this directory
  * </p>
  * <p>
- * The configuration of this consumer closely mirrors that of the FsConsumer though it does not, at the moment, share any common
- * hierarchy with a key difference; although multiple file-filters can be configured only filters that work with the filepath will
- * work. Other filter implementations (such as those based on size /last modified) may not work.
+ * The configuration of this consumer closely mirrors that of the
+ * FsConsumer though it does not, at the moment, share any common
+ * hierarchy with a key difference; although multiple file-filters can
+ * be configured only filters that work with the filepath will work.
+ * Other filter implementations (such as those based on size/last
+ * modified) may not work.
  * </p>
  *
  * @config ftp-consumer
@@ -78,17 +85,28 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 public class FtpConsumer extends FtpConsumerImpl {
   private static final String DEFAULT_WIP_SUFFIX = "_wip";
 
+  /**
+   * The working directory for the consumer. Files are consumed from
+   * here.
+   */
   @NotNull
   @AutoPopulated
   @Getter
   @Setter
   private String workDirectory = "/work";
 
+  /**
+   * The directory where files are moved to after processing. If null,
+   * the file will be deleted instead.
+   */
   @AdvancedConfig(rare = true)
   @Getter
   @Setter
   private String procDirectory;
 
+  /**
+   * The suffix of the file to indicate it is being processed.
+   */
   @AdvancedConfig(rare = true)
   @Getter
   @Setter

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpConsumerImpl.java
@@ -206,7 +206,7 @@ public abstract class FtpConsumerImpl extends AdaptrisPollingConsumer {
     return count;
   }
 
-  private boolean handle(String fileToGet) {
+  protected boolean handle(String fileToGet) {
     try {
       if (accept(fileToGet)) {
         return fetchAndProcess(fileToGet);

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpHelper.java
@@ -59,17 +59,4 @@ public abstract class FtpHelper {
   public static String getDirectory(String fullPath) {
     return getDirectory(fullPath, false);
   }
-
-  public static String getParentDirectoryName(String fullPath, boolean windows) {
-    String result = fullPath;
-    int slash = lastSlash(result, windows);
-    if (slash >= 0) {
-      result = result.substring(0, slash); // this is now the full path to the parent
-    }
-    return getFilename(result, windows);
-  }
-
-  public static String getParentDirectoryName(String fullPath) {
-    return getParentDirectoryName(fullPath, false);
-  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpHelper.java
@@ -60,4 +60,16 @@ public abstract class FtpHelper {
     return getDirectory(fullPath, false);
   }
 
+  public static String getParentDirectoryName(String fullPath, boolean windows) {
+    String result = fullPath;
+    int slash = lastSlash(result, windows);
+    if (slash >= 0) {
+      result = result.substring(0, slash); // this is now the full path to the parent
+    }
+    return getFilename(result, windows);
+  }
+
+  public static String getParentDirectoryName(String fullPath) {
+    return getParentDirectoryName(fullPath, false);
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.ftp;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+
+import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
+import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
+
+/**
+ * FTP implementation of the AdaptrisMessageConsumer interface.
+ * <p>
+ * The connection type for this consumer should always be a concrete implementation of {@link FileTransferConnection}.
+ * </p>
+ * <p>
+ * The destination returned by the ConsumeDestination implementation should be in the form in the URL form dictated by the
+ * <code>FileTransferConnection</code> flavour or simply the IP Address / DNS name of the target Server. If the URL form is used,
+ * then it is possible to override the username, password, and port settings of the server, in all other cases the configuration
+ * specified in the <code>FileTransferConnection</code> object will be used.
+ * </p>
+ * <p>
+ * In the event the proc-directory is not configured, then after processing the file, it is deleted. If proc-directory is
+ * configured, then the remote file will be renamed to this directory
+ * </p>
+ * <p>
+ * The configuration of this consumer closely mirrors that of the FsConsumer though it does not, at the moment, share any common
+ * hierarchy with a key difference; although multiple file-filters can be configured only filters that work with the filepath will
+ * work. Other filter implementations (such as those based on size /last modified) may not work.
+ * </p>
+ * <p>
+ * TODO Update about recursion...
+ *
+ * @author lchan
+ * @config ftp-consumer
+ * @see FtpConnection
+ * @see FileTransferConnection
+ */
+@XStreamAlias("ftp-recursive-consumer")
+@AdapterComponent
+@ComponentProfile(summary = "Pickup messages from an FTP or SFTP server", tag = "consumer,ftp,ftps,sftp,recursive", metadata =
+    {
+        CoreConstants.ORIGINAL_NAME_KEY, CoreConstants.FS_FILE_SIZE,
+        CoreConstants.FS_CONSUME_DIRECTORY, CoreConstants.MESSAGE_CONSUME_LOCATION
+    },
+    recommended = { FileTransferConnection.class })
+@DisplayOrder(order = { "ftpEndpoint", "filterExpression", "fileFilterImp", "poller",
+    "workDirectory", "procDirectory", "wipSuffix", "quietInterval" })
+public class FtpRecursiveConsumer extends FtpConsumer
+{
+
+  private static final String DEFAULT_WIP_SUFFIX = "_wip";
+
+  @NotNull
+  @AutoPopulated
+  @Getter
+  @Setter
+  private String workDirectory = "/work";
+
+  @Getter
+  @Setter
+  @AdvancedConfig(rare = true)
+  private String procDirectory;
+
+  @Getter
+  @Setter
+  @AdvancedConfig(rare = true)
+  private String wipSuffix;
+
+  public FtpRecursiveConsumer()
+  {
+    setReacquireLockBetweenMessages(true);
+  }
+
+  @Override
+  protected boolean fetchAndProcess(String fullPath) throws Exception
+  {
+    String procDir = null;
+    String hostUrl = ftpURL();
+    if (procDirectory != null)
+    {
+      procDir = retrieveConnection(FileTransferConnection.class).getDirectoryRoot(hostUrl) + procDirectory;
+    }
+    return processMessage(fullPath, procDir);
+  }
+
+  @Override
+  protected int processMessages()
+  {
+    String pollDirectory;
+    FileTransferConnection connection = retrieveConnection(FileTransferConnection.class);
+    String hostUrl = ftpURL();
+    try
+    {
+      ftpClient = connection.connect(hostUrl);
+      pollDirectory = configureWorkDir(connection.getDirectoryRoot(hostUrl));
+    }
+    catch (Exception e)
+    {
+      log.error("Failed to connect to [{}]", hostUrl, e);
+      return 0;
+    }
+    try
+    {
+      return processMessages(connection, pollDirectory);
+    }
+    catch (Exception e)
+    {
+      log.warn("Failed to poll [{}] hoping for success next poll time", pollDirectory);
+      if (additionalDebug())
+      {
+        log.trace("Exception was : {}", e.getMessage(), e);
+      }
+      return 0;
+    }
+    finally
+    {
+      connection.disconnect(ftpClient);
+      ftpClient = null;
+    }
+  }
+
+  private int processMessages(FileTransferConnection connection, String path) throws IOException
+  {
+    int count = 0;
+    if (additionalDebug())
+    {
+      log.trace("Polling [{}]", path);
+    }
+    String[] files = ftpClient.dir(path, fileFilter);
+    if (additionalDebug())
+    {
+      log.trace("There are potentially [{}] more messages to process", files.length);
+    }
+    for (String file : files)
+    {
+      String fileToGet = path + FORWARD_SLASH + FtpHelper.getFilename(file, connection.windowsWorkaround());
+
+      boolean isDirectory = ftpClient.isDirectory(fileToGet);
+      if (isDirectory)
+      {
+        count += processMessages(connection, fileToGet);
+      }
+      else
+      {
+        count += handle(fileToGet) ? 1 : 0;
+      }
+      if (!continueProcessingMessages(count))
+      {
+        break;
+      }
+    }
+    return count;
+  }
+
+  private boolean processMessage(String fullPath, String procDir) throws Exception
+  {
+    String wipFile = fullPath + wipSuffix();
+    String filename = FtpHelper.getFilename(fullPath);
+    if (additionalDebug())
+    {
+      log.trace("Renaming [{}] to [{}]", fullPath, wipFile);
+    }
+    ftpClient.rename(fullPath, wipFile);
+    EncoderWrapper encWrapper = new EncoderWrapper(defaultIfNull(getMessageFactory()).newMessage(), getEncoder());
+    try (EncoderWrapper wrapper = encWrapper)
+    {
+      ftpClient.get(wrapper, wipFile);
+    }
+    AdaptrisMessage adpMsg = addStandardMetadata(encWrapper.build(), filename, FtpHelper.getDirectory(fullPath));
+    retrieveAdaptrisMessageListener().onAdaptrisMessage(adpMsg);
+
+    if (procDir != null)
+    {
+      moveToProcDir(wipFile, filename, procDir);
+    }
+    else
+    {
+      ftpClient.delete(wipFile);
+    }
+    return true;
+  }
+
+  private void moveToProcDir(String wipFile, final String filename, String procDir)
+  {
+    try
+    {
+      String[] existingFileNames = ftpClient.dir(procDir, f ->
+      {
+        boolean result = f.getName().equals(filename);
+        return result;
+      });
+
+      String procFile = procDir + FORWARD_SLASH + filename;
+      if (existingFileNames.length != 0)
+      {
+        procFile = procFile + "-" + System.currentTimeMillis();
+      }
+      log.trace("Renaming processed file to [{}]", procFile);
+      ftpClient.rename(wipFile, procFile);
+    }
+    catch (Exception e)
+    {
+      log.warn("Failed to rename to [{}] to [{}]", filename, procDir);
+    }
+  }
+
+  /**
+   * Return the wip Suffix with null protection.
+   *
+   * @return the suffix, default is "_wip" if not configured.
+   */
+  String wipSuffix()
+  {
+    return getWipSuffix() != null ? getWipSuffix() : DEFAULT_WIP_SUFFIX;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
@@ -31,25 +31,33 @@ import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
 /**
  * FTP implementation of the AdaptrisMessageConsumer interface.
  * <p>
- * The connection type for this consumer should always be a concrete implementation of {@link FileTransferConnection}.
+ * The connection type for this consumer should always be a concrete
+ * implementation of {@link FileTransferConnection}.
  * </p>
  * <p>
- * The destination returned by the ConsumeDestination implementation should be in the form in the URL form dictated by the
- * <code>FileTransferConnection</code> flavour or simply the IP Address / DNS name of the target Server. If the URL form is used,
- * then it is possible to override the username, password, and port settings of the server, in all other cases the configuration
- * specified in the <code>FileTransferConnection</code> object will be used.
+ * The destination should be in the form in the URL form dictated by the
+ * <code>FileTransferConnection</code> flavour or simply the IP
+ * Address/DNS name of the target Server. If the URL form is used, then
+ * it is possible to override the username, password, and port settings
+ * of the server, in all other cases the configuration specified in the
+ * <code>FileTransferConnection</code> object will be used.
  * </p>
  * <p>
- * In the event the proc-directory is not configured, then after processing the file, it is deleted. If proc-directory is
- * configured, then the remote file will be renamed to this directory
+ * In the event the proc-directory is not configured, then after
+ * processing the file, it is deleted. If proc-directory is configured,
+ * then the remote file will be renamed to this directory
  * </p>
  * <p>
- * The configuration of this consumer closely mirrors that of the FsConsumer though it does not, at the moment, share any common
- * hierarchy with a key difference; although multiple file-filters can be configured only filters that work with the filepath will
- * work. Other filter implementations (such as those based on size /last modified) may not work.
+ * The configuration of this consumer closely mirrors that of the
+ * FsConsumer though it does not, at the moment, share any common
+ * hierarchy with a key difference; although multiple file-filters can
+ * be configured only filters that work with the filepath will work.
+ * Other filter implementations (such as those based on size /last
+ * modified) may not work.
  * </p>
  * <p>
- * Unlike the original FTP consumer, this will recurse into any directories found.
+ * Unlike the original FTP consumer, this will recurse into any
+ * directories found.
  * </p>
  *
  * @author lchan

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
@@ -23,6 +23,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import java.io.File;
 import java.io.IOException;
 
 import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
@@ -142,8 +143,10 @@ public class FtpRecursiveConsumer extends FtpConsumer
   @Override
   protected AdaptrisMessage addStandardMetadata(AdaptrisMessage msg, String filename, String dir) {
     super.addStandardMetadata(msg, filename, dir);
-    String parent = FtpHelper.getParentDirectoryName(dir);
-    msg.addMetadata(CoreConstants.FS_CONSUME_PARENT_DIR, parent);
+    File parent = new File(dir);
+    if (parent != null) {
+      msg.addMetadata(CoreConstants.FS_CONSUME_PARENT_DIR, parent.getName());
+    }
     return msg;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
@@ -17,20 +17,14 @@
 package com.adaptris.core.ftp;
 
 import com.adaptris.annotation.AdapterComponent;
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import lombok.Getter;
-import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
 import java.io.IOException;
 
-import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static com.adaptris.core.ftp.FtpHelper.FORWARD_SLASH;
 
 /**
@@ -143,6 +137,14 @@ public class FtpRecursiveConsumer extends FtpConsumer
       }
     }
     return count;
+  }
+
+  @Override
+  protected AdaptrisMessage addStandardMetadata(AdaptrisMessage msg, String filename, String dir) {
+    super.addStandardMetadata(msg, filename, dir);
+    String parent = FtpHelper.getParentDirectoryName(dir);
+    msg.addMetadata(CoreConstants.FS_CONSUME_PARENT_DIR, parent);
+    return msg;
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/filetransfer/FileTransferClient.java
+++ b/interlok-core/src/main/java/com/adaptris/filetransfer/FileTransferClient.java
@@ -271,6 +271,8 @@ public interface FileTransferClient extends Closeable {
    */
   void chdir(String dir) throws IOException, FileTransferException;
 
+  boolean isDirectory(String path) throws IOException;
+
   /**
    * Quit the FTP session
    *

--- a/interlok-core/src/main/java/com/adaptris/ftp/ApacheFtpClientImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/ftp/ApacheFtpClientImpl.java
@@ -388,24 +388,51 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
   public boolean isDirectory(String path) throws IOException {
     try {
       acquireLock();
-      log("{} {}", FTPCmd.STAT, path);
-      ftpClient().stat(path);
-      Reply reply = validateReply(ftpClient().getReplyString(), "213");
-      String[] lines = reply.getReplyText().split("\n");
-      /*
-line 0 * 213-Status follows:
-line 1 * drwxr-xr-x    2 1000     1000         4096 Apr 19 15:20 .
-       * drwxr-xr-x    3 1000     1000         4096 Apr 20 13:58 ..
-       * -rw-r--r--    1 1000     1000         3314 Apr 19 15:20 f1
-       * 213 End of status
-       *
-line 0 * 213-Status follows:
-line 1 * -rw-r--r--    1 1000     1000            6 Apr 20 13:58 world
-       * 213 End of status
-       */
-      if (lines[1].startsWith("d")) {
+      String cwd = ftpClient().printWorkingDirectory();
+      if (ftpClient().changeWorkingDirectory(path)) {
+        log("Successfully changed to {} - must be a directory", path);
+        ftpClient().changeWorkingDirectory(cwd);
         return true;
       }
+      log("Could not change to {} - must not be a directory", path);
+//      log("{} {}", FTPCmd.STAT, path);
+//      int i = ftpClient().stat(path);
+//      /*
+//       * So STAT can do one of 2 things: return the system status or
+//       * the details of a file, and while my FTP server (vsftpd) does
+//       * both depending on whether you give it a path, the Mock FTP
+//       * server only does the first - perhaps others do too.
+//       */
+//      log("{} returned {}", FTPCmd.STAT, i);
+//      Reply reply = null;
+//      if (i > 502) {
+//        // try something else, like MLST
+//        log("{} {}", FTPCmd.MLST, path);
+//        i = ftpClient().mlst(path);
+//        log("{} returned {}", FTPCmd.MLST, i);
+//
+//
+//      } else if (i == 213) {
+//        reply = validateReply(ftpClient().getReplyString(), "213");
+//      }
+//      if (reply != null) {
+//        String[] lines = reply.getReplyText().split("\n");
+//        /*
+//
+//  line 0 * 213-Status follows:
+//  line 1 * drwxr-xr-x    2 1000     1000         4096 Apr 19 15:20 .
+//         * drwxr-xr-x    3 1000     1000         4096 Apr 20 13:58 ..
+//         * -rw-r--r--    1 1000     1000         3314 Apr 19 15:20 f1
+//         * 213 End of status
+//         *
+//  line 0 * 213-Status follows:
+//  line 1 * -rw-r--r--    1 1000     1000            6 Apr 20 13:58 world
+//         * 213 End of status
+//         */
+//        if (lines[1].startsWith("d")) {
+//          return true;
+//        }
+//      }
       return false;
     } finally {
       logReply(ftpClient().getReplyStrings());

--- a/interlok-core/src/main/java/com/adaptris/ftp/ApacheFtpClientImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/ftp/ApacheFtpClientImpl.java
@@ -395,44 +395,6 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
         return true;
       }
       log("Could not change to {} - must not be a directory", path);
-//      log("{} {}", FTPCmd.STAT, path);
-//      int i = ftpClient().stat(path);
-//      /*
-//       * So STAT can do one of 2 things: return the system status or
-//       * the details of a file, and while my FTP server (vsftpd) does
-//       * both depending on whether you give it a path, the Mock FTP
-//       * server only does the first - perhaps others do too.
-//       */
-//      log("{} returned {}", FTPCmd.STAT, i);
-//      Reply reply = null;
-//      if (i > 502) {
-//        // try something else, like MLST
-//        log("{} {}", FTPCmd.MLST, path);
-//        i = ftpClient().mlst(path);
-//        log("{} returned {}", FTPCmd.MLST, i);
-//
-//
-//      } else if (i == 213) {
-//        reply = validateReply(ftpClient().getReplyString(), "213");
-//      }
-//      if (reply != null) {
-//        String[] lines = reply.getReplyText().split("\n");
-//        /*
-//
-//  line 0 * 213-Status follows:
-//  line 1 * drwxr-xr-x    2 1000     1000         4096 Apr 19 15:20 .
-//         * drwxr-xr-x    3 1000     1000         4096 Apr 20 13:58 ..
-//         * -rw-r--r--    1 1000     1000         3314 Apr 19 15:20 f1
-//         * 213 End of status
-//         *
-//  line 0 * 213-Status follows:
-//  line 1 * -rw-r--r--    1 1000     1000            6 Apr 20 13:58 world
-//         * 213 End of status
-//         */
-//        if (lines[1].startsWith("d")) {
-//          return true;
-//        }
-//      }
       return false;
     } finally {
       logReply(ftpClient().getReplyStrings());

--- a/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
+++ b/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
@@ -439,6 +439,21 @@ public class SftpClient extends FileTransferClientImp {
     }
   }
 
+  @Override
+  public boolean isDirectory(String path) throws IOException {
+    checkConnected();
+    try {
+      acquireLock();
+      log("STAT {}", path);
+      SftpATTRS attrs = sftpChannel.stat(path);
+      return attrs.isDir();
+    } catch (Exception e) {
+      throw SftpException.wrapException("Could not stat [" + path + "]", e);
+    } finally {
+      releaseLock();
+    }
+  }
+
   /**
    *
    * @see FileTransferClient#lastModifiedDate(java.lang.String)

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpHelperTest.java
@@ -1,8 +1,11 @@
 package com.adaptris.core.ftp;
 
+import org.junit.Test;
+
+import java.io.File;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import org.junit.Test;
 
 public class FtpHelperTest extends FtpHelper {
 
@@ -27,7 +30,6 @@ public class FtpHelperTest extends FtpHelper {
     filename = getFilename(WINDOWS_PATH, false);
     assertNotEquals(FILENAME, filename);
     assertEquals(WINDOWS_PATH, filename);
-
   }
 
   @Test
@@ -45,8 +47,22 @@ public class FtpHelperTest extends FtpHelper {
     directory = getDirectory(WINDOWS_PATH, false);
     assertNotEquals(WINDOWS_DIR, directory);
     assertEquals(WINDOWS_PATH, directory);
-
   }
 
+  @Test
+  public void testGetParentDirectoryName() {
+    String parentName = new File(UNIX_DIR).getParentFile().getName();
 
+    String directoryName = getParentDirectoryName(UNIX_DIR);
+    assertEquals(parentName, directoryName);
+
+    directoryName = getParentDirectoryName(UNIX_PATH, true);
+    assertNotEquals(parentName, directoryName);
+
+    directoryName = getParentDirectoryName(WINDOWS_DIR, true);
+    assertEquals(parentName, directoryName);
+
+    directoryName = getParentDirectoryName(WINDOWS_PATH, false);
+    assertNotEquals(WINDOWS_DIR, directoryName);
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpHelperTest.java
@@ -48,21 +48,4 @@ public class FtpHelperTest extends FtpHelper {
     assertNotEquals(WINDOWS_DIR, directory);
     assertEquals(WINDOWS_PATH, directory);
   }
-
-  @Test
-  public void testGetParentDirectoryName() {
-    String parentName = new File(UNIX_DIR).getParentFile().getName();
-
-    String directoryName = getParentDirectoryName(UNIX_DIR);
-    assertEquals(parentName, directoryName);
-
-    directoryName = getParentDirectoryName(UNIX_PATH, true);
-    assertNotEquals(parentName, directoryName);
-
-    directoryName = getParentDirectoryName(WINDOWS_DIR, true);
-    assertEquals(parentName, directoryName);
-
-    directoryName = getParentDirectoryName(WINDOWS_PATH, false);
-    assertNotEquals(WINDOWS_DIR, directoryName);
-  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpRecursiveConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpRecursiveConsumerTest.java
@@ -18,6 +18,7 @@ package com.adaptris.core.ftp;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreConstants;
 import com.adaptris.core.FixedIntervalPoller;
 import com.adaptris.core.MimeEncoder;
 import com.adaptris.core.Poller;
@@ -38,22 +39,17 @@ import org.mockftpserver.fake.FakeFtpServer;
 import org.mockftpserver.fake.filesystem.DirectoryEntry;
 import org.mockftpserver.fake.filesystem.FileEntry;
 import org.mockftpserver.fake.filesystem.FileSystem;
-import org.mockftpserver.fake.filesystem.FileSystemEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_BUILD_DIR_NAME;
 import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_FILENAME;
-import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_HOME_DIR;
 import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_PASSWORD;
 import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_PROC_DIR_CANONICAL;
-import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_PROC_DIR_NAME;
 import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_USERNAME;
 import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_WORK_DIR_CANONICAL;
 import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_WORK_DIR_NAME;
@@ -131,7 +127,11 @@ public class FtpRecursiveConsumerTest extends FtpConsumerCase {
       LifecycleHelper.prepare(sc);
       start(sc);
       waitForMessages(listener, count + (count * subDirectories.length)); // account for files in sub directories
-      helper.assertMessages(listener.getMessages(), count + (count * subDirectories.length));
+      List<AdaptrisMessage> messages = listener.getMessages();
+      helper.assertMessages(messages, count + (count * subDirectories.length));
+      for (AdaptrisMessage message : messages) {
+        assertTrue(message.headersContainsKey(CoreConstants.FS_CONSUME_PARENT_DIR));
+      }
     }
     catch (Exception e) {
       throw e;

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpRecursiveConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpRecursiveConsumerTest.java
@@ -1,0 +1,617 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.ftp;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.FixedIntervalPoller;
+import com.adaptris.core.MimeEncoder;
+import com.adaptris.core.Poller;
+import com.adaptris.core.PollerImp;
+import com.adaptris.core.StandaloneConsumer;
+import com.adaptris.core.lms.FileBackedMessageFactory;
+import com.adaptris.core.stubs.MockMessageListener;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.ftp.ClientSettings;
+import com.adaptris.ftp.FtpDataMode;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+import com.adaptris.util.TimeInterval;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.apache.oro.io.GlobFilenameFilter;
+import org.junit.Test;
+import org.mockftpserver.fake.FakeFtpServer;
+import org.mockftpserver.fake.filesystem.DirectoryEntry;
+import org.mockftpserver.fake.filesystem.FileEntry;
+import org.mockftpserver.fake.filesystem.FileSystem;
+import org.mockftpserver.fake.filesystem.FileSystemEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_BUILD_DIR_NAME;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_FILENAME;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_HOME_DIR;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_PASSWORD;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_PROC_DIR_CANONICAL;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_PROC_DIR_NAME;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_USERNAME;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_WORK_DIR_CANONICAL;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DEFAULT_WORK_DIR_NAME;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.DESTINATION_URL_OVERRIDE;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.PAYLOAD;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.SERVER_ADDRESS;
+import static com.adaptris.core.ftp.EmbeddedFtpServer.SLASH;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class FtpRecursiveConsumerTest extends FtpConsumerCase {
+
+  private transient Logger log = LoggerFactory.getLogger(this.getClass());
+
+  private static final String[] subDirectories = { "dir1", "dir2", "dir3" };
+
+  @Override
+  protected FtpConnection createConnectionForExamples() {
+    return FtpExampleHelper.ftpConnection();
+  }
+
+  @Override
+  protected String getScheme() {
+    return "ftp";
+  }
+
+  @Override
+  protected String createBaseFileName(Object object) {
+    return super.createBaseFileName(object);
+  }
+
+  @Test
+  public void testFileFilterImp() throws Exception {
+    FtpRecursiveConsumer ftpConsumer = new FtpRecursiveConsumer();
+    assertNull(ftpConsumer.getFileFilterImp());
+    assertEquals(RegexFileFilter.class.getCanonicalName(), ftpConsumer.fileFilterImp());
+
+    ftpConsumer.setFileFilterImp("ABCDE");
+    assertEquals("ABCDE", ftpConsumer.getFileFilterImp());
+    assertEquals("ABCDE", ftpConsumer.fileFilterImp());
+
+    ftpConsumer.setFileFilterImp(null);
+    assertNull(ftpConsumer.getFileFilterImp());
+    assertEquals(RegexFileFilter.class.getCanonicalName(), ftpConsumer.fileFilterImp());
+  }
+
+  @Test
+  public void testWipSuffix() throws Exception {
+    FtpRecursiveConsumer ftpConsumer = new FtpRecursiveConsumer();
+    assertNull(ftpConsumer.getWipSuffix());
+    assertEquals("_wip", ftpConsumer.wipSuffix());
+
+    ftpConsumer.setWipSuffix("ABCDE");
+    assertEquals("ABCDE", ftpConsumer.getWipSuffix());
+    assertEquals("ABCDE", ftpConsumer.wipSuffix());
+
+    ftpConsumer.setWipSuffix(null);
+    assertNull(ftpConsumer.getWipSuffix());
+    assertEquals("_wip", ftpConsumer.wipSuffix());
+  }
+
+  @Test
+  public void testBasicConsume() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener();
+    FakeFtpServer server = helper.createAndStart(createFilesystem(helper, count));
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      // INTERLOK-3329 For coverage so the prepare() warning is executed 2x
+      LifecycleHelper.prepare(sc);
+      start(sc);
+      waitForMessages(listener, count + (count * subDirectories.length)); // account for files in sub directories
+      helper.assertMessages(listener.getMessages(), count + (count * subDirectories.length));
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+
+  }
+
+  @Test
+  public void testBasicConsume_NoDebug() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener();
+    FakeFtpServer server = helper.createAndStart(createFilesystem(helper, count));
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      FtpConnection consumeConnection = create(server);
+      consumeConnection.setAdditionalDebug(false);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, 1);//count + (count * subDirectories.length));
+      helper.assertMessages(listener.getMessages(), count + (count * subDirectories.length));
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+
+  }
+
+  @Test
+  public void testConsumeWithOverride() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener();
+    FakeFtpServer server = helper.createAndStart(createFilesystem(helper, count));
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener, DESTINATION_URL_OVERRIDE);
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count + (count * subDirectories.length));
+      helper.assertMessages(listener.getMessages(), count + (count * subDirectories.length));
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsumeWithFilter() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener();
+    FileSystem filesystem = helper.createFilesystem_DirsOnly();
+    for (int i = 0; i < count; i++) {
+      filesystem.add(new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + DEFAULT_FILENAME + i + ".txt", PAYLOAD));
+    }
+    FakeFtpServer server = helper.createAndStart(filesystem);
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener, SERVER_ADDRESS);
+      ftpConsumer.setFilterExpression("*.txt");
+      ftpConsumer.setFileFilterImp(GlobFilenameFilter.class.getCanonicalName());
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count);
+      helper.assertMessages(listener.getMessages(), count);
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsumeWithQuietPeriod() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener();
+    FakeFtpServer server = helper.createAndStart(createFilesystem(helper, count));
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      ftpConsumer.setQuietInterval(new TimeInterval(1L, TimeUnit.SECONDS));
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count + (count * subDirectories.length));
+      helper.assertMessages(listener.getMessages(), count + (count * subDirectories.length));
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsumeWithNonMatchingFilter() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener();
+    FileSystem filesystem = helper.createFilesystem_DirsOnly();
+    for (int i = 0; i < count; i++) {
+      filesystem.add(new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + DEFAULT_FILENAME + i + ".txt", PAYLOAD));
+    }
+    FakeFtpServer server = helper.createAndStart(filesystem);
+    StandaloneConsumer sc = null;
+    try {
+      AtomicBoolean pollFired = new AtomicBoolean(false);
+      FixedIntervalPoller poller = new FixedIntervalPoller(new TimeInterval(300L, TimeUnit.MILLISECONDS)).withPollerCallback(e -> {
+        log.trace("Poll Fired {}", getName());
+        if (e == 0) {
+          pollFired.set(true);
+        }
+      });
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener, SERVER_ADDRESS, poller);
+      ftpConsumer.setFilterExpression("^*.xml$");
+      ftpConsumer.setFileFilterImp(RegexFileFilter.class.getCanonicalName());
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      long waitTime = waitForPollCallback(pollFired);
+      log.trace("Waited for {}ms for == 0 poll", waitTime);
+      helper.assertMessages(listener.getMessages(), 0);
+      assertEquals(count, filesystem.listFiles(DEFAULT_WORK_DIR_CANONICAL).size());
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testActiveModeConsume() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener(100);
+    FakeFtpServer server = helper.createAndStart(createFilesystem(helper, count));
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      FtpConnection consumeConnection = create(server);
+      consumeConnection.setFtpDataMode(FtpDataMode.ACTIVE);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count + (count * subDirectories.length));
+      helper.assertMessages(listener.getMessages(), count + (count * subDirectories.length));
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testPassiveModeConsume() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener(100);
+    FakeFtpServer server = helper.createAndStart(helper.createFilesystem(count));
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      FtpConnection consumeConnection = create(server);
+      consumeConnection.setFtpDataMode(FtpDataMode.PASSIVE);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count + (count * subDirectories.length));
+      helper.assertMessages(listener.getMessages(), count + (count * subDirectories.length));
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsume_ForceRelativePath() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener(100);
+    FakeFtpServer server = helper.createAndStart(createFilesystem(helper, count));
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      ftpConsumer.setWorkDirectory(SLASH + DEFAULT_WORK_DIR_NAME);
+      FtpConnection consumeConnection = create(server);
+      consumeConnection.setForceRelativePath(Boolean.TRUE);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count + (count * subDirectories.length));
+      helper.assertMessages(listener.getMessages(), count + (count * subDirectories.length));
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsumeWithQuietPeriodAndTimezone() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener(100);
+    FileSystem filesystem = helper.createFilesystem_DirsOnly();
+    for (int i = 0; i < count; i++) {
+      filesystem.add(new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + DEFAULT_FILENAME + i + ".txt", PAYLOAD));
+    }
+    FakeFtpServer server = helper.createAndStart(filesystem);
+    StandaloneConsumer sc = null;
+    try {
+
+      AtomicBoolean pollFired = new AtomicBoolean(false);
+      PollerImp poller = new FixedIntervalPoller(new TimeInterval(300L, TimeUnit.MILLISECONDS)).withPollerCallback(e -> {
+        log.trace("Poll Fired {}", getName());
+        if (e == 0) {
+          pollFired.set(true);
+        }
+      });
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener, "testConsumeWithQuietPeriodAndTimezone", poller);
+
+      ftpConsumer.setQuietInterval(new TimeInterval(3L, TimeUnit.SECONDS));
+      FtpConnection consumeConnection = create(server);
+      consumeConnection.setAdditionalDebug(true);
+      consumeConnection.setServerTimezone("America/Los_Angeles");
+
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      long waitTime = waitForPollCallback(pollFired);
+      log.trace("Waited for {}ms for == 0 poll", waitTime);
+
+      helper.assertMessages(listener.getMessages(), 0);
+      assertEquals(count, filesystem.listFiles(DEFAULT_WORK_DIR_CANONICAL).size());
+
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsume_WithProcDirectory() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener(100);
+    FileSystem filesystem = helper.createFilesystem_DirsOnly();
+    for (int i = 0; i < count; i++) {
+      filesystem.add(new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + DEFAULT_FILENAME + i + ".txt", PAYLOAD));
+    }
+    FakeFtpServer server = helper.createAndStart(filesystem);
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      ftpConsumer.setProcDirectory(DEFAULT_PROC_DIR_CANONICAL);
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count);
+      Thread.sleep(500);
+      helper.assertMessages(listener.getMessages(), count);
+      assertEquals(count, filesystem.listFiles(DEFAULT_PROC_DIR_CANONICAL).size());
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsume_WithProcDirectory_FileAlreadyExists() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener(100);
+    FileSystem filesystem = helper.createFilesystem_DirsOnly();
+    for (int i = 0; i < count; i++) {
+      filesystem.add(new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + DEFAULT_FILENAME + i + ".txt", PAYLOAD));
+      filesystem.add(new FileEntry(DEFAULT_PROC_DIR_CANONICAL + SLASH + DEFAULT_FILENAME + i + ".txt", PAYLOAD));
+    }
+    FakeFtpServer server = helper.createAndStart(filesystem);
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      ftpConsumer.setProcDirectory(DEFAULT_PROC_DIR_CANONICAL);
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count);
+      Thread.sleep(500);
+      // Because the files already exist in the PROC dir, we expect file1.txt and file1.txt.timestamp;
+      // assertEquals(count * 2, filesystem.listFiles(DEFAULT_PROC_DIR_CANONICAL).size());
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsumeWithEncoder() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener(100);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD);
+    byte[] bytes = new MimeEncoder().encode(msg);
+    FileSystem filesystem = helper.createFilesystem_DirsOnly();
+    for (int i = 0; i < count; i++) {
+      FileEntry entry = new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + DEFAULT_FILENAME + i + ".txt");
+      entry.setContents(bytes);
+      filesystem.add(entry);
+    }
+    FakeFtpServer server = helper.createAndStart(filesystem);
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      ftpConsumer.setEncoder(new MimeEncoder());
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count);
+      helper.assertMessages(listener.getMessages(), count);
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testConsume_IgnoresWipFiles() throws Exception {
+
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener(100);
+    FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+    FileSystem filesystem = helper.createFilesystem_DirsOnly();
+    for (int i = 0; i < count; i++) {
+      filesystem.add(new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + DEFAULT_FILENAME + i + ".txt", PAYLOAD));
+    }
+    // Now create some files that have a _wip extension.
+    filesystem.add(new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + "shouldBeIgnored.txt" + ftpConsumer.wipSuffix(), PAYLOAD));
+    FakeFtpServer server = helper.createAndStart(filesystem);
+    StandaloneConsumer sc = null;
+    try {
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count);
+      helper.assertMessages(listener.getMessages(), count);
+      Thread.sleep(2000); // allow the consumer to consume the single message, should be 1 file left - the .wip file.
+      assertTrue(filesystem.listFiles(DEFAULT_WORK_DIR_CANONICAL).size() > 0);
+    }
+    catch (Exception e) {
+      throw e;
+    }
+    finally {
+      stop(sc);
+      server.stop();
+    }
+  }
+
+  private FtpConnection create(FakeFtpServer server) {
+    FtpConnection consumeConnection = new FtpConnection();
+    consumeConnection.setDefaultControlPort(server.getServerControlPort());
+    consumeConnection.setDefaultPassword(DEFAULT_PASSWORD);
+    consumeConnection.setDefaultUserName(DEFAULT_USERNAME);
+    consumeConnection.setCacheConnection(true);
+    consumeConnection.setAdditionalDebug(true);
+    KeyValuePairSet settings = new KeyValuePairSet();
+    settings.add(new KeyValuePair(ClientSettings.FTP.RemoteVerificationEnabled.name(), "false"));
+    consumeConnection.setAdditionalSettings(settings);
+    return consumeConnection;
+  }
+
+  private FtpRecursiveConsumer createForTests(MockMessageListener listener) {
+    return createForTests(listener, SERVER_ADDRESS);
+  }
+
+  private FtpRecursiveConsumer createForTests(MockMessageListener listener, Poller p) {
+    return createForTests(listener, SERVER_ADDRESS, p);
+  }
+
+  @SuppressWarnings("deprecation")
+  private FtpRecursiveConsumer createForTests(MockMessageListener listener, String url, Poller poller) {
+    FtpRecursiveConsumer ftpConsumer = new FtpRecursiveConsumer();
+    if (url.equals(SERVER_ADDRESS)) {
+      ftpConsumer.setWorkDirectory(DEFAULT_WORK_DIR_CANONICAL);
+    }
+    else {
+      ftpConsumer.setWorkDirectory(SLASH + DEFAULT_WORK_DIR_NAME);
+    }
+    ftpConsumer.setFtpEndpoint(url);
+    ftpConsumer.setPoller(poller);
+    ftpConsumer.registerAdaptrisMessageListener(listener);
+    return ftpConsumer;
+  }
+
+  private FtpRecursiveConsumer createForTests(MockMessageListener listener, String url) {
+    return createForTests(listener, url, new FixedIntervalPoller(new TimeInterval(300L, TimeUnit.MILLISECONDS)));
+  }
+
+  private FileSystem createFilesystem(EmbeddedFtpServer server, int count) {
+    FileSystem fs = server.createFilesystem(count);
+    for (String dir : subDirectories) {
+      fs.add(new DirectoryEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + dir));
+      for (int i = 0; i < count; i++) {
+        FileEntry entry = new FileEntry(DEFAULT_WORK_DIR_CANONICAL + SLASH + dir + SLASH + DEFAULT_FILENAME + i, PAYLOAD);
+        entry.setLastModified(new Date());
+        fs.add(entry);
+      }
+    }
+    return fs;
+  }
+
+  @Test
+  public void testBasicConsume_WithFileBackedMessage() throws Exception {
+    int count = 1;
+    EmbeddedFtpServer helper = new EmbeddedFtpServer();
+    MockMessageListener listener = new MockMessageListener();
+    FakeFtpServer server = helper.createAndStart(helper.createFilesystem(count));
+    StandaloneConsumer sc = null;
+    try {
+      FtpRecursiveConsumer ftpConsumer = createForTests(listener);
+      ftpConsumer.setMessageFactory(new FileBackedMessageFactory());
+      FtpConnection consumeConnection = create(server);
+      sc = new StandaloneConsumer(consumeConnection, ftpConsumer);
+      start(sc);
+      waitForMessages(listener, count);
+      helper.assertMessages(listener.getMessages(), count);
+    } catch (Exception e) {
+      throw e;
+    } finally {
+      stop(sc);
+      server.stop();
+    }
+
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpRecursiveConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpRecursiveConsumerTest.java
@@ -42,6 +42,7 @@ import org.mockftpserver.fake.filesystem.FileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -131,6 +132,8 @@ public class FtpRecursiveConsumerTest extends FtpConsumerCase {
       helper.assertMessages(messages, count + (count * subDirectories.length));
       for (AdaptrisMessage message : messages) {
         assertTrue(message.headersContainsKey(CoreConstants.FS_CONSUME_PARENT_DIR));
+        String path = message.getMetadataValue(CoreConstants.FS_CONSUME_DIRECTORY);
+        assertEquals(new File(path).getName(), message.getMetadataValue(CoreConstants.FS_CONSUME_PARENT_DIR));
       }
     }
     catch (Exception e) {

--- a/interlok-core/src/test/java/com/adaptris/sftp/test/TestSftp.java
+++ b/interlok-core/src/test/java/com/adaptris/sftp/test/TestSftp.java
@@ -13,6 +13,7 @@
 
 package com.adaptris.sftp.test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
@@ -49,6 +50,7 @@ public class TestSftp extends FtpCase {
       try {
         Random r = new Random();
         String dir = config.getProperty(SFTP_GET_REMOTEDIR) + "/" + r.nextInt();
+        assertFalse(client.isDirectory(dir));
         client.dir(dir);
         fail("LS of  " + dir + " should not work");
       } catch (Exception e) {


### PR DESCRIPTION
## Motivation

The current FTP consumer will only consume files that are within the current working directory, without descending into any child directories. In certain situations it may be beneficial to scan sub directories too.

## Modification

Add a new consumer that will recursively descend into any sub directories it find.

## Result

All files found in sub directories get consumed.

## Testing

The unit tests mock a fake FTP server (which is how i discovered not all FTP servers are created equal or implement all commands). I also started an FTP server locally to confirm [adapter.xml](https://github.com/adaptris/interlok/files/6351491/adapter.txt).


