### PR TITLE
bug/interlok-3304 - Unckecked Exceptions in FsConsumer causes hang

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
@@ -139,11 +139,8 @@ public class FsConsumer extends FsConsumerImpl {
         }
       }
     }
-    catch (FsException e) {
-      throw new CoreException(e);
-    }
-    catch (IOException e) {
-      throw new CoreException(e);
+    catch (Throwable t) {
+      throw ExceptionHelper.wrapCoreException(t);
     }
     return rc;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
@@ -140,6 +140,7 @@ public class FsConsumer extends FsConsumerImpl {
       }
     }
     catch (Throwable t) {
+      log.error("Unexpected error processing file {}", originalFile, t);
       throw ExceptionHelper.wrapCoreException(t);
     }
     return rc;

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
@@ -324,6 +324,7 @@ public abstract class FsConsumerImpl extends AdaptrisPollingConsumer {
       msg = decode(fsWorker.get(fileToProcess));
     }
     catch (Throwable t) {
+      log.error("Unexpected error creating message from file {}", fileToProcess, t);
       throw ExceptionHelper.wrapCoreException(t);
     }
     return msg;

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumerImpl.java
@@ -323,8 +323,8 @@ public abstract class FsConsumerImpl extends AdaptrisPollingConsumer {
     try {
       msg = decode(fsWorker.get(fileToProcess));
     }
-    catch (FsException e) {
-      throw new CoreException(e);
+    catch (Throwable t) {
+      throw ExceptionHelper.wrapCoreException(t);
     }
     return msg;
   }


### PR DESCRIPTION
## Motivation

If the user tries to consume a large file using the standard FS consumer, an out-of-memory error will occur, which causes the adapter to hang.

## Modification

Change the catch block so that it catches everything and rethrows wrapped in CoreException.

## Result

The error is now visible and the adapter doesn't require restarting.

## Testing

The new unit test should demonstrate the issue - it doesn't actually fail, it just times-out, but zero messages are generted. There is also this simply FS consumer config [adapter.xml](https://github.com/adaptris/interlok/files/6375094/adapter.xml.txt) - as the ticket said, just try and consume a sufficiently large file (1GB-ish).

