### PR TITLE
INTERLOK-1270

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -171,23 +171,27 @@ abstract class CmdLineBootstrap {
         @Override
         public void run() {
           Thread.currentThread().setName(threadName);
-          try {
-            bootstrap.start();
-          }
-          catch (Throwable e) {
-            System.err.println("(Error) Adapter Startup failure :" + e.getMessage());
-            logException(e);
-          }
+          bootStart(bootstrap);
         }
       });
       launcher.setDaemon(false);
       launcher.start();
     }
     else {
-      bootstrap.start();
+      bootStart(bootstrap);
     }
   }
 
+  private void bootStart(final UnifiedBootstrap bootstrap) {
+    try {
+      bootstrap.start();
+    }
+    catch (Throwable e) {
+      System.err.println("(Error) Adapter Startup failure :" + e.getMessage());
+      logException(e);
+    }
+  }
+  
   private static void logException(Throwable e) {
     try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw, true)) {
       pw.println("(Error) Adapter Startup Failure Exception Details");


### PR DESCRIPTION
## Motivation

If you use startAdapterQuietly =true in your bootstrap.properties then any failure will be reported as a stack trace.  Problem is if you don't set this flag, then any errors are not reported.

## Modification
Simply made sure the bootstrap.start() is wrapped in a try/catch and any error reported.

