### PR TITLE
Remove javaee-api.jar dependency

### DIFF
--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   api ("org.apache.commons:commons-pool2:2.11.1")
 
   api ("org.slf4j:slf4j-api:$slf4jVersion")
-  api ("javax:javaee-api:8.0.1")
   api ("javax.servlet:javax.servlet-api:4.0.1")
   api ("org.eclipse.jetty.aggregate:jetty-all:9.4.43.v20210629")
 

--- a/interlok-core-apt/build.gradle
+++ b/interlok-core-apt/build.gradle
@@ -6,7 +6,6 @@ ext {
 
 dependencies {
   api ("com.thoughtworks.xstream:xstream:1.4.18") {  transitive= false }
-  implementation ("javax:javaee-api:8.0.1")
   api ("jakarta.validation:jakarta.validation-api:2.0.2")
   // compile files("${System.getProperty('java.home')}/../lib/tools.jar")
 

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -60,9 +60,14 @@ dependencies {
   api ("org.apache.activemq:activemq-client:$activeMqVersion") {
     exclude group: "org.apache.geronimo.specs", module: "geronimo-jms_1.1_spec"
   }
-  api ("org.apache.geronimo.specs:geronimo-jms_2.0_spec:1.0-alpha-2")
-  api ("org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.2.Final")
+
+  // api ("org.apache.geronimo.specs:geronimo-jms_2.0_spec:1.0-alpha-2")
+  api ("jakarta.jms:jakarta.jms-api:2.0.3")
+  // api ("org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.2.Final")
+  api ("jakarta.persistence:jakarta.persistence-api:2.2.3")
   api ("jakarta.validation:jakarta.validation-api:2.0.2")
+  // Transitive from jetty.
+  // api ("jakarta.transaction:jakarta.transaction-api:1.3.3")
   api ("org.hibernate.validator:hibernate-validator:6.1.6.Final")
   api ("org.glassfish:javax.el:3.0.1-b12")
   api ("commons-io:commons-io:2.11.0")
@@ -90,7 +95,6 @@ dependencies {
   api ("xerces:xercesImpl:2.12.1")
   api ("com.mchange:c3p0:0.9.5.5")
   api ("org.apache-extras.beanshell:bsh:2.0b6")
-  api ("javax:javaee-api:8.0.1")
 
   api ("org.slf4j:slf4j-api:$slf4jVersion")
 
@@ -113,12 +117,12 @@ dependencies {
   testImplementation ("org.mockftpserver:MockFtpServer:2.8.0")
   testImplementation ("org.mockito:mockito-core:$mockitoVersion")
   testImplementation ("org.mockito:mockito-inline:$mockitoVersion")
-  testImplementation("net.sourceforge.jtds:jtds:1.3.1")
-  testImplementation("com.microsoft.sqlserver:mssql-jdbc:$mssqlDriverVersion")
+  testImplementation ("net.sourceforge.jtds:jtds:1.3.1")
+  testImplementation ("com.microsoft.sqlserver:mssql-jdbc:$mssqlDriverVersion")
   testImplementation ("mysql:mysql-connector-java:$mysqlDriverVersion")
 
-  antSql("net.sourceforge.jtds:jtds:1.3.1")
-  antSql("com.microsoft.sqlserver:mssql-jdbc:$mssqlDriverVersion")
+  antSql ("net.sourceforge.jtds:jtds:1.3.1")
+  antSql ("com.microsoft.sqlserver:mssql-jdbc:$mssqlDriverVersion")
   antSql ("mysql:mysql-connector-java:$mysqlDriverVersion")
 
   annotationProcessor project(':interlok-core-apt')


### PR DESCRIPTION
## Motivation

Fixes https://github.com/adaptris/interlok/issues/806

Relates tangentially to 
- https://github.com/adaptris/interlok/issues/782
- https://github.com/adaptris/interlok/pull/788
- https://github.com/adaptris/interlok-jolokia/pull/50

## Modification

Removed explicit dependency on javaee-api.jar
Switch hibernate-jpa -> jakarta persistence.
Switch geronimo-jms -> jakarta jms


## PR Checklist

- [x] been self-reviewed.

## Result

Potential runtime issues that need verification.

## Testing

gradle test works, but we don't  yet know the downstream impact.
