### PR TITLE
INTERLOK-3776 nashorn config checker

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/config/NashornChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/NashornChecker.java
@@ -10,6 +10,10 @@ import com.adaptris.core.util.ObjectScanner;
 import com.adaptris.core.util.ScriptingUtil;
 import lombok.NoArgsConstructor;
 
+/**
+ * Configuration check that checks if a scripting service impl requires nashorn and warns about it.
+ *
+ */
 @NoArgsConstructor
 public class NashornChecker extends ValidationCheckerImpl {
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/NashornChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/NashornChecker.java
@@ -1,0 +1,49 @@
+package com.adaptris.core.management.config;
+
+import java.util.Collection;
+import java.util.function.Function;
+import javax.script.ScriptEngineManager;
+import com.adaptris.core.Adapter;
+import com.adaptris.core.services.ScriptingServiceImp;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.core.util.ObjectScanner;
+import com.adaptris.core.util.ScriptingUtil;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class NashornChecker extends ValidationCheckerImpl {
+
+  private static final String FRIENDLY_NAME = "Nashorn Scripting Engine check";
+
+
+  @Override
+  protected void validate(Adapter adapter, ConfigurationCheckReport report) {
+    try {
+      ScriptEngineManager engineManager = new ScriptEngineManager(this.getClass().getClassLoader());
+      Collection<ScriptingServiceImp> scripts = new ScriptingServiceScanner().scan(adapter);
+      for (ScriptingServiceImp s : scripts) {
+        if (ScriptingUtil.dependsOnNashorn(engineManager, s.getLanguage())) {
+          report.getWarnings()
+              .add(String.format(
+                  "[%s] relies on the deprecated Nashorn scripting engine; consider switching to Graal JS",
+              LoggingHelper.friendlyName(s)));
+        }
+      }
+    } catch (Exception ex) {
+      report.getFailureExceptions().add(ex);
+    }
+  }
+
+  @Override
+  public String getFriendlyName() {
+    return FRIENDLY_NAME;
+  }
+
+  private class ScriptingServiceScanner extends ObjectScanner<ScriptingServiceImp> {
+
+    @Override
+    protected Function<Object, Boolean> objectMatcher() {
+      return (object) -> ScriptingServiceImp.class.isAssignableFrom(object.getClass());
+    }
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/NashornChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/NashornChecker.java
@@ -24,7 +24,7 @@ public class NashornChecker extends ValidationCheckerImpl {
   protected void validate(Adapter adapter, ConfigurationCheckReport report) {
     try {
       ScriptEngineManager engineManager = new ScriptEngineManager(this.getClass().getClassLoader());
-      Collection<ScriptingServiceImp> scripts = new ScriptingServiceScanner().scan(adapter);
+      Collection<ScriptingServiceImp> scripts = scanner().scan(adapter);
       for (ScriptingServiceImp s : scripts) {
         if (ScriptingUtil.dependsOnNashorn(engineManager, s.getLanguage())) {
           report.getWarnings()
@@ -41,6 +41,10 @@ public class NashornChecker extends ValidationCheckerImpl {
   @Override
   public String getFriendlyName() {
     return FRIENDLY_NAME;
+  }
+
+  protected ObjectScanner<ScriptingServiceImp> scanner() {
+    return new ScriptingServiceScanner();
   }
 
   private class ScriptingServiceScanner extends ObjectScanner<ScriptingServiceImp> {

--- a/interlok-core/src/main/java/com/adaptris/core/services/ScriptingService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/ScriptingService.java
@@ -103,9 +103,4 @@ public class ScriptingService extends ScriptingServiceImp {
   protected Reader createReader() throws IOException {
     return new FileReader(getScriptFilename());
   }
-
-  @Override
-  public void prepare() throws CoreException {
-  }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/ObjectScanner.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/ObjectScanner.java
@@ -97,6 +97,12 @@ public abstract class ObjectScanner<T> {
   private transient Function<Object, Boolean> objectMatcher;
   private final transient Object locker = new Object();
 
+  /**
+   * Scan the tree for a match.
+   *
+   * @param root the top of the tree
+   * @return a collection of matching objects.
+   */
   @Synchronized(value = "locker")
   public Collection<T> scan(Object root) {
     if (root == null) {
@@ -112,6 +118,10 @@ public abstract class ObjectScanner<T> {
     return Collections.unmodifiableCollection(matches);
   }
 
+  /**
+   * Return the function doing the match.
+   *
+   */
   protected abstract Function<Object, Boolean> objectMatcher();
 
   private void addIfNotVisited(Object object, Class<?> clazz) {

--- a/interlok-core/src/main/java/com/adaptris/core/util/ObjectScanner.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/ObjectScanner.java
@@ -18,7 +18,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ClassUtils;
 import com.adaptris.interlok.util.Args;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import lombok.Synchronized;
 
 /**
@@ -131,18 +130,16 @@ public abstract class ObjectScanner<T> {
     }
   }
 
-  private static Scanner handlerFor(Object o, Class<?> clazz) {
-    Scanner result = null;
-    for (Scanner h : Scanner.values()) {
-      if (h.traversable(o, clazz)) {
-        result = h;
-        break;
-      }
-    }
+  private static Scanner handlerFor(final Object o, final Class<?> clazz) {
+    Scanner result = List.of(Scanner.values()).stream()
+        .filter((scanner) -> scanner.traversable(o, clazz))
+        .findFirst().orElse(null);
     return Args.notNull(result, "handler-for-class");
   }
 
-  private static List<Field> getAllFields(@NonNull List<Field> fields, @NonNull Class<?> clazz) {
+  private static List<Field> getAllFields(List<Field> fields, Class<?> clazz) {
+    Args.notNull(fields, "fields");
+    Args.notNull(clazz, "class");
     fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
     if (clazz.getSuperclass() != null) {
       getAllFields(fields, clazz.getSuperclass());

--- a/interlok-core/src/main/java/com/adaptris/core/util/ObjectScanner.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/ObjectScanner.java
@@ -1,0 +1,169 @@
+package com.adaptris.core.util;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ClassUtils;
+import com.adaptris.interlok.util.Args;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Synchronized;
+
+/**
+ * Breadth first object tree traversal to find all the matches within a tree.
+ * <p>
+ * Not especially clever really. Since our "components" might implement equals() we use an
+ * IdentityHashMap with the object as the key, so even if say a KeyValuePairSet contains the "same"
+ * elements they'll be different for the purposes of the scanner.
+ * </p>
+ */
+@NoArgsConstructor
+public abstract class ObjectScanner<T> {
+
+
+  private enum Scanner {
+    ARRAY {
+      @Override
+      public boolean traversable(Object o, Class<?> clazz) {
+        return clazz.isArray();
+      }
+      @Override
+      public void traverse(Class<?> clazz, Object obj, BiConsumer<Object, Class<?>> consumer) {
+        final int len = Array.getLength(obj);
+        for (int i = 0; i < len; i++) {
+          Object o = Array.get(obj, i);
+          consumer.accept(o, o.getClass());
+        }
+      }
+    },
+    ITERABLE {
+      @Override
+      public boolean traversable(Object o, Class<?> clazz) {
+        return Iterable.class.isAssignableFrom(o.getClass());
+      }
+      @Override
+      public void traverse(Class<?> clazz, Object obj, BiConsumer<Object, Class<?>> consumer) {
+        for (Object o : (Iterable<?>) obj) {
+          consumer.accept(o, o.getClass());
+        }
+      }
+    },
+    FALLBACK {
+      @Override
+      public boolean traversable(Object o, Class<?> clazz) {
+        return true;
+      }
+      @Override
+      public void traverse(Class<?> clazz, Object obj, BiConsumer<Object, Class<?>> consumer) {
+        List<Field> fields = getAllFields(new ArrayList<>(), obj.getClass());
+        for (Field field : fields) {
+          if (skipField(field.getModifiers())) {
+            continue;
+          }
+          Class<?> fieldType = field.getType();
+          try {
+            field.setAccessible(true);
+            Object value = field.get(obj);
+            // The object might be null here, so we use fieldType.
+            consumer.accept(value, fieldType);
+          } catch (IllegalAccessException e) {
+            // Ignore the exception
+          }
+        }
+      }
+    };
+
+    abstract void traverse(Class<?> clazz, Object obj, BiConsumer<Object, Class<?>> consumer);
+    abstract boolean traversable(Object obj, Class<?> clazz);
+
+  }
+
+  private final transient Map<Object, Class<?>> visited = new IdentityHashMap<>();
+  private final transient Queue<Object> toVisit = new ArrayDeque<>();
+
+  private final transient List<T> matches = new ArrayList<>();
+  private transient Function<Object, Boolean> objectMatcher;
+  private final transient Object locker = new Object();
+
+  @Synchronized(value = "locker")
+  public Collection<T> scan(Object root) {
+    if (root == null) {
+      return Collections.emptyList();
+    }
+    // Reset the state
+    visited.clear();
+    toVisit.clear();
+    matches.clear();
+    objectMatcher = objectMatcher();
+    addIfNotVisited(root, root.getClass());
+    doScan();
+    return Collections.unmodifiableCollection(matches);
+  }
+
+  protected abstract Function<Object, Boolean> objectMatcher();
+
+  private void addIfNotVisited(Object object, Class<?> clazz) {
+    if (object != null && !visited.containsKey(object)) {
+      toVisit.add(object);
+      visited.put(object, clazz);
+    }
+  }
+
+  private static Scanner handlerFor(Object o, Class<?> clazz) {
+    Scanner result = null;
+    for (Scanner h : Scanner.values()) {
+      if (h.traversable(o, clazz)) {
+        result = h;
+        break;
+      }
+    }
+    return Args.notNull(result, "handler-for-class");
+  }
+
+  private static List<Field> getAllFields(@NonNull List<Field> fields, @NonNull Class<?> clazz) {
+    fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
+    if (clazz.getSuperclass() != null) {
+      getAllFields(fields, clazz.getSuperclass());
+    }
+    return Collections.unmodifiableList(fields);
+  }
+
+  private void doScan() {
+    while (!toVisit.isEmpty()) {
+      Object obj = toVisit.remove();
+      Class<?> clazz = visited.get(obj);
+      if (objectMatcher.apply(obj)) {
+        matches.add((T) obj);
+      }
+      if (consideredPrimitive(clazz))
+        continue;
+
+      handlerFor(obj, clazz).traverse(clazz, obj, (o, c) -> addIfNotVisited(o, c));
+    }
+  }
+
+  private static boolean consideredPrimitive(Class<?> clazz) {
+    return BooleanUtils.or(new boolean[] {ClassUtils.isPrimitiveOrWrapper(clazz),
+        String.class.isAssignableFrom(clazz)});
+  }
+
+  private static boolean skipField(int fieldModifier) {
+    if ((fieldModifier & Modifier.STATIC) == Modifier.STATIC)
+      return true;
+    if ((fieldModifier & Modifier.TRANSIENT) == Modifier.TRANSIENT)
+      return true;
+    return false;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/util/ScriptingUtil.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/ScriptingUtil.java
@@ -1,0 +1,57 @@
+package com.adaptris.core.util;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.script.ScriptEngineManager;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScriptingUtil {
+
+  static final String NASHORN_ENGINE = "Oracle Nashorn";
+  static final String GRAAL_JS_ENGINE = "Graal.js";
+  static final String NASHORN = "Nashorn";
+
+  /**
+   * Checks if the script variant requested will end up using nashorn or not.
+   * <p>
+   * Since Java 17 will remove the nashorn scripting engine, we need to have a check in place to
+   * detect that.
+   * </p>
+   *
+   * @param engineManager the engineManager
+   * @param lang the language
+   * @return true if we're going to end up using nashorn.
+   */
+  public static final boolean dependsOnNashorn(ScriptEngineManager engineManager, String lang) {
+    Args.notBlank(lang, "scripting-language");
+    Args.notNull(engineManager, "scripting-engine");
+    if (nashornNames(engineManager).contains(lang)) {
+      // Nashorn engine javascript short names ("js", "JS", "JavaScript", "javascript",
+      // "ECMAScript", "ecmascript") are also used by GraalJS via -Dpolyglot.js.nashorn-compat=true
+      // so we only warn the user if he uses directly nashorn or if GraalJS can not be found.
+      if (isNashorn(lang) || !hasGraalJsEngine(engineManager)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+  private static List<String> nashornNames(ScriptEngineManager engineManager) {
+    // List of short names which may be used to identify the Nashorn ScriptEngine.
+    return engineManager.getEngineFactories().stream()
+        .filter(e -> NASHORN_ENGINE.equals(e.getEngineName())).flatMap(e -> e.getNames().stream())
+        .collect(Collectors.toList());
+  }
+
+  private static boolean isNashorn(String language) {
+    return NASHORN.equalsIgnoreCase(language);
+  }
+
+  private static boolean hasGraalJsEngine(ScriptEngineManager engineManager) {
+    return Optional.ofNullable(engineManager.getEngineByName(GRAAL_JS_ENGINE)).isPresent();
+  }
+}

--- a/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationChecker
+++ b/interlok-core/src/main/resources/META-INF/services/com.adaptris.core.management.config.ConfigurationChecker
@@ -4,3 +4,4 @@ com.adaptris.core.management.config.JavaxValidationChecker
 com.adaptris.core.management.config.DeprecatedConfigurationChecker
 com.adaptris.core.management.config.SharedConnectionConfigurationChecker
 com.adaptris.core.management.config.SharedServiceConfigurationChecker
+com.adaptris.core.management.config.NashornChecker

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/NashornCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/NashornCheckerTest.java
@@ -1,0 +1,58 @@
+package com.adaptris.core.management.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.adaptris.core.Adapter;
+import com.adaptris.core.management.config.ConfigurationCheckReport;
+import com.adaptris.core.management.config.NashornChecker;
+import com.adaptris.core.services.EmbeddedScriptingService;
+import com.adaptris.util.GuidGenerator;
+
+public class NashornCheckerTest {
+
+  private static final GuidGenerator GUID = new GuidGenerator();
+
+  @Test
+  public void testNashorn() throws Exception {
+    NashornChecker checker = new NashornChecker();
+
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(createAdapterConfig(true), report);
+    assertFalse(report.isCheckPassed());
+    assertEquals(0, report.getFailureExceptions().size());
+    assertEquals(1, report.getWarnings().size());
+    assertTrue(report.getWarnings().get(0).contains("explicit_nashorn"));
+  }
+
+  @Test
+  public void testNoNashorn() throws Exception {
+    NashornChecker checker = new NashornChecker();
+
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(createAdapterConfig(false), report);
+    assertTrue(report.isCheckPassed());
+    assertEquals(0, report.getFailureExceptions().size());
+    assertEquals(0, report.getWarnings().size());
+  }
+
+  private Adapter createAdapterConfig(boolean hasNashorn) {
+    Adapter result = new Adapter();
+    result.setUniqueId(GUID.safeUUID());
+    result.getSharedComponents()
+        .addService(new EmbeddedScriptingService(GUID.safeUUID()).withScript("jruby", ""));
+    result.getSharedComponents()
+        .addService(new EmbeddedScriptingService(GUID.safeUUID()).withScript("jruby", ""));
+    result.getSharedComponents()
+        .addService(new EmbeddedScriptingService(GUID.safeUUID()).withScript("jruby", ""));
+    if (hasNashorn) {
+      result.getSharedComponents()
+          .addService(new EmbeddedScriptingService("explicit_nashorn").withScript("nashorn", ""));
+    }
+    return result;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/NashornCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/NashornCheckerTest.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
-import com.adaptris.core.management.config.ConfigurationCheckReport;
-import com.adaptris.core.management.config.NashornChecker;
 import com.adaptris.core.services.EmbeddedScriptingService;
+import com.adaptris.core.services.ScriptingServiceImp;
+import com.adaptris.core.util.ObjectScanner;
 import com.adaptris.util.GuidGenerator;
 
 public class NashornCheckerTest {
@@ -39,6 +39,18 @@ public class NashornCheckerTest {
     assertEquals(0, report.getWarnings().size());
   }
 
+  @Test
+  public void testWithException() throws Exception {
+    DefectiveNashornChecker checker = new DefectiveNashornChecker();
+
+    ConfigurationCheckReport report = new ConfigurationCheckReport();
+    report.setCheckName(checker.getFriendlyName());
+    checker.validate(createAdapterConfig(false), report);
+    assertFalse(report.isCheckPassed());
+    assertEquals(1, report.getFailureExceptions().size());
+  }
+
+
   private Adapter createAdapterConfig(boolean hasNashorn) {
     Adapter result = new Adapter();
     result.setUniqueId(GUID.safeUUID());
@@ -55,4 +67,10 @@ public class NashornCheckerTest {
     return result;
   }
 
+  private class DefectiveNashornChecker extends NashornChecker {
+    @Override
+    protected ObjectScanner<ScriptingServiceImp> scanner() {
+      throw new RuntimeException();
+    }
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/EmbeddedScriptingServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/EmbeddedScriptingServiceTest.java
@@ -22,19 +22,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineFactory;
-import javax.script.ScriptEngineManager;
-
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.BranchingServiceCollection;
@@ -140,80 +130,6 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
     LifecycleHelper.close(service);
   }
 
-  @Test
-  public void testLanguageJavascriptEngineNashorn() throws Exception {
-    EmbeddedScriptingService service = new EmbeddedScriptingService();
-    service.setLanguage("javascript");
-
-    ScriptEngineManager engineManager = initEngineManager();
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageJavascriptEngineGraalJs() throws Exception {
-    EmbeddedScriptingService service = new EmbeddedScriptingService();
-    service.setLanguage("javascript");
-
-    ScriptEngineManager engineManager = initEngineManager();
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    when(engineManager.getEngineByName(ScriptingService.GRAAL_JS_ENGINE)).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageJavascriptEngineNoNashorn() throws Exception {
-    EmbeddedScriptingService service = new EmbeddedScriptingService();
-    service.setLanguage("javascript");
-
-    ScriptEngineManager engineManager = initEngineManager();
-
-    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(null);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageNashornEngineNashorn() throws Exception {
-    EmbeddedScriptingService service = new EmbeddedScriptingService();
-    service.setLanguage(ScriptingService.NASHORN);
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
-    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageNashornEngineNashornAndGraalJs() throws Exception {
-    EmbeddedScriptingService service = new EmbeddedScriptingService();
-    service.setLanguage(ScriptingService.NASHORN);
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
-    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
-    when(engineManager.getEngineByName(ScriptingService.GRAAL_JS_ENGINE)).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageJruby() throws Exception {
-    EmbeddedScriptingService service = new EmbeddedScriptingService();
-    service.setLanguage("jruby");
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
-    when(engineManager.getEngineByName("jruby")).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
 
   @Test
   public void testDoServiceWithEmptyScript() throws Exception {
@@ -269,19 +185,6 @@ public class EmbeddedScriptingServiceTest extends GeneralServiceExample {
         + "\nThe example below simply reverses an item of metadata using jruby as the scripting"
         + "\nlanguage. This isn't something that is easily supported with existing services "
         +"\n(but why would you want to do it?)" + "\n-->\n";
-  }
-
-  private ScriptEngineManager initEngineManager() {
-    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
-
-    ScriptEngineFactory graaljsEngineFactory = mock(ScriptEngineFactory.class);
-    when(graaljsEngineFactory.getEngineName()).thenReturn(ScriptingService.GRAAL_JS_ENGINE);
-    ScriptEngineFactory nashornEngineFactory = mock(ScriptEngineFactory.class);
-    when(nashornEngineFactory.getEngineName()).thenReturn(ScriptingService.NASHORN_ENGINE);
-    when(nashornEngineFactory.getNames())
-    .thenReturn(List.of("nashorn", "Nashorn", "js", "JS", "JavaScript", "javascript", "ECMAScript", "ecmascript"));
-    when(engineManager.getEngineFactories()).thenReturn(List.of(graaljsEngineFactory, nashornEngineFactory));
-    return engineManager;
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/ScriptingServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/ScriptingServiceTest.java
@@ -20,20 +20,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.List;
-
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineFactory;
-import javax.script.ScriptEngineManager;
-
 import org.junit.Test;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.GeneralServiceExample;
@@ -131,80 +121,6 @@ public class ScriptingServiceTest extends GeneralServiceExample {
     delete(script);
   }
 
-  @Test
-  public void testLanguageJavascriptEngineNashorn() throws Exception {
-    ScriptingService service = new ScriptingService();
-    service.setLanguage("javascript");
-
-    ScriptEngineManager engineManager = initEngineManager();
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageJavascriptEngineGraalJs() throws Exception {
-    ScriptingService service = new ScriptingService();
-    service.setLanguage("javascript");
-
-    ScriptEngineManager engineManager = initEngineManager();
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    when(engineManager.getEngineByName(ScriptingService.GRAAL_JS_ENGINE)).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageJavascriptEngineNoNashorn() throws Exception {
-    ScriptingService service = new ScriptingService();
-    service.setLanguage("javascript");
-
-    ScriptEngineManager engineManager = initEngineManager();
-
-    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(null);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageNashornEngineNashorn() throws Exception {
-    ScriptingService service = new ScriptingService();
-    service.setLanguage(ScriptingService.NASHORN);
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
-    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageNashornEngineNashornAndGraalJs() throws Exception {
-    ScriptingService service = new ScriptingService();
-    service.setLanguage(ScriptingService.NASHORN);
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
-    when(engineManager.getEngineByName(ScriptingService.NASHORN_ENGINE)).thenReturn(scriptEngine);
-    when(engineManager.getEngineByName(ScriptingService.GRAAL_JS_ENGINE)).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
-
-  @Test
-  public void testLanguageJruby() throws Exception {
-    ScriptingService service = new ScriptingService();
-    service.setLanguage("jruby");
-
-    ScriptEngine scriptEngine = mock(ScriptEngine.class);
-    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
-    when(engineManager.getEngineByName("jruby")).thenReturn(scriptEngine);
-
-    service.checkEngine(engineManager);
-  }
 
   @Test
   public void testDoServiceWithFailingScript() throws Exception {
@@ -238,19 +154,6 @@ public class ScriptingServiceTest extends GeneralServiceExample {
         + "\nThe script is executed and the AdaptrisMessage that is due to be processed is"
         + "\nbound against the key 'message' and an instance of org.slf4j.Logger is also bound "
         + "\nto key 'log'. These can be used as a standard variable within the script." + "\n-->\n";
-  }
-
-  private ScriptEngineManager initEngineManager() {
-    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
-
-    ScriptEngineFactory graaljsEngineFactory = mock(ScriptEngineFactory.class);
-    when(graaljsEngineFactory.getEngineName()).thenReturn(ScriptingService.GRAAL_JS_ENGINE);
-    ScriptEngineFactory nashornEngineFactory = mock(ScriptEngineFactory.class);
-    when(nashornEngineFactory.getEngineName()).thenReturn(ScriptingService.NASHORN_ENGINE);
-    when(nashornEngineFactory.getNames())
-        .thenReturn(List.of("nashorn", "Nashorn", "js", "JS", "JavaScript", "javascript", "ECMAScript", "ecmascript"));
-    when(engineManager.getEngineFactories()).thenReturn(List.of(graaljsEngineFactory, nashornEngineFactory));
-    return engineManager;
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/util/ObjectScannerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/ObjectScannerTest.java
@@ -1,0 +1,106 @@
+package com.adaptris.core.util;
+
+import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.adaptris.core.util.ObjectScanner;
+import lombok.Getter;
+import lombok.Setter;
+
+public class ObjectScannerTest {
+
+
+  @Test
+  public void testScan_Array() throws Exception {
+    LeafScanner scanner = new LeafScanner();
+    Flower root = new Flower(10, 10);
+    Object[] children = root.getChildren().toArray();
+    Collection<Leaf> matched = scanner.scan(children);
+    assertEquals(10, matched.size());
+  }
+
+  @Test
+  public void testScan_Nested() throws Exception {
+    LeafScanner scanner = new LeafScanner();
+    Flower root = new Flower(10, 10);
+    Collection<Leaf> matched = scanner.scan(root);
+    assertEquals(10, matched.size());
+  }
+
+  @Test
+  public void testScan_Nested_SelfReferential() throws Exception {
+    LeafScanner scanner = new LeafScanner();
+    SelfReferential root = new SelfReferential(10, 10);
+    Collection<Leaf> matched = scanner.scan(root);
+    assertEquals(10, matched.size());
+  }
+
+  @Test
+  public void testScan_Null() throws Exception {
+    LeafScanner scanner = new LeafScanner();
+    assertEquals(0, scanner.scan(null).size());
+  }
+
+  // Object tree that has self referential items.
+  // And obvious identity duplicates of each other.
+  // So we use this to check that toBeVisted/visited is fit for purpose.
+  private class SelfReferential {
+    @Getter
+    @Setter
+    private List<Object> children = new ArrayList<>();
+
+    public SelfReferential(int petals, int leaves) {
+      Flower p = new Flower(petals, leaves);
+      p.getChildren().add(p);
+      children.add(p);
+      children.add(p);
+      children.addAll(p.getChildren());
+    }
+  }
+
+
+  private class Flower {
+    @Getter
+    @Setter
+    private List<Object> children = new ArrayList<>();
+    private static final String CONSTANT = "";
+    @Getter
+    @Setter
+    private String someString;
+    @Getter
+    @Setter
+    private int somePrimitive;
+
+    public Flower(int petals, int leaves) {
+      for (int i = 0; i < petals; i++) {
+        children.add(new Petal());
+      }
+      for (int i = 0; i < leaves; i++) {
+        children.add(new Leaf());
+      }
+    }
+  }
+
+  private class Petal {
+    private transient Logger logger = LoggerFactory.getLogger(ObjectScannerTest.class);
+    private static final String PETAL = "";
+  }
+
+  private class Leaf {
+    private transient Logger logger = LoggerFactory.getLogger(ObjectScannerTest.class);
+    private static final String LEAF = "";
+  }
+
+  private class LeafScanner extends ObjectScanner<Leaf> {
+
+    @Override
+    protected Function<Object, Boolean> objectMatcher() {
+      return (object) -> Leaf.class.isAssignableFrom(object.getClass());
+    }
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/util/ScriptingUtilTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/ScriptingUtilTest.java
@@ -1,0 +1,63 @@
+package com.adaptris.core.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import org.junit.Test;
+
+public class ScriptingUtilTest {
+
+  @Test
+  public void testLanguageJavascript_NashornEngine() throws Exception {
+    ScriptEngineManager engineManager = initEngineManager();
+    assertTrue(ScriptingUtil.dependsOnNashorn(engineManager, "javascript"));
+  }
+
+  @Test
+  public void testLanguageJavascript_GraalEngineAvailable() throws Exception {
+    ScriptEngineManager engineManager = initEngineManager();
+    ScriptEngine scriptEngine = mock(ScriptEngine.class);
+    when(engineManager.getEngineByName(ScriptingUtil.GRAAL_JS_ENGINE)).thenReturn(scriptEngine);
+    assertFalse(ScriptingUtil.dependsOnNashorn(engineManager, "javascript"));
+  }
+
+  @Test
+  public void testLanguageNashorn_GraalEngineAvailable() throws Exception {
+    ScriptEngineManager engineManager = initEngineManager();
+    ScriptEngine scriptEngine = mock(ScriptEngine.class);
+    when(engineManager.getEngineByName(ScriptingUtil.GRAAL_JS_ENGINE)).thenReturn(scriptEngine);
+    assertTrue(ScriptingUtil.dependsOnNashorn(engineManager, ScriptingUtil.NASHORN));
+  }
+
+  @Test
+  public void testLanguageNashorn_NashornEngine() throws Exception {
+    ScriptEngineManager engineManager = initEngineManager();
+    assertTrue(ScriptingUtil.dependsOnNashorn(engineManager, ScriptingUtil.NASHORN));
+  }
+
+  @Test
+  public void testLanguageJruby() throws Exception {
+    ScriptEngineManager engineManager = initEngineManager();
+    assertFalse(ScriptingUtil.dependsOnNashorn(engineManager, "jruby"));
+  }
+
+
+  private ScriptEngineManager initEngineManager() {
+    ScriptEngineManager engineManager = mock(ScriptEngineManager.class);
+
+    ScriptEngineFactory graaljsEngineFactory = mock(ScriptEngineFactory.class);
+    when(graaljsEngineFactory.getEngineName()).thenReturn(ScriptingUtil.GRAAL_JS_ENGINE);
+    ScriptEngineFactory nashornEngineFactory = mock(ScriptEngineFactory.class);
+    when(nashornEngineFactory.getEngineName()).thenReturn(ScriptingUtil.NASHORN_ENGINE);
+    when(nashornEngineFactory.getNames()).thenReturn(List.of("nashorn", "Nashorn", "js", "JS",
+        "JavaScript", "javascript", "ECMAScript", "ecmascript"));
+    when(engineManager.getEngineFactories())
+        .thenReturn(List.of(graaljsEngineFactory, nashornEngineFactory));
+    return engineManager;
+  }
+}


### PR DESCRIPTION
## Motivation

Since the nashorn scripting engine is deprecated in java 11 and due for removal in Java 17 we need to have some method whereby we notify people that their config is going to break.

## Modification

- Refactor out graal / nashorn detection into a separate utility class
- Add a generic "object scanner" so that we can parse out ScriptingService implementations out the Adapter tree
- Add a Configuration Checker implementation

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

There is now a new __Nashorn Scripting Engine Check__ being reported on so if you have a scripting service impl (probably `embedded-scripting-service`)  that depends on nashorn because of any of the following reasons 
- The language is `nashorn`
- The language is one of `"js", "JS", "JavaScript", "javascript","ECMAScript", "ecmascript"` but graal js is not available

A configuration warning will be logged.

## Testing

The minimal adapter configuration is probably this : 

```xml
<adapter>
  <unique-id>MyInterlokInstance</unique-id>
  <shared-components>
    <connections/>
    <services>
      <embedded-scripting-service>
        <unique-id>jruby-script</unique-id>
        <language>jruby</language>
      </embedded-scripting-service>
      <embedded-scripting-service>
        <unique-id>nashorn-script</unique-id>
        <language>javascript</language>
      </embedded-scripting-service>
    </services>
  </shared-components>
</adapter>
```

Assuming parent gradle then the additional artefacts are (jruby isn't strictly necessary since shared-services won't have _prepare()_ executed on it so no attempt is actually made to create the scripting engine); it's just included for completeness...

```
  interlokRuntime ("org.jruby:jruby-complete:9.2.17.0")
```

Then your output running -configcheck will be : 

```
$ java -jar lib/interlok-boot.jar -configcheck
...
Shared service check:
Warnings found;
Shared service unused: jruby-script
Shared service unused: nashorn-script

Nashorn Scripting Engine check:
Warnings found;
[EmbeddedScriptingService(nashorn-script)] relies on the deprecated Nashorn scripting engine; consider switching to Graal JS

Config check only; terminating
```

If you then switch to including graal js (as per https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-scripting) 

```
  interlokRuntime ("org.graalvm.sdk:graal-sdk:21.1.0")
  interlokRuntime ("org.graalvm.js:js:21.1.0")
  interlokRuntime ("org.graalvm.js:js-scriptengine:21.1.0")
```

```
$ java -Dpolyglot.js.nashorn-compat=true -jar lib/interlok-boot.jar -configcheck
...
Shared service check:
Warnings found;
Shared service unused: jruby-script
Shared service unused: nashorn-script

Nashorn Scripting Engine check:
Passed.

Config check only; terminating
```
 