### PR TITLE
INTERLOK-3326 Conditional Logging

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionAnd.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionAnd.java
@@ -56,6 +56,7 @@ public class ConditionAnd extends ConditionListImpl {
         break;
       }
     }
+    logCondition("{}: evaluated to : {}", getClass().getSimpleName(), returnValue);
     return returnValue;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionExpression.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionExpression.java
@@ -85,7 +85,7 @@ public class ConditionExpression extends ConditionImpl {
       String expr = msg.resolve(this.getAlgorithm());
       interpreter.eval("result = (" + expr + ")");
       String stringResult = interpreter.get("result").toString();
-      log.trace("{} evaluated to : {}", expr, stringResult);
+      logCondition("{}: {} evaluated to : {}", getClass().getSimpleName(), expr, stringResult);
       rc = BooleanUtils.toBoolean(stringResult);
     } catch (Exception ex) {
       throw new ServiceException(ex);

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionFunction.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionFunction.java
@@ -64,6 +64,7 @@ public class ConditionFunction extends ConditionImpl {
   public boolean evaluate(AdaptrisMessage msg) throws ServiceException {
     try {
       Object o = ((Invocable) engine).invokeFunction("evaluateScript", msg);
+      logCondition("{}: evaluated to : {}", getClass().getSimpleName(), o.toString());
       return BooleanUtils.toBoolean(o.toString());
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionImpl.java
@@ -1,11 +1,28 @@
 package com.adaptris.core.services.conditional.conditions;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adaptris.core.services.conditional.Condition;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public abstract class ConditionImpl implements Condition {
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
+  @Getter
+  @Setter
+  private Boolean additionalLogging;
+  
+  protected void logCondition(String message, Object... args) {
+    if(additionalLogging()) {      
+      log.trace(message, args);
+    }
+  }
+  
+  private boolean additionalLogging() {
+    return BooleanUtils.toBooleanDefaultIfNull(getAdditionalLogging(), false);
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionImpl.java
@@ -4,16 +4,22 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.services.conditional.Condition;
 
 import lombok.Getter;
 import lombok.Setter;
 
 public abstract class ConditionImpl implements Condition {
+  
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
   @Getter
   @Setter
+  @InputFieldDefault(value = "false")
+  /**
+   * Log the details of the conditions source and the result of the evaluation.
+   */
   private Boolean additionalLogging;
   
   protected void logCondition(String message, Object... args) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionImpl.java
@@ -14,12 +14,12 @@ public abstract class ConditionImpl implements Condition {
   
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-  @Getter
-  @Setter
-  @InputFieldDefault(value = "false")
   /**
    * Log the details of the conditions source and the result of the evaluation.
    */
+  @Setter
+  @Getter
+  @InputFieldDefault(value = "false")
   private Boolean additionalLogging;
   
   protected void logCondition(String message, Object... args) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionMetadata.java
@@ -51,8 +51,9 @@ public class ConditionMetadata extends ConditionWithOperator {
   @Override
   public boolean evaluate(AdaptrisMessage message) throws CoreException {
     if(!StringUtils.isEmpty(this.getMetadataKey())) {
-      log.trace("Testing metadata condition with key: {}", this.getMetadataKey());
-      return operator().apply(message, message.getMetadataValue(this.getMetadataKey()));
+      boolean result = operator().apply(message, message.getMetadataValue(this.getMetadataKey()));
+      logCondition("{}: evaluating {} {} : result {}", getClass().getSimpleName(), this.getMetadataKey(), getOperator(), result);
+      return result;
     } else {
       log.warn("No metadata key supplied, returning false.");
       return false;

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionNot.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionNot.java
@@ -29,8 +29,9 @@ public class ConditionNot extends ConditionImpl {
 
   @Override
   public boolean evaluate(AdaptrisMessage message) throws CoreException {
-    log.trace("Testing not condition");
-    return !getCondition().evaluate(message);
+    boolean result = !getCondition().evaluate(message);
+    logCondition("{}: evaluated to : {}", getClass().getSimpleName(), result);
+    return result;
   }
 
   public Condition getCondition() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionOr.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionOr.java
@@ -53,6 +53,7 @@ public class ConditionOr extends ConditionListImpl {
         break;
       }
     }
+    logCondition("{}: evaluated to : {}", getClass().getSimpleName(), returnValue);
     return returnValue;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionPayload.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/conditions/ConditionPayload.java
@@ -43,7 +43,8 @@ public class ConditionPayload extends ConditionWithOperator {
   
   @Override
   public boolean evaluate(AdaptrisMessage message) throws CoreException {
-    log.trace("Testing payload condition");
-    return operator().apply(message, message.getContent());
+    boolean result = operator().apply(message, message.getContent());
+    logCondition("{}: evaluating payload {} : result {}", getClass().getSimpleName(), getOperator(), result);
+    return result;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/Equals.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/Equals.java
@@ -68,5 +68,9 @@ public class Equals implements Operator {
   public void setValue(String value) {
     this.value = value;
   }
+  
+  public String toString() {
+    return "equals " + getValue();
+  }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/IsEmpty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/IsEmpty.java
@@ -52,4 +52,8 @@ public class IsEmpty implements Operator {
   public void setIgnoreWhitespace(Boolean ignoreWhitespace) {
     this.ignoreWhitespace = ignoreWhitespace;
   }
+  
+  public String toString() {
+    return "is empty";
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/IsIn.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/IsIn.java
@@ -48,4 +48,8 @@ public class IsIn implements Operator {
   public void setValues(List<String> values) {
     this.values =  Args.notNull(values,"values");
   }
+  
+  public String toString() {
+    return "is in " + getValues();
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/IsNull.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/IsNull.java
@@ -48,4 +48,7 @@ public class IsNull implements Operator {
     return StringUtils.isEmpty(object);
   }
 
+  public String toString() {
+    return "is null";
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/Matches.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/Matches.java
@@ -73,4 +73,7 @@ public class Matches implements Operator {
     this.value = value;
   }
 
+  public String toString() {
+    return "matches " + getValue();
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/NotEmpty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/NotEmpty.java
@@ -30,4 +30,8 @@ public class NotEmpty extends IsEmpty {
   public boolean apply(AdaptrisMessage message, String object) {
     return !(super.apply(message, object));
   }
+  
+  public String toString() {
+    return "not empty";
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/NotEquals.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/NotEquals.java
@@ -69,4 +69,7 @@ public class NotEquals implements Operator {
     this.value = value;
   }
 
+  public String toString() {
+    return "not equals to " + getValue();
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/NotIn.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/NotIn.java
@@ -28,4 +28,8 @@ public class NotIn extends IsIn {
   public boolean apply(AdaptrisMessage message, String object) {
     return !(super.apply(message, object));
   }
+  
+  public String toString() {
+    return "is not in " + getValues();
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/NotNull.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/conditional/operator/NotNull.java
@@ -47,4 +47,7 @@ public class NotNull implements Operator {
     return object != null;
   }
 
+  public String toString() {
+    return "is not null";
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/conditions/ConditionMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/conditions/ConditionMetadataTest.java
@@ -22,11 +22,11 @@ import static org.junit.Assert.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.services.conditional.conditions.ConditionMetadata;
-import com.adaptris.core.services.conditional.operator.NotNull;
 import com.adaptris.core.services.conditional.operator.IsNull;
+import com.adaptris.core.services.conditional.operator.NotNull;
 import com.adaptris.core.util.LifecycleHelper;
 
 public class ConditionMetadataTest {
@@ -38,6 +38,7 @@ public class ConditionMetadataTest {
   public void setUp() throws Exception {
     message = DefaultMessageFactory.getDefaultInstance().newMessage();
     condition = new ConditionMetadata();
+    condition.setAdditionalLogging(true);
     LifecycleHelper.initAndStart(condition);
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/EqualsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/EqualsTest.java
@@ -54,4 +54,8 @@ public class EqualsTest {
     assertFalse(operator.apply(message, "xxxx"));
   }
   
+  @Test
+  public void testToString() {
+    assertTrue(operator.toString().contains("equals"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/IsEmptyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/IsEmptyTest.java
@@ -70,4 +70,9 @@ public class IsEmptyTest {
     ((IsEmpty)operator).setIgnoreWhitespace(true);
     assertTrue(operator.apply(message, null));
   }
+  
+  @Test
+  public void testToString() {
+    assertTrue(operator.toString().contains("is empty"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/IsInTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/IsInTest.java
@@ -60,4 +60,9 @@ public class IsInTest {
   public void testNotInEmptyArray() {
     assertFalse(operator.apply(message, "xyz"));
   }
+  
+  @Test
+  public void testToString() {
+    assertTrue(operator.toString().contains("is in"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/IsNullTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/IsNullTest.java
@@ -47,4 +47,8 @@ public class IsNullTest {
     assertTrue(operator.apply(message, null));
   }
 
+  @Test
+  public void testToString() {
+    assertTrue(operator.toString().contains("is null"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/MatchesTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/MatchesTest.java
@@ -38,4 +38,10 @@ public class MatchesTest {
     assertFalse(operator.apply(AdaptrisMessageFactory.getDefaultInstance().newMessage(), "xxxx"));
   }
   
+  @Test
+  public void testToString() {
+    Matches operator = new Matches();
+    operator.setValue(".*");
+    assertTrue(operator.toString().contains("matches"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/NotEmptyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/NotEmptyTest.java
@@ -96,4 +96,8 @@ public class NotEmptyTest {
     assertTrue(operator.apply(message, " string \t"));
   }
 
+  @Test
+  public void testToString() {
+    assertTrue(operator.toString().contains("not empty"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/NotEqualsTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/NotEqualsTest.java
@@ -54,4 +54,8 @@ public class NotEqualsTest {
     assertTrue(operator.apply(message, "xxxx"));
   }
   
+  @Test
+  public void testToString() {
+    assertTrue(operator.toString().contains("not equals"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/NotInTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/NotInTest.java
@@ -62,5 +62,8 @@ public class NotInTest {
     assertTrue(operator.apply(message, "xyz"));
   }
 
-
+  @Test
+  public void testToString() {
+    assertTrue(operator.toString().contains("not in"));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/NotNullTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/operator/NotNullTest.java
@@ -48,4 +48,8 @@ public class NotNullTest {
     assertFalse(operator.apply(message, null));
   }
 
+  @Test
+  public void testToString() {
+    assertTrue(operator.toString().contains("not null"));
+  }
 }


### PR DESCRIPTION
## Motivation

Our logging for conditional services is either too verbose in places or just doesn't show anything useful, therefore we will review the logging for the conditions and fix up where appropriate.

## Modification

We have a new logging method "logCondition" in the condition abstract class, all children conditions will call this method when they evaluate.  Additionally we have a new flag for this additionalLogging.  The flag defaults to false in case your data is sensitive and shouldn't be printed to logs.
The Operators now have a toString method that represents what they're testing; for example the Equals operator will return "equals myValue".
Any Condition that requires an Operator will call it's Operators toString method when building up the logging string; this means our conditions will log the condition type (Metadata/Payload/Expression etc), the source of the data and the boolean result of the evaluation.

## PR Checklist

- [x] been self-reviewed.
- [x] Added supporting annotations (like XStreamAlias / ComponentProfile)
- [x] Tested new/updated components in the UI
- [x] Checked the display of the component in the UI

## Result

Optional useful logging for all conditional services, examples below;
`ConditionMetadata: evaluating key1 equals Value1 : result false`
`ConditionExpression: 1 == 2 evaluated to : false`
`ConditionPayload: evaluating payload equals some value : result false`
`ConditionMetadata: evaluating key1 is not in [val, val2, val3] : result true`

## Testing

Configure a conditional service, make sure you set the additionalLogging flag to true and then give it some activity.
Alternatively use the config enclosed.

[FS-Conditionals.txt](https://github.com/adaptris/interlok/files/6532501/FS-Conditionals.txt)

