### PR TITLE
Force interlok-boot to resolve files alphabetically for consistency

### DIFF
--- a/interlok-boot/src/main/java/com/adaptris/interlok/boot/InterlokLauncher.java
+++ b/interlok-boot/src/main/java/com/adaptris/interlok/boot/InterlokLauncher.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import org.springframework.boot.loader.Launcher;
 import org.springframework.boot.loader.PropertiesLauncher;
@@ -290,6 +291,7 @@ public class InterlokLauncher extends Launcher {
     }
     debug("Adding jars from " + dir.getCanonicalPath());
     File[] files = dir.listFiles(JAR_FILTER);
+    Arrays.sort(files, new FileComparator());
     for (File jar : files) {
       debug("Adding ", jar.getName());
       addArchive(jar, jars);
@@ -309,5 +311,15 @@ public class InterlokLauncher extends Launcher {
     if (f.exists()) {
       list.add(new JarFileArchive(f));
     }
+  }
+  
+  private static class FileComparator implements Comparator<File> {
+
+    @Override
+    public int compare(File o1, File o2) {
+      // Just sort on the name rather than the canonical name.
+      return o1.getName().compareTo(o2.getName());
+    }
+    
   }
 }


### PR DESCRIPTION
## Motivation

This is a PR that alleviates the symptom of #782 (that's the motivation).

## Modification

Makes the scenario described by #782 more predictable (it doesn't solve it) by making the jars that are added by the spring-boot-classloader are ordered alphabetically vis String.compareTo rather than leaving it to the order returned by .listFiles() which may not be.

Did not make the utlimate List<Archive> (that is used by spring-boot-loader) a Treeset, because making the Archives sorted might have additional ramifications we don't understand. So, for a given directory, _ensure that the list of jar files is sorted alphabetically only_; the other behaviour is left as-is.

## PR Checklist

- [x] been self-reviewed.

## Result

Running against the docker image defined in the issue you now get, which resolves the specific symptom.

```
+ exec java -Xms488m -Xmx488m -Dpolyglot.js.nashorn-compat=true -Dpolyglot.engine.WarnInterpreterOnly=false -Dinterlok.bootstrap.debug=true -jar lib/interlok-boot.jar bootstrap.properties
(InterlokLauncher) Nested archive paths: [config/, lib/]
(InterlokLauncher) Main-Class: com.adaptris.core.management.SimpleBootstrap
(InterlokLauncher) Args for Main-Class : [bootstrap.properties]
(InterlokLauncher) Added config
(InterlokLauncher) Added lib
(InterlokLauncher) Adding jars from /opt/interlok/lib
(InterlokLauncher) Adding HdrHistogram.jar
(InterlokLauncher) Adding HikariCP.jar
(InterlokLauncher) Adding Saxon-HE.jar
(InterlokLauncher) Adding accessors-smart.jar
...
(InterlokLauncher) Adding geronimo-j2ee-management_1.1_spec.jar
(InterlokLauncher) Adding geronimo-jaspi.jar
(InterlokLauncher) Adding geronimo-jaspic_1.0_spec.jar
(InterlokLauncher) Adding geronimo-jms_1.1_spec.jar
(InterlokLauncher) Adding geronimo-jms_2.0_spec.jar
(InterlokLauncher) Adding geronimo-jta_1.1_spec.jar
...
(InterlokLauncher) Adding javaee-api.jar
...
(InterlokLauncher) Adding zjsonpatch.jar
```

This is also true running on WSL2 (Ubuntu20.04) + Mingw 64 (Git-Bash). This means that we have predictable behaviour even if we haven't figured out how javaee-api is screwing with jaspi (I think it might be the javax.security.auth.Message stuff still).

## Testing

Run against the described steps to reproduce in #782 
