### PR TITLE
Force SimpleDateFormat where used to be strict

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdapterStateSummary.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdapterStateSummary.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,8 @@
 package com.adaptris.core;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import com.adaptris.util.text.DateFormatUtil;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import com.adaptris.core.util.Args;
@@ -28,13 +30,13 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * Summary of the state of an {@link Adapter} and associated {@link com.adaptris.core.Channel}s
  * </p>
- * 
+ *
  * @config adapter-state-summary
  */
 @XStreamAlias("adapter-state-summary")
 public class AdapterStateSummary {
 
-  private transient final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+  private transient final SimpleDateFormat DATE_FORMAT = DateFormatUtil.strictFormatter("yyyy-MM-dd'T'HH:mm:ssZ");
 
   private String lastStartTime;
   private String lastStopTime;
@@ -53,7 +55,7 @@ public class AdapterStateSummary {
    * <p>
    * Utility constructor that summarises the current state of the passed <code>Adapter</code>.
    * </p>
-   * 
+   *
    * @param adapter the <code>Adapter</code> to report the state of
    */
   public AdapterStateSummary(Adapter adapter) {
@@ -70,7 +72,7 @@ public class AdapterStateSummary {
    * <p>
    * Sets the state of the <code>Adapter</code>.
    * </p>
-   * 
+   *
    * @param uniqueId the unique ID, may not be null or empty
    * @param state the state, may not be null or empty
    */
@@ -86,7 +88,7 @@ public class AdapterStateSummary {
    * <p>
    * Sets the state of the <code>Adapter</code>.
    * </p>
-   * 
+   *
    * @param state a <code>KeyValuePair</code> of state against unique ID
    */
   public void setAdapterState(KeyValuePair state) {
@@ -100,7 +102,7 @@ public class AdapterStateSummary {
    * <p>
    * Returns the state of the <code>Adapter</code>.
    * </p>
-   * 
+   *
    * @return the state of the <code>Adapter</code>
    */
   public KeyValuePair getAdapterState() {
@@ -112,7 +114,7 @@ public class AdapterStateSummary {
    * Adds the state of a <code>Channel</code> to the internal store. If state for the passed unique ID has already been stored it
    * will be over-written. Non-uniquely identified <code>Channel</code>s are ignored.
    * </p>
-   * 
+   *
    * @param uniqueId the unique ID of the <code>Channel</code>
    * @param state the state may not be null
    */
@@ -128,7 +130,7 @@ public class AdapterStateSummary {
    * <p>
    * Adds the state of a <code>Channel</code> to the internal store.
    * </p>
-   * 
+   *
    * @param state the state of the <code>Channel</code> to add
    */
   public void addChannelState(KeyValuePair state) {

--- a/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RandomIntervalPoller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2020 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.adaptris.core;
 
+import com.adaptris.util.text.DateFormatUtil;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.concurrent.ThreadLocalRandom;
@@ -29,13 +30,13 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 /**
  * Implementation of {@linkplain Poller} which polls at a random interval with a delay between each execution of up-to the
  * configured poll interval (in ms).
- * 
+ *
  * <p>
  * This implementation is of marginal use, and is best used to generate messages at pseudo-random intervals.
  * </p>
- * 
+ *
  * @config random-interval-poller
- * 
+ *
  */
 @XStreamAlias("random-interval-poller")
 public class RandomIntervalPoller extends FixedIntervalPoller {
@@ -55,7 +56,7 @@ public class RandomIntervalPoller extends FixedIntervalPoller {
       pollerTask = executor.schedule(new MyPollerTask(), delay, TimeUnit.MILLISECONDS);
       Calendar currentTime = Calendar.getInstance();
       currentTime.add(Calendar.MILLISECOND, (int)delay);
-      SimpleDateFormat approxFormat = new SimpleDateFormat("HH:mm");
+      SimpleDateFormat approxFormat = DateFormatUtil.strictFormatter("HH:mm");
       log.trace("Next Execution scheduled in {} approx {}", DurationFormatUtils.formatDurationWords(delay, true, true), approxFormat.format(currentTime.getTime()));
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/event/LicenseExpiryWarningEvent.java
+++ b/interlok-core/src/main/java/com/adaptris/core/event/LicenseExpiryWarningEvent.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.adaptris.core.event;
 
+import com.adaptris.util.text.DateFormatUtil;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -30,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * <code>AdapterLifecycleEvent</code> indicating that this Adapter's license is about to expire.
  * </p>
- * 
+ *
  * @config license-expiry-warning-event
  */
 @XStreamAlias("license-expiry-warning-event")
@@ -39,7 +40,7 @@ public class LicenseExpiryWarningEvent extends AdapterLifecycleEvent {
 
   private Date expiryDate;
   private String licenseExpiry;
-  private transient SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+  private transient SimpleDateFormat sdf = DateFormatUtil.strictFormatter("yyyy-MM-dd");
 
   /**
    * <p>

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducerImpl.java
@@ -22,6 +22,7 @@ import static com.adaptris.core.jms.JmsConstants.JMS_EXPIRATION;
 import static com.adaptris.core.jms.JmsConstants.JMS_PRIORITY;
 import static com.adaptris.core.jms.NullCorrelationIdSource.defaultIfNull;
 
+import com.adaptris.util.text.DateFormatUtil;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -136,7 +137,7 @@ public abstract class JmsProducerImpl extends RequestReplyProducerBase implement
     ISO8601 {
       @Override
       Date convert(String s) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat(EXPIRATION_DATE_FORMAT);
+        SimpleDateFormat sdf = DateFormatUtil.strictFormatter(EXPIRATION_DATE_FORMAT);
         return sdf.parse(s);
       }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/DatetimeStatementParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/DatetimeStatementParameter.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
 */
 package com.adaptris.core.services.jdbc;
 
+import com.adaptris.util.text.DateFormatUtil;
 import java.text.SimpleDateFormat;
 import javax.validation.constraints.NotBlank;
 
@@ -54,7 +55,7 @@ public abstract class DatetimeStatementParameter<T> extends TypedStatementParame
 
   protected SimpleDateFormat getFormatter() {
     if (dateFormatter == null) {
-      dateFormatter = new SimpleDateFormat(getDateFormat());
+      dateFormatter = DateFormatUtil.strictFormatter(getDateFormat());
     }
     return dateFormatter;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/DateColumnTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/jdbc/types/DateColumnTranslator.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.adaptris.core.services.jdbc.types;
 
+import com.adaptris.util.text.DateFormatUtil;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
@@ -28,11 +29,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Column Translator implementation for handling date types
- * 
+ *
  * @config jdbc-type-date-column-translator
- * 
- * @author lchan
- * 
+ *
  */
 @XStreamAlias("jdbc-type-date-column-translator")
 public class DateColumnTranslator implements ColumnTranslator {
@@ -50,10 +49,10 @@ public class DateColumnTranslator implements ColumnTranslator {
   @Override
   public String translate(JdbcResultRow rs, int column) throws SQLException, IOException {
     Object fieldValue = rs.getFieldValue(column);
-    
+
     if(fieldValue instanceof GregorianCalendar)
       fieldValue = ((GregorianCalendar) fieldValue).getTime();
-    
+
     return toString((Date) fieldValue);
   }
 
@@ -62,12 +61,12 @@ public class DateColumnTranslator implements ColumnTranslator {
     Object fieldValue = rs.getFieldValue(columnName);
     if(fieldValue instanceof GregorianCalendar)
       fieldValue = ((GregorianCalendar) fieldValue).getTime();
-    
+
     return toString((Date) fieldValue);
   }
 
   protected String toString(Date d) throws SQLException, IOException {
-    SimpleDateFormat sdf = new SimpleDateFormat(getDateFormat());
+    SimpleDateFormat sdf = DateFormatUtil.strictFormatter(getDateFormat());
     return sdf.format(d);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/DateFormatBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/DateFormatBuilder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Builds a DateFormat instance for use with {@link ReformatDateService} and {@link AddTimestampMetadataService}.
- * 
+ *
  * @config date-format-builder
  */
 @XStreamAlias("date-format-builder")
@@ -97,7 +97,11 @@ public class DateFormatBuilder {
   private SimpleDateFormat createWithLocale(AdaptrisMessage msg) {
     String language = msg.resolve(getLanguageTag());
     String format = msg.resolve(getFormat());
-    return !isBlank(language) ? new SimpleDateFormat(format, Locale.forLanguageTag(language)) : new SimpleDateFormat(format);
+    SimpleDateFormat formatter =
+        !isBlank(language) ? new SimpleDateFormat(format, Locale.forLanguageTag(language))
+            : new SimpleDateFormat(format);
+    formatter.setLenient(false);
+    return formatter;
   }
 
   private DateFormatter withTimeZone(SimpleDateFormat format, String id) {
@@ -111,7 +115,7 @@ public class DateFormatBuilder {
 
   /**
    * Set the format.
-   * 
+   *
    * @param format the dateformat, default is {@value #DEFAULT_DATE_FORMAT} if not specified.
    */
   public void setFormat(String format) {
@@ -129,7 +133,7 @@ public class DateFormatBuilder {
 
   /**
    * Set the language tag for the {@link java.util.Locale} which is resolved via {@link Locale#forLanguageTag(String)}.
-   * 
+   *
    * @param locale the locale using the IETF BCP 47 language tag string e.g. {@code fr-FR} or {@code en-GB}.
    * @see Locale#forLanguageTag(String)
    */
@@ -148,7 +152,7 @@ public class DateFormatBuilder {
 
   /**
    * Set the timezone
-   * 
+   *
    * @param tz the timezone e.g. {@code UTC} or {@code GMT}.
    * @see java.util.TimeZone#getTimeZone(String)
    */

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/CompareTimestamps.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/compare/CompareTimestamps.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.util.text.DateFormatUtil;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import java.text.ParseException;
@@ -31,17 +32,15 @@ import java.util.Date;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
- * 
+ *
  * Used with {@link MetadataComparisonService}.
- * 
+ *
  * <p>
  * Compares two dates using {@link Date#compareTo(Date)}. The result will be the result of that operation as a string so effectively
  * {@code -1, 0, or 1}.
  * </p>
- * 
+ *
  * @config metadata-compare-timestamps
- * @author lchan
- * 
  */
 @XStreamAlias("metadata-compare-timestamps")
 @AdapterComponent
@@ -91,7 +90,7 @@ public class CompareTimestamps extends ComparatorImpl {
 
   /**
    * Set the date format to parse the metadata values.
-   * 
+   *
    * @param f the dateFormat to set, the default is {@code yyyy-MM-dd'T'HH:mm:ssZ} if not specified.
    */
   public void setDateFormat(String f) {
@@ -108,7 +107,7 @@ public class CompareTimestamps extends ComparatorImpl {
   }
 
   private int compareFormattedDates(String a, String b) throws ParseException {
-    SimpleDateFormat sdf = new SimpleDateFormat(dateFormat());
+    SimpleDateFormat sdf = DateFormatUtil.strictFormatter(dateFormat());
     Date firstDate = sdf.parse(a);
     Date secondDate = sdf.parse(b);
     return firstDate.compareTo(secondDate);

--- a/interlok-core/src/main/java/com/adaptris/ftp/ApacheFtpClientImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/ftp/ApacheFtpClientImpl.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.adaptris.ftp;
 
+import com.adaptris.util.text.DateFormatUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileFilter;
@@ -45,7 +46,7 @@ import com.adaptris.util.FifoMutexLock;
 /**
  * Base implementation of {@link FileTransferClient} that uses the apache
  * commons net FTP implementation.
- * 
+ *
  */
 public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTransferClientImp implements FtpFileTransferClient {
 
@@ -71,7 +72,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * Constructor
-   * 
+   *
    * @param remoteHost the remote hostname
    * @param port connection port
    * @param timeout connection timeout
@@ -113,7 +114,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * Create the base commons net client.
-   * 
+   *
    * @return the actual FtpClient implementation that will be used.
    */
   protected abstract T createFTPClient();
@@ -193,7 +194,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * Get data from a remote file
-   * 
+   *
    * @param destStream output target data stream
    * @param remoteFile file to be read on the server
    */
@@ -212,7 +213,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * Get data as a byte array from a server file
-   * 
+   *
    * @param remoteFile file to be read on the server
    */
   @Override
@@ -286,7 +287,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * delete a file on the server
-   * 
+   *
    * @param remoteFile to be deleted
    */
   @Override
@@ -304,7 +305,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * rename a file on the server
-   * 
+   *
    * @param from file to be renamed
    * @param to new name for file
    */
@@ -324,7 +325,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * remove a directory from the server
-   * 
+   *
    * @param dir directory name
    */
   @Override
@@ -343,7 +344,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * create a directory on the server
-   * 
+   *
    * @param dir directory name
    */
   @Override
@@ -361,7 +362,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * change directory on the server
-   * 
+   *
    * @param dir directory name
    */
   @Override
@@ -421,7 +422,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * Set transfer type eg. ASCII, BINARY
-   * 
+   *
    * @param ftpFileType FILE_TYPE constant from the Apache commons net FtpClient
    *          class
    */
@@ -471,11 +472,11 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * Set the FTP Server timezone handler for modification times.
-   * 
+   *
    * If not explicitly set, then the server is assumed to be in the same
    * timezone as the client; this could lead to incorrect modification times
    * being reported.
-   * 
+   *
    * @param tz the handler.
    */
   public void setServerTimezone(TimeZone tz) {
@@ -493,7 +494,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * Get the type of the OS at the server
-   * 
+   *
    * @return the type of server OS
    * @throws IOException if a comms error occurs
    */
@@ -512,7 +513,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
 
   /**
    * Get the current working directory on the server
-   * 
+   *
    * @return the directory
    * @throws IOException if a comms error occurs
    */
@@ -537,7 +538,7 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
     private transient SimpleDateFormat tsFormat;
 
     TimezoneDateHandler(TimeZone tz) {
-      tsFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+      tsFormat = DateFormatUtil.strictFormatter("yyyyMMddHHmmss");
       if (tz != null) {
         tsFormat.setTimeZone(tz);
       }
@@ -566,10 +567,10 @@ public abstract class ApacheFtpClientImpl<T extends FTPClient> extends FileTrans
    * Validate the response the host has supplied against the expected reply. If
    * we get an unexpected reply we throw an exception, setting the message to
    * that returned by the FTP server
-   * 
+   *
    * @param reply the entire reply string we received
    * @param expectedReplyCode the reply we expected to receive
-   * 
+   *
    */
   private Reply validateReply(String reply, String expectedReplyCode) throws IOException, FileTransferException {
 

--- a/interlok-core/src/main/java/com/adaptris/transform/MappingUtils.java
+++ b/interlok-core/src/main/java/com/adaptris/transform/MappingUtils.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.adaptris.transform;
 
+import com.adaptris.util.text.DateFormatUtil;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -24,7 +25,7 @@ import com.adaptris.util.text.Justify;
 public class MappingUtils {
   /**
    * This method can be called to pad a value out to a given length.
-   * 
+   *
    * @deprecated use {@link #leftJust(String, int)}or
    *             {@link #rightJust(String, int)}
    * @param input - value to be padded out
@@ -80,7 +81,7 @@ public class MappingUtils {
 
   /**
    * Get the current system date.
-   * 
+   *
    * @return the date in yyyyMMdd format
    */
   public static String getSystemDate() {
@@ -89,7 +90,7 @@ public class MappingUtils {
 
   /**
    * Get the current system time.
-   * 
+   *
    * @return the time in HH:mm:ss format.
    */
   public static String getSystemTime() {
@@ -98,7 +99,7 @@ public class MappingUtils {
 
   /**
    * Get the system date and time.
-   * 
+   *
    * @return the date and time in "yyyyMMdd HH:mm"
    */
   public static String getSystemDateTime() {
@@ -106,7 +107,7 @@ public class MappingUtils {
   }
 
   private static String getFormattedDate(String format) {
-    SimpleDateFormat sdf = new SimpleDateFormat(format);
+    SimpleDateFormat sdf = DateFormatUtil.strictFormatter(format);
     return sdf.format(new Date());
   }
 
@@ -116,10 +117,10 @@ public class MappingUtils {
    * This method returns the smaller of two string representations of numbers.
    * All non-numeric characters are removed during comparison but the original
    * string is returned.
-   * 
+   *
    * Example: 123xxx01 and 23+42 would be compared as 12301 and 2342
    * </p>
-   * 
+   *
    * @param one - the first value
    * @param two - the second value
    */
@@ -139,10 +140,10 @@ public class MappingUtils {
    * This method returns the larger of two string representations of numbers.
    * All non-numeric characters are removed during comparison but the original
    * string is returned.
-   * 
+   *
    * Example: 123xxx01 and 23+42 would be compared as 12301 and 2342
    * </p>
-   * 
+   *
    * @param one - the first value
    * @param two - the second value
    */
@@ -163,7 +164,7 @@ public class MappingUtils {
    * dates must be in either of the following formats: yyyyMMdd (e.g. 20011225)
    * yyyyMMdd HH:mm (e.g. 20011225 12:01)
    * </p>
-   * 
+   *
    * @param one - the first date
    * @param two - the second date
    */
@@ -185,7 +186,7 @@ public class MappingUtils {
    * dates must be in either of the following formats: yyyyMMdd (e.g. 20011225)
    * yyyyMMdd HH:mm (e.g. 20011225 12:01)
    * </p>
-   * 
+   *
    * @param one - the first date
    * @param two - the second date
    */

--- a/interlok-core/src/main/java/com/adaptris/util/text/DateFormatUtil.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/DateFormatUtil.java
@@ -231,6 +231,11 @@ public final class DateFormatUtil {
     return format;
   }
 
+  /** Return a {@code SimpleDateFormat} instance that is not lenient.
+   *
+   * @param pattern the pattern
+   * @return a SimpleDateFormat.
+   */
   public static SimpleDateFormat strictFormatter(String pattern) {
     SimpleDateFormat f = new SimpleDateFormat(pattern);
     f.setLenient(false);

--- a/interlok-core/src/main/java/com/adaptris/util/text/DateFormatUtil.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/DateFormatUtil.java
@@ -212,8 +212,7 @@ public final class DateFormatUtil {
   }
 
   private static Date useDefaultFormatter(String str) {
-    return Optional.ofNullable(DateFormat.getDateTimeInstance().parse(str, new ParsePosition(0)))
-        .orElse(null);
+    return DateFormat.getDateTimeInstance().parse(str, new ParsePosition(0));
   }
 
   private static CustomDateFormatter getFormatter(String pattern) {

--- a/interlok-core/src/test/java/com/adaptris/util/text/DateFormatUtilTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/DateFormatUtilTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 package com.adaptris.util.text;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -50,6 +51,22 @@ public class DateFormatUtilTest {
       assertNotNull(parsedDate);
       assertTrue(now + " should be after " + parsedDate, now.after(parsedDate));
     }
+  }
+
+  @Test
+  public void testLenientParsing() throws Exception {
+    SimpleDateFormat lenientFormatter = new SimpleDateFormat("yyyyMMdd");
+    // Because lenient, this will parse, but won't be the date we expect.
+    Date lenientDate = lenientFormatter.parse("2021-08-18");
+    String lenient = lenientFormatter.format(lenientDate);
+    assertNotEquals("20210818", lenient);
+
+    // This should skip past the yyyyMMdd parser, and only hit the yyyy-MM-dd parser.
+    Date strictDate = DateFormatUtil.parse("2021-08-18");
+    String strict = lenientFormatter.format(strictDate);
+    assertEquals("20210818", strict);
+    assertNotEquals(lenient, strict);
+
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/util/text/DateFormatUtilTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/DateFormatUtilTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -44,6 +45,7 @@ public class DateFormatUtilTest {
   public void testDateParser() {
     Date dateToParse = new Date(System.currentTimeMillis() - 3600 * 48);
     Date now = new Date(System.currentTimeMillis());
+    assertNotNull(DateFormatUtil.parse(DateFormat.getDateTimeInstance().format(now), null));
     for (int i=0; i < DATE_FORMATS.length; i++) {
       SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMATS[i]);
       String datetime = sdf.format(dateToParse);


### PR DESCRIPTION
## Motivation

```java
SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
Date d = format.parse("2021-08-18");
```

That string with that format will _parse_ but the date parsed won't be 18th August 2021. It'll be some time in 2020. This is because SimpleDateFormat is by default lenient and it has accepted the first 8 characters as the date.

## Modification

- Add a strictFormatter() static method to DateFormatUtil
- Rather than creating a new SimpleDateFormat for every attempt to parse, make it a static ThreadLocal list of formatters in DateFormatUtil
- Where appropriate force delegation to the new strictFormatter() method rather than new SimpleDateFormat(). 
    - This is generally where it's obvious that we're going to use the `parse` method.
- Add a new explicit test to show difference between lenient/strict in DateFormatUtilTest.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Checked that javadoc generation doesn't report errors

## Result

No visible change to the user; 

No existing tests are broken, so there is no regression; however, at runtime people may see _more parsing errors_ if they are running into the situation described above. That's actually better because having wrong dates is probably not a good thing. We have probably been getting away with it because a lot of the time we're transforming *from ISO8601 to something else* and a lenient ISO8601 parser is going to fail if `T` doesn't exist.

## Testing

- Use "ReformatDateService" and reformat the date from `yyyyMMdd` to `yyyy-MM-dd`
- Test the service against the latest release (using 2021-08-18 as your input), and check the new formatted key.
- Test the service against this PR branch...


