### PR TITLE
INTERLOK-3806 Add a new getter that can be used by jolokia to get the message error stackTrace

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/runtime/MessageDigestErrorEntry.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/MessageDigestErrorEntry.java
@@ -12,21 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.runtime;
 
 import static com.adaptris.core.CoreConstants.FS_PRODUCE_DIRECTORY;
 import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION;
 import static com.adaptris.core.CoreConstants.PRODUCED_NAME_KEY;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Date;
 import java.util.Map;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MessageLifecycleEvent;
 
@@ -49,7 +52,6 @@ public class MessageDigestErrorEntry extends MessageDigestEntry {
   public MessageDigestErrorEntry(String uniqueId, String workflowId, Date date) {
     super(uniqueId, workflowId, date);
   }
-
 
   @Override
   public String toString() {
@@ -81,10 +83,14 @@ public class MessageDigestErrorEntry extends MessageDigestEntry {
     return stackTrace;
   }
 
+  // return the stack trace but can also be used by jolokia as stackTrace is a special word
+  public String getExceptionStackTrace() {
+    return getStackTrace();
+  }
+
   public String getFileSystemPath() {
     return fileSystemPath;
   }
-
 
   public void setFileSystemPath(String s) {
     fileSystemPath = s;
@@ -121,8 +127,7 @@ public class MessageDigestErrorEntry extends MessageDigestEntry {
   private void addLifecycleEvent(AdaptrisMessage msg) {
     try {
       setLifecycleEvent(msg.getMessageLifecycleEvent().clone());
-    }
-    catch (CloneNotSupportedException unlikely) {
+    } catch (CloneNotSupportedException unlikely) {
       setLifecycleEvent(null);
     }
   }
@@ -133,13 +138,11 @@ public class MessageDigestErrorEntry extends MessageDigestEntry {
       if (msg.headersContainsKey(PRODUCED_NAME_KEY)) {
         if (msg.headersContainsKey(FS_PRODUCE_DIRECTORY)) {
           setFileSystemFile(new File(msg.getMetadataValue(FS_PRODUCE_DIRECTORY), msg.getMetadataValue(PRODUCED_NAME_KEY)));
-        }
-        else {
+        } else {
           setFileSystemPath(msg.getMetadataValue(PRODUCED_NAME_KEY));
         }
       }
-    }
-    catch (IOException e) {
+    } catch (IOException e) {
       setFileSystemPath(null);
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/MessageDigestErrorEntryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/MessageDigestErrorEntryTest.java
@@ -117,7 +117,6 @@ public class MessageDigestErrorEntryTest {
 
   private File deleteLater(Object marker) throws IOException {
     File file = File.createTempFile(this.getClass().getSimpleName(), "");
-    file.deleteOnExit();
     cleaner.track(file, marker, FileDeleteStrategy.FORCE);
     return file;
   }

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/MessageDigestErrorEntryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/MessageDigestErrorEntryTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.runtime;
 
@@ -26,8 +26,6 @@ import java.util.Date;
 
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.adaptris.core.MessageLifecycleEvent;
@@ -35,14 +33,6 @@ import com.adaptris.core.MessageLifecycleEvent;
 public class MessageDigestErrorEntryTest {
 
   private static FileCleaningTracker cleaner = new FileCleaningTracker();
-
-  @Before
-  public void setUp() throws Exception {
-  }
-
-  @After
-  public void tearDown() throws Exception {
-  }
 
   @Test
   public void testConstructors() throws Exception {
@@ -58,6 +48,7 @@ public class MessageDigestErrorEntryTest {
     assertEquals("234", entry.getWorkflowId());
     assertNull(entry.getFileSystemPath());
     assertNull(entry.getStackTrace());
+    assertNull(entry.getExceptionStackTrace());
     Date d = new Date();
     entry = new MessageDigestErrorEntry("123", "234", d);
     assertNotNull(entry.getDate());
@@ -66,6 +57,7 @@ public class MessageDigestErrorEntryTest {
     assertEquals("234", entry.getWorkflowId());
     assertNull(entry.getFileSystemPath());
     assertNull(entry.getStackTrace());
+    assertNull(entry.getExceptionStackTrace());
   }
 
   @Test
@@ -74,13 +66,17 @@ public class MessageDigestErrorEntryTest {
     entry = new MessageDigestErrorEntry("123", "234");
     assertNull(entry.getFileSystemPath());
     assertNull(entry.getStackTrace());
+    assertNull(entry.getExceptionStackTrace());
     Exception e = new Exception(this.getClass().getSimpleName());
     entry.setStackTrace(e);
     assertNotNull(entry.getStackTrace());
+    assertNotNull(entry.getExceptionStackTrace());
     entry.setStackTrace(e.getMessage());
     assertEquals(e.getMessage(), entry.getStackTrace());
+    assertEquals(e.getMessage(), entry.getExceptionStackTrace());
     entry.setStackTrace((Exception) null);
     assertEquals("", entry.getStackTrace());
+    assertEquals("", entry.getExceptionStackTrace());
   }
 
   @Test
@@ -89,6 +85,7 @@ public class MessageDigestErrorEntryTest {
     entry = new MessageDigestErrorEntry("123", "234");
     assertNull(entry.getFileSystemPath());
     assertNull(entry.getStackTrace());
+    assertNull(entry.getExceptionStackTrace());
     File fsLocation = deleteLater(entry);
     File fsLocation2 = deleteLater(entry);
     entry.setFileSystemFile(fsLocation);
@@ -111,7 +108,6 @@ public class MessageDigestErrorEntryTest {
 
   @Test
   public void testToString() throws Exception {
-    Exception e = new Exception();
     MessageDigestErrorEntry entry = new MessageDigestErrorEntry("123", "234");
     assertNotNull(entry.toString());
 
@@ -120,9 +116,10 @@ public class MessageDigestErrorEntryTest {
   }
 
   private File deleteLater(Object marker) throws IOException {
-    File f = File.createTempFile(this.getClass().getSimpleName(), "");
-    f.deleteOnExit();
-    cleaner.track(f, marker, FileDeleteStrategy.FORCE);
-    return f;
+    File file = File.createTempFile(this.getClass().getSimpleName(), "");
+    file.deleteOnExit();
+    cleaner.track(file, marker, FileDeleteStrategy.FORCE);
+    return file;
   }
+
 }


### PR DESCRIPTION
## Motivation

The failed message stacktrace are not retrieved with the failed messages when using jolokia.
It seems that Jolokia does not work well with getStackTrace as stackTrace a special word.

## Modification

Add a new getter that can be used by jolokia to get the message error stackTrace
Add test assertions for the new getter

## PR Checklist

- [x] been self-reviewed.
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

We can now get the stackTrace when using jolokia

## Testing

- Build interlok-core.jar from this branch and use it.

- Start a new instance of interlok with interlok-jolokia (https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jolokia):
  - interlok-jolokia and its dependencies in the classpath
  - Jolokia management component enabled: managementComponents=jolokia

- Make sure the interlok instance generate some errors. You can use the example config in [config.zip](https://github.com/adaptris/interlok/files/7132575/config.zip)


- When at least one error has occurred do a get request to http://localhost:8081/jolokia/read/com.adaptris:type=MessageErrorDigest,adapter=MyInterlokInstance,id=ErrorDigest
You should see something like:

```json
{
  "request":{
    "mbean":"com.adaptris:adapter=MyInterlokInstance,id=ErrorDigest,type=MessageErrorDigest",
    "type":"read"
  },
  "value":{
    "ParentId":"MyInterlokInstance",
    "Digest":[
      {
        "date":"2021-09-09T01:48:45+01:00",
        "lifecycleEvent":{
          "sourceId":null,
          "messageUniqueId":"60fb491e-bbee-4b67-a6ae-5b10b6d25217",
          "creationTime":1631148524884,
          "mleMarkers":[
            {
              "sequenceNumber":1,
              "isConfirmation":false,
              "creationTime":1631148525712,
              "isTrackingEndpoint":false,
              "qualifier":"nauseous-thompson",
              "name":"com.adaptris.core.fs.FsProducer",
              "wasSuccessful":true,
              "confirmationId":null,
              "uniqueId":"f77adbe1-d252-47dc-a631-fd31c0d81fbc"
            }
          ],
          "nameSpace":"event.mle.success",
          "destinationId":null,
          "workflowId":null,
          "channelId":null,
          "uniqueId":"7ded6aff-5bc0-4ac6-9362-d6bb73ee5619"
        },
        "fileSystemPath":"C:\\Adaptris\\Interlok420B1\\messages\\bad\\60fb491e-bbee-4b67-a6ae-5b10b6d25217",
        "exceptionStackTrace":"com.adaptris.core.ServiceException: InventoryUpdate Send marked as Failed\r\n\tat com.adaptris.core.services.exception.ExceptionFromMetadata.create(ExceptionFromMetadata.java:85)\r\n\tat com.adaptris.core.services.exception.ThrowExceptionService.doService(ThrowExceptionService.java:73)\r\n\tat com.adaptris.core.ServiceList.applyServices(ServiceList.java:96)\r\n\tat com.adaptris.core.ServiceCollectionImp.doService(ServiceCollectionImp.java:204)\r\n\tat com.adaptris.core.BranchingServiceCollection.applyServices(BranchingServiceCollection.java:92)\r\n\tat com.adaptris.core.ServiceCollectionImp.doService(ServiceCollectionImp.java:204)\r\n\tat com.adaptris.core.ServiceList.applyServices(ServiceList.java:96)\r\n\tat com.adaptris.core.ServiceCollectionImp.doService(ServiceCollectionImp.java:204)\r\n\tat com.adaptris.core.StandardWorkflowImpl.handleMessage(StandardWorkflowImpl.java:107)\r\n\tat com.adaptris.core.StandardWorkflowImpl.onAdaptrisMessage(StandardWorkflowImpl.java:82)\r\n\tat com.adaptris.core.StandardWorkflow.onAdaptrisMessage(StandardWorkflow.java:63)\r\n\tat com.adaptris.core.AdaptrisMessageListener.onAdaptrisMessage(AdaptrisMessageListener.java:48)\r\n\tat com.adaptris.core.PollingTrigger.processMessages(PollingTrigger.java:89)\r\n\tat com.adaptris.core.PollerImp.processMessages(PollerImp.java:78)\r\n\tat com.adaptris.core.RandomIntervalPoller$MyPollerTask.run(RandomIntervalPoller.java:66)\r\n\tat java.base\/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)\r\n\tat java.base\/java.util.concurrent.FutureTask.run(FutureTask.java:264)\r\n\tat java.base\/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)\r\n\tat java.base\/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\r\n\tat java.base\/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\r\n\tat java.base\/java.lang.Thread.run(Thread.java:834)\r\n",
        "workflowId":"Send@InventoryUpdates",
        "uniqueId":"60fb491e-bbee-4b67-a6ae-5b10b6d25217"
      }
    ],
    "TotalErrorCount":1,
    "ParentObjectName":{
      "objectName":"com.adaptris:id=MyInterlokInstance,type=Adapter"
    }
  },
  "timestamp":1631148584,
  "status":200
}
```
Make sure there is a correct **exceptionStackTrace**