### PR TITLE
JETTY : Initialise handlers in init() method not lazily

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/BasicJettyConsumer.java
@@ -16,29 +16,14 @@
 
 package com.adaptris.core.http.jetty;
 
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageConsumerImp;
-import com.adaptris.core.AdaptrisMessageListener;
-import com.adaptris.core.ClosedState;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.WorkflowImp;
-import com.adaptris.core.WorkflowInterceptor;
-import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
-import com.adaptris.util.TimeInterval;
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotBlank;
+import static com.adaptris.core.CoreConstants.HTTP_METHOD;
+import static com.adaptris.core.http.jetty.JettyConstants.JETTY_QUERY_STRING;
+import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URI;
+import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URL;
+import static com.adaptris.core.http.jetty.JettyConstants.JETTY_USER_ROLES;
+import static com.adaptris.core.http.jetty.JettyConstants.JETTY_USER_ROLE_ATTR;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.join;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -56,15 +41,28 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import static com.adaptris.core.CoreConstants.HTTP_METHOD;
-import static com.adaptris.core.http.jetty.JettyConstants.JETTY_QUERY_STRING;
-import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URI;
-import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URL;
-import static com.adaptris.core.http.jetty.JettyConstants.JETTY_USER_ROLES;
-import static com.adaptris.core.http.jetty.JettyConstants.JETTY_USER_ROLE_ATTR;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.join;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotBlank;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageConsumerImp;
+import com.adaptris.core.ClosedState;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.WorkflowImp;
+import com.adaptris.core.WorkflowInterceptor;
+import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
+import com.adaptris.util.TimeInterval;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Synchronized;
 
 /**
  * This is the abstract class for all implementations that make use of Jetty to receive messages.
@@ -377,6 +375,7 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
     @Override
     public void init() throws ServletException {
       super.init();
+      initialiseHandlers();
       processingTimer = new Timer(true);
     }
 
@@ -397,25 +396,27 @@ public abstract class BasicJettyConsumer extends AdaptrisMessageConsumerImp {
       }
     }
 
-    protected Map<String, HttpOperation> handlers() {
-      if (httpHandlers == null) {
-        httpHandlers = new HashMap<>();
-        HttpOperation defaultHandler = new HttpOperation() {
-          @Override
-          public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
-            processRequest(request, response);
-          }
-        };
-        for (String m : acceptedMethods) {
-          httpHandlers.put(m.toUpperCase().trim(), defaultHandler);
+    @Synchronized
+    private void initialiseHandlers() {
+      httpHandlers = new HashMap<>();
+      HttpOperation defaultHandler = new HttpOperation() {
+        @Override
+        public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+          processRequest(request, response);
         }
-        httpHandlers.put(RequestMethod.OPTIONS.name(), new HttpOperation() {
-          @Override
-          public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
-            addAllow(response).setStatus(HttpURLConnection.HTTP_OK);
-          }
-        });
+      };
+      for (String m : acceptedMethods) {
+        httpHandlers.put(m.toUpperCase().trim(), defaultHandler);
       }
+      httpHandlers.put(RequestMethod.OPTIONS.name(), new HttpOperation() {
+        @Override
+        public void handle(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+          addAllow(response).setStatus(HttpURLConnection.HTTP_OK);
+        }
+      });
+    }
+    
+    protected Map<String, HttpOperation> handlers() {
       return httpHandlers;
     }
 


### PR DESCRIPTION
## Motivation
Lazy initialisation of handler map isn't suitable in high load environments since there is a chance of thread contention vis a vis state.

## Modification

Add new initialiseHandlers() method which removes the if null detection so that the handlers are no longer lazily initialised on first request.

## PR Checklist

- [x] been self-reviewed.

## Result

No configuration change
Bug fix
