### PR TITLE
bug/INTERLOK-3846 - deprecation annotation for destination objects

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ConfiguredConsumeDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfiguredConsumeDestination.java
@@ -18,6 +18,7 @@ package com.adaptris.core;
 
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -31,6 +32,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("configured-consume-destination")
 @DisplayOrder(order = {"destination", "filterExpression"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public final class ConfiguredConsumeDestination extends ConsumeDestinationImp {
 
   private String destination;

--- a/interlok-core/src/main/java/com/adaptris/core/ConfiguredConsumeDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfiguredConsumeDestination.java
@@ -32,7 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("configured-consume-destination")
 @DisplayOrder(order = {"destination", "filterExpression"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public final class ConfiguredConsumeDestination extends ConsumeDestinationImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ConfiguredDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfiguredDestination.java
@@ -22,6 +22,7 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.util.Args;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -32,6 +33,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("configured-destination")
 @DisplayOrder(order = {"destination"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class ConfiguredDestination implements MessageDrivenDestination {
 
   @InputFieldHint(expression = true)

--- a/interlok-core/src/main/java/com/adaptris/core/ConfiguredDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfiguredDestination.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("configured-destination")
 @DisplayOrder(order = {"destination"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class ConfiguredDestination implements MessageDrivenDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ConfiguredProduceDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfiguredProduceDestination.java
@@ -17,6 +17,7 @@
 package com.adaptris.core;
 
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -29,6 +30,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 // just looks shit.
 @XStreamAlias("configured-produce-destination")
 @DisplayOrder(order = {"destination"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public final class ConfiguredProduceDestination extends ConfiguredDestination {
 
   public ConfiguredProduceDestination() {

--- a/interlok-core/src/main/java/com/adaptris/core/ConfiguredProduceDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfiguredProduceDestination.java
@@ -30,7 +30,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 // just looks shit.
 @XStreamAlias("configured-produce-destination")
 @DisplayOrder(order = {"destination"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public final class ConfiguredProduceDestination extends ConfiguredDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ConsumeDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConsumeDestination.java
@@ -26,7 +26,7 @@ import com.adaptris.validation.constraints.ConfigDeprecated;
  * messages to consume.
  * </p>
  */
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public interface ConsumeDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ConsumeDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConsumeDestination.java
@@ -17,6 +17,8 @@
 package com.adaptris.core;
 
 
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 /**
  * <p>
  * Represents a destination such as a directory or JMS Queue in the Framework.
@@ -24,6 +26,8 @@ package com.adaptris.core;
  * messages to consume.
  * </p>
  */
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public interface ConsumeDestination {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/ConsumeDestinationImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConsumeDestinationImp.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import org.apache.commons.lang3.StringUtils;
 
 import com.adaptris.core.util.Args;
@@ -26,6 +27,8 @@ import com.adaptris.core.util.Args;
  * behaviour common to all implementations.
  * </p>
  */
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public abstract class ConsumeDestinationImp implements ConsumeDestination {
 
   private String configuredThreadName;

--- a/interlok-core/src/main/java/com/adaptris/core/ConsumeDestinationImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConsumeDestinationImp.java
@@ -27,7 +27,7 @@ import com.adaptris.core.util.Args;
  * behaviour common to all implementations.
  * </p>
  */
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public abstract class ConsumeDestinationImp implements ConsumeDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ExceptionDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ExceptionDestination.java
@@ -41,7 +41,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("exception-destination")
 @DisplayOrder(order = {"exceptionMapping", "defaultDestination"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class ExceptionDestination implements MessageDrivenDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ExceptionDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ExceptionDestination.java
@@ -20,6 +20,7 @@ import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION;
 
 import javax.validation.constraints.NotNull;
 
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +41,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("exception-destination")
 @DisplayOrder(order = {"exceptionMapping", "defaultDestination"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class ExceptionDestination implements MessageDrivenDestination {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());

--- a/interlok-core/src/main/java/com/adaptris/core/FormattedMetadataDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FormattedMetadataDestination.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.adaptris.annotation.DisplayOrder;
@@ -66,6 +68,8 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  */
 @XStreamAlias("formatted-metadata-destination")
 @DisplayOrder(order = {"destinationTemplate", "metadataKeys", "objectMetadataKeys"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class FormattedMetadataDestination implements MessageDrivenDestination {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());

--- a/interlok-core/src/main/java/com/adaptris/core/FormattedMetadataDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/FormattedMetadataDestination.java
@@ -68,7 +68,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  */
 @XStreamAlias("formatted-metadata-destination")
 @DisplayOrder(order = {"destinationTemplate", "metadataKeys", "objectMetadataKeys"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class FormattedMetadataDestination implements MessageDrivenDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/MarshalledClassDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MarshalledClassDestination.java
@@ -45,7 +45,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("marshalled-class-destination")
 @DisplayOrder(order = {"defaultDestination", "mappings", "marshaller"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public final class MarshalledClassDestination implements MessageDrivenDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/MarshalledClassDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MarshalledClassDestination.java
@@ -18,6 +18,8 @@ package com.adaptris.core;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +45,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("marshalled-class-destination")
 @DisplayOrder(order = {"defaultDestination", "mappings", "marshaller"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public final class MarshalledClassDestination implements MessageDrivenDestination {
 
   @NotNull

--- a/interlok-core/src/main/java/com/adaptris/core/MessageDrivenDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MessageDrivenDestination.java
@@ -25,7 +25,7 @@ import com.adaptris.validation.constraints.ConfigDeprecated;
  * (e.g. queue name, URL) to be used by <code>AdaptrisMessageProducer</code>.
  * </p>
  */
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public interface MessageDrivenDestination extends ProduceDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/MessageDrivenDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MessageDrivenDestination.java
@@ -17,12 +17,16 @@
 package com.adaptris.core;
 
 
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 /**
  * <p>
  * Implementations of this interface return a <code>String</code> destination
  * (e.g. queue name, URL) to be used by <code>AdaptrisMessageProducer</code>.
  * </p>
  */
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public interface MessageDrivenDestination extends ProduceDestination {
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/MetadataDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MetadataDestination.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,8 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  */
 @XStreamAlias("metadata-destination")
 @DisplayOrder(order = {"keys"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class MetadataDestination implements MessageDrivenDestination {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());

--- a/interlok-core/src/main/java/com/adaptris/core/MetadataDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MetadataDestination.java
@@ -38,7 +38,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  */
 @XStreamAlias("metadata-destination")
 @DisplayOrder(order = {"keys"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class MetadataDestination implements MessageDrivenDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ProduceDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ProduceDestination.java
@@ -26,7 +26,7 @@ import com.adaptris.validation.constraints.ConfigDeprecated;
  * </p>
  *
  */
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 @FunctionalInterface
 public interface ProduceDestination {

--- a/interlok-core/src/main/java/com/adaptris/core/ProduceDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ProduceDestination.java
@@ -17,6 +17,8 @@
 package com.adaptris.core;
 
 
+import com.adaptris.validation.constraints.ConfigDeprecated;
+
 /**
  * <p>
  * Implementations of this interface return a <code>String</code> destination
@@ -24,6 +26,8 @@ package com.adaptris.core;
  * </p>
  *
  */
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 @FunctionalInterface
 public interface ProduceDestination {
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/XpathProduceDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/XpathProduceDestination.java
@@ -49,7 +49,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("xpath-produce-destination")
 @DisplayOrder(order = {"xpath", "defaultDestination", "namespaceContext", "xmlDocumentFactoryConfig"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class XpathProduceDestination implements MessageDrivenDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/XpathProduceDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/XpathProduceDestination.java
@@ -21,6 +21,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.namespace.NamespaceContext;
+
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
@@ -47,6 +49,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("xpath-produce-destination")
 @DisplayOrder(order = {"xpath", "defaultDestination", "namespaceContext", "xmlDocumentFactoryConfig"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class XpathProduceDestination implements MessageDrivenDestination {
 
   @NotNull

--- a/interlok-core/src/main/java/com/adaptris/core/common/FileParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/FileParameter.java
@@ -35,7 +35,7 @@ public abstract class FileParameter {
 
   @Valid
   @Getter
-  @Deprecated(forRemoval = true)
+  @Deprecated()
   @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'destination-path' instead", groups = Deprecated.class)
   private MessageDrivenDestination destination;
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsReplyToDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsReplyToDestination.java
@@ -38,7 +38,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("jms-reply-to-destination")
 @DisplayOrder(order = {"objectMetadataKey"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class JmsReplyToDestination implements MessageDrivenDestination {
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsReplyToDestination.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsReplyToDestination.java
@@ -18,6 +18,8 @@ package com.adaptris.core.jms;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import javax.jms.Destination;
+
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.adaptris.annotation.AdvancedConfig;
@@ -36,6 +38,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("jms-reply-to-destination")
 @DisplayOrder(order = {"objectMetadataKey"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class JmsReplyToDestination implements MessageDrivenDestination {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass());

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ConsumeDestinationFromMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ConsumeDestinationFromMetadata.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("consume-destination-from-metadata")
 @DisplayOrder(order = {"destinationMetadataKey", "defaultDestination", "filterMetadataKey", "defaultFilterExpression"})
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class ConsumeDestinationFromMetadata implements ConsumeDestinationGenerator {
   private String defaultDestination;

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ConsumeDestinationFromMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ConsumeDestinationFromMetadata.java
@@ -22,6 +22,7 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConsumeDestination;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -32,6 +33,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("consume-destination-from-metadata")
 @DisplayOrder(order = {"destinationMetadataKey", "defaultDestination", "filterMetadataKey", "defaultFilterExpression"})
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class ConsumeDestinationFromMetadata implements ConsumeDestinationGenerator {
   private String defaultDestination;
   private String destinationMetadataKey;

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ConsumeDestinationGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ConsumeDestinationGenerator.java
@@ -18,12 +18,15 @@ package com.adaptris.core.services.aggregator;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConsumeDestination;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 
 /**
  * Generate a {@link ConsumeDestination} based on the message currently being processed.
  * 
  * 
  */
+@Deprecated(forRemoval = true)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public interface ConsumeDestinationGenerator {
 
   ConsumeDestination generate(AdaptrisMessage msg);

--- a/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ConsumeDestinationGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/aggregator/ConsumeDestinationGenerator.java
@@ -25,7 +25,7 @@ import com.adaptris.validation.constraints.ConfigDeprecated;
  * 
  * 
  */
-@Deprecated(forRemoval = true)
+@Deprecated()
 @ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public interface ConsumeDestinationGenerator {
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
@@ -31,6 +31,7 @@ import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.fs.FsHelper;
 import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -164,9 +165,13 @@ public class ReadMetadataFromFilesystem extends MetadataServiceImpl {
 
   @Override
   protected void initService() throws CoreException {
-    logWarningIfNotNull(destWarning, () -> destWarning = true, destination,
-          "{} uses destination, use 'base-url' instead", LoggingHelper.friendlyName(this));
-    mustHaveEither(baseUrl, destination);
+    try {
+      logWarningIfNotNull(destWarning, () -> destWarning = true, destination,
+              "{} uses destination, use 'base-url' instead", LoggingHelper.friendlyName(this));
+      mustHaveEither(baseUrl, destination);
+    } catch (IllegalArgumentException e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
   }
 
   public InputStyle getInputStyle() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
@@ -76,7 +76,7 @@ public class ReadMetadataFromFilesystem extends MetadataServiceImpl {
   private InputStyle inputStyle;
 
   @Valid
-  @Deprecated(forRemoval = true)
+  @Deprecated()
   @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'destination-path' instead", groups = Deprecated.class)
   private MessageDrivenDestination destination;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystem.java
@@ -16,21 +16,12 @@
 
 package com.adaptris.core.services.metadata;
 
-import static com.adaptris.core.util.MetadataHelper.convertFromProperties;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-import java.util.Set;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.FileNameCreator;
@@ -40,8 +31,24 @@ import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.fs.FsHelper;
 import com.adaptris.core.util.Args;
-import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
+
+import javax.validation.Valid;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
+import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
+import static com.adaptris.core.util.MetadataHelper.convertFromProperties;
 
 /**
  * <p>
@@ -67,11 +74,24 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 public class ReadMetadataFromFilesystem extends MetadataServiceImpl {
 
   private InputStyle inputStyle;
-  @NotNull
+
   @Valid
+  @Deprecated(forRemoval = true)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'destination-path' instead", groups = Deprecated.class)
   private MessageDrivenDestination destination;
+
+  @Valid
+  @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  // Needs to be @NotBlank when destination is removed.
+  private String baseUrl;
+
+  private transient boolean destWarning;
+
   @InputFieldDefault(value = "false")
   private Boolean overwriteExistingMetadata;
+
   @AdvancedConfig
   @Valid
   private FileNameCreator filenameCreator;
@@ -112,8 +132,13 @@ public class ReadMetadataFromFilesystem extends MetadataServiceImpl {
   public void doService(AdaptrisMessage msg) throws ServiceException {
     String filenameToRead = "[could not create filename]";
     try {
-      String baseUrl = getDestination().getDestination(msg);
-      File parentFile = FsHelper.toFile(baseUrl);
+      String resolved;
+      if (baseUrl != null) {
+        resolved = msg.resolve(baseUrl);
+      } else {
+        resolved = getDestination().getDestination(msg);
+      }
+      File parentFile = FsHelper.toFile(resolved);
       File fileToRead = new File(parentFile, filenameCreator().createName(msg));
       if (parentFile.isFile()) {
         fileToRead = parentFile;
@@ -139,11 +164,9 @@ public class ReadMetadataFromFilesystem extends MetadataServiceImpl {
 
   @Override
   protected void initService() throws CoreException {
-    try {
-      Args.notNull(getDestination(), "destination");
-    } catch (Exception e) {
-      throw ExceptionHelper.wrapCoreException(e);
-    }
+    logWarningIfNotNull(destWarning, () -> destWarning = true, destination,
+          "{} uses destination, use 'base-url' instead", LoggingHelper.friendlyName(this));
+    mustHaveEither(baseUrl, destination);
   }
 
   public InputStyle getInputStyle() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystem.java
@@ -82,7 +82,7 @@ public class WriteMetadataToFilesystem extends ServiceImp {
   private OutputStyle outputStyle;
 
   @Valid
-  @Deprecated(forRemoval = true)
+  @Deprecated()
   @ConfigDeprecated(removalVersion = "4.0.0", message = "Use 'destination-path' instead", groups = Deprecated.class)
   private MessageDrivenDestination destination;
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystem.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystem.java
@@ -34,6 +34,7 @@ import com.adaptris.core.fs.FsHelper;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.util.Args;
+import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.validation.constraints.ConfigDeprecated;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -159,9 +160,13 @@ public class WriteMetadataToFilesystem extends ServiceImp {
 
   @Override
   protected void initService() throws CoreException {
-    logWarningIfNotNull(destWarning, () -> destWarning = true, destination,
-            "{} uses destination, use 'base-url' instead", LoggingHelper.friendlyName(this));
-    mustHaveEither(baseUrl, destination);
+    try {
+      logWarningIfNotNull(destWarning, () -> destWarning = true, destination,
+              "{} uses destination, use 'base-url' instead", LoggingHelper.friendlyName(this));
+      mustHaveEither(baseUrl, destination);
+    } catch (IllegalArgumentException e) {
+      throw ExceptionHelper.wrapCoreException(e);
+    }
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/config/DeprecatedConfigurationCheckerTest.java
@@ -75,7 +75,7 @@ public class DeprecatedConfigurationCheckerTest {
     // Should be 4 warnings,
     // deprecated class, deprecated member, consumer destination, deprecated service inside a
     // service list.
-    assertEquals(4, report.getWarnings().size());
+    assertEquals(5, report.getWarnings().size());
     assertTrue(violationsAsExpected(report.getWarnings(), "sharedComponents.services[1]",
         "sharedComponents.services[2]",
         "channelList.channels[0].workflowList.workflows[0].serviceCollection.services[0]",

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystemTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/ReadMetadataFromFilesystemTest.java
@@ -16,17 +16,6 @@
 
 package com.adaptris.core.services.metadata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.util.Properties;
-import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredDestination;
 import com.adaptris.core.ConfiguredProduceDestination;
@@ -38,6 +27,19 @@ import com.adaptris.core.fs.FsHelper;
 import com.adaptris.core.services.metadata.ReadMetadataFromFilesystem.InputStyle;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.GuidGenerator;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ReadMetadataFromFilesystemTest extends MetadataServiceExample {
 
@@ -67,6 +69,14 @@ public class ReadMetadataFromFilesystemTest extends MetadataServiceExample {
     }
     assertNotNull(service.getDestination());
     assertEquals("dest", service.getDestination().getDestination(new DefaultMessageFactory().newMessage()));
+  }
+
+  @Test
+  public void testDestinationReplacement() {
+    ReadMetadataFromFilesystem service = new ReadMetadataFromFilesystem();
+    assertNull(service.getDestination());
+    service.setBaseUrl("C://some/path/to/somewhere");
+    assertEquals("C://some/path/to/somewhere", service.getBaseUrl());
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystemTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystemTest.java
@@ -16,20 +16,6 @@
 
 package com.adaptris.core.services.metadata;
 
-import static com.adaptris.core.services.metadata.ReadMetadataFromFilesystemTest.BASE_DIR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredProduceDestination;
 import com.adaptris.core.CoreException;
@@ -43,6 +29,22 @@ import com.adaptris.core.metadata.RegexMetadataFilter;
 import com.adaptris.core.services.metadata.WriteMetadataToFilesystem.OutputStyle;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.GuidGenerator;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static com.adaptris.core.services.metadata.ReadMetadataFromFilesystemTest.BASE_DIR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class WriteMetadataToFilesystemTest extends MetadataServiceExample {
 
@@ -72,6 +74,15 @@ public class WriteMetadataToFilesystemTest extends MetadataServiceExample {
     assertNotNull(service.getDestination());
     assertEquals("dest", service.getDestination().getDestination(new DefaultMessageFactory().newMessage()));
   }
+
+  @Test
+  public void testDestinationReplacement() {
+    WriteMetadataToFilesystem service = new WriteMetadataToFilesystem();
+    assertNull(service.getDestination());
+    service.setBaseUrl("C://some/path/to/somewhere");
+    assertEquals("C://some/path/to/somewhere", service.getBaseUrl());
+  }
+
 
   @Test
   public void testSetMetadataFilter() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystemTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/WriteMetadataToFilesystemTest.java
@@ -50,10 +50,11 @@ public class WriteMetadataToFilesystemTest extends MetadataServiceExample {
   @Test
   public void testDestination() throws Exception {
     WriteMetadataToFilesystem service = new WriteMetadataToFilesystem();
+    assertNull(service.getBaseUrl());
     assertNull(service.getDestination());
     try {
       LifecycleHelper.init(service);
-      fail("Service initialised with a null destination");
+      fail("Service initialised with a null destination and base URL");
     }
     catch (CoreException expected) {
 


### PR DESCRIPTION
## Motivation

It looks as though we missed a deprecation annotation in core's `FileParameter` class that uses a Destination object. Then, when it was removed from the code in 4.0, no one was warned. It also means our transform to help with updating doesn't work very well.

## Modification

Add deprecation annotations to destinations and their (missed) usages.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

There should now be warnings for deprecated destination objects where there wasn't before. This then allows the user to fix the warnings before attempting to use the config in a v4 adapter.

## Testing

Have an adapter configuration that uses destinations, specifically `FileParameter` - in a v3 adapter there should now be deprecation warnings, which highlight what to change for v4 - making said changes should allow the config to work in a v4 adapter.