### PR TITLE
feature/INTERLOK-3757 - MultiItemXpathQuery that renders a node-list as a String of XML

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQuery.java
@@ -18,9 +18,11 @@ package com.adaptris.core.services.metadata.xpath;
 
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.MetadataElement;
+import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 /**
  * {@linkplain XpathQuery} implementation that retuns a single text item from the configured xpath.
@@ -43,7 +45,13 @@ public class ConfiguredXpathQuery extends ConfiguredXpathQueryImpl implements Xp
 
   @Override
   public MetadataElement resolveXpath(Document doc, XPath xpath, String expr) throws Exception {
-    return new MetadataElement(getMetadataKey(), XpathQueryHelper.resolveSingleTextItem(doc, xpath, expr,
-        allowEmptyResults()));
+    String result;
+    if (asXmlString()) {
+      Node node = XpathQueryHelper.resolveSingleNode(doc, xpath, expr, allowEmptyResults());
+      result = XmlHelper.nodeToString(node);
+    } else {
+      result = XpathQueryHelper.resolveSingleTextItem(doc, xpath, expr, allowEmptyResults());
+    }
+    return new MetadataElement(getMetadataKey(), result);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQuery.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.services.metadata.xpath;
 
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
@@ -28,8 +29,12 @@ import org.w3c.dom.Node;
  * {@linkplain XpathQuery} implementation that retuns a single text item from an xpath derived from metadata.
  * 
  * @config metadata-xpath-query
- * 
+ *
+ * @deprecated Use ConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.
+ *
  */
