### PR TITLE
INTERLOK-2866 More useful error message with no config

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/config/ConfigPreProcessors.java
+++ b/interlok-core/src/main/java/com/adaptris/core/config/ConfigPreProcessors.java
@@ -26,11 +26,13 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.ExceptionHelper;
 
+@Slf4j
 public class ConfigPreProcessors extends AbstractCollection<ConfigPreProcessor> {
 
   private List<ConfigPreProcessor> preProcessors;
@@ -53,6 +55,7 @@ public class ConfigPreProcessors extends AbstractCollection<ConfigPreProcessor> 
       String xml = IOUtils.toString(inputStream, Charset.defaultCharset());
       return this.process(xml);
     } catch (Exception ex) {
+      log.error("Could not read from/find XML configuration file : {} ", urlToXml.getPath());
       throw ExceptionHelper.wrapCoreException(ex);
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/BootstrapProperties.java
@@ -298,7 +298,7 @@ public class BootstrapProperties extends Properties {
       rc = false;
     }
     if (DBG) {
-      log.trace("[{}] {}", u.toString(), rc ? "found" : "not found");
+      log.trace("[{}] {}", u, rc ? "found" : "not found");
     }
     return rc;
   }

--- a/interlok-core/src/main/java/com/adaptris/util/URLString.java
+++ b/interlok-core/src/main/java/com/adaptris/util/URLString.java
@@ -18,7 +18,6 @@ package com.adaptris.util;
 
 import com.adaptris.core.management.Constants;
 
-import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import java.io.File;
 import java.io.Serializable;
@@ -259,7 +258,7 @@ public class URLString implements Serializable {
   }
 
   /**
-   * Constructs a URL from the URLString.
+   * Constructs a URL from the URLString. If the protocol is an empty string or null the file protocol will be used.
    */
   public URL getURL() throws MalformedURLException {
     String protocol = getProtocol();

--- a/interlok-core/src/main/java/com/adaptris/util/URLString.java
+++ b/interlok-core/src/main/java/com/adaptris/util/URLString.java
@@ -16,6 +16,9 @@
 
 package com.adaptris.util;
 
+import com.adaptris.core.management.Constants;
+
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import java.io.File;
 import java.io.Serializable;
@@ -47,8 +50,6 @@ import javax.mail.URLName;
 public class URLString implements Serializable {
 
   private static final long serialVersionUID = -4356146361589831204L;
-
-  private static final String PROTOCOL_FILE = "file";
 
   private transient URLName urlProxy;
 
@@ -261,13 +262,17 @@ public class URLString implements Serializable {
    * Constructs a URL from the URLString.
    */
   public URL getURL() throws MalformedURLException {
-    if (PROTOCOL_FILE.equalsIgnoreCase(getProtocol()) || isEmpty(getProtocol())) {
+    String protocol = getProtocol();
+    if (isEmpty(protocol)) {
+      protocol = Constants.PROTOCOL_FILE;
+    }
+    if (Constants.PROTOCOL_FILE.equalsIgnoreCase(protocol)) {
       // Cope with file:///./path/to/my/thing and perhaps ./path/to/my/thing
-      return new URL(getProtocol(), getHost(), getPort(), getFile());
+      return new URL(protocol, getHost(), getPort(), getFile());
     }
     // Otherwise add a / prefix if it doesn't already exist so that http://my.server/path/to/my/thing
     // is a valid URL
-    return new URL(getProtocol(), getHost(), getPort(), slashPrefix(getFile()));
+    return new URL(protocol, getHost(), getPort(), slashPrefix(getFile()));
   }
 
 


### PR DESCRIPTION
## Motivation

If you configure an adapter config file in your bootstrap.properties that does not exist, then you end up with a null pointer.

## Modification

* Log error message if there's an exception
* Better handler the protocol of the config URL - this is what was causing the null pointer exception because apparently the protocol cannot be null

## PR Checklist

- [x] been self-reviewed.
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)

## Result

A more useful error message, and some indication of what went wrong during startup.

## Testing

Delete your adapter.xml configuration and then start the adapter.
