### PR TITLE
Add support for human readable sizes when creating size filters

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/fs/CompositeFileFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/CompositeFileFilter.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The filter only accepts the file if all the underlying filters accept the file, thus this
  * represents an implicit AND condition. So for example we would use
- * <code>SizeGT=4096__@@__Perl=.*\.xml</code> to match all files ending with <code>.xml</code> whose
+ * <code>SizeGT=4096__@@__Regex=.*\.xml</code> to match all files ending with <code>.xml</code> whose
  * size is greater than 4096 bytes
  * </p>
  *

--- a/interlok-core/src/main/java/com/adaptris/core/fs/SizeBasedFileFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/SizeBasedFileFilter.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,16 +17,25 @@
 package com.adaptris.core.fs;
 
 import java.io.FileFilter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A {@link FileFilter} that works based on the size of a file.
- * 
- * @author lchan
- * @author $Author: lchan $
+ *
  */
+@Slf4j
 abstract class SizeBasedFileFilter implements FileFilter {
 
+  @Getter(AccessLevel.PROTECTED)
   private long filesize;
+  private static final String UNITS = "BKMGTPEZY";
+  private static final Pattern UNITS_PATTERN = Pattern.compile("[A-Za-z]");
+  // That's right, No sir, we don't care about SI Units here.
+  private static final int FACTOR = 1024;
 
   /**
    * Default constructor
@@ -38,10 +47,10 @@ abstract class SizeBasedFileFilter implements FileFilter {
   /**
    * Create the filefilter using the specified size.
    *
-   * @param size the size of the file in bytes.
+   * @param size the size of the file in bytes or something like 1.1G
    */
   public SizeBasedFileFilter(String size) {
-    this(Long.parseLong(size));
+    this(humanReadbleToBytes(size));
   }
 
   /**
@@ -54,7 +63,21 @@ abstract class SizeBasedFileFilter implements FileFilter {
     filesize = size;
   }
 
-  protected long getFilesize() {
-    return filesize;
+  private static int indexOfUnitSpecifier(String s) {
+    Matcher matcher = UNITS_PATTERN.matcher(s);
+    return matcher.find() ? matcher.start() : -1;
+  }
+
+  private static long humanReadbleToBytes(String str) {
+    int index = indexOfUnitSpecifier(str);
+    if (index == -1) {
+      return Long.parseLong(str);
+    }
+    double rawValue = Double.parseDouble(str.substring(0, index));
+    int p = UNITS.indexOf(str.substring(index).toUpperCase().charAt(0));
+    int power = (p == -1) ? 0 : p;
+    long computedSize = Double.valueOf(rawValue * Math.pow(FACTOR, power)).longValue();
+    log.trace("{} converts to {}bytes", str, computedSize);
+    return computedSize;
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/fs/SizeBasedFilterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/SizeBasedFilterTest.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core.fs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import java.io.File;
 import org.junit.Before;
@@ -43,17 +45,17 @@ public class SizeBasedFilterTest extends com.adaptris.interlok.junit.scaffolding
   @Test
   public void testSizeLessThanFileIsLarger() throws Exception {
     SizeBasedFileFilter filter = new SizeLessThan(String.valueOf(file.length() - DIFF));
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
     filter = new SizeLessThan(file.length() - DIFF);
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
   }
 
   @Test
   public void testSizeLessThanFileIsExact() throws Exception {
     SizeBasedFileFilter filter = new SizeLessThan(String.valueOf(file.length()));
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
     filter = new SizeLessThan(file.length());
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
   }
 
   @Test
@@ -67,9 +69,9 @@ public class SizeBasedFilterTest extends com.adaptris.interlok.junit.scaffolding
   @Test
   public void testSizeLessThanOrEqualFileIsLarger() throws Exception {
     SizeBasedFileFilter filter = new SizeLessThanOrEqual(String.valueOf(file.length() - DIFF));
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
     filter = new SizeLessThanOrEqual(file.length() - DIFF);
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
   }
 
   @Test
@@ -83,9 +85,9 @@ public class SizeBasedFilterTest extends com.adaptris.interlok.junit.scaffolding
   @Test
   public void testSizeGreaterThanFileIsSmaller() throws Exception {
     SizeBasedFileFilter filter = new SizeGreaterThan(String.valueOf(file.length() + DIFF));
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
     filter = new SizeGreaterThan(file.length() + DIFF);
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
   }
 
   @Test
@@ -99,17 +101,17 @@ public class SizeBasedFilterTest extends com.adaptris.interlok.junit.scaffolding
   @Test
   public void testSizeGreaterThanFileIsExact() throws Exception {
     SizeBasedFileFilter filter = new SizeGreaterThan(String.valueOf(file.length()));
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
     filter = new SizeGreaterThan(file.length());
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
   }
 
   @Test
   public void testSizeGreaterThanOrEqualFileIsSmaller() throws Exception {
     SizeBasedFileFilter filter = new SizeGreaterThanOrEqual(String.valueOf(file.length() + DIFF));
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
     filter = new SizeGreaterThanOrEqual(file.length() + DIFF);
-    assertTrue("filter.accept() should be false", !filter.accept(file));
+    assertFalse("filter.accept() should be false", filter.accept(file));
   }
 
   @Test
@@ -126,5 +128,21 @@ public class SizeBasedFilterTest extends com.adaptris.interlok.junit.scaffolding
     assertTrue("filter.accept() should be true", filter.accept(file));
     filter = new SizeGreaterThanOrEqual(file.length());
     assertTrue("filter.accept() should be true", filter.accept(file));
+  }
+
+  @Test
+  public void testSizeBasedHumanReadableConstructor() throws Exception {
+    final long kilobyte = 1024;
+    final long megabyte = 1024*kilobyte;
+    final long gigabyte = 1024*megabyte;
+    final long ten_gigabytes = 10 * gigabyte;
+    assertEquals(1024, new SizeGreaterThan("1024").getFilesize());
+    assertEquals(1024, new SizeGreaterThan("1024J").getFilesize());
+    assertEquals(1024, new SizeGreaterThan("1024b").getFilesize());
+    assertEquals(kilobyte, new SizeGreaterThanOrEqual("1k").getFilesize());
+    assertEquals(megabyte, new SizeGreaterThan("1M").getFilesize());
+    assertEquals(megabyte, new SizeGreaterThan("1MB").getFilesize());
+    assertEquals(gigabyte, new SizeLessThan("1G").getFilesize());
+    assertEquals(ten_gigabytes, new SizeLessThanOrEqual("10Gb").getFilesize());
   }
 }


### PR DESCRIPTION
## Motivation

If you want a composite file filter you can have the string `SizeGTE=<some number in bytes>__@@__Regex=.*\.xml` but it's hard to figure out the number of bytes, who remembers that 1048760 is 10Megabytes?

It would be easier to have a human readable form of the bytes.

## Modification

Since SizeBasedFilter takes a String argument we can take a human readable form and automagically convert it into the correct number of bytes.

Based on https://stackoverflow.com/a/52565585 

- 10G is transformed into 10 gigabytes
- 10M is transformed into 10 megabytes etc.
- Only the first char of the specifier counts, so 10MB = 10M
- Uppercase for the unit specifier so 10m == 10Megabytes.
- If no specifier (or an invalid one) is included, then defaults to bytes
- Has supports up to Yottabytes (which is largely irrelevant) to be honest.
- No support for SI style.

## PR Checklist

- [x] been self-reviewed.

## Result

There is no change for the user, since existing file-filter-implementations will take the raw bytes value as it always did.

## Testing

- Filesystem consumer with a file-filter-imp == SizeGreaterThanOrEqual
- Use something like 1k as the filter-expression.
- Start it, and create some files that match the the boundaries in question.


