### PR TITLE
Add a InputFieldExpressionHelper for determining when config truly needs to be dynamic

### DIFF
--- a/interlok-common/src/main/resources/META-INF/services/com.adaptris.interlok.resolver.Resolver
+++ b/interlok-common/src/main/resources/META-INF/services/com.adaptris.interlok.resolver.Resolver
@@ -1,4 +1,3 @@
 com.adaptris.interlok.resolver.FromEnvironment
 com.adaptris.interlok.resolver.FromSystemProperties
 com.adaptris.interlok.resolver.FileResolver
-com.adaptris.interlok.resolver.FileResolver

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageImp.java
@@ -66,12 +66,17 @@ public abstract class AdaptrisMessageImp implements AdaptrisMessage, Cloneable {
 
   // If we have %message{key1}%message{key2} group(1) is key2
   // Which is then replaced so it all works out int the end.
-  private static final String RESOLVE_REGEXP = "^.*%message\\{([\\w!\\$\"#&%'\\*\\+,\\-\\.:=]+)\\}.*$";
-  private static final String OBJECT_RESOLVE_REGEXP = "^.*%messageObject\\{([\\w!\\$\"#&%'\\*\\+,\\-\\.:=]+)\\}.*$";
+  public static final String METADATA_RESOLVE_REGEXP = "^.*%message\\{([\\w!\\$\"#&%'\\*\\+,\\-\\.:=]+)\\}.*$";
+  public static final String OBJECT_RESOLVE_REGEXP = "^.*%messageObject\\{([\\w!\\$\"#&%'\\*\\+,\\-\\.:=]+)\\}.*$";
 
+
+  public static final String UID_RESOLVE_KEY = "%uniqueId";
+  public static final String SIZE_RESOLVE_KEY = "%size";
+  public static final String PAYLOAD_RESOLVE_KEY = "%payload";
+  
   private transient Logger log = LoggerFactory.getLogger(AdaptrisMessage.class);
-  private transient Pattern normalResolver = Pattern.compile(RESOLVE_REGEXP);
-  private transient Pattern dotAllResolver = Pattern.compile(RESOLVE_REGEXP, Pattern.DOTALL);
+  private transient Pattern normalResolver = Pattern.compile(METADATA_RESOLVE_REGEXP);
+  private transient Pattern dotAllResolver = Pattern.compile(METADATA_RESOLVE_REGEXP, Pattern.DOTALL);
 
   private transient Pattern objectResolver = Pattern.compile(OBJECT_RESOLVE_REGEXP);
 
@@ -91,7 +96,7 @@ public abstract class AdaptrisMessageImp implements AdaptrisMessage, Cloneable {
     UniqueId {
       @Override
       String resolve(String key, AdaptrisMessage msg) {
-        if ("%uniqueId".equalsIgnoreCase(key)) {
+        if (UID_RESOLVE_KEY.equalsIgnoreCase(key)) {
           return msg.getUniqueId();
         }
         return null;
@@ -100,7 +105,7 @@ public abstract class AdaptrisMessageImp implements AdaptrisMessage, Cloneable {
     Size {
       @Override
       String resolve(String key, AdaptrisMessage msg) {
-        if ("%size".equalsIgnoreCase(key)) {
+        if (SIZE_RESOLVE_KEY.equalsIgnoreCase(key)) {
           return String.valueOf(msg.getSize());
         }
         return null;
@@ -109,7 +114,7 @@ public abstract class AdaptrisMessageImp implements AdaptrisMessage, Cloneable {
     Payload {
       @Override
       String resolve(String key, AdaptrisMessage msg) {
-        if ("%payload".equalsIgnoreCase(key)) {
+        if (PAYLOAD_RESOLVE_KEY.equalsIgnoreCase(key)) {
           return msg.getContent();
         }
         return null;

--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
@@ -54,12 +54,12 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
  */
 @ComponentProfile(summary = "A multi-payload message implementation", tag = "multi-payload,message", since="3.9.3")
 public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implements MultiPayloadAdaptrisMessage {
-  private static final String RESOLVE_REGEXP = "^.*%payload_id\\{([\\w!\\$\"#&%'\\*\\+,\\-\\.:=]+)\\}.*$";
-  private static final String RESOLVE_2_REGEX = "^.*%payload\\{id:([\\w!\\$\"#&%'\\*\\+,\\-\\.:=]+)\\}.*$";
-  private static final transient Pattern normalPayloadResolver = Pattern.compile(RESOLVE_REGEXP);
-  private static final transient Pattern dotAllPayloadResolver = Pattern.compile(RESOLVE_REGEXP, Pattern.DOTALL);
-  private static final transient Pattern normalPayloadResolver2 = Pattern.compile(RESOLVE_2_REGEX);
-  private static final transient Pattern dotAllPayloadResolver2 = Pattern.compile(RESOLVE_2_REGEX, Pattern.DOTALL);
+  public static final String EXPLICIT_PAYLOAD_REGEXP = "^.*%payload_id\\{([\\w!\\$\"#&%'\\*\\+,\\-\\.:=]+)\\}.*$";
+  public static final String IMPLICIT_PAYLOAD_REGEXP = "^.*%payload\\{id:([\\w!\\$\"#&%'\\*\\+,\\-\\.:=]+)\\}.*$";
+  private static final transient Pattern normalPayloadResolver = Pattern.compile(EXPLICIT_PAYLOAD_REGEXP);
+  private static final transient Pattern dotAllPayloadResolver = Pattern.compile(EXPLICIT_PAYLOAD_REGEXP, Pattern.DOTALL);
+  private static final transient Pattern normalPayloadResolver2 = Pattern.compile(IMPLICIT_PAYLOAD_REGEXP);
+  private static final transient Pattern dotAllPayloadResolver2 = Pattern.compile(IMPLICIT_PAYLOAD_REGEXP, Pattern.DOTALL);
 
   private Map<String, Payload> payloads = new HashMap<>();
 

--- a/interlok-core/src/main/java/com/adaptris/core/util/InputFieldExpression.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/InputFieldExpression.java
@@ -2,7 +2,6 @@ package com.adaptris.core.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.ServiceLoader;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageImp;
@@ -27,6 +26,7 @@ import lombok.Getter;
  * </p>
  * 
  * @see ExternalResolver
+ * @see Resolver#canHandle(String)
  * @see AdaptrisMessage#resolve(String)
  */
 public class InputFieldExpression {
@@ -71,7 +71,7 @@ public class InputFieldExpression {
    * </p>
    * 
    * @param configuredValue the configured value.
-   * @return if the value is considered something that is an expression (within reason).
+   * @return true if the value is considered something that is an expression (within reason).
    */
   public static boolean isExpression(String configuredValue) {
     return IMPL.getExpressionList().stream().filter((resolver) -> resolver.matches(configuredValue)).findFirst()

--- a/interlok-core/src/main/java/com/adaptris/core/util/InputFieldExpression.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/InputFieldExpression.java
@@ -47,7 +47,7 @@ public class InputFieldExpression {
 
   private static final InputFieldExpression IMPL = new InputFieldExpression();
 
-  public InputFieldExpression() {
+  private InputFieldExpression() {
     Iterable<Resolver> resolvers = ServiceLoader.load(Resolver.class);
     for (Resolver r : resolvers) {
       expressionList.add((v) -> r.canHandle(v));

--- a/interlok-core/src/main/java/com/adaptris/core/util/InputFieldExpression.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/InputFieldExpression.java
@@ -1,0 +1,85 @@
+package com.adaptris.core.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageImp;
+import com.adaptris.core.MultiPayloadAdaptrisMessageImp;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.interlok.resolver.Resolver;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+/**
+ * Convenience helper to see if configuration is considered an expression
+ * <p>
+ * If we have configuration that is something like {@code %payload} then this needs to be resolved
+ * from the message object at runtime. In the event that the value is something like
+ * {@code a-hard-coded-queue} then this does not need to be resolved on a per-message basis. For
+ * efficiency if the configuration does not need to be resolved on a per-message basis then we could
+ * pre-empt some activity for performance purposes.
+ * </p>
+ * <p>
+ * For the purposes of determining expressions, things like "%sysprop" are considered expressions
+ * since {@link ExternalResolver} also supports xpath/json resolution from the payload.
+ * </p>
+ * 
+ * @see ExternalResolver
+ * @see AdaptrisMessage#resolve(String)
+ */
+public class InputFieldExpression {
+
+  // AdaptrisMessage regular expression matchers.
+  private static final String[] REGEXPS =
+      {AdaptrisMessageImp.METADATA_RESOLVE_REGEXP, AdaptrisMessageImp.OBJECT_RESOLVE_REGEXP,
+          MultiPayloadAdaptrisMessageImp.EXPLICIT_PAYLOAD_REGEXP,
+          MultiPayloadAdaptrisMessageImp.IMPLICIT_PAYLOAD_REGEXP};
+
+
+  // Taken from AdaptrisMessageImp#Resolvers.
+  private static final String[] KEY_MATCHES = {AdaptrisMessageImp.UID_RESOLVE_KEY,
+      AdaptrisMessageImp.SIZE_RESOLVE_KEY, AdaptrisMessageImp.PAYLOAD_RESOLVE_KEY};
+
+  @Getter(AccessLevel.PRIVATE)
+  private Collection<IsExpression> expressionList = new ArrayList<>();
+
+  private static final InputFieldExpression IMPL = new InputFieldExpression();
+
+  public InputFieldExpression() {
+    Iterable<Resolver> resolvers = ServiceLoader.load(Resolver.class);
+    for (Resolver r : resolvers) {
+      expressionList.add((v) -> r.canHandle(v));
+    }
+    for (String regex : REGEXPS) {
+      expressionList.add((v) -> v.matches(regex));
+    }
+    for (String exact : KEY_MATCHES) {
+      expressionList.add((v) -> v.equalsIgnoreCase(exact));
+    }
+  }
+
+  /**
+   * Check if the configured value is considered an expression.
+   * <p>
+   * If we have configuration that is something like {@code %payload} then this needs to be resolved
+   * from the message object at runtime. In the event that the value is something like
+   * {@code a-hard-coded-queue} then this does not need to be resolved on a per-message basis. For
+   * efficiency if the configuration does not need to be resolved on a per-message basis then we
+   * could pre-empt some activity for performance purposes.
+   * </p>
+   * 
+   * @param configuredValue the configured value.
+   * @return if the value is considered something that is an expression (within reason).
+   */
+  public static boolean isExpression(String configuredValue) {
+    return IMPL.getExpressionList().stream().filter((resolver) -> resolver.matches(configuredValue)).findFirst()
+        .isPresent();
+  }
+
+  @FunctionalInterface
+  private interface IsExpression {
+    boolean matches(String value);
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/util/InputFieldExpressionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/InputFieldExpressionTest.java
@@ -1,0 +1,22 @@
+package com.adaptris.core.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class InputFieldExpressionTest {
+
+
+  @Test
+  public void testIsExpression() throws Exception {
+    assertTrue(InputFieldExpression.isExpression("%message{myKey}"));
+    assertTrue(InputFieldExpression.isExpression("%sysprop{MY_SYS_PROP}"));
+    assertTrue(InputFieldExpression.isExpression("%env{MY_ENV_VAR}"));
+    assertTrue(InputFieldExpression.isExpression("%payload"));
+    assertTrue(InputFieldExpression.isExpression("%payload{id:1}"));
+    assertTrue(InputFieldExpression.isExpression("XXX_%payload{xpath:/Document/Header}"));
+    assertFalse(InputFieldExpression.isExpression("hello world"));
+  }
+
+
+}


### PR DESCRIPTION
## Motivation

Fields are marked as resolvable which means they can be configured such that we resolve them on a per-message basis. In that situation we can't preempt performance improvements (like creating a queue on start() during Producer lifecycle. 

This helper allows us to determine if a field is an expression so that components can decide whether to potentially improve performance by pre-declaring high cost items if they aren't going to change during the component lifecycle.


## Modification

- Removed a duplicate resolver from META-INF/services
- Renamed some constants in AdaptrisMessageImp + MultiPayloadMessage and made them public.
- Added InputFieldExpression with a static method.

In this situation things like environment variables + system properties are considered expressions since we have to make use of the Resolver interface (since that also handles the json/xpath stuffs).

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

No change for the end user.
Additional method available for a developer.

## Testing

Since this is an API change; you can eyeball the test (InputFieldExpressionTest).

