### PR TITLE
INTERLOK-3828 Remove unnecessary test

### DIFF
--- a/interlok-common/src/test/java/com/adaptris/interlok/resolver/FileResolverTest.java
+++ b/interlok-common/src/test/java/com/adaptris/interlok/resolver/FileResolverTest.java
@@ -69,17 +69,6 @@ public class FileResolverTest
     {
       // expected
     }
-
-    try
-    {
-      // non-existent path
-      resolver.resolve("%file{./unknown:%type%permissions}");
-      fail();
-    }
-    catch (UnresolvableException e)
-    {
-      // expected
-    }
   }
 
   @Test


### PR DESCRIPTION
## Motivation

Foolishly thought there was only 1 test failure, because gradle said there was only 1 test failure, not realising that the subsequent check just didn't happen.

## Modification

Remove unnecessary code.

## PR Checklist

- [x] been self-reviewed.

## Result

No change for end user but tests are successful for developers.

## Testing

`gradle build` (optional `clean` first).
