### PR TITLE
Don't use sourceSets to create the version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Gemfile.lock
 _site
 */src/main/generated
 .jekyll-cache
+**/adaptris-version

--- a/build.gradle
+++ b/build.gradle
@@ -159,27 +159,17 @@ subprojects { subproject ->
     check.dependsOn jacocoTestReport
   }
 
-  sourceSets {
-    main {
-      output.dir(versionDir, builtBy: 'generateVersion')
-    }
-  }
-
-  // Generate the META-INF/adaptris-version file
-  task generateVersion {
-    doLast {
-      def versionFile = new File(new File(versionDir, 'META-INF'), 'adaptris-version')
-      versionFile.getParentFile().mkdirs()
-      ant.propertyfile(file: versionFile) {
-        entry(key: 'component.name', value: componentName)
-        entry(key: 'component.description', value: componentDesc)
-        entry(key: 'build.version', value: project.version)
-        entry(key: 'groupId', value: project.group)
-        entry(key: 'artifactId', value: project.name)
-        entry(key: 'build.date', value: new Date().format('yyyy-MM-dd'))
-        entry(key: 'build.info', value: buildDetails.buildInfo())
-      }
-    }
+  def generateVersionFile = tasks.register('generateVersionFile', WriteProperties) {
+    group = 'Build'
+    description = 'Generate Interlok version information'
+    outputFile file('src/main/resources/META-INF/adaptris-version')
+    property 'component.name', componentName
+    property 'component.description', componentDesc
+    property 'build.version', project.version
+    property 'groupId', project.group
+    property 'artifactId', project.name
+    property 'build.date', new Date().format('yyyy-MM-dd')
+    property 'build.info', buildDetails.buildInfo()
   }
 
   jar {
@@ -234,4 +224,5 @@ subprojects { subproject ->
     }
   }
 
+  processResources.dependsOn generateVersionFile
 }


### PR DESCRIPTION
## Motivation

If you're an eclipse user then you often get a spurious error message about a missing `build/version` file. The problem goes away if you either compile on the commandline (thus generating the file) or in fact do a eclipse clean all...

The reason for this is that generating the version file is part of the sourceset definition, which it doesn't need to be.

I'm annoyed enough that I fixed the problem.

## Modification

- Create a new generateVersionFile task that 
- generateVersionFile uses WriteProperties rather than ant.propertyFile()
- Add a .gitignore for `**/adaptris-version`

Note that the outputfile could write directly to the right place (classDir or where the resources end up) : `outputfile=file(processResources.destinationDir.getCanonicalPath() + '/META-INF/adaptris-version')` but this causes a gradle validation problem (implicit dependency) in interlok-stubs.


## PR Checklist

- [x] been self-reviewed.

## Result

Eclipse now opens the project and you don't need to do the rebuild.

## Testing

- Check out a fresh copy of the project (such that bin/ .classpath / .project and the usual eclipse arifacts don't exist)
- Switch to the develop branch
- import the project into eclipse.

This will register an error along the lines of build/version doesn't exist.

- Repeat with this branch (make sure you delete all the eclipse artifacts).
- Should be no error.
- 
