### PR TITLE
INTERLOK-3330 Deprecate ProduceExceptionHandler

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ChannelRestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelRestartProduceExceptionHandler.java
@@ -16,15 +16,21 @@
 
 package com.adaptris.core;
 
+import com.adaptris.annotation.Removal;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Implementation of {@link ProduceExceptionHandler} which attempts to restart the parent {@link com.adaptris.core.Channel} of the {@code Workflow}
  * that had the failure.
  * 
- * 
  * @config channel-restart-produce-exception-handler
+ *
+ * @deprecated since 4.2.0
  */
+@Deprecated(since = "4.2.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
 @XStreamAlias("channel-restart-produce-exception-handler")
 public class ChannelRestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 
@@ -44,7 +50,7 @@ public class ChannelRestartProduceExceptionHandler extends ProduceExceptionHandl
         super.restart(workflow.obtainChannel());
       }
     }
-    else { // sthg else is rebooting the Channel...
+    else { // something else is rebooting the Channel...
       // do nothing?
       log.debug("Channel is not available, returning...");
 

--- a/interlok-core/src/main/java/com/adaptris/core/NullProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NullProduceExceptionHandler.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core;
 
+import com.adaptris.annotation.Removal;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -24,7 +26,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * </p>
  * 
  * @config null-produce-exception-handler
+ *
+ * @deprecated since 4.2.0
  */
+@Deprecated(since = "4.2.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
 @XStreamAlias("null-produce-exception-handler")
 public class NullProduceExceptionHandler extends ProduceExceptionHandlerImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ProduceExceptionHandler.java
@@ -17,12 +17,20 @@
 package com.adaptris.core;
 
 
+import com.adaptris.annotation.Removal;
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 /**
  * <p> 
  * Implementations are pluggable responses to <code>ProduceException</code>s 
  * in a <code>Workflow</code>.
  * </p>
+ *
+ * @deprecated since 4.2.0
  */
+@Deprecated(since = "4.2.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
 public interface ProduceExceptionHandler {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/ProduceExceptionHandlerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ProduceExceptionHandlerImp.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core;
 
+import com.adaptris.annotation.Removal;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +29,12 @@ import com.adaptris.core.util.ManagedThreadFactory;
  * <p>
  * Implementation of behaviour common to {@link ProduceExceptionHandler} instances
  * </p>
+ *
+ * @deprecated since 4.2.0
  */
+@Deprecated(since = "4.2.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
 public abstract class ProduceExceptionHandlerImp implements ProduceExceptionHandler {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());

--- a/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+import com.adaptris.annotation.Removal;
 import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -26,8 +27,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *
  * @deprecated since 3.10.2
  */
-@Deprecated
-@ConfigDeprecated(message = "If you need restarting capability use channel-restart-produce-exception-handler or wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "4.0.0", groups = Deprecated.class)
+@Deprecated(since = "3.10.2")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
 @XStreamAlias("restart-produce-exception-handler")
 public class RestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/WorkflowImp.java
@@ -52,7 +52,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * @see PoolingWorkflow
  */
 public abstract class WorkflowImp implements Workflow {
-  private static final TimeInterval DEFAULT_CHANNEL_UNAVAILBLE_WAIT = new TimeInterval(30L, TimeUnit.SECONDS);
+  private static final TimeInterval DEFAULT_CHANNEL_UNAVAILABLE_WAIT = new TimeInterval(30L, TimeUnit.SECONDS);
   private static final String ID_SEPARATOR = "@";
   private static final MessageLogger DEFAULT_MSG_LOGGER = new DefaultMessageLogger();
 
@@ -84,7 +84,7 @@ public abstract class WorkflowImp implements Workflow {
   @AdvancedConfig
   @InputFieldDefault(value = "true")
   private Boolean sendEvents;
-  @NotNull
+
   @AutoPopulated
   @Valid
   @AdvancedConfig
@@ -130,7 +130,6 @@ public abstract class WorkflowImp implements Workflow {
     // default configured MEH is in Adapter, this is MEHToUse...
     registerActiveMsgErrorHandler(new NullProcessingExceptionHandler());
 
-    setProduceExceptionHandler(new NullProduceExceptionHandler());
     setInterceptors(new ArrayList<WorkflowInterceptor>());
     state = ClosedState.getInstance();
   }
@@ -360,7 +359,9 @@ public abstract class WorkflowImp implements Workflow {
   /** @see com.adaptris.core.Workflow#handleProduceException() */
   @Override
   public void handleProduceException() {
-    produceExceptionHandler.handle(this);
+    if (produceExceptionHandler != null) {
+      produceExceptionHandler.handle(this);
+    }
   }
 
   /**
@@ -617,7 +618,7 @@ public abstract class WorkflowImp implements Workflow {
   }
 
   public long channelUnavailableWait() {
-    return TimeInterval.toMillisecondsDefaultIfNull(getChannelUnavailableWaitInterval(), DEFAULT_CHANNEL_UNAVAILBLE_WAIT);
+    return TimeInterval.toMillisecondsDefaultIfNull(getChannelUnavailableWaitInterval(), DEFAULT_CHANNEL_UNAVAILABLE_WAIT);
   }
 
   /**
@@ -639,8 +640,7 @@ public abstract class WorkflowImp implements Workflow {
    * @param p the produceExceptionHandler to set
    */
   public void setProduceExceptionHandler(ProduceExceptionHandler p) {
-    produceExceptionHandler = Args.notNull(p, "produceExceptionHandler");
-
+    produceExceptionHandler = p;
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsTransactedWorkflow.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsTransactedWorkflow.java
@@ -18,6 +18,7 @@ package com.adaptris.core.jms;
 
 import java.util.concurrent.TimeUnit;
 
+import com.adaptris.core.ProduceExceptionHandler;
 import org.apache.commons.lang3.BooleanUtils;
 
 import com.adaptris.annotation.AdapterComponent;
@@ -32,7 +33,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.NullMessageConsumer;
 import com.adaptris.core.NullProduceExceptionHandler;
 import com.adaptris.core.ProduceException;
-import com.adaptris.core.ProduceExceptionHandler;
 import com.adaptris.core.RetryMessageErrorHandler;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.StandardWorkflow;
@@ -46,9 +46,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * informed of any failures so the messages can be rolled back.
  * </p>
  * <p>
- * Additionally, this workflow may not be configured with any {@link ProduceExceptionHandler} as this will not allow the transaction
- * to rolled back correctly. In order to get behaviour similiar to {@link ProduceExceptionHandler}, you should use
- * {@link com.adaptris.core.StandaloneProducer} as part of the service collection in order to produce the payload to the required destination.
+ * This workflow may not be configured with a {@link com.adaptris.core.StandaloneProducer}
+ * as part of the service collection in order to produce the payload to the required destination.
  * </p>
  * 
  * @config jms-transacted-workflow
@@ -92,7 +91,8 @@ public final class JmsTransactedWorkflow extends StandardWorkflow {
     else if (!(amc instanceof NullMessageConsumer)) {
       throw new CoreException(this.getClass().getSimpleName() + " must be used with a JMSConsumer");
     }
-    if (!(getProduceExceptionHandler() instanceof NullProduceExceptionHandler)) {
+    ProduceExceptionHandler produceExceptionHandler = getProduceExceptionHandler();
+    if (produceExceptionHandler != null && !(produceExceptionHandler instanceof NullProduceExceptionHandler)) {
       throw new CoreException(this.getClass().getSimpleName() + " may not have a ProduceExceptionHandler set");
     }
     super.initialiseWorkflow();

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
@@ -73,14 +73,15 @@ public class DeprecatedConfigurationCheckerTest {
     checker.validate(createAdapterConfig(false, true), report);
 
     assertFalse(report.isCheckPassed());
-    // Should be 3 warnings,
+    // Should be 4 warnings,
     // deprecated class, deprecated member, deprecated service inside a
     // service list.
-    assertEquals(3, report.getWarnings().size());
+    assertEquals(4, report.getWarnings().size());
     assertTrue(violationsAsExpected(report.getWarnings(), "sharedComponents.services[1]",
         "sharedComponents.services[2]",
         "channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]",
-        "channelList.channels[0].workflowList.workflows[0].consumer.destination"));
+        "channelList.channels[0].workflowList.workflows[0].consumer.destination",
+        "channelList.channels[0].workflowList.workflows[0].produceExceptionHandler"));
     assertEquals(0, report.getFailureExceptions().size());
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
@@ -76,7 +76,7 @@ public class DeprecatedConfigurationCheckerTest {
     // Should be 4 warnings,
     // deprecated class, deprecated member, deprecated service inside a
     // service list.
-    assertEquals(4, report.getWarnings().size());
+    assertEquals(3, report.getWarnings().size());
     assertTrue(violationsAsExpected(report.getWarnings(), "sharedComponents.services[1]",
         "sharedComponents.services[2]",
         "channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]",

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/ExampleWorkflowCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/ExampleWorkflowCase.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+
+import com.adaptris.core.NullProduceExceptionHandler;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisMessage;
@@ -190,14 +192,9 @@ public abstract class ExampleWorkflowCase extends ExampleConfigGenerator {
   @Test
   public void testSetProduceExceptionHandler() throws Exception {
     WorkflowImp wf = createWorkflowForGenericTests();
-    ProduceExceptionHandler obj = wf.getProduceExceptionHandler();
-    try {
-      wf.setProduceExceptionHandler(null);
-      fail();
-    }
-    catch (IllegalArgumentException e) {
-
-    }
+    assertNull(wf.getProduceExceptionHandler());
+    ProduceExceptionHandler obj = new NullProduceExceptionHandler();
+    wf.setProduceExceptionHandler(obj);
     assertEquals(obj, wf.getProduceExceptionHandler());
   }
 


### PR DESCRIPTION
## Motivation

We have already deprecated the restart-produce-exception-handler because it causes more problems than it solves. Currently there are only 3 implementations; one of them being a NullProduceExceptionHandler. One of last two has been deprecated which leaves the channel-restart-produce-exception-handler.

## Modification

* Add annotations, with messages and removal version info
* Update unit test

## PR Checklist

- [x] been self-reviewed.
- [x] Added supporting annotations (like XStreamAlias / ComponentProfile)
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
