### PR TITLE
Backed out INTERLOK-1270. 

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/CmdLineBootstrap.java
@@ -171,24 +171,20 @@ abstract class CmdLineBootstrap {
         @Override
         public void run() {
           Thread.currentThread().setName(threadName);
-          bootStart(bootstrap);
+          try {
+            bootstrap.start();
+          }
+          catch (Throwable e) {
+            System.err.println("(Error) Adapter Startup failure :" + e.getMessage());
+            logException(e);
+          }
         }
       });
       launcher.setDaemon(false);
       launcher.start();
     }
     else {
-      bootStart(bootstrap);
-    }
-  }
-
-  private void bootStart(final UnifiedBootstrap bootstrap) {
-    try {
       bootstrap.start();
-    }
-    catch (Throwable e) {
-      System.err.println("(Error) Adapter Startup failure :" + e.getMessage());
-      logException(e);
     }
   }
   


### PR DESCRIPTION
## Motivation

StartAdapterQuietly = false would exit the JVM when a runtime exception would occur during start-up in the past.  But 1270 changes this behaviour, making startAdapterQuietly pointless.

## Modification

Backed out 1270 from the CmdLineBootstrap class.

## PR Checklist

- [x] been self-reviewed.

## Result

Previous behaviour of JVM exit has been re-introduced.

