### PR TITLE
Add LGTM suppressions.

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,8 +2,6 @@ extraction:
   java:
     index:
       java_version: 11
-      gradle:
-        version: 7.1
       # Run individual commands since otherwise you get implicit dependency issues.
       build_command:
         - ./gradlew -S :interlok-core-apt:lgtmCompile
@@ -13,7 +11,6 @@ extraction:
         - ./gradlew -S :interlok-core:lgtmCompile
         - ./gradlew -S :interlok-client:lgtmCompile
         - ./gradlew -S :interlok-client-jmx:lgtmCompile
-        - ./gradlew --stop
 
 path_classifiers:
   docs:

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,9 +3,17 @@ extraction:
     index:
       java_version: 11
       gradle:
-        version: 6.8.1
+        version: 7.1
+      # Run individual commands since otherwise you get implicit dependency issues.
       build_command:
-        - ./gradlew --no-daemon -S lgtmCompile
+        - ./gradlew -S :interlok-core-apt:lgtmCompile
+        - ./gradlew -S :interlok-common:lgtmCompile
+        - ./gradlew -S :interlok-logging:lgtmCompile
+        - ./gradlew -S :interlok-boot:lgtmCompile
+        - ./gradlew -S :interlok-core:lgtmCompile
+        - ./gradlew -S :interlok-client:lgtmCompile
+        - ./gradlew -S :interlok-client-jmx:lgtmCompile
+        - ./gradlew --stop
 
 path_classifiers:
   docs:

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
   id "io.freefair.lombok" version "6.4.1" apply false
   // id 'org.kordamp.gradle.jdeps' version '0.12.0' apply false
   id "org.gradle.test-retry" version "1.3.1" apply false
+  id 'org.barfuin.gradle.taskinfo' version '1.3.1'
 }
 
 ext {

--- a/interlok-common/src/main/java/com/adaptris/interlok/resolver/FileResolver.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/resolver/FileResolver.java
@@ -85,6 +85,7 @@ public class FileResolver extends ResolverImp
   }
 
   @Override
