### PR TITLE
Add keyboard-interactive shim to SftpClient

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
+++ b/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
@@ -137,7 +137,7 @@ public class SftpClient extends FileTransferClientImp {
    * Constructor assuming the default SSH port.
    *
    * @param addr the remote ssh host.
-   * @deprecated since 4.5.0
+   * @deprecated since 4.4.0
    */
   @Deprecated
   @Generated
@@ -151,7 +151,7 @@ public class SftpClient extends FileTransferClientImp {
    * @param addr the remote ssh host.
    * @param port the ssh port.
    * @param timeoutMillis the timeout in milliseconds
-   * @deprecated since 4.5.0
+   * @deprecated since 4.4.0
    */
   @Deprecated
   @Generated

--- a/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
+++ b/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
@@ -46,6 +46,10 @@ import com.jcraft.jsch.Proxy;
 import com.jcraft.jsch.Session;
 import com.jcraft.jsch.SftpATTRS;
 import com.jcraft.jsch.UserInfo;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Provides SSH File Transfer Protocol implementation of FileTransferClient
@@ -530,35 +534,15 @@ public class SftpClient extends FileTransferClientImp {
     boolean connected();
   }
 
+  @NoArgsConstructor
   private abstract class SessionWrapperImpl implements SessionWrapper {
+    @Getter(AccessLevel.PROTECTED)
+    @Setter(AccessLevel.PROTECTED)
     private transient String username;
+    @Getter(AccessLevel.PROTECTED)
     private transient Session sftpSession;
+    @Getter
     private transient ChannelSftp sftpChannel;
-
-    public SessionWrapperImpl() {
-
-    }
-
-
-    protected String getUsername() {
-      return username;
-    }
-
-    protected void setUsername(String username) {
-      this.username = username;
-    }
-
-
-    private Session getSftpSession() {
-      return sftpSession;
-    }
-
-
-    @Override
-    public ChannelSftp getSftpChannel() {
-      return sftpChannel;
-    }
-
 
     private Session createSession() throws Exception {
       Session s = jsch.getSession(getUsername(), sshHost, sshPort);

--- a/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
+++ b/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.Vector;
 import org.apache.commons.lang3.StringUtils;
 import com.adaptris.filetransfer.FileTransferClient;
@@ -38,6 +39,7 @@ import com.adaptris.interlok.cloud.RemoteFile;
 import com.adaptris.util.FifoMutexLock;
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.ChannelSftp.LsEntry;
 import com.jcraft.jsch.ConfigRepository;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Proxy;
@@ -64,6 +66,12 @@ public class SftpClient extends FileTransferClientImp {
   private static final int DEFAULT_SSH_PORT = 22;
 
   private static final int DEFAULT_TIMEOUT = 1000 * 60 * 5;
+  /**
+   * Whether not extended debugging is emitted; defaults to false unless explicitly set via either the system property
+   * {@code interlok.jsch.debug}.
+   *
+   */
+  public static final transient boolean JSCH_DEBUG = Boolean.getBoolean("interlok.jsch.debug");
 
   private String sshHost;
   private int sshPort;
@@ -71,11 +79,16 @@ public class SftpClient extends FileTransferClientImp {
   private long keepAliveTimeout = 0;
 
   private transient JSch jsch;
-  private transient Session sftpSession;
-  private transient ChannelSftp sftpChannel;
   private transient FifoMutexLock lock;
   private transient ConfigRepository configRepository = ConfigRepository.nullConfig;
   private transient Proxy proxy = null;
+  private transient SessionWrapper sessionWrapper;
+
+  static {
+    if (JSCH_DEBUG) {
+      JSch.setLogger(new SftpClientLogger());
+    }
+  }
 
   private SftpClient(File knownHostsFile, ConfigBuilder configBuilder) throws SftpException {
     try {
@@ -170,7 +183,7 @@ public class SftpClient extends FileTransferClientImp {
    */
   @Override
   public void connect(String user, String password) throws IOException, FileTransferException {
-    connect(user, new StandardUserInfo(password));
+    sessionWrapper = tryConnect(new PasswordWrapper(user,  password), new KeyboardInteractiveWrapper(user, password));
   }
 
   /**
@@ -182,41 +195,24 @@ public class SftpClient extends FileTransferClientImp {
    * @throws FileTransferException if an FTP specific exception occurs
    */
   public void connect(String user, final byte[] prvKey, byte[] prvKeyPwd) throws FileTransferException {
-    try {
-      acquireLock();
-      jsch.addIdentity(user, prvKey, null, prvKeyPwd);
-      connect(user, new StandardUserInfo(null));
-    }
-    catch (Exception e) {
-      throw SftpException.wrapException(e);
-    }
-    finally {
-      releaseLock();
-    }
-
+    sessionWrapper = tryConnect(new PublickeyWrapper(user,  prvKey,  prvKeyPwd));
   }
 
-  private void connect(String user, UserInfo ui) throws FileTransferException {
+  private SessionWrapper tryConnect(SessionWrapper... wrappers) throws SftpException {
+    Exception lastAuthFailure = new Exception("Failed to authenticate via any permitted method");
     try {
-      sftpSession = jsch.getSession(user, sshHost, sshPort);
-      if (configRepository.getConfig(sshHost) == null
-          || StringUtils.isBlank(configRepository.getConfig(sshHost).getValue(SSH_PREFERRED_AUTHENTICATIONS))) {
-        // No config, let's killoff #995
-        sftpSession.setConfig(SSH_PREFERRED_AUTHENTICATIONS, NO_KERBEROS_AUTH);
+      for (SessionWrapper wrapper : wrappers) {
+        try {
+          wrapper.connect();
+          return wrapper;
+        } catch (Exception e) {
+          lastAuthFailure = e;
+        }
       }
-      sftpSession.setProxy(proxy);
-      sftpSession.setDaemonThread(true);
-      sftpSession.setUserInfo(ui);
-      sftpSession.connect(timeout);
-      sftpSession.setServerAliveInterval(Long.valueOf(getKeepAliveTimeout()).intValue());
-      log("OPEN {}:{}", sshHost, sshPort);
-      Channel c = sftpSession.openChannel("sftp");
-      c.connect(timeout);
-      sftpChannel = (ChannelSftp) c;
+    } finally {
+      releaseLock();
     }
-    catch (Exception e) {
-      throw SftpException.wrapException(e);
-    }
+    throw SftpException.wrapException(lastAuthFailure);
   }
 
   @Override
@@ -271,9 +267,8 @@ public class SftpClient extends FileTransferClientImp {
       acquireLock();
       String path = defaultIfBlank(dirname, CURRENT_DIR);
       log("DIR {}", path);
-      Vector v = sftpChannel.ls(path);
-      for (Object o : v) {
-        ChannelSftp.LsEntry entry = (ChannelSftp.LsEntry) o;
+      Vector<LsEntry> v = sessionWrapper.getSftpChannel().ls(path);
+      for (LsEntry entry : v) {
         if (!(entry.getFilename().equals(CURRENT_DIR) || entry.getFilename().equals(PARENT_DIR))) {
           result.add(entry);
         }
@@ -295,13 +290,13 @@ public class SftpClient extends FileTransferClientImp {
     try {
       acquireLock();
       log("BYE");
-      sftpChannel.disconnect();
-      sftpSession.disconnect();
+      sessionWrapper.close();
     }
     catch (NullPointerException e) {
 
     }
     finally {
+      sessionWrapper = null;
       releaseLock();
     }
   }
@@ -315,7 +310,7 @@ public class SftpClient extends FileTransferClientImp {
     try {
       checkConnected();
       log("PUT {}", remoteFile);
-      sftpChannel.put(srcStream, remoteFile, append ? ChannelSftp.APPEND : ChannelSftp.OVERWRITE);
+      sessionWrapper.getSftpChannel().put(srcStream, remoteFile, append ? ChannelSftp.APPEND : ChannelSftp.OVERWRITE);
     }
     catch (Exception e) {
       throw SftpException.wrapException("Could not write remote file [" + remoteFile + "]", e);
@@ -333,7 +328,7 @@ public class SftpClient extends FileTransferClientImp {
     try {
       acquireLock();
       log("GET {}", remoteFile);
-      sftpChannel.get(remoteFile, destStream);
+      sessionWrapper.getSftpChannel().get(remoteFile, destStream);
     }
     catch (Exception e) {
       throw SftpException.wrapException("Could not retrieve remote file [" + remoteFile + "]", e);
@@ -365,7 +360,7 @@ public class SftpClient extends FileTransferClientImp {
     try {
       acquireLock();
       log("RM {}", remoteFile);
-      sftpChannel.rm(remoteFile);
+      sessionWrapper.getSftpChannel().rm(remoteFile);
     }
     catch (Exception e) {
       throw SftpException.wrapException("Could not delete remote file [" + remoteFile + "]", e);
@@ -381,7 +376,7 @@ public class SftpClient extends FileTransferClientImp {
     try {
       acquireLock();
       log("REN {} to {}", from, to);
-      sftpChannel.rename(from, to);
+      sessionWrapper.getSftpChannel().rename(from, to);
     }
     catch (Exception e) {
       throw SftpException.wrapException("Could not rename file [" + from + "] to [" + to + "]", e);
@@ -397,7 +392,7 @@ public class SftpClient extends FileTransferClientImp {
     try {
       acquireLock();
       log("RMDIR {}", dir);
-      sftpChannel.rmdir(dir);
+      sessionWrapper.getSftpChannel().rmdir(dir);
     }
     catch (Exception e) {
       throw SftpException.wrapException("Could not remove directory [" + dir + "]", e);
@@ -413,7 +408,7 @@ public class SftpClient extends FileTransferClientImp {
     try {
       acquireLock();
       log("MKDIR {}", dir);
-      sftpChannel.mkdir(dir);
+      sessionWrapper.getSftpChannel().mkdir(dir);
     }
     catch (Exception e) {
       throw SftpException.wrapException("Could not create directory [" + dir + "]", e);
@@ -429,7 +424,7 @@ public class SftpClient extends FileTransferClientImp {
     try {
       acquireLock();
       log("CD {}", dir);
-      sftpChannel.cd(dir);
+      sessionWrapper.getSftpChannel().cd(dir);
     }
     catch (Exception e) {
       throw SftpException.wrapException("Could not chdir to [" + dir + "]", e);
@@ -445,7 +440,7 @@ public class SftpClient extends FileTransferClientImp {
     try {
       acquireLock();
       log("STAT {}", path);
-      SftpATTRS attrs = sftpChannel.stat(path);
+      SftpATTRS attrs = sessionWrapper.getSftpChannel().stat(path);
       return attrs.isDir();
     } catch (Exception e) {
       throw SftpException.wrapException("Could not stat [" + path + "]", e);
@@ -470,10 +465,11 @@ public class SftpClient extends FileTransferClientImp {
   @Override
   public long lastModified(String remoteFile) throws IOException, FileTransferException {
     long mtime;
+    checkConnected();
     try {
       acquireLock();
       log("STAT {}", remoteFile);
-      SftpATTRS attr = sftpChannel.stat(remoteFile);
+      SftpATTRS attr = sessionWrapper.getSftpChannel().stat(remoteFile);
       mtime = (long) attr.getMTime() * 1000;
     }
     catch (Exception e) {
@@ -488,6 +484,183 @@ public class SftpClient extends FileTransferClientImp {
   private void checkConnected() throws SftpException {
     if (!isConnected()) {
       throw new SftpException("Not currently connected, use connect()");
+    }
+  }
+
+  @Override
+  public long getKeepAliveTimeout() throws FtpException {
+    return keepAliveTimeout;
+  }
+
+  @Override
+  public void setKeepAliveTimeout(long seconds) throws FtpException {
+    if (seconds > 0) {
+      keepAliveTimeout = seconds * 1000;
+    }
+  }
+
+  public SftpClient withKeepAliveTimeout(long seconds) throws FtpException {
+    setKeepAliveTimeout(seconds);
+    return this;
+  }
+
+  public SftpClient withAdditionalDebug(boolean onoff) {
+    setAdditionalDebug(onoff);
+    return this;
+  }
+
+  @Override
+  public boolean isConnected() {
+    return Optional.ofNullable(sessionWrapper).map((s) -> s.connected()).orElse(false);
+  }
+
+  public void setKnownHosts(String knownHostsFilename) throws SftpException {
+    try {
+      jsch.setKnownHosts(knownHostsFilename);
+    }
+    catch (Exception e) {
+      throw SftpException.wrapException(e);
+    }
+  }
+
+  private interface SessionWrapper {
+    void connect() throws Exception;
+    void close();
+    ChannelSftp getSftpChannel();
+    boolean connected();
+  }
+
+  private abstract class SessionWrapperImpl implements SessionWrapper {
+    private transient String username;
+    private transient Session sftpSession;
+    private transient ChannelSftp sftpChannel;
+
+    public SessionWrapperImpl() {
+
+    }
+
+
+    protected String getUsername() {
+      return username;
+    }
+
+    protected void setUsername(String username) {
+      this.username = username;
+    }
+
+
+    private Session getSftpSession() {
+      return sftpSession;
+    }
+
+
+    @Override
+    public ChannelSftp getSftpChannel() {
+      return sftpChannel;
+    }
+
+
+    private Session createSession() throws Exception {
+      Session s = jsch.getSession(getUsername(), sshHost, sshPort);
+      if (configRepository.getConfig(sshHost) == null
+          || StringUtils.isBlank(configRepository.getConfig(sshHost).getValue(SSH_PREFERRED_AUTHENTICATIONS))) {
+        // No config, let's killoff #995
+        s.setConfig(SSH_PREFERRED_AUTHENTICATIONS, NO_KERBEROS_AUTH);
+      }
+      s.setProxy(proxy);
+      s.setDaemonThread(true);
+      return s;
+    }
+
+    @Override
+    public void connect() throws Exception {
+      sftpSession = configureAuth(createSession());
+      sftpSession.connect(timeout);
+      sftpSession.setServerAliveInterval(Long.valueOf(getKeepAliveTimeout()).intValue());
+      log("OPEN {}:{}", sshHost, sshPort);
+      Channel c = sftpSession.openChannel("sftp");
+      c.connect(timeout);
+      sftpChannel = (ChannelSftp) c;
+    }
+
+    protected abstract Session configureAuth(Session s) throws Exception;
+
+    @Override
+    public void close() {
+      Optional.ofNullable(getSftpChannel()).ifPresent((c) -> c.disconnect());
+      Optional.ofNullable(getSftpSession()).ifPresent((c) -> c.disconnect());
+    }
+
+    @Override
+    public boolean connected() {
+      return Optional.ofNullable(sftpChannel).map((s) -> s.isConnected()).orElse(false);
+    }
+  }
+
+  // the password part of 'PreferredAuthentications=publickey,keyboard-interactive,password'
+  // "PasswordAuthentication" is a built-in method of using a password.
+  // RFC-4252
+  private class PasswordWrapper extends SessionWrapperImpl {
+
+    private transient UserInfo userInfo;
+
+    PasswordWrapper(String user, String pw) {
+      userInfo = new StandardUserInfo(pw);
+      setUsername(user);
+    }
+
+    @Override
+    protected Session configureAuth(Session s) throws Exception {
+      s.setUserInfo(userInfo);
+      return s;
+    }
+  }
+
+  // the keyboard-interactive part of 'PreferredAuthentications=publickey,keyboard-interactive,password'
+  // "ChallengeResponseAuthentication" is a method to tunnel the authentication process.
+  // It just so happens that if you don't do extra configuration ChallengeResponseAuth just acts
+  // like PasswordAuthentation (because of PAM configuration on Linux)
+  // This is a bit of a shim in the sense that we wouldn't normally expect it to work if
+  // the server is *configured properly*...
+  // RFC-4252
+  private class KeyboardInteractiveWrapper extends SessionWrapperImpl {
+
+    private transient String password;
+
+    KeyboardInteractiveWrapper(String user, String pw) {
+      password = pw;
+      setUsername(user);
+    }
+
+    @Override
+    protected Session configureAuth(Session s) throws Exception {
+      // Check com.jcraft.jsch.UserAuthKeyboardInteractive for more details.
+      // We need to bypass this check
+      // if(userinfo!=null && !(userinfo instanceof UIKeyboardInteractive)){
+      // return false;
+      // } which allows us to proceed to the next step.
+      // we won't use UIKeyboardInteractive since we aren't truly supporting CRA
+      s.setPassword(password);
+      return s;
+    }
+  }
+
+  // the publickey part of 'PreferredAuthentications=publickey,keyboard-interactive,password'
+  private class PublickeyWrapper extends SessionWrapperImpl {
+
+    private transient byte[] privateKey;
+    private transient byte[] privateKeyPassword;
+
+    PublickeyWrapper(String user, byte[] prvKey, byte[] prvKeyPwd) {
+      setUsername(user);
+      privateKey = prvKey;
+      privateKeyPassword = prvKeyPwd;
+    }
+
+    @Override
+    protected Session configureAuth(Session s) throws Exception {
+      jsch.addIdentity(getUsername(), privateKey, null, privateKeyPassword);
+      return s;
     }
   }
 
@@ -530,43 +703,4 @@ public class SftpClient extends FileTransferClientImp {
     }
   }
 
-  @Override
-  public long getKeepAliveTimeout() throws FtpException {
-    return keepAliveTimeout;
-  }
-
-  @Override
-  public void setKeepAliveTimeout(long seconds) throws FtpException {
-    if (seconds > 0) {
-      keepAliveTimeout = seconds * 1000;
-    }
-  }
-
-  public SftpClient withKeepAliveTimeout(long seconds) throws FtpException {
-    setKeepAliveTimeout(seconds);
-    return this;
-  }
-
-  public SftpClient withAdditionalDebug(boolean onoff) {
-    setAdditionalDebug(onoff);
-    return this;
-  }
-
-  @Override
-  public boolean isConnected() {
-    boolean result = false;
-    if (sftpChannel != null) {
-      result = sftpChannel.isConnected();
-    }
-    return result;
-  }
-
-  public void setKnownHosts(String knownHostsFilename) throws SftpException {
-    try {
-      jsch.setKnownHosts(knownHostsFilename);
-    }
-    catch (Exception e) {
-      throw SftpException.wrapException(e);
-    }
-  }
 }

--- a/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
+++ b/interlok-core/src/main/java/com/adaptris/sftp/SftpClient.java
@@ -47,6 +47,7 @@ import com.jcraft.jsch.Session;
 import com.jcraft.jsch.SftpATTRS;
 import com.jcraft.jsch.UserInfo;
 import lombok.AccessLevel;
+import lombok.Generated;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -99,7 +100,7 @@ public class SftpClient extends FileTransferClientImp {
       jsch = new JSch();
       lock = new FifoMutexLock();
       if (knownHostsFile != null) {
-        jsch.setKnownHosts(knownHostsFile.getAbsolutePath());
+        setKnownHosts(knownHostsFile.getAbsolutePath());
       }
       if (configBuilder != null) {
         configRepository = configBuilder.buildConfigRepository();
@@ -116,15 +117,30 @@ public class SftpClient extends FileTransferClientImp {
    *
    * @param host the remote ssh host.
    */
+  @Generated
   public SftpClient(String host) throws SftpException {
-    this(host, DEFAULT_SSH_PORT, DEFAULT_TIMEOUT, null, null);
+    this(host, DEFAULT_SSH_PORT);
+  }
+
+  /**
+   * Constructor assuming the default SSH port.
+   *
+   * @param host the remote ssh host.
+   * @param port the ssh port.
+   */
+  @Generated
+  public SftpClient(String host, int port) throws SftpException {
+    this(host, port, DEFAULT_TIMEOUT);
   }
 
   /**
    * Constructor assuming the default SSH port.
    *
    * @param addr the remote ssh host.
+   * @deprecated since 4.5.0
    */
+  @Deprecated
+  @Generated
   public SftpClient(InetAddress addr) throws SftpException {
     this(addr.getHostAddress(), DEFAULT_SSH_PORT, DEFAULT_TIMEOUT, null, null);
   }
@@ -134,10 +150,13 @@ public class SftpClient extends FileTransferClientImp {
    *
    * @param addr the remote ssh host.
    * @param port the ssh port.
-   * @param timeout the timeout;
+   * @param timeoutMillis the timeout in milliseconds
+   * @deprecated since 4.5.0
    */
-  public SftpClient(InetAddress addr, int port, int timeout) throws SftpException {
-    this(addr.getHostAddress(), port, timeout, null, null);
+  @Deprecated
+  @Generated
+  public SftpClient(InetAddress addr, int port, int timeoutMillis) throws SftpException {
+    this(addr.getHostAddress(), port, timeoutMillis, null, null);
   }
 
   /**
@@ -145,10 +164,11 @@ public class SftpClient extends FileTransferClientImp {
    *
    * @param host the host
    * @param port the port
-   * @param timeout the timeout;
+   * @param timeoutMillis the timeout in milliseconds
    */
-  public SftpClient(String host, int port, int timeout) throws SftpException {
-    this(host, port, timeout, null, null);
+  @Generated
+  public SftpClient(String host, int port, int timeoutMillis) throws SftpException {
+    this(host, port, timeoutMillis, null, null);
   }
 
   /**
@@ -156,14 +176,15 @@ public class SftpClient extends FileTransferClientImp {
    *
    * @param host the host
    * @param port the port
-   * @param timeout the timeout;
+   * @param timeoutMillis the timeout in milliseconds
+   * @param knownHostsFile the {@code 'known_hosts'} which can be null
    * @param configBuilder any required behaviour for this client;
    */
-  public SftpClient(String host, int port, int timeout, File knownHostsFile, ConfigBuilder configBuilder) throws SftpException {
+  public SftpClient(String host, int port, int timeoutMillis, File knownHostsFile, ConfigBuilder configBuilder) throws SftpException {
     this(knownHostsFile, configBuilder);
     sshHost = host;
     sshPort = port;
-    this.timeout = timeout;
+    this.timeout = timeoutMillis;
   }
 
   private void acquireLock() {

--- a/interlok-core/src/main/java/com/adaptris/sftp/SftpClientLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/sftp/SftpClientLogger.java
@@ -3,14 +3,14 @@ package com.adaptris.sftp;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.MarkerFactory;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-
+@Slf4j
+@NoArgsConstructor(access=AccessLevel.PACKAGE)
 public class SftpClientLogger implements com.jcraft.jsch.Logger {
-
-  private static Logger log = LoggerFactory.getLogger(SftpClientLogger.class);
 
   private static enum Slf4jLoggingProxy {
     FATAL {

--- a/interlok-core/src/main/java/com/adaptris/sftp/SftpClientLogger.java
+++ b/interlok-core/src/main/java/com/adaptris/sftp/SftpClientLogger.java
@@ -1,0 +1,95 @@
+package com.adaptris.sftp;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
+
+
+public class SftpClientLogger implements com.jcraft.jsch.Logger {
+
+  private static Logger log = LoggerFactory.getLogger(SftpClientLogger.class);
+
+  private static enum Slf4jLoggingProxy {
+    FATAL {
+      @Override
+      boolean isEnabled() {
+        return true;
+      }
+      @Override
+      void log(String s) {
+        log.error(MarkerFactory.getMarker("FATAL"), s);
+      }
+    },
+    ERROR {
+      @Override
+      boolean isEnabled() {
+        return log.isErrorEnabled();
+      }
+      @Override
+      void log(String s) {
+        log.error(s);
+      }
+    },
+    WARNING {
+      @Override
+      boolean isEnabled() {
+        return log.isWarnEnabled();
+      }
+      @Override
+      void log(String s) {
+        log.warn(s);
+      }
+    },
+    INFO {
+      @Override
+      boolean isEnabled() {
+        return log.isInfoEnabled();
+      }
+      @Override
+      void log(String s) {
+        log.info(s);
+      }
+    },
+    DEBUG {
+      @Override
+      boolean isEnabled() {
+        return log.isDebugEnabled();
+      }
+      @Override
+      void log(String s) {
+        log.debug(s);
+      }
+    };
+
+    abstract void log(String s);
+    abstract boolean isEnabled();
+  }
+
+  private static final Map<Integer,Slf4jLoggingProxy> loggers;
+
+
+  static {
+    Map<Integer,Slf4jLoggingProxy> m = new HashMap<>(5);
+    m.put(com.jcraft.jsch.Logger.FATAL, Slf4jLoggingProxy.FATAL);
+    m.put(com.jcraft.jsch.Logger.ERROR, Slf4jLoggingProxy.ERROR);
+    m.put(com.jcraft.jsch.Logger.WARN, Slf4jLoggingProxy.WARNING);
+    m.put(com.jcraft.jsch.Logger.INFO, Slf4jLoggingProxy.INFO);
+    m.put(com.jcraft.jsch.Logger.DEBUG, Slf4jLoggingProxy.DEBUG);
+    loggers = Collections.unmodifiableMap(m);
+  }
+
+
+  @Override
+  public boolean isEnabled(int level) {
+    return loggers.get(level).isEnabled();
+  }
+
+  @Override
+  public void log(int level, String message) {
+    loggers.get(level).log(message);
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpConnectionCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpConnectionCase.java
@@ -43,6 +43,7 @@ public abstract class FtpConnectionCase extends com.adaptris.interlok.junit.scaf
   @Test
   public void testDefaultControlPort() throws Exception {
     FileTransferConnection connection = createConnection();
+    connection.setDefaultControlPort(null);
     assertNull(connection.getDefaultControlPort());
     assertDefaultControlPort(connection.defaultControlPort());
 

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpRecursiveConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpRecursiveConsumerTest.java
@@ -318,7 +318,7 @@ public class FtpRecursiveConsumerTest extends FtpConsumerCase {
     int count = 1;
     EmbeddedFtpServer helper = new EmbeddedFtpServer();
     MockMessageListener listener = new MockMessageListener(100);
-    FakeFtpServer server = helper.createAndStart(helper.createFilesystem(count));
+    FakeFtpServer server = helper.createAndStart(createFilesystem(helper, count));
     StandaloneConsumer sc = null;
     try {
       FtpRecursiveConsumer ftpConsumer = createForTests(listener);

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/SftpExampleHelper.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/SftpExampleHelper.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,9 +21,7 @@ import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.commons.lang3.BooleanUtils;
-
 import com.adaptris.core.FixedIntervalPoller;
 import com.adaptris.core.GaussianIntervalPoller;
 import com.adaptris.core.Poller;
@@ -38,6 +36,7 @@ import com.adaptris.util.KeyValuePair;
 
 public class SftpExampleHelper {
   public static final String CFG_HOST = "SftpConsumerTest.host";
+  public static final String CFG_PORT = "SftpConsumerTest.port";
   public static final String CFG_USER = "SftpConsumerTest.username";
   public static final String CFG_PASSWORD = "SftpConsumerTest.password";
   public static final String CFG_REMOTE_DIR = "SftpConsumerTest.remotedir";

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/StandardSftpConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/StandardSftpConnectionTest.java
@@ -34,7 +34,9 @@ import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import com.adaptris.core.stubs.ExternalResourcesHelper;
 import com.adaptris.filetransfer.FileTransferClient;
 import com.adaptris.filetransfer.FileTransferException;
 import com.adaptris.security.exc.PasswordException;
@@ -46,11 +48,18 @@ public class StandardSftpConnectionTest extends FtpConnectionCase {
 
   private static FileCleaningTracker cleaner = new FileCleaningTracker();
   private Object fileTracker = new Object();
-
+  private static boolean serverAvailable = false;
 
   @Override
   protected boolean areTestsEnabled() {
-    return Boolean.parseBoolean(PROPERTIES.getProperty("sftp.tests.enabled", "false"));
+    return Boolean.parseBoolean(PROPERTIES.getProperty("sftp.tests.enabled", "false")) && serverAvailable;
+  }
+
+  @BeforeClass
+  public static void beforeAnyTests() {
+    String host = PROPERTIES.getProperty(CFG_HOST);
+    int port = Integer.parseInt(PROPERTIES.getProperty(CFG_PORT, "22"));
+    serverAvailable = ExternalResourcesHelper.isExternalServerAvailable(host, port);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/StandardSftpConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/StandardSftpConnectionTest.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
@@ -16,6 +16,7 @@ package com.adaptris.core.ftp;
 import static com.adaptris.core.ftp.SftpExampleHelper.CFG_HOST;
 import static com.adaptris.core.ftp.SftpExampleHelper.CFG_KNOWN_HOSTS_FILE;
 import static com.adaptris.core.ftp.SftpExampleHelper.CFG_PASSWORD;
+import static com.adaptris.core.ftp.SftpExampleHelper.CFG_PORT;
 import static com.adaptris.core.ftp.SftpExampleHelper.CFG_PRIVATE_KEY_FILE;
 import static com.adaptris.core.ftp.SftpExampleHelper.CFG_PRIVATE_KEY_PW;
 import static com.adaptris.core.ftp.SftpExampleHelper.CFG_REMOTE_DIR;
@@ -271,19 +272,23 @@ public class StandardSftpConnectionTest extends FtpConnectionCase {
       c.setAuthentication(
           new SftpKeyAuthentication(PROPERTIES.getProperty(CFG_PRIVATE_KEY_FILE), PROPERTIES.getProperty(CFG_PRIVATE_KEY_PW)));
     }
+    c.setDefaultControlPort(Integer.parseInt(PROPERTIES.getProperty(CFG_PORT, "22")));
     c.setAdditionalDebug(true);
     return c;
   }
 
   @Override
   protected String getDestinationStringWithOverride() throws Exception {
-    return "sftp://" + PROPERTIES.getProperty(CFG_USER) + "@" + PROPERTIES.getProperty(CFG_HOST) + "/"
+    return "sftp://" + PROPERTIES.getProperty(CFG_USER) + "@" + PROPERTIES.getProperty(CFG_HOST)
+        + ":" + PROPERTIES.getProperty(CFG_PORT, "22") + "/"
         + PROPERTIES.getProperty(CFG_REMOTE_DIR);
   }
 
   protected String getDestinationStringWithOverridePassword() throws Exception {
-    return "sftp://" + PROPERTIES.getProperty(CFG_USER) + ":" + Password.decode(PROPERTIES.getProperty(CFG_PASSWORD)) + "@"
-        + PROPERTIES.getProperty(CFG_HOST) + "/" + PROPERTIES.getProperty(CFG_REMOTE_DIR);
+    return "sftp://" + PROPERTIES.getProperty(CFG_USER) + ":"
+        + Password.decode(PROPERTIES.getProperty(CFG_PASSWORD)) + "@"
+        + PROPERTIES.getProperty(CFG_HOST) + ":" + PROPERTIES.getProperty(CFG_PORT, "22") + "/"
+        + PROPERTIES.getProperty(CFG_REMOTE_DIR);
   }
 
 

--- a/interlok-core/src/test/java/com/adaptris/filetransfer/FtpCase.java
+++ b/interlok-core/src/test/java/com/adaptris/filetransfer/FtpCase.java
@@ -30,11 +30,9 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.stubs.TempFileUtils;
 import com.adaptris.util.GuidGenerator;
 
-@SuppressWarnings("deprecation")
 public abstract class FtpCase extends com.adaptris.interlok.junit.scaffolding.BaseCase {
   protected static final String FILE_TEXT = "The quick brown fox jumps over the lazy dog";
 
@@ -400,7 +398,7 @@ public abstract class FtpCase extends com.adaptris.interlok.junit.scaffolding.Ba
 
   protected void initialiseConfig() throws IOException {
     if (config == null) {
-      config = BaseCase.PROPERTIES;
+      config = PROPERTIES;
     }
     if (config == null)
       throw new IOException("No Configuration available");

--- a/interlok-core/src/test/java/com/adaptris/sftp/SftpClientLoggerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/sftp/SftpClientLoggerTest.java
@@ -1,0 +1,31 @@
+package com.adaptris.sftp;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+public class SftpClientLoggerTest  {
+
+  @Test
+  public void testEnabled() {
+    org.slf4j.Logger logger = LoggerFactory.getLogger(SftpClientLogger.class);
+    SftpClientLogger clientLogger = new SftpClientLogger();
+    assertEquals(logger.isDebugEnabled(), clientLogger.isEnabled(com.jcraft.jsch.Logger.DEBUG));
+    assertEquals(logger.isInfoEnabled(), clientLogger.isEnabled(com.jcraft.jsch.Logger.INFO));
+    assertEquals(logger.isWarnEnabled(), clientLogger.isEnabled(com.jcraft.jsch.Logger.WARN));
+    assertEquals(logger.isErrorEnabled(), clientLogger.isEnabled(com.jcraft.jsch.Logger.ERROR));
+    assertEquals(true, clientLogger.isEnabled(com.jcraft.jsch.Logger.FATAL));
+  }
+
+  @Test
+  public void testLogging() {
+    org.slf4j.Logger logger = LoggerFactory.getLogger(SftpClientLogger.class);
+    SftpClientLogger clientLogger = new SftpClientLogger();
+    clientLogger.log(com.jcraft.jsch.Logger.DEBUG, "hello");
+    clientLogger.log(com.jcraft.jsch.Logger.INFO, "hello");
+    clientLogger.log(com.jcraft.jsch.Logger.WARN, "hello");
+    clientLogger.log(com.jcraft.jsch.Logger.ERROR, "hello");
+    clientLogger.log(com.jcraft.jsch.Logger.FATAL, "hello");
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/sftp/test/TestSftp.java
+++ b/interlok-core/src/test/java/com/adaptris/sftp/test/TestSftp.java
@@ -22,7 +22,9 @@ import java.util.Random;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.oro.io.GlobFilenameFilter;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import com.adaptris.core.stubs.ExternalResourcesHelper;
 import com.adaptris.filetransfer.FileTransferClient;
 import com.adaptris.filetransfer.FtpCase;
 import com.adaptris.security.password.Password;
@@ -39,6 +41,15 @@ public class TestSftp extends FtpCase {
   private static final String SFTP_PORT = "sftp.port";
   private static final String SFTP_PASSWORD = "sftp.password";
   private static final String SFTP_USERNAME = "sftp.username";
+
+  private static boolean serverAvailable = false;
+
+  @BeforeClass
+  public static void beforeAnyTests() {
+    String host = PROPERTIES.getProperty(SFTP_HOST);
+    int port = Integer.valueOf(PROPERTIES.getProperty(SFTP_PORT, "22"));
+    serverAvailable = ExternalResourcesHelper.isExternalServerAvailable(host, port);
+  }
 
 
   @Test
@@ -110,7 +121,7 @@ public class TestSftp extends FtpCase {
   protected boolean areTestsEnabled() {
     String sftpTests = config.getProperty("sftp.tests.enabled");
     if (!StringUtils.isEmpty(sftpTests)) {
-      return Boolean.parseBoolean(sftpTests);
+      return Boolean.parseBoolean(sftpTests) && serverAvailable;
     }
     return super.areTestsEnabled();
   }

--- a/interlok-core/src/test/java/com/adaptris/sftp/test/TestSftp.java
+++ b/interlok-core/src/test/java/com/adaptris/sftp/test/TestSftp.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
@@ -36,6 +36,7 @@ public class TestSftp extends FtpCase {
   private static final String SFTP_GET_FILENAME = "sftp.get.filename";
   private static final String SFTP_GET_REMOTEDIR = "sftp.get.remotedir";
   private static final String SFTP_HOST = "sftp.host";
+  private static final String SFTP_PORT = "sftp.port";
   private static final String SFTP_PASSWORD = "sftp.password";
   private static final String SFTP_USERNAME = "sftp.username";
 
@@ -99,7 +100,7 @@ public class TestSftp extends FtpCase {
 
   @Override
   protected FileTransferClient connectClientImpl() throws Exception {
-    SftpClient client = new SftpClient(config.getProperty(SFTP_HOST));
+    SftpClient client = new SftpClient(config.getProperty(SFTP_HOST), Integer.valueOf(config.getProperty(SFTP_PORT, "22")));
     client.setAdditionalDebug(true);
     client.connect(config.getProperty(SFTP_USERNAME), Password.decode(config.getProperty(SFTP_PASSWORD)));
     return client;

--- a/interlok-core/src/test/resources/default-test.properties.template
+++ b/interlok-core/src/test/resources/default-test.properties.template
@@ -8,6 +8,8 @@ default.ftp.host=
 default.ftp.user=
 default.ftp.password=
 
+default.sftp.port=22
+
 # For running JDBC Stored procedure tests.
 # Enable the tests if you have it all setup, otherwise let's not bother.
 default.jdbc.storedproc.tests.enabled=false

--- a/interlok-core/src/test/resources/unit-tests.properties.template
+++ b/interlok-core/src/test/resources/unit-tests.properties.template
@@ -175,6 +175,7 @@ junit.FtpConsumerTest.remotedir=/junit
 junit.FtpConsumerTest.password=${default.ftp.password}
 
 junit.SftpConsumerTest.host=${default.ftp.host}
+junit.SftpConsumerTest.port=${default.sftp.port}
 junit.SftpConsumerTest.password=${default.ftp.password}
 junit.SftpConsumerTest.username=${default.ftp.user}
 junit.SftpConsumerTest.homedir=/home/${default.ftp.user}
@@ -204,6 +205,7 @@ junit.ftp.get.filter=*.txt
 junit.ftp.password=${default.ftp.password}
 
 junit.sftp.host=${default.ftp.host}
+junit.sftp.port=${default.sftp.port}
 junit.sftp.username=${default.ftp.user}
 junit.sftp.password=${default.ftp.password}
 junit.sftp.get.remotedir=/home/${junit.sftp.username}/junit/get


### PR DESCRIPTION
## Motivation

Resolves #832 

If `ChallengeResponseAuthentication` is set to true in OpenSSH+Linux _and_ PAM is not reconfigured, then it is functionally equivalent to _password_ authentication (since PAM will just check the unix users password). So, realistically this is not true keyboard-interactive support since there's no way to programatically "ask the user" to respond to the server's challenge. However, it will fix the situation where OpenSSH is configured something like this, but with no additional PAM changes.

```
PasswordAuthentication no
KbdInteractiveAuthentication yes
ChallengeResponseAuthentication yes
```


## Modification

Add a `SessionWrapper` to SftpClient which and private implementations that handle the publickey, keyboard-interactive, and password portions of SSH Authentication.

Add a `SftpClientLogger` class that is used to enable debug logging in JSch in `interlok.jsch.debug` is set to true.

## PR Checklist

- [x] been self-reviewed.
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance

## Result

- There's no UI change for the user
- Behavioural change to support keyboard-interactive as a possible auth mechanism.

## Testing

### Unit Tests

By default the unit tests that are specific to SFTP are skipped. They're actually relatively hard to setup as well since they expect a certainly file structure / file availablity. If have previously had it setup, then _TestSFTP_ still works but those tests should probably be rewritten to use mockito to stub out JSch where possible.

However, if you can run the tests then you end up with this level of coverage on the tests that check for `sftp.tests.enabled`

![image](https://user-images.githubusercontent.com/8480608/143482673-d059d28c-dd69-4b8f-b76c-f8ddc21e1574.png)

![image](https://user-images.githubusercontent.com/8480608/143482758-27d95ccf-fd3a-4575-9b0f-f8c35ce723de.png)

### Runtime Testing

- Use https://github.com/quotidian-ennui/docker-sshd + docker-compose to start a SSH server. 
- Make a note of the password because you'll need that; the user is `user`
- `java -Dinterlok.jsch.debug=true -jar lib/interlok-boot.jar`
- The channel can be something like this (turn off _StrictHostKeyChecking_ since the server keys are likely to constantly change)

```xml
    <channel>
      <consume-connection class="standard-sftp-connection">
        <default-user-name>user</default-user-name>
        <default-control-port>2222</default-control-port>
        <authentication class="sftp-password-authentication">
          <default-password>7774620a48</default-password>
        </authentication>
        <configuration class="sftp-inline-config">
          <config>
            <key-value-pair>
              <key>StrictHostKeyChecking</key>
              <value>no</value>
            </key-value-pair>
          </config>
        </configuration>
      </consume-connection>
      <workflow-list>
        <standard-workflow>
          <consumer class="ftp-consumer">
            <poller class="random-interval-poller"/>
            <ftp-endpoint>localhost</ftp-endpoint>
            <work-directory>/home/user/</work-directory>
          </consumer>
          <unique-id>sftp-consumer</unique-id>
        </standard-workflow>
      </workflow-list>
      <auto-start>false</auto-start>
      <unique-id>default-channel</unique-id>
    </channel>
```

And you will see that looks something like (SftpClientLogger logging because of `interlok.jsch.debug`)

```
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] SSH_MSG_NEWKEYS sent
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] SSH_MSG_NEWKEYS received
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] SSH_MSG_SERVICE_REQUEST sent
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] SSH_MSG_EXT_INFO received
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] server-sig-algs=<rsa-sha2-256,rsa-sha2-512>
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] OpenSSH 7.4 detected: adding rsa-sha2-256 & rsa-sha2-512 to server-sig-algs
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] SSH_MSG_SERVICE_ACCEPT received
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] Authentications that can continue: publickey,keyboard-interactive,password
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] Next authentication method: publickey
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] Authentications that can continue: keyboard-interactive,password
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] Next authentication method: keyboard-interactive
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] Authentication succeeded (keyboard-interactive).
INFO  [sftp-consumer@default-channel] [c.a.s.SftpClientLogger.log()] [{}] Disconnecting from localhost port 2222
DEBUG [sftp-consumer@default-channel] [c.a.c.RandomIntervalPoller.processMessages()] [{}] time to process [0] messages [427] ms
```