### PR TITLE
INTERLOK-3713 Decode base64 data

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -288,4 +288,6 @@ public abstract class CoreConstants {
    */
   public static final String OBJ_METADATA_ON_FAILURE_CALLBACK = "_onFailureCallback";
 
+
+  public static final String SERIALIZED_MESSAGE_ENCODING = "_interlokMessageSerialization";
 }

--- a/interlok-core/src/main/java/com/adaptris/core/DefaultSerializableMessageTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DefaultSerializableMessageTranslator.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.adaptris.util.text.mime.MimeConstants;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -91,10 +92,8 @@ public class DefaultSerializableMessageTranslator implements SerializableMessage
             convertMap(message.getMessageHeaders()));
       }
 
-      if (message.getMessageHeaders().containsKey("_interlokMessageSerialization")) {
-        if (message.getMessageHeaders().get("_interlokMessageSerialization").equals("BASE64")) {
-          adaptrisMessage.setPayload(Base64.getDecoder().decode(message.getContent()));
-        }
+      if (MimeConstants.ENCODING_BASE64.equalsIgnoreCase(message.getMessageHeaders().get(CoreConstants.SERIALIZED_MESSAGE_ENCODING))) {
+        adaptrisMessage.setPayload(Base64.getDecoder().decode(message.getContent()));
       }
 
       if(StringUtils.isEmpty(message.getUniqueId()))

--- a/interlok-core/src/main/java/com/adaptris/core/DefaultSerializableMessageTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DefaultSerializableMessageTranslator.java
@@ -19,6 +19,7 @@ package com.adaptris.core;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
@@ -85,10 +86,15 @@ public class DefaultSerializableMessageTranslator implements SerializableMessage
       if (StringUtils.isEmpty(message.getContentEncoding())) {
         adaptrisMessage = messageFactory.newMessage(message.getContent(), convertMap(message.getMessageHeaders()));
       }
+      else if (message.getContentEncoding().equals("BASE64")) {
+        adaptrisMessage = messageFactory.newMessage("", convertMap(message.getMessageHeaders()));
+        adaptrisMessage.setPayload(Base64.getDecoder().decode(message.getContent()));
+      }
       else {
         adaptrisMessage = messageFactory.newMessage(message.getContent(), message.getContentEncoding(),
             convertMap(message.getMessageHeaders()));
       }
+
       if(StringUtils.isEmpty(message.getUniqueId()))
         message.setUniqueId(new GuidGenerator().create(this));
         

--- a/interlok-core/src/main/java/com/adaptris/core/DefaultSerializableMessageTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DefaultSerializableMessageTranslator.java
@@ -86,13 +86,15 @@ public class DefaultSerializableMessageTranslator implements SerializableMessage
       if (StringUtils.isEmpty(message.getContentEncoding())) {
         adaptrisMessage = messageFactory.newMessage(message.getContent(), convertMap(message.getMessageHeaders()));
       }
-      else if (message.getContentEncoding().equals("BASE64")) {
-        adaptrisMessage = messageFactory.newMessage("", convertMap(message.getMessageHeaders()));
-        adaptrisMessage.setPayload(Base64.getDecoder().decode(message.getContent()));
-      }
       else {
         adaptrisMessage = messageFactory.newMessage(message.getContent(), message.getContentEncoding(),
             convertMap(message.getMessageHeaders()));
+      }
+
+      if (message.getMessageHeaders().containsKey("_interlokMessageSerialization")) {
+        if (message.getMessageHeaders().get("_interlokMessageSerialization").equals("BASE64")) {
+          adaptrisMessage.setPayload(Base64.getDecoder().decode(message.getContent()));
+        }
       }
 
       if(StringUtils.isEmpty(message.getUniqueId()))

--- a/interlok-core/src/test/java/com/adaptris/core/DefaultSerializableMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/DefaultSerializableMessageTranslatorTest.java
@@ -17,11 +17,15 @@
 package com.adaptris.core;
 
 import static org.junit.Assert.assertEquals;
+
+import com.adaptris.interlok.types.DefaultSerializableMessage;
 import org.junit.Test;
 import com.adaptris.interlok.types.SerializableMessage;
 
 public class DefaultSerializableMessageTranslatorTest {
 
+  private static final String BASE64_ORIGINAL = "Mistakes are often the stepping stones to utter failure.";
+  public static final String BASE64_ENCODED = "TWlzdGFrZXMgYXJlIG9mdGVuIHRoZSBzdGVwcGluZyBzdG9uZXMgdG8gdXR0ZXIgZmFpbHVyZS4=";
 
   @Test
   public void testMetadataTranslated() throws Exception {
@@ -79,5 +83,27 @@ public class DefaultSerializableMessageTranslatorTest {
     
     assertEquals("An Error Happened", translated.getMessageHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION));
   }
-  
+
+  @Test
+  public void testBase64Decode() throws Exception {
+    DefaultSerializableMessage serializableMessage = new DefaultSerializableMessage();
+    serializableMessage.setContent(BASE64_ENCODED);
+    serializableMessage.addMessageHeader("_interlokMessageSerialization", "BASE64");
+
+    DefaultSerializableMessageTranslator translator = new DefaultSerializableMessageTranslator();
+    AdaptrisMessage adaptrisMessage = translator.translate(serializableMessage);
+    assertEquals(BASE64_ORIGINAL, adaptrisMessage.getContent());
+  }
+
+  @Test
+  public void testBase64WrongValue() throws Exception {
+    DefaultSerializableMessage serializableMessage = new DefaultSerializableMessage();
+    serializableMessage.setUniqueId(null);
+    serializableMessage.setContent(BASE64_ENCODED);
+    serializableMessage.addMessageHeader("_interlokMessageSerialization", "something-else");
+
+    DefaultSerializableMessageTranslator translator = new DefaultSerializableMessageTranslator();
+    AdaptrisMessage adaptrisMessage = translator.translate(serializableMessage);
+    assertEquals(BASE64_ENCODED, adaptrisMessage.getContent());
+  }
 }


### PR DESCRIPTION
## Motivation

Service Tester cannot handle Excel files with a file-payload-provider in a test-case. This is due to serializable message, et al. all only handling strings.

## Modification

The DefaultSerializableMessageTranslator will now perform an Base64 decode to byte[] iff ContentEncoding is the string "BASE64".

## PR Checklist

- [x] been self-reviewed.
- [ ] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked the display of the component in the UI

## Result

This will allows any binary file to be used in the service tester when using a file payload.

## Testing

To test this, follow the instructions on the [original ticket](https://adaptris.atlassian.net/browse/INTERLOK-3713).