### PR TITLE
INTERLOK-3775 annotations not taglets

### DIFF
--- a/interlok-core-apt/src/main/java/com/adaptris/annotation/GenerateBeanInfo.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/annotation/GenerateBeanInfo.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,12 +24,12 @@ import com.thoughtworks.xstream.converters.javabean.JavaBeanConverter;
  * Use this to force XStream to use the setters and getters rather than the member variables directly. This is generally useful if
  * the setters and getters have behaviour associated with them that are not simple <code>this.x = x</code>.
  * </p>
- * 
+ *
  * @deprecated since 3.4.0 with no replacement; due to changes in XStream as of 1.4.9 {@link JavaBeanConverter} may not generate the
  *             desired output; and call a setter with null.
- * 
+ *
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "3.4.0")
 public @interface GenerateBeanInfo {
 
 }

--- a/interlok-core-apt/src/main/java/com/adaptris/annotation/InterlokAlias.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/annotation/InterlokAlias.java
@@ -1,0 +1,18 @@
+package com.adaptris.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Documented
+public @interface InterlokAlias {
+  /**
+   *
+   * The alias (which should match the corresponding {@code XStreamAlias}
+   */
+  String value();
+}

--- a/interlok-core-apt/src/main/java/com/adaptris/annotation/InterlokLicence.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/annotation/InterlokLicence.java
@@ -1,0 +1,42 @@
+package com.adaptris.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Documented
+public @interface InterlokLicence {
+
+  public enum Type {
+    /**
+     * No License Required.
+     *
+     */
+    NONE,
+    /**
+     * Basic license Required
+     *
+     */
+    BASIC,
+    /**
+     * Standard license Required
+     *
+     */
+    STANDARD,
+    /**
+     * Enterprise license Required
+     *
+     */
+    ENTERPRISE;
+  }
+
+  /**
+   *
+   * The required licensing
+   */
+  Type value();
+}

--- a/interlok-core-apt/src/main/java/com/adaptris/taglet/ConfigTaglet.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/taglet/ConfigTaglet.java
@@ -16,16 +16,16 @@
 
 package com.adaptris.taglet;
 
-import jdk.javadoc.doclet.Taglet;
-
 import java.util.Map;
+import jdk.javadoc.doclet.Taglet;
 
 /**
  * Simple taglet that allows us to quickly specify the config requirements.
  *
- * @author lchan
- *
+ * @deprecated since 4.2.0, we have switched to using annotations instead.
  */
+@Deprecated(forRemoval = true, since = "4.2.0")
+@SuppressWarnings("deprecation")
 public class ConfigTaglet extends AbstractTaglet {
   private static final String NAME = "config";
   private static final String START = " <p>In the adapter configuration file this class is aliased as <b>";

--- a/interlok-core-apt/src/main/java/com/adaptris/taglet/LicenseTaglet.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/taglet/LicenseTaglet.java
@@ -16,16 +16,16 @@
 
 package com.adaptris.taglet;
 
-import jdk.javadoc.doclet.Taglet;
-
 import java.util.Map;
+import jdk.javadoc.doclet.Taglet;
 
 /**
  * Simple taglet that allows us to quickly specify the license requirements.
  *
- * @author lchan
- *
+ * @deprecated since 4.2.0, we have switched to using annotations instead.
  */
+@Deprecated(forRemoval = true, since = "4.2.0")
+@SuppressWarnings("deprecation")
 public class LicenseTaglet extends AbstractTaglet {
   private static final String START = "<p>License Required: <strong>";
   private static final String END = "</strong></p>";
@@ -34,6 +34,7 @@ public class LicenseTaglet extends AbstractTaglet {
   /**
    * Return the name of this custom tag.
    */
+  @Override
   public String getName() {
       return NAME;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/NullService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NullService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,16 +18,19 @@ package com.adaptris.core;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InterlokAlias;
+import com.adaptris.annotation.InterlokLicence;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * <p>
  * Null implementation of <code>Service</code>.
  * </p>
- * 
- * @config null-service
+ *
  */
 @XStreamAlias("null-service")
+@InterlokAlias("null-service")
+@InterlokLicence(InterlokLicence.Type.NONE)
 @AdapterComponent
 @ComponentProfile(summary = "A NO-OP service", tag = "service")
 public class NullService extends ServiceImp {
@@ -41,14 +44,17 @@ public class NullService extends ServiceImp {
     setUniqueId(uniqueId);
   }
 
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     // do nothing
   }
 
+  @Override
   protected void initService() throws CoreException {
     // do nothing
   }
 
+  @Override
   protected void closeService() {
     // do nothing
   }


### PR DESCRIPTION
## Motivation

Taglets basically change between JVM versions (such that 11 broke us and we can't go back). If we switch to using documented annotations then they still present themselves in javadocs, but we *could* go back to java 8.

## Modification

- Add `InterlokAlias` and `InterlokLicence` as annotations inside core-apt
- Add those annotations to `NullService`; and removed the `@config` annotation.
- Marked ConfigTaglet and LicenseTaglet as deprecated though I'm unsure if this will ever manifest itself IRL.


## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like XStreamAlias / ComponentProfile)
- [x] Checked that javadoc generation doesn't report errors

## Result

For NullService javadocs you should see something like this 
```
@InterlokAlias("null-service")
@InterlokLicence(NONE)
@ComponentProfile(summary="A NO-OP service",
                  tag="service")
public class NullService
extends ServiceImp
Null implementation of Service.
```

## Testing

`./gradlew javadoc` and then view the javadocs generated, paying attention to NullService (see above). Since the config taglet has been removed from NullService you won't see the _in the adapter configuration file_ stuff.
