### PR TITLE
INTERLOK-3828 POSIX permissions aren't supported on Windows

### DIFF
--- a/interlok-common/src/test/java/com/adaptris/interlok/resolver/FileResolverTest.java
+++ b/interlok-common/src/test/java/com/adaptris/interlok/resolver/FileResolverTest.java
@@ -28,11 +28,15 @@ public class FileResolverTest
     String type = resolver.resolve("%file{./build.gradle:%type}");
     assertEquals(FileResolver.Type.FILE.name(), type);
 
-    String permissions = resolver.resolve("%file{./build.gradle:%permissions}");
-    assertTrue(permissions.contains(PosixFilePermission.OWNER_READ.name()));
+    String permissions = "";
+    if (!System.getProperty("os.name").contains("Windows"))
+    {
+      permissions = resolver.resolve("%file{./build.gradle:%permissions}");
+      assertTrue(permissions.contains(PosixFilePermission.OWNER_READ.name()));
+    }
 
     String combined = resolver.resolve("%file{./build.gradle:%size%type%permissions}");
-    String expected = s + "," + type + "," + permissions;
+    String expected = s + "," + type + (permissions.length() > 0 ? "," + permissions : "");
     assertEquals(expected, combined);
 
     d = resolver.resolve("%file{./build.gradle:%date_create}");


### PR DESCRIPTION
## Motivation

The tests all passed in Unix land, but not on dev machines running Windows.

## Modification

Catch the opporation not supported exception when trying to get POSIX permissions and just return an empty String. Then update the unit test to skip resolving the permissions.

## PR Checklist

- [x] been self-reviewed.
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

No change for end user, but devs using Windows should now not experience test failures.

## Testing

Run the unit tests, specifically FileResolverTest.