+  @SuppressWarnings({"lgtm [java/path-injection]"})
   public String resolve(String lookupValue, InterlokMessage target)
   {
     if (lookupValue == null)

--- a/interlok-core/src/main/java/com/adaptris/core/SharedComponent.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedComponent.java
@@ -42,6 +42,7 @@ public class SharedComponent {
     return new InitialContext(env);
   }
 
+  @SuppressWarnings({"lgtm [java/jndi-injection]"})
   private AdaptrisComponent lookupQuietly(InitialContext ctx, String name) {
     AdaptrisComponent result = null;
     try {

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -47,6 +47,7 @@ public abstract class FsHelper {
    * Go straight to a {@link File} from a url style string.
    *
    */
+  @SuppressWarnings({"lgtm [java/path-injection]"})
   public static File toFile(String s) throws IOException, URISyntaxException {
     try {
       return createFileReference(createUrlFromString(s, true));

--- a/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ftp/FtpRecursiveConsumer.java
@@ -151,10 +151,7 @@ public class FtpRecursiveConsumer extends FtpConsumer
   @Override
   protected AdaptrisMessage addStandardMetadata(AdaptrisMessage msg, String filename, String dir) {
     super.addStandardMetadata(msg, filename, dir);
-    File parent = new File(dir);
-    if (parent != null) {
-      msg.addMetadata(CoreConstants.FS_CONSUME_PARENT_DIR, parent.getName());
-    }
+    msg.addMetadata(CoreConstants.FS_CONSUME_PARENT_DIR, new File(dir).getName());
     return msg;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -196,6 +196,7 @@ public class FilesystemRetryStore implements RetryStore {
   }
 
   @Override
+  @SuppressWarnings({"lgtm [java/path-injection]"})
   public boolean delete(String msgId) throws InterlokException {
     try {
       File target = new File(FsHelper.toFile(getBaseUrl()), msgId);

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/JdbcService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -128,7 +128,7 @@ public abstract class JdbcService extends ServiceImp implements ConnectedService
 
   /**
    * Get the {@link Connection} either from the {@link com.adaptris.core.AdaptrisMessage} object or from configuration.
-   * 
+   *
    * @param msg the adaptrisMessage object
    * @return the connection either from the adaptris message or from configuration.
    */
@@ -142,7 +142,7 @@ public abstract class JdbcService extends ServiceImp implements ConnectedService
 
   /**
    * Set the statement timeout.
-   * 
+   *
    * @param statementTimeout the statement timeout.
    * @since 3.0.1
    */
@@ -156,12 +156,14 @@ public abstract class JdbcService extends ServiceImp implements ConnectedService
     return s;
   }
 
+  @SuppressWarnings({"lgtm [java/sql-injection]"})
   protected PreparedStatement prepareStatement(Connection c, String sql) throws SQLException {
     PreparedStatement p = c.prepareStatement(sql);
     applyTimeout(p);
     return p;
   }
 
+  @SuppressWarnings({"lgtm [java/sql-injection]"})
   protected PreparedStatement prepareStatement(Connection c, String sql, int autoGenKeys) throws SQLException {
     PreparedStatement p = c.prepareStatement(sql, autoGenKeys);
     applyTimeout(p);

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/ProxySqlConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/ProxySqlConnection.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 import java.util.concurrent.Executor;
 import com.adaptris.core.util.JdbcUtil;
 
+@SuppressWarnings({"lgtm [java/sql-injection]"})
 public class ProxySqlConnection implements Connection {
 
   private Connection connection;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/jndi/BaseJndiImplementation.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/jndi/BaseJndiImplementation.java
@@ -61,6 +61,7 @@ public abstract class BaseJndiImplementation extends VendorImplementationImp {
     setExtraFactoryConfiguration(new NoOpFactoryConfiguration());
   }
 
+  @SuppressWarnings({"lgtm [java/jndi-injection]"})
   protected Object lookup(String name) throws JMSException {
     Object result = null;
     try {

--- a/interlok-core/src/main/java/com/adaptris/core/jmx/JmxConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jmx/JmxConnection.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -147,6 +147,7 @@ public class JmxConnection extends AllowsRetriesConnection {
   }
 
 
+  @SuppressWarnings({"lgtm [java/jndi-injection]"})
   private MBeanServerConnection createConnection() throws IOException, AdaptrisSecurityException {
     MBeanServerConnection result = null;
     if (!isBlank(getJmxServiceUrl())) {
@@ -177,7 +178,7 @@ public class JmxConnection extends AllowsRetriesConnection {
 
   /**
    * Set the JMX ServiceURL.
-   * 
+   *
    * @param s the jmxServiceUrl to set; if not specified, then a local JMX connector is assumed.
    */
   public void setJmxServiceUrl(String s) {
@@ -212,7 +213,7 @@ public class JmxConnection extends AllowsRetriesConnection {
    * If both the username / password are set, then a {@code jmx.remote.profiles="SASL/PLAIN"} is added to the environment
    * if it doesn't already exist.
    * </p>
-   * 
+   *
    * @param s the username to set
    */
   public void setUsername(String s) {
@@ -232,7 +233,7 @@ public class JmxConnection extends AllowsRetriesConnection {
    * If both the username / password are set, then a {@code jmx.remote.profiles="SASL/PLAIN"} is added to the environment
    * if it doesn't already exist.
    * </p>
-   * 
+   *
    * @param s the password to set
    */
   public void setPassword(String s) {
@@ -245,7 +246,7 @@ public class JmxConnection extends AllowsRetriesConnection {
 
   /**
    * Whether or not to generate additional TRACE level debug when attempting connections.
-   * 
+   *
    * @param b true to enable additional logging; default false.
    */
   public void setAdditionalDebug(Boolean b) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/ReadFileService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/ReadFileService.java
@@ -72,7 +72,8 @@ public class ReadFileService extends ServiceImp {
       throw ExceptionHelper.wrapServiceException(e);
     }
   }
-  
+
+  @SuppressWarnings({"lgtm [java/path-injection]"})
   private static File convertToFile(String filepath) throws FsException {
     try {
       return isFile(checkReadable(FsHelper.toFile(filepath)));
@@ -106,7 +107,7 @@ public class ReadFileService extends ServiceImp {
 
   /**
    * Get the file path parameter.
-   * 
+   *
    * @return The file path parameter.
    */
   public String getFilePath() {
@@ -115,7 +116,7 @@ public class ReadFileService extends ServiceImp {
 
   /**
    * Set the file path parameter.
-   * 
+   *
    * @param filePath The file path parameter.
    */
   public void setFilePath(final String filePath) {
@@ -128,7 +129,7 @@ public class ReadFileService extends ServiceImp {
 
   /**
    * Sets the metadata key set the content type as, if not provided will not be set. (default: null)
-   * 
+   *
    * @param contentTypeMetadataKey
    */
   public void setContentTypeMetadataKey(String contentTypeMetadataKey) {
@@ -146,7 +147,7 @@ public class ReadFileService extends ServiceImp {
    * By default {@link Files#probeContentType(java.nio.file.Path)} is used which means no additional jars are required. This
    * implementation is platform dependent; so an alternative is available in the {@code com.adaptris:interlok-filesystem} module.
    * </p>
-   * 
+   *
    * @param contentTypeProbe how to probe for the content type; by default uses {@link Files#probeContentType(java.nio.file.Path)}
    *        if not explicitly configured.
    */

--- a/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/dynamic/ServiceFromDatabase.java
@@ -79,6 +79,7 @@ public class ServiceFromDatabase extends ExtractorWithConnection {
   }
 
   @Override
+  @SuppressWarnings({"lgtm [java/sql-injection]"})
   public InputStream getInputStream(AdaptrisMessage m) throws Exception {
     Args.notBlank(getQuery(), "query");
     Connection jdbcCon = getConnection().retrieveConnection(DatabaseConnection.class).connect();

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddFormattedMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddFormattedMetadataService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,7 +44,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * <p>
  * Allows you to add a new metadata key using {@code String.format()} as the syntax.
  * </p>
- * 
+ *
  * @config add-formatted-metadata-service
  */
 @XStreamAlias("add-formatted-metadata-service")
@@ -74,6 +74,7 @@ public class AddFormattedMetadataService extends ServiceImp {
   }
 
   @Override
+  @SuppressWarnings({"lgtm [java/tainted-format-string]"})
   public void doService(AdaptrisMessage msg) throws ServiceException {
     String toFormat = msg.resolve(getFormatString());
     String formattedValue = String.format(toFormat, resolveMetadata(msg));
@@ -110,7 +111,7 @@ public class AddFormattedMetadataService extends ServiceImp {
 
   /**
    * Set the format string that complies with {@link String#format(String, Object...)}.
-   * 
+   *
    * @param formatString the formatString to set
    */
   public void setFormatString(String formatString) {
@@ -167,7 +168,7 @@ public class AddFormattedMetadataService extends ServiceImp {
 
   /**
    * Get the element formatter.
-   * 
+   *
    * @return The element formatter.
    */
   public ElementFormatter getElementFormatter() {
@@ -176,7 +177,7 @@ public class AddFormattedMetadataService extends ServiceImp {
 
   /**
    * Set the element formatter.
-   * 
+   *
    * @param elementFormatter The element formatter.
    */
   public void setElementFormatter(ElementFormatter elementFormatter) {

--- a/interlok-core/src/main/java/com/adaptris/core/transform/schema/XmlSchemaValidatorImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/schema/XmlSchemaValidatorImpl.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2020 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -99,6 +99,7 @@ public abstract class XmlSchemaValidatorImpl extends MessageValidatorImpl {
     return resolveFromCache(schemaUrl);
   }
 
+  @SuppressWarnings({"lgtm [java/xxe]"})
   protected Schema resolveFromCache(String urlString) throws Exception {
     Cache cache = schemaCacheConnection.retrieveConnection(CacheConnection.class).retrieveCache();
     Schema schema = (Schema) cache.get(urlString);
@@ -111,7 +112,7 @@ public abstract class XmlSchemaValidatorImpl extends MessageValidatorImpl {
 
   /**
    * Sets the schema to validate against. May not be null or empty.
-   * 
+   *
    * @param s the schema to validate against, normally a URL.
    */
   public void setSchema(String s) {
@@ -120,7 +121,7 @@ public abstract class XmlSchemaValidatorImpl extends MessageValidatorImpl {
 
   /**
    * Returns the schema to validate against.
-   * 
+   *
    * @return the schema to validate against
    */
   public String getSchema() {
@@ -140,7 +141,7 @@ public abstract class XmlSchemaValidatorImpl extends MessageValidatorImpl {
    * behaviour is to cache 16 schemas for a max of 2 hours (last-access) if you don't explicitly
    * configure it differently.
    * </p>
-   * 
+   *
    * @param cache the cache, generally a {@link CacheConnection} or {@link SharedConnection}.
    */
   public void setSchemaCache(AdaptrisConnection cache) {

--- a/interlok-core/src/main/java/com/adaptris/jdbc/connection/FailoverDataSource.java
+++ b/interlok-core/src/main/java/com/adaptris/jdbc/connection/FailoverDataSource.java
@@ -340,6 +340,7 @@ public class FailoverDataSource implements DataSource {
    * resources that are held by this object.
    * </p>
    */
+  @SuppressWarnings({"lgtm [java/sql-injection]"})
   protected class ConnectionProxy implements Connection {
     private FailoverConnection conn;
 


### PR DESCRIPTION
## Motivation

https://lgtm.com/projects/g/adaptris/interlok/alerts/?mode=list has 33 alerts all around
`path-injection, xxe, jndi-injection, sql-injection, tainted-format-string` which are all ignorable in this context.

## Modification

- Add SuppressWarning annotations where required.
- Attempt to fix lgtm double reporting (it's reporting on src/main/java && src/main/generated); this might not work

## PR Checklist

- [x] been self-reviewed.


## Result

No Change

## Testing

Once merged, check the alerts in lgtm; I checked the analysis in LGTM and that is correct.

