### PR TITLE
INTERLOK-3818 Shutdown Operation Timeout now configurable

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
@@ -25,11 +25,12 @@ import static com.adaptris.core.management.Constants.CFG_KEY_LOGGING_URL;
 import static com.adaptris.core.management.Constants.CFG_KEY_MANAGEMENT_COMPONENT;
 import static com.adaptris.core.management.Constants.DBG;
 import static com.adaptris.core.management.Constants.DEFAULT_CONFIG_MANAGER;
+import static com.adaptris.core.management.Constants.DEFAULT_OPERATION_TIMEOUT;
 import static com.adaptris.core.management.Constants.DEFAULT_PROPS_RESOURCE;
+import static com.adaptris.core.management.Constants.OPERATION_TIMEOUT_PROPERTY;
 import static com.adaptris.core.management.Constants.PROTOCOL_FILE;
 import static com.adaptris.core.util.PropertyHelper.getPropertyIgnoringCase;
 import static com.adaptris.core.util.PropertyHelper.getPropertySubset;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -44,13 +45,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.Adapter;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.management.logging.LoggingConfigurator;
@@ -170,6 +169,22 @@ public class BootstrapProperties extends Properties {
    */
   public Long getProperty(String key, Long defaultValue) {
     return NumberUtils.toLong( getProperty(key), defaultValue);
+  }
+
+
+  /**
+   * Get the operation timeout specified.
+   *
+   * @return the operation timeout specified by {@link Constants#OPERATION_TIMEOUT_PROPERTY} or the
+   *         default value if {@code < 1} or not specified.
+   */
+  public long getOperationTimeout() {
+    long defaultTimeout = DEFAULT_OPERATION_TIMEOUT.toMilliseconds();
+    long timeout = getProperty(OPERATION_TIMEOUT_PROPERTY, defaultTimeout);
+    if (timeout < 1) {
+      return defaultTimeout;
+    }
+    return timeout;
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/management/Constants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/Constants.java
@@ -16,6 +16,9 @@
 
 package com.adaptris.core.management;
 
+import java.util.concurrent.TimeUnit;
+import com.adaptris.util.TimeInterval;
+
 /**
  * Constants and lots of them.
  *
@@ -152,5 +155,19 @@ public final class Constants {
    */
   public static final String CFG_KEY_LOGGING_RECONFIGURE = "loggingReconfigure";
 
+  /**
+   * Bootstrap Property specifying the timeout for operations in milliseconds.
+   * <p>
+   * This has effect when initially launching Interlok and also when the {@link ShutdownHandler} is
+   * invoked as part of shutdown.
+   * </p>
+   */
+  public static final String OPERATION_TIMEOUT_PROPERTY = "operationTimeout";
+  /**
+   * The default timeout for operations if not specified.
+   *
+   */
+  public static final TimeInterval DEFAULT_OPERATION_TIMEOUT =
+      new TimeInterval(2L, TimeUnit.MINUTES);
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/management/ShutdownHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ShutdownHandler.java
@@ -86,7 +86,7 @@ public class ShutdownHandler extends Thread {
     log.info("Adapter(s) closed");
   }
 
-  private void shutdown(Set<ObjectName> adapterManagers) {
+  void shutdown(Set<ObjectName> adapterManagers) {
     int count = adapterManagers.size();
     final CountDownLatch barrier = new CountDownLatch(count + 1);
     // Set this to be slightly higher than the operation timeout because we don't want to fail
@@ -119,7 +119,7 @@ public class ShutdownHandler extends Thread {
     }
   }
 
-  private void forceShutdown(Set<ObjectName> adapterManagers) {
+  void forceShutdown(Set<ObjectName> adapterManagers) {
     int count = adapterManagers.size();
     final CountDownLatch barrier = new CountDownLatch(count + 1);
 

--- a/interlok-core/src/test/java/com/adaptris/core/management/AdapterConfigManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/AdapterConfigManagerTest.java
@@ -22,7 +22,6 @@ import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.core.management.config.XStreamConfigManager;
-import com.adaptris.core.runtime.AdapterRegistry;
 import com.adaptris.core.stubs.JunitBootstrapProperties;
 
 public class AdapterConfigManagerTest extends com.adaptris.interlok.junit.scaffolding.BaseCase {
@@ -47,6 +46,5 @@ public class AdapterConfigManagerTest extends com.adaptris.interlok.junit.scaffo
   public void testGetAdapterRegistryMBean() throws Exception {
     AdapterConfigManager configManager = bootstrap.getConfigManager();
     assertNotNull(configManager.getAdapterRegistry());
-    assertEquals(AdapterRegistry.class, configManager.getAdapterRegistry().getClass());
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/management/BootstrapPropertiesTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/BootstrapPropertiesTest.java
@@ -47,6 +47,16 @@ public class BootstrapPropertiesTest {
   }
 
   @Test
+  public void testGetOperationTimeout() {
+    BootstrapProperties boot = new BootstrapProperties();
+    assertEquals(Constants.DEFAULT_OPERATION_TIMEOUT.toMilliseconds(), boot.getOperationTimeout());
+    boot.setProperty(Constants.OPERATION_TIMEOUT_PROPERTY, "0");
+    assertEquals(Constants.DEFAULT_OPERATION_TIMEOUT.toMilliseconds(), boot.getOperationTimeout());
+    boot.setProperty(Constants.OPERATION_TIMEOUT_PROPERTY, "5000");
+    assertEquals(5000, boot.getOperationTimeout());
+  }
+
+  @Test
   public void testConstructor() throws Exception {
     new BootstrapProperties();
     Object marker = new Object();

--- a/interlok-core/src/test/java/com/adaptris/core/management/ShutdownHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/ShutdownHandlerTest.java
@@ -1,0 +1,90 @@
+package com.adaptris.core.management;
+
+import static com.adaptris.core.runtime.AdapterComponentMBean.ID_PREFIX;
+import static com.adaptris.core.runtime.AdapterComponentMBean.JMX_ADAPTER_TYPE;
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import javax.management.ObjectName;
+import org.junit.Test;
+import com.adaptris.core.Adapter;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.runtime.AdapterComponentMBean;
+import com.adaptris.core.runtime.AdapterManagerMBean;
+import com.adaptris.core.stubs.TempFileUtils;
+import com.adaptris.util.GuidGenerator;
+
+@SuppressWarnings("deprecation")
+public class ShutdownHandlerTest {
+
+  private static GuidGenerator nameGenerator = new GuidGenerator();
+
+  @Test
+  public void testRun() throws Exception {
+    String adapterName = nameGenerator.safeUUID();
+    Adapter adapter = new Adapter();
+    adapter.setUniqueId(adapterName);
+    BootstrapProperties boot = bootstrapWithAdapter(adapter);
+    AdapterManagerMBean mgmtBean = boot.getConfigManager().createAdapter();
+    try {
+      mgmtBean.requestStart();
+      ShutdownHandler shutdown = new ShutdownHandler(boot);
+      shutdown.run();
+    } finally {
+      unregisterQuietly(mgmtBean);
+    }
+  }
+
+  @Test
+  public void testShutdown() throws Exception {
+    String adapterName = nameGenerator.safeUUID();
+    Adapter adapter = new Adapter();
+    adapter.setUniqueId(adapterName);
+    BootstrapProperties boot = bootstrapWithAdapter(adapter);
+    AdapterManagerMBean mgmtBean = boot.getConfigManager().createAdapter();
+    try {
+      mgmtBean.requestStart();
+      HashSet<ObjectName> set = new HashSet(Arrays.asList(mgmtBean.createObjectName(), ObjectName
+          .getInstance(JMX_ADAPTER_TYPE + ID_PREFIX + nameGenerator.safeUUID())));
+      ShutdownHandler shutdown = new ShutdownHandler(boot);
+      shutdown.shutdown(set);
+    } finally {
+      unregisterQuietly(mgmtBean);
+    }
+  }
+
+  @Test
+  public void testForceShutdown() throws Exception {
+    String adapterName = nameGenerator.safeUUID();
+    Adapter adapter = new Adapter();
+    adapter.setUniqueId(adapterName);
+    BootstrapProperties boot = bootstrapWithAdapter(adapter);
+    AdapterManagerMBean mgmtBean = boot.getConfigManager().createAdapter();
+    try {
+      mgmtBean.requestStart();
+      HashSet<ObjectName> set = new HashSet(Arrays.asList(mgmtBean.createObjectName(), ObjectName
+          .getInstance(JMX_ADAPTER_TYPE + ID_PREFIX + nameGenerator.safeUUID())));
+      ShutdownHandler shutdown = new ShutdownHandler(boot);
+      shutdown.forceShutdown(set);
+    } finally {
+      unregisterQuietly(mgmtBean);
+    }
+  }
+
+  private BootstrapProperties bootstrapWithAdapter(Adapter adapter) throws Exception {
+    File filename = TempFileUtils.createTrackedFile(adapter.getUniqueId(), null, adapter);
+    DefaultMarshaller.getDefaultMarshaller().marshal(adapter, filename);
+    BootstrapProperties boot = new BootstrapProperties(new Properties());
+    boot.put("adapterConfigUrl.1", filename.toURI().toURL().toString());
+    return boot;
+  }
+
+  private void unregisterQuietly(AdapterComponentMBean mgmtBean) {
+    try {
+      mgmtBean.unregisterMBean();
+    } catch (Exception e) {
+
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

ShutdownHandler has a hard-coded timeout (before it decides to force kill) of 30 seconds. This should be configurable based on the existing `operationTimeout` flag that contains startup.

## Modification

- Moved the private constant from UnifiedBootstrap into Constants.
- Added a helper method getOperationTimeout() to BootstrapProperties since we want to have a floor for the value so that it's positive.
- Use getOperationTimeout() in both UnifedBootstrap + ShutdownHandler
- Add logging to that effect.
- Add tests for BootstrapProperties

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

The shutdown handler now obeys a configurable timeout.

## Testing

- Modify your bootstrap.properties with `operationTimeout=3000` (3 seconds timeout).
- Start Interlok
```
TRACE [SimpleBootstrap] [c.a.c.m.UnifiedBootstrap.tryStart()] [{}] Start operationTimeout : 3 seconds
```
- Issue a ctrl-c (or using JPS, figure out the pid and do kill -15 `pid`)

```
Running ShutdownHandler, please wait...
INFO  [Shutdown Handler] [j.l.Thread.run()] [{}] Running ShutdownHandler...
TRACE [Shutdown Handler] [j.l.Thread.run()] [{}] Sending Shutdown events for all adapters
INFO  [Shutdown Handler] [j.l.Thread.run()] [{}] Shutting down Adapter(s)
TRACE [Shutdown Handler] [j.l.Thread.shutdown()] [{}] Shutdown Operation Timeout approx: 3 seconds
INFO  [JMX-Request-1] [c.a.c.Adapter.stop()] [{}] stopping adapter [MyInterlokInstance] if there are polling loops configured this may take some time
...
INFO  [Shutdown Handler] [j.l.Thread.run()] [{}] Adapter(s) closed
```

- Remove the bootstrap.properties value and you should see the logging change to 2 minutes.

