### PR TITLE
Update example XML in XmlHelperTest

### DIFF
--- a/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
@@ -36,11 +36,10 @@ import static org.mockito.Mockito.mock;
 @SuppressWarnings("deprecation")
 public class XmlHelperTest extends XmlHelper {
   private static final String EXAMPLE_XML =
-      "<document>" + System.lineSeparator() + "   <content>text body</content>" + System.lineSeparator()
-          + "   <attachment encoding=\"base64\" filename=\"attachment1.txt\">dp/HSJfonUsSMM7QRBSRfg==</attachment>"
-          + System.lineSeparator()
-          + "   <attachment encoding=\"base64\" filename=\"attachment2.txt\">OdjozpCZB9PbCCLZlKregQ</attachment>"
-          + System.lineSeparator() + "</document>";
+      "<document>\n   <content>text body</content>\n"
+          + "   <attachment encoding=\"base64\" filename=\"attachment1.txt\">dp/HSJfonUsSMM7QRBSRfg==</attachment>\n"
+          + "   <attachment encoding=\"base64\" filename=\"attachment2.txt\">OdjozpCZB9PbCCLZlKregQ</attachment>\n"
+          + "</document>";
 
   private static final String ILLEGAL_XML_CHAR = new String(new byte[]
   {


### PR DESCRIPTION
## Motivation

One of the tests in XmlHelperTest was failing due to a line ending mismatch.

## Modification

Update the example XML so that the line endings are consistent.

## PR Checklist

- [x] been self-reviewed.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance

## Result

The unit tests and `gradle check` should now complete successfully.

## Testing

Run `gradle check` - I've had success on both Windows and Linux.
