### PR TITLE
interlok-2752 Add new XML resolver

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class SaferXMLResolver extends ResolverImp
 {
-	private static final String RESOLVE_REGEXP = "^.*%resolveXml\\{(.+)\\}.*$";
+	private static final String RESOLVE_REGEXP = "^.*%asCDATA\\{(.+)\\}.*$";
 	private final transient Pattern resolverPattern;
 
 	private static final String CDATA_PRE = "<![CDATA[";
@@ -77,7 +77,7 @@ public class SaferXMLResolver extends ResolverImp
 			sb.append(value);
 
 			sb.append(CDATA_POST);
-			String toReplace = "%resolveXml{" + replace + "}";
+			String toReplace = "%asCDATA{" + replace + "}";
 			result = result.replace(toReplace, sb.toString());
 			m = resolverPattern.matcher(result);
 		}

--- a/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
@@ -19,6 +19,7 @@ public class SaferXMLResolver extends ResolverImp
 
 	private static final String CDATA_PRE = "<![CDATA[";
 	private static final String CDATA_POST = "]]>";
+	private static final String SPECIAL_CASE = "<![CDATA[]]]]><![CDATA[>]]>";
 
 	public SaferXMLResolver()
 	{
@@ -57,6 +58,11 @@ public class SaferXMLResolver extends ResolverImp
 
 			String value = target.resolve(replace);
 			log.trace("Found value {} within target message", value);
+			if (value.contains(CDATA_POST))
+			{
+				// special case for when the resolved text contains its own CDATA section
+				value = value.replace(CDATA_POST, SPECIAL_CASE);
+			}
 			sb.append(value);
 
 			sb.append(CDATA_POST);

--- a/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
@@ -4,6 +4,7 @@ import com.adaptris.interlok.resolver.FileResolver;
 import com.adaptris.interlok.resolver.ResolverImp;
 import com.adaptris.interlok.resolver.UnresolvableException;
 import com.adaptris.interlok.types.InterlokMessage;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,10 +18,10 @@ import java.util.regex.Pattern;
  * %resolveXml{...}, and will place the result inside of CDATA tags.
  * </p>
  */
+
+@Slf4j
 public class SaferXMLResolver extends ResolverImp
 {
-	private static final Logger log = LoggerFactory.getLogger(FileResolver.class);
-
 	private static final String RESOLVE_REGEXP = "^.*%resolveXml\\{(.+)\\}.*$";
 	private final transient Pattern resolverPattern;
 

--- a/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
@@ -1,0 +1,78 @@
+package com.adaptris.core;
+
+import com.adaptris.interlok.resolver.FileResolver;
+import com.adaptris.interlok.resolver.ResolverImp;
+import com.adaptris.interlok.resolver.UnresolvableException;
+import com.adaptris.interlok.types.InterlokMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SaferXMLResolver extends ResolverImp
+{
+	private static final Logger log = LoggerFactory.getLogger(FileResolver.class);
+
+	private static final String RESOLVE_REGEXP = "^.*%resolveXml\\{(.+)\\}.*$";
+	private final transient Pattern resolverPattern;
+
+	private static final String CDATA_PRE = "<![CDATA[";
+	private static final String CDATA_POST = "]]>";
+
+	public SaferXMLResolver()
+	{
+		resolverPattern = Pattern.compile(RESOLVE_REGEXP, Pattern.DOTALL);
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public String resolve(String lookupValue)
+	{
+		throw new UnresolvableException("Safer XML resolver requires a target message!");
+	}
+
+	@Override
+	public String resolve(String lookupValue, InterlokMessage target)
+	{
+		if (lookupValue == null)
+		{
+			return null;
+		}
+		if (target == null)
+		{
+			throw new UnresolvableException("Target message cannot be null!");
+		}
+		String result = lookupValue;
+		log.trace("Resolving {} from XML", lookupValue);
+		Matcher m = resolverPattern.matcher(lookupValue);
+		while (m.matches())
+		{
+			String replace = m.group(1);
+
+			StringBuffer sb = new StringBuffer();
+			sb.append(CDATA_PRE);
+
+			String value = target.resolve(replace);
+			log.trace("Found value {} within target message", value);
+			sb.append(value);
+
+			sb.append(CDATA_POST);
+			String toReplace = "%resolveXml{" + replace + "}";
+			result = result.replace(toReplace, sb.toString());
+			m = resolverPattern.matcher(result);
+		}
+		return result;
+	}
+
+	/**
+	 * {@inheritDoc}.
+	 */
+	@Override
+	public boolean canHandle(String value)
+	{
+		return resolverPattern.matcher(value).matches();
+	}
+}

--- a/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
@@ -1,12 +1,9 @@
 package com.adaptris.core;
 
-import com.adaptris.interlok.resolver.FileResolver;
 import com.adaptris.interlok.resolver.ResolverImp;
 import com.adaptris.interlok.resolver.UnresolvableException;
 import com.adaptris.interlok.types.InterlokMessage;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -15,10 +12,9 @@ import java.util.regex.Pattern;
  * Resolver implementation that resolves and escapes XML content.
  * <p>
  * This resolver resolves values based on the following:
- * %resolveXml{...}, and will place the result inside of CDATA tags.
+ * %asCDATA{...}, and will place the result inside of CDATA tags.
  * </p>
  */
-
 @Slf4j
 public class SaferXMLResolver extends ResolverImp
 {

--- a/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SaferXMLResolver.java
@@ -10,6 +10,13 @@ import org.slf4j.LoggerFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Resolver implementation that resolves and escapes XML content.
+ * <p>
+ * This resolver resolves values based on the following:
+ * %resolveXml{...}, and will place the result inside of CDATA tags.
+ * </p>
+ */
 public class SaferXMLResolver extends ResolverImp
 {
 	private static final Logger log = LoggerFactory.getLogger(FileResolver.class);
@@ -35,16 +42,19 @@ public class SaferXMLResolver extends ResolverImp
 		throw new UnresolvableException("Safer XML resolver requires a target message!");
 	}
 
+	/**
+	 * {@inheritDoc}.
+	 */
 	@Override
 	public String resolve(String lookupValue, InterlokMessage target)
 	{
-		if (lookupValue == null)
-		{
-			return null;
-		}
 		if (target == null)
 		{
 			throw new UnresolvableException("Target message cannot be null!");
+		}
+		if (lookupValue == null)
+		{
+			lookupValue = target.getContent();
 		}
 		String result = lookupValue;
 		log.trace("Resolving {} from XML", lookupValue);

--- a/interlok-core/src/main/resources/META-INF/services/com.adaptris.interlok.resolver.Resolver
+++ b/interlok-core/src/main/resources/META-INF/services/com.adaptris.interlok.resolver.Resolver
@@ -1,1 +1,2 @@
 com.adaptris.core.ResolveFromPayloadUsingXPath
+com.adaptris.core.SaferXMLResolver

--- a/interlok-core/src/test/java/com/adaptris/core/resolver/SaferXMLResolverTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/resolver/SaferXMLResolverTest.java
@@ -3,9 +3,12 @@ package com.adaptris.core.resolver;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.SaferXMLResolver;
+import com.adaptris.core.UnresolvedMetadataException;
+import com.adaptris.interlok.resolver.UnresolvableException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class SaferXMLResolverTest
@@ -13,8 +16,9 @@ public class SaferXMLResolverTest
 	private static final String KEY = "eq";
 	private static final String EQUATION = "x - 5 < 10";
 	private static final String XML_SOURCE = "<equation>%resolveXml{%message{" + KEY + "}}</equation>";
-	private static final String XML_GOOD = "<equation><![CDATA[" + EQUATION + "]]></equation>";
-	private static final String XML_BAD = "<equation>" + EQUATION + "</equation>";
+	private static final String XML_RESOLVED = "<equation><![CDATA[" + EQUATION + "]]></equation>";
+	private static final String SPECIAL_CASE = "<![CDATA[WTF is this?]]>";
+	private static final String SPECIAL_RESULT = "<equation><![CDATA[<![CDATA[WTF is this?<![CDATA[]]]]><![CDATA[>]]>]]></equation>";
 
 	@Test
 	public void testCanResolve()
@@ -27,11 +31,44 @@ public class SaferXMLResolverTest
 	{
 		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
 		message.addMetadata(KEY, EQUATION);
-
 		SaferXMLResolver resolver = new SaferXMLResolver();
-
 		String result = resolver.resolve(XML_SOURCE, message);
+		assertEquals(XML_RESOLVED, result);
+	}
 
-		assertEquals(XML_GOOD, result);
+	@Test(expected = UnresolvedMetadataException.class)
+	public void testResolveNoValue()
+	{
+		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+		SaferXMLResolver resolver = new SaferXMLResolver();
+		resolver.resolve(XML_SOURCE, message);
+	}
+
+	@Test(expected = UnresolvableException.class)
+	public void testNoMessage()
+	{
+		new SaferXMLResolver().resolve(XML_SOURCE);
+	}
+
+	@Test(expected = UnresolvableException.class)
+	public void testNullMessage()
+	{
+		new SaferXMLResolver().resolve(XML_SOURCE, null);
+	}
+
+	@Test
+	public void testNullExpression()
+	{
+		assertNull(new SaferXMLResolver().resolve(null, null));
+	}
+
+	@Test
+	public void testSpecialCase()
+	{
+		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+		message.addMetadata(KEY, SPECIAL_CASE);
+		SaferXMLResolver resolver = new SaferXMLResolver();
+		String result = resolver.resolve(XML_SOURCE, message);
+		assertEquals(SPECIAL_RESULT, result);
 	}
 }

--- a/interlok-core/src/test/java/com/adaptris/core/resolver/SaferXMLResolverTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/resolver/SaferXMLResolverTest.java
@@ -14,7 +14,7 @@ public class SaferXMLResolverTest
 {
 	private static final String KEY = "eq";
 	private static final String EQUATION = "x - 5 < 10";
-	private static final String XML_SOURCE = "<equation>%resolveXml{%message{" + KEY + "}}</equation>";
+	private static final String XML_SOURCE = "<equation>%asCDATA{%message{" + KEY + "}}</equation>";
 	private static final String XML_RESOLVED = "<equation><![CDATA[" + EQUATION + "]]></equation>";
 	private static final String SPECIAL_CASE = "<![CDATA[WTF is this?]]>";
 	private static final String SPECIAL_RESULT = "<equation><![CDATA[<![CDATA[WTF is this?<![CDATA[]]]]><![CDATA[>]]>]]></equation>";

--- a/interlok-core/src/test/java/com/adaptris/core/resolver/SaferXMLResolverTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/resolver/SaferXMLResolverTest.java
@@ -1,0 +1,37 @@
+package com.adaptris.core.resolver;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.SaferXMLResolver;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SaferXMLResolverTest
+{
+	private static final String KEY = "eq";
+	private static final String EQUATION = "x - 5 < 10";
+	private static final String XML_SOURCE = "<equation>%resolveXml{%message{" + KEY + "}}</equation>";
+	private static final String XML_GOOD = "<equation><![CDATA[" + EQUATION + "]]></equation>";
+	private static final String XML_BAD = "<equation>" + EQUATION + "</equation>";
+
+	@Test
+	public void testCanResolve()
+	{
+		assertTrue(new SaferXMLResolver().canHandle(XML_SOURCE));
+	}
+
+	@Test
+	public void testResolve()
+	{
+		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+		message.addMetadata(KEY, EQUATION);
+
+		SaferXMLResolver resolver = new SaferXMLResolver();
+
+		String result = resolver.resolve(XML_SOURCE, message);
+
+		assertEquals(XML_GOOD, result);
+	}
+}

--- a/interlok-core/src/test/java/com/adaptris/core/resolver/SaferXMLResolverTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/resolver/SaferXMLResolverTest.java
@@ -8,7 +8,6 @@ import com.adaptris.interlok.resolver.UnresolvableException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class SaferXMLResolverTest
@@ -36,6 +35,16 @@ public class SaferXMLResolverTest
 		assertEquals(XML_RESOLVED, result);
 	}
 
+	@Test
+	public void testResolveMessageContent()
+	{
+		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_SOURCE);
+		message.addMetadata(KEY, EQUATION);
+		SaferXMLResolver resolver = new SaferXMLResolver();
+		String result = resolver.resolve(null, message);
+		assertEquals(XML_RESOLVED, result);
+	}
+
 	@Test(expected = UnresolvedMetadataException.class)
 	public void testResolveNoValue()
 	{
@@ -56,10 +65,10 @@ public class SaferXMLResolverTest
 		new SaferXMLResolver().resolve(XML_SOURCE, null);
 	}
 
-	@Test
+	@Test(expected = UnresolvableException.class)
 	public void testNullExpression()
 	{
-		assertNull(new SaferXMLResolver().resolve(null, null));
+		new SaferXMLResolver().resolve(null, null);
 	}
 
 	@Test


### PR DESCRIPTION
## Motivation

What if the resolved data isn't safe for XML? It should be escaped, or in this case, enclosed in CDATA tags.

## Modification

Add new resolver that will wrap the resolved data in CDATA tags.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

(Hopefully) the user can now include whatever they want when resolving into an XML document.

## Testing

[Sample config](https://github.com/adaptris/interlok-json/files/7821836/adapter.xml.txt) that will resolve metadata and insert in into the XML payload. Used in combination with the [new JSON resolver](https://github.com/adaptris/interlok-json/pull/284).

NB The config will need updating to use `%asCDATA{...}`