### PR TITLE
feature/interlok-3756

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQuery.java
@@ -16,12 +16,11 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
-import org.w3c.dom.Document;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.w3c.dom.Document;
 
 /**
  * {@linkplain XpathQuery} implementation that retuns a single text item from the configured xpath.

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQueryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQueryImpl.java
@@ -16,12 +16,11 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
 import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
 
@@ -35,8 +34,10 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
  */
 public abstract class ConfiguredXpathQueryImpl extends XpathQueryImpl {
 
+  /** The XPath query string. */
   @Getter
   @NotBlank
+  @InputFieldHint(expression = true)
   private String xpathQuery;
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQueryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQueryImpl.java
@@ -16,11 +16,16 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import javax.validation.constraints.NotBlank;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.Args;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Abstract base class for {@linkplain XpathQuery} implementations that are statically configured.
@@ -30,15 +35,9 @@ import com.adaptris.core.util.Args;
  */
 public abstract class ConfiguredXpathQueryImpl extends XpathQueryImpl {
 
+  @Getter
   @NotBlank
   private String xpathQuery;
-
-  public ConfiguredXpathQueryImpl() {
-  }
-
-  public String getXpathQuery() {
-    return xpathQuery;
-  }
 
   /**
    * Set the xpath.
@@ -51,7 +50,7 @@ public abstract class ConfiguredXpathQueryImpl extends XpathQueryImpl {
 
   @Override
   public String createXpathQuery(AdaptrisMessage msg) {
-    return xpathQuery;
+    return msg == null ? xpathQuery : msg.resolve(xpathQuery);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathQueryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathQueryImpl.java
@@ -39,12 +39,14 @@ public abstract class XpathQueryImpl implements XpathMetadataQuery {
 
   protected transient Logger logR = LoggerFactory.getLogger(this.getClass());
 
+  /** Specify whether or not an xpath that does not resolve should throw an exception. */
   @Getter
   @Setter
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean allowEmptyResults;
 
+  /** The metadata key that will be associated with the resolved xpath expression. */
   @Getter
   @NotBlank
   @AffectsMetadata

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathQueryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathQueryImpl.java
@@ -17,6 +17,10 @@
 package com.adaptris.core.services.metadata.xpath;
 
 import javax.validation.constraints.NotBlank;
+
+import com.adaptris.annotation.InputFieldHint;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,21 +39,16 @@ public abstract class XpathQueryImpl implements XpathMetadataQuery {
 
   protected transient Logger logR = LoggerFactory.getLogger(this.getClass());
 
+  @Getter
+  @Setter
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean allowEmptyResults;
+
+  @Getter
   @NotBlank
   @AffectsMetadata
   private String metadataKey;
-
-  public XpathQueryImpl() {
-  }
-
-
-  @Override
-  public String getMetadataKey() {
-    return metadataKey;
-  }
 
   /**
    * Set the metadata key that will be associated with the resolved xpath expression.
@@ -58,20 +57,6 @@ public abstract class XpathQueryImpl implements XpathMetadataQuery {
    */
   public void setMetadataKey(String key) {
     metadataKey = Args.notBlank(key, "metadataKey");
-  }
-
-  public Boolean getAllowEmptyResults() {
-    return allowEmptyResults;
-  }
-
-  /**
-   * Specify whether or not an xpath that does not resolve should throw an exception.
-   *
-   *
-   * @param b true to allow no results (which may result in an empty string being added as metadata), default false.
-   */
-  public void setAllowEmptyResults(Boolean b) {
-    allowEmptyResults = b;
   }
 
   protected boolean allowEmptyResults() {

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQueryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQueryTest.java
@@ -106,4 +106,23 @@ public class ConfiguredXpathQueryTest extends ConfiguredXpathQueryCase {
     assertEquals("2", result.getValue());
   }
 
+  @Test
+  public void testMessageResolveXpath() throws Exception {
+    ConfiguredXpathQuery query = init(create(), "//message/extra[%message{which-extra}]");
+    query.setAllowEmptyResults(Boolean.FALSE);
+    Document doc = XmlHelper.createDocument(XML);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
+
+    msg.addMetadata("which-extra", "1");
+    MetadataElement result = query.resolveXpath(doc, new XPath(), query.createXpathQuery(msg));
+    assertEquals("one", result.getValue());
+
+    msg.addMetadata("which-extra", "2");
+    result = query.resolveXpath(doc, new XPath(), query.createXpathQuery(msg));
+    assertEquals("two", result.getValue());
+
+    msg.addMetadata("which-extra", "3");
+    result = query.resolveXpath(doc, new XPath(), query.createXpathQuery(msg));
+    assertEquals("three", result.getValue());
+  }
 }


### PR DESCRIPTION
## Motivation

Allow for the support of expressions so that to generate an Xpath dynamically the user does not need to:

* Add `FormattedMetadata`: `key`=`xpath` `value`=`some/xpath/%message{value}`
* Then do `MetadataXpathQuery` and refer to it

But can instead do:

* `some/xpath/%message{value}` directly within the `XpathMetadataQuery`

## Modification

* Change the `createXpathQuery` method to resolve the query string (if there's a message - some existing tests do not pass in a message)
* Lombok-ify member variables where possible
* Add unit test

## Result

The user can now use expressions in any class that extends `ConfiguredXpathQueryImpl`

## Testing

To test, use [adapter.xml](https://github.com/adaptris/interlok/files/6358860/adapter.xml.txt) and add a couple of variable sets with variable `book-number` and a sensible value. Every minute the same message will be generated and the logs should show that the correct title is extracted from the XML and put into metadata.