+@Deprecated(since = "4.1.0")
+@Removal(message = "Use ConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.")
 @XStreamAlias("metadata-xpath-query")
 @DisplayOrder(order = {"metadataKey", "xpathMetadataKey"})
 public class MetadataXpathQuery extends MetadataXpathQueryImpl implements XpathQuery {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQuery.java
@@ -16,12 +16,13 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
-import org.w3c.dom.Document;
-
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.MetadataElement;
+import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 /**
  * {@linkplain XpathQuery} implementation that retuns a single text item from an xpath derived from metadata.
@@ -44,7 +45,14 @@ public class MetadataXpathQuery extends MetadataXpathQueryImpl implements XpathQ
 
   @Override
   public MetadataElement resolveXpath(Document doc, XPath xpath, String expr) throws Exception {
-    return new MetadataElement(getMetadataKey(), XpathQueryHelper.resolveSingleTextItem(doc, xpath, expr, allowEmptyResults()));
-  }
+    String result;
+    if (asXmlString()) {
+      Node node = XpathQueryHelper.resolveSingleNode(doc, xpath, expr, allowEmptyResults());
+      result = XmlHelper.nodeToString(node);
+    } else {
+      result = XpathQueryHelper.resolveSingleTextItem(doc, xpath, expr, allowEmptyResults());
+    }
+    return new MetadataElement(getMetadataKey(), result);
 
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQuery.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,25 +16,26 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.Removal;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
 
 /**
  * {@linkplain XpathQuery} implementation that retuns a single text item from an xpath derived from metadata.
- * 
+ *
  * @config metadata-xpath-query
  *
  * @deprecated Use ConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.
  *
  */
 @Deprecated(since = "4.1.0")
-@Removal(message = "Use ConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.")
+@Removal(version = "5.0.0",
+    message = "Use ConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.")
 @XStreamAlias("metadata-xpath-query")
 @DisplayOrder(order = {"metadataKey", "xpathMetadataKey"})
 public class MetadataXpathQuery extends MetadataXpathQueryImpl implements XpathQuery {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQueryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQueryImpl.java
@@ -27,7 +27,10 @@ import com.adaptris.core.util.Args;
  *
  * @author lchan
  *
+ * @deprecated Use ConfiguredXpathQueryImpl with %message{metadata} syntax to extract XPath from metadata.
+ *
  */
+@Deprecated(since = "4.1.0")
 public abstract class MetadataXpathQueryImpl extends XpathQueryImpl {
 
   @NotBlank

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemConfiguredXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemConfiguredXpathQuery.java
@@ -59,10 +59,10 @@ public class MultiItemConfiguredXpathQuery extends ConfiguredXpathQueryImpl impl
   /**
    * Get the raw XML as the result, instead of text() values.
    */
-  @AdvancedConfig()
   @Getter
   @Setter
-  @InputFieldDefault("false")
+  @AdvancedConfig
+  @InputFieldDefault(value = "false")
   private Boolean asXmlString;
 
   public MultiItemConfiguredXpathQuery() {
@@ -83,7 +83,7 @@ public class MultiItemConfiguredXpathQuery extends ConfiguredXpathQueryImpl impl
   @Override
   public MetadataElement resolveXpath(Document doc, XPath xpath, String expr) throws CoreException {
     String items = "";
-    if (allowNodeResults()) {
+    if (asXmlString()) {
       NodeList nodes = XpathQueryHelper.resolveNodeList(doc, xpath, expr, allowEmptyResults());
       for (int i = 0; i < nodes.getLength(); i++) {
         Node node = nodes.item(i);
@@ -104,7 +104,7 @@ public class MultiItemConfiguredXpathQuery extends ConfiguredXpathQueryImpl impl
     separator = Args.notNull(s, "separator");
   }
 
-  private boolean allowNodeResults() {
+  private boolean asXmlString() {
     return BooleanUtils.toBooleanDefaultIfNull(getAsXmlString(), false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemConfiguredXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemConfiguredXpathQuery.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,10 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
+import javax.validation.constraints.NotNull;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
@@ -27,17 +31,12 @@ import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import javax.validation.constraints.NotNull;
 
 /**
  * {@linkplain XpathQuery} implementation that retuns a multiple text items from the configured xpath.
- * 
+ *
  * @config multi-item-configured-xpath-query
- * 
+ *
  */
 @XStreamAlias("multi-item-configured-xpath-query")
 @DisplayOrder(order = {"metadataKey", "xpathQuery"})
@@ -45,6 +44,10 @@ public class MultiItemConfiguredXpathQuery extends ConfiguredXpathQueryImpl impl
 
   /**
    * The separator used to separate items.
+   * <p>
+   * Note that this item will be ignored in when you have specified {@link #setAsXmlString(Boolean)}
+   * to be true since that renders the nodelist as pseudo XML.
+   * </p>
    */
   @NotNull
   @AdvancedConfig

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemConfiguredXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemConfiguredXpathQuery.java
@@ -19,7 +19,6 @@ package com.adaptris.core.services.metadata.xpath;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
@@ -28,8 +27,6 @@ import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
-import lombok.Setter;
-import org.apache.commons.lang3.BooleanUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -55,15 +52,6 @@ public class MultiItemConfiguredXpathQuery extends ConfiguredXpathQueryImpl impl
   @Getter
   @InputFieldHint(style = "BLANKABLE")
   private String separator;
-
-  /**
-   * Get the raw XML as the result, instead of text() values.
-   */
-  @Getter
-  @Setter
-  @AdvancedConfig
-  @InputFieldDefault(value = "false")
-  private Boolean asXmlString;
 
   public MultiItemConfiguredXpathQuery() {
     setSeparator("|");
@@ -102,9 +90,5 @@ public class MultiItemConfiguredXpathQuery extends ConfiguredXpathQueryImpl impl
    */
   public void setSeparator(String s) {
     separator = Args.notNull(s, "separator");
-  }
-
-  private boolean asXmlString() {
-    return BooleanUtils.toBooleanDefaultIfNull(getAsXmlString(), false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
@@ -20,6 +20,7 @@ import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.Args;
@@ -37,8 +38,12 @@ import javax.validation.constraints.NotNull;
  * {@linkplain XpathQuery} implementation that retuns a multiple text items from an xpath derived from metadata.
  * 
  * @config multi-item-metadata-xpath-query
- * 
+ *
+ * @deprecated Use MultiItemConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.
+ *
  */
+@Deprecated(since = "4.1.0")
+@Removal(message = "Use MultiItemConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.")
 @XStreamAlias("multi-item-metadata-xpath-query")
 @DisplayOrder(order = {"metadataKey", "xpathMetadataKey"})
 public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implements XpathQuery {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
@@ -19,7 +19,6 @@ package com.adaptris.core.services.metadata.xpath;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
@@ -28,8 +27,6 @@ import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
-import lombok.Setter;
-import org.apache.commons.lang3.BooleanUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -55,15 +52,6 @@ public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implemen
   @Getter
   @InputFieldHint(style = "BLANKABLE")
   private String separator;
-
-  /**
-   * Get the raw XML as the result, instead of text() values.
-   */
-  @Getter
-  @Setter
-  @AdvancedConfig
-  @InputFieldDefault(value = "false")
-  private Boolean asXmlString;
 
   public MultiItemMetadataXpathQuery()
   {
@@ -105,9 +93,5 @@ public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implemen
    */
   public void setSeparator(String s) {
     separator = Args.notNull(s, "separator");
-  }
-
-  private boolean asXmlString() {
-    return BooleanUtils.toBooleanDefaultIfNull(getAsXmlString(), false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
@@ -44,8 +44,7 @@ import javax.validation.constraints.NotNull;
  */
 @XStreamAlias("multi-item-metadata-xpath-query")
 @DisplayOrder(order = {"metadataKey", "xpathMetadataKey"})
-public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implements XpathQuery
-{
+public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implements XpathQuery {
 
   /**
    * The separator used to separate items.
@@ -60,12 +59,11 @@ public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implemen
   /**
    * Get the raw XML as the result, instead of text() values.
    */
-  @AdvancedConfig()
   @Getter
   @Setter
-  @InputFieldDefault("false")
+  @AdvancedConfig
+  @InputFieldDefault(value = "false")
   private Boolean asXmlString;
-
 
   public MultiItemMetadataXpathQuery()
   {
@@ -88,7 +86,7 @@ public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implemen
   @Override
   public MetadataElement resolveXpath(Document doc, XPath xpath, String expr) throws CoreException {
     String items = "";
-    if (allowNodeResults()) {
+    if (asXmlString()) {
       NodeList nodes = XpathQueryHelper.resolveNodeList(doc, xpath, expr, allowEmptyResults());
       for (int i = 0; i < nodes.getLength(); i++) {
         Node node = nodes.item(i);
@@ -109,7 +107,7 @@ public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implemen
     separator = Args.notNull(s, "separator");
   }
 
-  private boolean allowNodeResults() {
+  private boolean asXmlString() {
     return BooleanUtils.toBooleanDefaultIfNull(getAsXmlString(), false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,10 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
+import javax.validation.constraints.NotNull;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
@@ -28,28 +32,28 @@ import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import javax.validation.constraints.NotNull;
 
 /**
  * {@linkplain XpathQuery} implementation that retuns a multiple text items from an xpath derived from metadata.
- * 
+ *
  * @config multi-item-metadata-xpath-query
  *
  * @deprecated Use MultiItemConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.
  *
  */
 @Deprecated(since = "4.1.0")
-@Removal(message = "Use MultiItemConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.")
+@Removal(version = "5.0.0",
+    message = "Use MultiItemConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.")
 @XStreamAlias("multi-item-metadata-xpath-query")
 @DisplayOrder(order = {"metadataKey", "xpathMetadataKey"})
 public class MultiItemMetadataXpathQuery extends MetadataXpathQueryImpl implements XpathQuery {
 
   /**
    * The separator used to separate items.
+   * <p>
+   * Note that this item will be ignored in when you have specified {@link #setAsXmlString(Boolean)}
+   * to be true since that renders the nodelist as pseudo XML.
+   * </p>
    */
   @NotNull
   @AdvancedConfig

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathMetadataQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathMetadataQuery.java
@@ -22,12 +22,8 @@ import com.adaptris.core.CoreException;
 /**
  * Base interface for generating metadata from an xpath.
  * 
- * @author lchan
- *
- * @deprecated Use XpathQuery with %message{metadata} syntax to extract XPath from metadata.
  *
  */
-@Deprecated(since = "4.1.0")
 public interface XpathMetadataQuery {
   /**
    * Get the key that this Xpath query will be associated with.

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathMetadataQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathMetadataQuery.java
@@ -23,8 +23,11 @@ import com.adaptris.core.CoreException;
  * Base interface for generating metadata from an xpath.
  * 
  * @author lchan
- * 
+ *
+ * @deprecated Use XpathQuery with %message{metadata} syntax to extract XPath from metadata.
+ *
  */
+@Deprecated(since = "4.1.0")
 public interface XpathMetadataQuery {
   /**
    * Get the key that this Xpath query will be associated with.

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathQueryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/XpathQueryImpl.java
@@ -16,18 +16,17 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
-import javax.validation.constraints.NotBlank;
-
-import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AffectsMetadata;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.util.Args;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AffectsMetadata;
-import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.core.util.Args;
+
+import javax.validation.constraints.NotBlank;
 
 /**
  * Abstract base class for Metadata Xpath Queries.
@@ -46,6 +45,15 @@ public abstract class XpathQueryImpl implements XpathMetadataQuery {
   @InputFieldDefault(value = "false")
   private Boolean allowEmptyResults;
 
+  /**
+   * Get the raw XML as the result, instead of text() values.
+   */
+  @Getter
+  @Setter
+  @AdvancedConfig
+  @InputFieldDefault(value = "false")
+  private Boolean asXmlString;
+
   /** The metadata key that will be associated with the resolved xpath expression. */
   @Getter
   @NotBlank
@@ -63,5 +71,9 @@ public abstract class XpathQueryImpl implements XpathMetadataQuery {
 
   protected boolean allowEmptyResults() {
     return BooleanUtils.toBooleanDefaultIfNull(getAllowEmptyResults(), false);
+  }
+
+  protected boolean asXmlString() {
+    return BooleanUtils.toBooleanDefaultIfNull(getAsXmlString(), false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
@@ -24,12 +24,15 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
@@ -37,6 +40,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.xerces.util.XMLChar;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -419,6 +423,26 @@ public class XmlHelper {
       encoding = msg.getContentEncoding();
     }
     return encoding;
+  }
+
+  /**
+   * Convert an XML Node into a String snippet.
+   *
+   * @param node The node to get as an XML String.
+   *
+   * @return The XML String representation of the Node.
+   */
+  public static String nodeToString(Node node) {
+    try (Writer out = new StringWriter()) {
+      Transformer tf = TransformerFactory.newInstance().newTransformer();
+      tf.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+      tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+      tf.setOutputProperty(OutputKeys.INDENT, "yes");
+      tf.transform(new DOMSource(node), new StreamResult(out));
+      return out.toString();
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   private static Transformer configure(Transformer serializer, String encoding)

--- a/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
@@ -16,8 +16,28 @@
 
 package com.adaptris.core.util;
 
-import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.util.XmlUtils;
+import org.apache.xerces.util.XMLChar;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,28 +46,9 @@ import java.io.PrintStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
-import javax.xml.namespace.NamespaceContext;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.TransformerFactoryConfigurationError;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-import org.apache.xerces.util.XMLChar;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
-import com.adaptris.util.XmlUtils;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Helper class for handling XML within an {@linkplain com.adaptris.core.AdaptrisMessage}
@@ -439,7 +440,7 @@ public class XmlHelper {
       tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
       tf.setOutputProperty(OutputKeys.INDENT, "yes");
       tf.transform(new DOMSource(node), new StreamResult(out));
-      return out.toString();
+      return out.toString().strip();
     } catch (Exception e) {
       return null;
     }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQueryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/ConfiguredXpathQueryTest.java
@@ -16,16 +16,17 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import org.junit.Test;
-import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
 public class ConfiguredXpathQueryTest extends ConfiguredXpathQueryCase {
@@ -124,5 +125,14 @@ public class ConfiguredXpathQueryTest extends ConfiguredXpathQueryCase {
     msg.addMetadata("which-extra", "3");
     result = query.resolveXpath(doc, new XPath(), query.createXpathQuery(msg));
     assertEquals("three", result.getValue());
+  }
+
+  @Test
+  public void testResolveNodesAsString() throws Exception {
+    ConfiguredXpathQuery query = new ConfiguredXpathQuery("result", "//source-id");
+    query.setAsXmlString(true);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
+    MetadataElement result = query.resolveXpath(XmlHelper.createDocument(msg.getContent()), new XPath(), query.createXpathQuery(msg));
+    assertEquals("<source-id>partnera</source-id>", result.getValue().strip());
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQueryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQueryTest.java
@@ -16,16 +16,17 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import org.junit.Test;
-import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
 public class MetadataXpathQueryTest extends MetadataXpathQueryCase {
@@ -115,4 +116,13 @@ public class MetadataXpathQueryTest extends MetadataXpathQueryCase {
     assertEquals("2", result.getValue());
   }
 
+  @Test
+  public void testResolveNodesAsString() throws Exception {
+    MetadataXpathQuery query = init(create());
+    query.setAsXmlString(true);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
+    msg.addMetadata("xpathMetadataKey", "//source-id");
+    MetadataElement result = query.resolveXpath(XmlHelper.createDocument(msg.getContent()), new XPath(), query.createXpathQuery(msg));
+    assertEquals("<source-id>partnera</source-id>", result.getValue().strip());
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/MultiItemConfiguredXpathQueryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/MultiItemConfiguredXpathQueryTest.java
@@ -16,21 +16,22 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import org.junit.Test;
-import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
 public class MultiItemConfiguredXpathQueryTest extends ConfiguredXpathQueryCase {
 
-  private static final String XML_WITH_EMPTY_NODES = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" + 
+  public static final String XML_WITH_EMPTY_NODES = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" +
       "<root>\n" + 
       "  <segment_PIX>\n" + 
       "    <segment_Contents>\n" + 
@@ -135,4 +136,15 @@ public class MultiItemConfiguredXpathQueryTest extends ConfiguredXpathQueryCase 
     assertEquals("two|three", result.getValue());
   }
 
+  @Test
+  public void testResolveNodesAsString() throws Exception {
+    MultiItemConfiguredXpathQuery query = new MultiItemConfiguredXpathQuery("result", "//PXREF1[string-length(text()) > 0]", "");
+    query.setAsXmlString(true);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_WITH_EMPTY_NODES);
+    MetadataElement result = query.resolveXpath(XmlHelper.createDocument(msg.getContent()), new XPath(), query.createXpathQuery(msg));
+
+    assertEquals("<PXREF1>91/01</PXREF1>\n" +
+            "<PXREF1>91/01</PXREF1>\n" +
+            "<PXREF1>91/01</PXREF1>", result.getValue().strip());
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQueryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQueryTest.java
@@ -16,16 +16,17 @@
 
 package com.adaptris.core.services.metadata.xpath;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import org.junit.Test;
-import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.text.xml.XPath;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
 public class MultiItemMetadataXpathQueryTest extends MetadataXpathQueryCase {
@@ -98,4 +99,16 @@ public class MultiItemMetadataXpathQueryTest extends MetadataXpathQueryCase {
     assertEquals("two|three", result.getValue());
   }
 
+  @Test
+  public void testResolveNodesAsString() throws Exception {
+    MultiItemMetadataXpathQuery query = new MultiItemMetadataXpathQuery("result", "xpathMetadataKey", "");
+    query.setAsXmlString(true);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MultiItemConfiguredXpathQueryTest.XML_WITH_EMPTY_NODES);
+    msg.addMetadata("xpathMetadataKey", "//PXREF1[string-length(text()) > 0]");
+    MetadataElement result = query.resolveXpath(XmlHelper.createDocument(msg.getContent()), new XPath(), query.createXpathQuery(msg));
+
+    assertEquals("<PXREF1>91/01</PXREF1>\n" +
+            "<PXREF1>91/01</PXREF1>\n" +
+            "<PXREF1>91/01</PXREF1>", result.getValue().strip());
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
@@ -16,26 +16,30 @@
 
 package com.adaptris.core.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import java.io.IOException;
-import javax.xml.namespace.NamespaceContext;
-import org.junit.Test;
-import org.w3c.dom.Document;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.util.XmlUtils;
+import org.junit.Test;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+
+import javax.xml.namespace.NamespaceContext;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("deprecation")
 public class XmlHelperTest extends XmlHelper {
   private static final String EXAMPLE_XML =
-      "<document>" + System.lineSeparator() + "  <content>text body</content>" + System.lineSeparator()
-          + "  <attachment encoding=\"base64\" filename=\"attachment1.txt\">dp/HSJfonUsSMM7QRBSRfg==</attachment>"
+      "<document>" + System.lineSeparator() + "   <content>text body</content>" + System.lineSeparator()
+          + "   <attachment encoding=\"base64\" filename=\"attachment1.txt\">dp/HSJfonUsSMM7QRBSRfg==</attachment>"
           + System.lineSeparator()
-          + "  <attachment encoding=\"base64\" filename=\"attachment2.txt\">OdjozpCZB9PbCCLZlKregQ</attachment>"
+          + "   <attachment encoding=\"base64\" filename=\"attachment2.txt\">OdjozpCZB9PbCCLZlKregQ</attachment>"
           + System.lineSeparator() + "</document>";
 
   private static final String ILLEGAL_XML_CHAR = new String(new byte[]
@@ -125,5 +129,19 @@ public class XmlHelperTest extends XmlHelper {
   public void testStripIllegalChars() throws Exception {
     assertEquals("hello", stripIllegalXmlCharacters("hel" + ILLEGAL_XML_CHAR + "lo"));
     assertEquals("hello", stripIllegalXmlCharacters("hello"));
+  }
+
+  @Test
+  public void testNodeToString() throws Exception {
+    Document d = XmlHelper.createDocument(EXAMPLE_XML);
+    String s = XmlHelper.nodeToString(d);
+    assertEquals(EXAMPLE_XML, s);
+  }
+
+  @Test
+  public void testNodeToStringException() throws Exception {
+    Document d = XmlHelper.createDocument(EXAMPLE_XML);
+    Attr a = d.createAttribute("x");
+    assertNull(XmlHelperTest.nodeToString(a));
   }
 }


### PR DESCRIPTION
## Motivation

Dave would like have the xpath output of a nodeset NOT be rendered as ```for-each:node()/text()``` but to actually give a string representation of all the node matches.

So instead of:

    2020-01 02  thing            12   whatever
    2022-01 02  differentThing   6    whatever
    2019-01 02  blah             9    whatever

He gets:

```xml
<fiscal_years>
            <end_date>2022-12-31</end_date>
            <fiscal_year>2022</fiscal_year>
            <id>34F253E1-E65D-49B4-906C-D3642596D5D9</id>
            <number_of_periods>12</number_of_periods>
            <start_date>2022-01-01</start_date>
</fiscal_years>
<fiscal_years>
            <end_date>2021-12-31</end_date>
            <fiscal_year>2021</fiscal_year>
            <id>8197BA42-CD21-4A53-A69C-E43F3271959E</id>
            <number_of_periods>12</number_of_periods>
            <start_date>2021-01-01</start_date>
</fiscal_years>
<fiscal_years>
            <end_date>2020-12-31</end_date>
            <fiscal_year>2020</fiscal_year>
            <id>39F4C8AB-BB0C-4BEB-8805-78CE1665FD7C</id>
            <number_of_periods>12</number_of_periods>
            <start_date>2020-01-01</start_date>
</fiscal_years>
```

## Modification

Add toggle to existing ```MultiItemConfiguredXpathQuery``` and ```MultiItemMetadataXpathQuery``` that will give the raw XML instead of ```text()``` data.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like XStreamAlias / ComponentProfile)
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI
- [x] Checked the display of the component in the UI

## Result

The result is that now the output data is the nodes as a set represented by a string. Not the ```element/text()``` of each element within the resulting set.

An xpath of ```//bookstore/book[price>35.00]```

and data of:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<bookstore>
<book category="cooking">
  <title lang="en">Everyday Italian</title>
  <author>Giada De Laurentiis</author>
  <year>2005</year>
  <price>30.00</price>
</book>
<book category="children">
  <title lang="en">Harry Potter</title>
  <author>J K. Rowling</author>
  <year>2005</year>
  <price>29.99</price>
</book>
<book category="web">
  <title lang="en">XQuery Kick Start</title>
  <author>James McGovern</author>
  <author>Per Bothner</author>
  <author>Kurt Cagle</author>
  <author>James Linn</author>
  <author>Vaidyanathan Nagarajan</author>
  <year>2003</year>
  <price>49.99</price>
</book>
<book category="web">
  <title lang="en">Learning XML</title>
  <author>Erik T. Ray</author>
  <year>2003</year>
  <price>39.95</price>
</book>
</bookstore>
```

gives output of:

```xml
<book category="web">
   <title lang="en">XQuery Kick Start</title>
   <author>James McGovern</author>
   <author>Per Bothner</author>
   <author>Kurt Cagle</author>
   <author>James Linn</author>
   <author>Vaidyanathan Nagarajan</author>
   <year>2003</year>
   <price>49.99</price>
</book>
<book category="web">
   <title lang="en">Learning XML</title>
   <author>Erik T. Ray</author>
   <year>2003</year>
   <price>39.95</price>
</book>
```

## Testing

The unit tests cover changes; those wishing to to check the UI: [config](https://github.com/adaptris/interlok/files/6501875/adapter.xml.txt) and [sample data](https://github.com/adaptris/interlok/files/6501877/sample-data.xml.txt).

