### PR TITLE
INTERLOK-3890 # comment Add two new components  to send a multipart m…

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/common/MultiPartMessageStreamInputParameter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/common/MultiPartMessageStreamInputParameter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.common;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import javax.mail.Header;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.http.client.net.MultiPartMessageRequestHeaders;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * This {@code DataInputParameter} is used when you want to source data from the {@link com.adaptris.core.AdaptrisMessage} multipart MIME
+ * payload. This will remove the multipart payload headers and only keep the content (All the parts). It is meant to be used in conjunction
+ * with {@link MultiPartMessageRequestHeaders}
+ *
+ * @config multipart-message-stream-input-parameter
+ *
+ */
+@XStreamAlias("multipart-message-stream-input-parameter")
+@AdapterComponent
+@ComponentProfile(summary = "Use a multipart message payload and remove its headers", tag = "mime,http")
+public class MultiPartMessageStreamInputParameter implements DataInputParameter<InputStream> {
+
+  public MultiPartMessageStreamInputParameter() {
+  }
+
+  @Override
+  public InputStream extract(InterlokMessage message) throws InterlokException {
+    InputStream result = null;
+
+    try {
+      MimeMessage mimeMessage = new MimeMessage(null, message.getInputStream());
+
+      List<String> headerNames = headerNames(mimeMessage);
+
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      mimeMessage.writeTo(baos, headerNames.toArray(String[]::new));
+
+      result = new ByteArrayInputStream(baos.toByteArray());
+    } catch (MessagingException | IOException expts) {
+      throw ExceptionHelper.wrapCoreException(expts);
+    }
+
+    return result;
+  }
+
+  private List<String> headerNames(MimeMessage mimeMessage) throws MessagingException {
+    List<String> headerNames = new ArrayList<>();
+    Enumeration<Header> headers = mimeMessage.getAllHeaders();
+    while (headers.hasMoreElements()) {
+      Header header = headers.nextElement();
+      headerNames.add(header.getName());
+    }
+    return headerNames;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/MetadataRequestHeaders.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/MetadataRequestHeaders.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.http.client.net;
 
@@ -21,12 +21,9 @@ import java.net.HttpURLConnection;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
@@ -38,20 +35,18 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 /**
  * Implementation of {@link RequestHeaderProvider} that applies {@link com.adaptris.core.AdaptrisMessage} metadata as
  * headers to a {@link HttpURLConnection}.
- * 
+ *
  * @config http-metadata-request-headers
- * 
+ *
  */
 @XStreamAlias("http-metadata-request-headers")
-public class MetadataRequestHeaders implements RequestHeaderProvider<HttpURLConnection> {
+public class MetadataRequestHeaders extends RequestHeaders implements RequestHeaderProvider<HttpURLConnection> {
   protected transient Logger log = LoggerFactory.getLogger(this.getClass());
+
+
   @NotNull
   @Valid
   private MetadataFilter filter;
-
-  @AdvancedConfig
-  @InputFieldDefault(value = "false")
-  private Boolean unfold;
 
   public MetadataRequestHeaders() {
   }
@@ -78,38 +73,11 @@ public class MetadataRequestHeaders implements RequestHeaderProvider<HttpURLConn
 
   /**
    * Set the filter to be applied to metadata before adding as request properties.
-   * 
+   *
    * @param mf the filter.
    */
   public void setFilter(MetadataFilter mf) {
-    this.filter = Args.notNull(mf, "metadata filter");
+    filter = Args.notNull(mf, "metadata filter");
   }
 
-  public Boolean getUnfold() {
-    return unfold;
-  }
-
-  /**
-   * Unfold headers onto a single line.
-   * <p>
-   * RFC7230 deprecates the folding of headers onto multiple lines; so HTTP headers are expected to be single line. This param
-   * allows you to enforce that unfolding metadata values happens before writing them as request properties.
-   * </p>
-   * 
-   * @param b true to unfold values (default is false to preserve legacy behaviour).
-   */
-  public void setUnfold(Boolean b) {
-    this.unfold = b;
-  }
-
-  boolean unfold() {
-    return BooleanUtils.toBooleanDefaultIfNull(getUnfold(), false);
-  }
-
-  String unfold(String s) {
-    if (unfold()) {
-      return s.replaceAll("\\s\\r\\n\\s+", " ").replaceAll("\\r\\n\\s+", " ");
-    }
-    return s;
-  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeaders.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeaders.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.http.client.net;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Enumeration;
+
+import javax.mail.Header;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.common.MultiPartMessageStreamInputParameter;
+import com.adaptris.core.http.client.RequestHeaderProvider;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Implementation of {@link RequestHeaderProvider} that applies multipart MIME message headers as headers to a {@link HttpURLConnection}. It
+ * is meant to be used in conjunction with {@link MultiPartMessageStreamInputParameter}
+ *
+ * @config http-multipart-message-request-headers
+ *
+ */
+@XStreamAlias("http-multipart-message-request-headers")
+@AdapterComponent
+@ComponentProfile(summary = "Use a multipart message headers and add them as headers to an http connection", tag = "mime,http")
+public class MultiPartMessageRequestHeaders extends RequestHeaders implements RequestHeaderProvider<HttpURLConnection> {
+  protected transient Logger log = LoggerFactory.getLogger(this.getClass());
+
+  public MultiPartMessageRequestHeaders() {
+  }
+
+  @Override
+  public HttpURLConnection addHeaders(AdaptrisMessage msg, HttpURLConnection target) {
+    try {
+      MimeMessage mimeMessage = new MimeMessage(null, msg.getInputStream());
+      Enumeration<Header> headers = mimeMessage.getAllHeaders();
+
+      while (headers.hasMoreElements()) {
+        Header header = headers.nextElement();
+        String value = unfold(header.getValue());
+        log.trace("Adding Request Property [{}: {}]", header.getName(), value);
+        target.addRequestProperty(header.getName(), value);
+      }
+
+    } catch (MessagingException | IOException expts) {
+      log.error("Invalid multipart MIME message. No request header will be added.", expts);
+    }
+    return target;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeaders.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeaders.java
@@ -86,7 +86,7 @@ public class MultiPartMessageRequestHeaders extends RequestHeaders implements Re
       }
 
     } catch (MessagingException | IOException expts) {
-      log.error("Invalid multipart MIME message. No request header will be added.", expts);
+      throw new RuntimeException("Invalid multipart MIME message", expts);
     }
     return target;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/RequestHeaders.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/RequestHeaders.java
@@ -1,0 +1,44 @@
+package com.adaptris.core.http.client.net;
+
+import java.net.HttpURLConnection;
+
+import org.apache.commons.lang3.BooleanUtils;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.http.client.RequestHeaderProvider;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public abstract class RequestHeaders implements RequestHeaderProvider<HttpURLConnection> {
+
+  /**
+   * Unfold headers onto a single line.
+   * <p>
+   * RFC7230 deprecates the folding of headers onto multiple lines; so HTTP headers are expected to be single line. This param allows you to
+   * enforce that unfolding metadata values happens before writing them as request properties.
+   * </p>
+   *
+   * @param unfold
+   *          true to unfold values (default is false to preserve legacy behaviour).
+   * @return true if set to unfold values.
+   */
+  @Getter
+  @Setter
+  @AdvancedConfig
+  @InputFieldDefault(value = "false")
+  private Boolean unfold;
+
+  boolean unfold() {
+    return BooleanUtils.toBooleanDefaultIfNull(getUnfold(), false);
+  }
+
+  String unfold(String s) {
+    if (unfold()) {
+      return s.replaceAll("\\s\\r\\n\\s+", " ").replaceAll("\\r\\n\\s+", " ");
+    }
+    return s;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/common/MultiPartMessageStreamInputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/MultiPartMessageStreamInputParameterTest.java
@@ -1,6 +1,7 @@
 package com.adaptris.core.common;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,12 +53,12 @@ public class MultiPartMessageStreamInputParameterTest {
     }
   }
 
-  @Test(expected = CoreException.class)
+  @Test
   public void testExtractWithException() throws Exception {
     MultiPartMessageStreamInputParameter p = new MultiPartMessageStreamInputParameter();
     AdaptrisMessage msg = new MyDefectiveMessage();
-    try (InputStream in = p.extract(msg)) {
-    }
+
+    assertThrows(CoreException.class, () -> { try (InputStream in = p.extract(msg)) {}});
   }
 
   private class MyDefectiveMessage extends DefectiveAdaptrisMessage {

--- a/interlok-core/src/test/java/com/adaptris/core/common/MultiPartMessageStreamInputParameterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/common/MultiPartMessageStreamInputParameterTest.java
@@ -1,0 +1,79 @@
+package com.adaptris.core.common;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.stubs.DefectiveAdaptrisMessage;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
+import com.adaptris.util.GuidGenerator;
+
+public class MultiPartMessageStreamInputParameterTest {
+
+  private static final String MULTI_PART_NO_HEADER = "\n"
+      + "------=_Part_1_1038479175.1649809692675\n"
+      + "Content-Type: text/plain\n"
+      + "Content-Disposition: form-data; name=\"file\"\n"
+      + "Content-ID: file\n"
+      + "\n"
+      + "Some text\n"
+      + "------=_Part_1_1038479175.1649809692675--\n"
+      + "";
+
+  private static final String MULTI_PART = "Message-ID: check-service-test-message\n"
+      + "Mime-Version: 1.0\n"
+      + "Content-Type: multipart/form-data; \n"
+      + "    boundary=\"----=_Part_1_1038479175.1649809692675\"\n"
+      + "Content-Length: 191\n"
+      + MULTI_PART_NO_HEADER;
+
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Test
+  public void testExtract() throws Exception {
+    MultiPartMessageStreamInputParameter streamInputParameter = new MultiPartMessageStreamInputParameter();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MULTI_PART.getBytes());
+    try (InputStream in = streamInputParameter.extract(msg)) {
+      String result = IOUtils.toString(in, Charset.defaultCharset());
+      assertEquals(MULTI_PART_NO_HEADER.replaceAll("\\r", ""), result.replaceAll("\\r", ""));
+    }
+  }
+
+  @Test(expected = CoreException.class)
+  public void testExtractWithException() throws Exception {
+    MultiPartMessageStreamInputParameter p = new MultiPartMessageStreamInputParameter();
+    AdaptrisMessage msg = new MyDefectiveMessage();
+    try (InputStream in = p.extract(msg)) {
+    }
+  }
+
+  private class MyDefectiveMessage extends DefectiveAdaptrisMessage {
+    public MyDefectiveMessage() {
+      super(new GuidGenerator(), new DefectiveMessageFactory());
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+      throw new IOException("broken");
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+      throw new IOException("broken");
+    }
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/MetadataRequestHeadersTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/MetadataRequestHeadersTest.java
@@ -16,30 +16,23 @@
 
 package com.adaptris.core.http.client.net;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.Channel;
-import com.adaptris.core.metadata.NoOpMetadataFilter;
-import com.adaptris.core.metadata.RegexMetadataFilter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.net.HttpURLConnection;
-import java.net.URL;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.Channel;
+import com.adaptris.core.metadata.NoOpMetadataFilter;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+
 public class MetadataRequestHeadersTest extends RequestHeadersCase {
-
-  @Before
-  public void setUp() throws Exception {}
-
-  @After
-  public void tearDown() throws Exception {}
 
   @Test
   public void testFilter() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeadersTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeadersTest.java
@@ -2,6 +2,7 @@ package com.adaptris.core.http.client.net;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.net.HttpURLConnection;
@@ -12,6 +13,7 @@ import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.Channel;
+import com.adaptris.core.stubs.DefectiveMessageFactory;
 
 public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
 
@@ -82,6 +84,22 @@ public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
       assertTrue(urlC.getRequestProperty("Content-Type").replaceAll("\\r", "")
           .equals("multipart/form-data; \n    boundary=\"----=_Part_1_1038479175.1649809692675\""));
       assertEquals("message-id", urlC.getRequestProperty("Message-ID"));
+    } finally {
+      HttpHelper.stopChannelAndRelease(c);
+    }
+  }
+
+  @Test
+  public void testAddHeadersInvalidMessage() throws Exception {
+    Channel c = null;
+    try {
+      c = HttpHelper.createAndStartChannel();
+      URL url = new URL(HttpHelper.createProduceDestination(c));
+      final HttpURLConnection urlC = (HttpURLConnection) url.openConnection();
+      MultiPartMessageRequestHeaders headers = new MultiPartMessageRequestHeaders();
+      AdaptrisMessage msg = new DefectiveMessageFactory().newMessage();
+
+      assertThrows(RuntimeException.class, () -> headers.addHeaders(msg, urlC));
     } finally {
       HttpHelper.stopChannelAndRelease(c);
     }

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeadersTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeadersTest.java
@@ -1,5 +1,7 @@
 package com.adaptris.core.http.client.net;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.HttpURLConnection;
@@ -25,6 +27,7 @@ public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
 
   private static final String MULTI_PART = "Message-ID: check-service-test-message\n"
       + "Mime-Version: 1.0\n"
+      + "Message-ID: message-id\n"
       + "Content-Type: multipart/form-data; \n"
       + "    boundary=\"----=_Part_1_1038479175.1649809692675\"\n"
       + "Content-Length: 191\n"
@@ -43,6 +46,7 @@ public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
       urlC = headers.addHeaders(msg, urlC);
       assertTrue(urlC.getRequestProperty("Content-Type").replaceAll("\\r", "")
           .equals("multipart/form-data; \n    boundary=\"----=_Part_1_1038479175.1649809692675\""));
+      assertNull(urlC.getRequestProperty("Message-ID"));
     } finally {
       HttpHelper.stopChannelAndRelease(c);
     }
@@ -61,6 +65,27 @@ public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MULTI_PART);
       urlC = headers.addHeaders(msg, urlC);
       assertTrue(contains(urlC, "Content-Type", "multipart/form-data; boundary=\"----=_Part_1_1038479175.1649809692675\""));
+      assertNull(urlC.getRequestProperty("Message-ID"));
+    } finally {
+      HttpHelper.stopChannelAndRelease(c);
+    }
+  }
+
+  @Test
+  public void testAddHeadersWithMessageId() throws Exception {
+    Channel c = null;
+    HttpURLConnection urlC = null;
+    try {
+      c = HttpHelper.createAndStartChannel();
+      URL url = new URL(HttpHelper.createProduceDestination(c));
+      urlC = (HttpURLConnection) url.openConnection();
+      MultiPartMessageRequestHeaders headers = new MultiPartMessageRequestHeaders();
+      headers.setExcludeMessageId(false);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MULTI_PART);
+      urlC = headers.addHeaders(msg, urlC);
+      assertTrue(urlC.getRequestProperty("Content-Type").replaceAll("\\r", "")
+          .equals("multipart/form-data; \n    boundary=\"----=_Part_1_1038479175.1649809692675\""));
+      assertEquals("message-id", urlC.getRequestProperty("Message-ID"));
     } finally {
       HttpHelper.stopChannelAndRelease(c);
     }

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeadersTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeadersTest.java
@@ -1,0 +1,69 @@
+package com.adaptris.core.http.client.net;
+
+import static org.junit.Assert.assertTrue;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.Channel;
+
+public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
+
+  private static final String MULTI_PART_NO_HEADER = "\n"
+      + "------=_Part_1_1038479175.1649809692675\n"
+      + "Content-Type: text/plain\n"
+      + "Content-Disposition: form-data; name=\"file\"\n"
+      + "Content-ID: file\n"
+      + "\n"
+      + "Some text\n"
+      + "------=_Part_1_1038479175.1649809692675--\n"
+      + "";
+
+  private static final String MULTI_PART = "Message-ID: check-service-test-message\n"
+      + "Mime-Version: 1.0\n"
+      + "Content-Type: multipart/form-data; \n"
+      + "    boundary=\"----=_Part_1_1038479175.1649809692675\"\n"
+      + "Content-Length: 191\n"
+      + MULTI_PART_NO_HEADER;
+
+  @Test
+  public void testAddHeaders() throws Exception {
+    Channel c = null;
+    HttpURLConnection urlC = null;
+    try {
+      c = HttpHelper.createAndStartChannel();
+      URL url = new URL(HttpHelper.createProduceDestination(c));
+      urlC = (HttpURLConnection) url.openConnection();
+      MultiPartMessageRequestHeaders headers = new MultiPartMessageRequestHeaders();
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MULTI_PART);
+      urlC = headers.addHeaders(msg, urlC);
+      assertTrue(urlC.getRequestProperty("Content-Type").replaceAll("\\r", "")
+          .equals("multipart/form-data; \n    boundary=\"----=_Part_1_1038479175.1649809692675\""));
+    } finally {
+      HttpHelper.stopChannelAndRelease(c);
+    }
+  }
+
+  @Test
+  public void testAddHeaders_Flatten() throws Exception {
+    Channel c = null;
+    HttpURLConnection urlC = null;
+    try {
+      c = HttpHelper.createAndStartChannel();
+      URL url = new URL(HttpHelper.createProduceDestination(c));
+      urlC = (HttpURLConnection) url.openConnection();
+      MultiPartMessageRequestHeaders headers = new MultiPartMessageRequestHeaders();
+      headers.setUnfold(true);
+      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MULTI_PART);
+      urlC = headers.addHeaders(msg, urlC);
+      assertTrue(contains(urlC, "Content-Type", "multipart/form-data; boundary=\"----=_Part_1_1038479175.1649809692675\""));
+    } finally {
+      HttpHelper.stopChannelAndRelease(c);
+    }
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeadersTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/MultiPartMessageRequestHeadersTest.java
@@ -25,8 +25,7 @@ public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
       + "------=_Part_1_1038479175.1649809692675--\n"
       + "";
 
-  private static final String MULTI_PART = "Message-ID: check-service-test-message\n"
-      + "Mime-Version: 1.0\n"
+  private static final String MULTI_PART = "Mime-Version: 1.0\n"
       + "Message-ID: message-id\n"
       + "Content-Type: multipart/form-data; \n"
       + "    boundary=\"----=_Part_1_1038479175.1649809692675\"\n"
@@ -36,11 +35,10 @@ public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
   @Test
   public void testAddHeaders() throws Exception {
     Channel c = null;
-    HttpURLConnection urlC = null;
     try {
       c = HttpHelper.createAndStartChannel();
       URL url = new URL(HttpHelper.createProduceDestination(c));
-      urlC = (HttpURLConnection) url.openConnection();
+      HttpURLConnection urlC = (HttpURLConnection) url.openConnection();
       MultiPartMessageRequestHeaders headers = new MultiPartMessageRequestHeaders();
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MULTI_PART);
       urlC = headers.addHeaders(msg, urlC);
@@ -55,11 +53,10 @@ public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
   @Test
   public void testAddHeaders_Flatten() throws Exception {
     Channel c = null;
-    HttpURLConnection urlC = null;
     try {
       c = HttpHelper.createAndStartChannel();
       URL url = new URL(HttpHelper.createProduceDestination(c));
-      urlC = (HttpURLConnection) url.openConnection();
+      HttpURLConnection urlC = (HttpURLConnection) url.openConnection();
       MultiPartMessageRequestHeaders headers = new MultiPartMessageRequestHeaders();
       headers.setUnfold(true);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MULTI_PART);
@@ -74,11 +71,10 @@ public class MultiPartMessageRequestHeadersTest extends RequestHeadersCase {
   @Test
   public void testAddHeadersWithMessageId() throws Exception {
     Channel c = null;
-    HttpURLConnection urlC = null;
     try {
       c = HttpHelper.createAndStartChannel();
       URL url = new URL(HttpHelper.createProduceDestination(c));
-      urlC = (HttpURLConnection) url.openConnection();
+      HttpURLConnection urlC = (HttpURLConnection) url.openConnection();
       MultiPartMessageRequestHeaders headers = new MultiPartMessageRequestHeaders();
       headers.setExcludeMessageId(false);
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MULTI_PART);


### PR DESCRIPTION
## Motivation

We need to be able to send a file as part of a multipart/form-data request.

## Modification

Add two new components  to send a multipart message with Standard HTTP Producer:

- A http-multipart-message-request-headers which is a request-header-provider taking multipart mime message headers and adding them to the http request headers.
- A multipart-message-stream-input-parameter which is a request-body taking the multipart mime message content (without the headers) and adding it to the http request body.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

The user can create a multipart MIME message containing a file with a multipart-message-builder.
Then the standalone-http-producer configured with the new http-multipart-message-request-headers and multipart-message-stream-input-parameter can send this multipart message.

## Testing

With a build of this branch you can have a configuration like the following:

```xml

  <!-- Read a file and put the content in the payload -->
  <read-file-service>
    <unique-id>jolly-lamarr</unique-id>
    <file-path>file:/path/to/pdf/file.pdf</file-path>
    <content-type-metadata-key>file-content-type</content-type-metadata-key>
  </read-file-service>

  <!-- Add a new multipart-message-builder service which will build your multipart message, assuming that your PDF is your payload -->
  <multipart-message-builder>
    <unique-id>build-multipart</unique-id>
    <inline-mime-body-part-builder>
      <body class="byte-array-from-payload"/>
      <part-header-filter class="fixed-values-metadata-filter">
        <metadata>
          <key-value-pair>
            <key>Content-Disposition</key>
            <value>form-data; name=&quot;file&quot;</value>
          </key-value-pair>
        </metadata>
      </part-header-filter>
      <content-type>application/pdf</content-type>
      <content-id>file</content-id>
    </inline-mime-body-part-builder>
    <mime-content-sub-type>form-data</mime-content-sub-type>
  </multipart-message-builder>

  <!--In the standalone-requestor you will need to use the two new components -->
  <standalone-requestor>
    <unique-id>attach-pdf-invoice</unique-id>
    <connection class="null-connection">
      <unique-id>null-connection</unique-id>
    </connection>
    <producer class="standard-http-producer">
      <unique-id>connect-caaps-api</unique-id>
      <url>http://localhost:8080/api/files</url>
      <method-provider class="http-configured-request-method">
        <method>POST</method>
      </method-provider>
     <ignore-server-response-code>true</ignore-server-response-code>
      <content-type-provider class="http-null-content-type-provider"/>
      <response-header-handler class="http-response-headers-as-metadata"/>
      <request-header-provider class="http-composite-request-headers">
        <http-multipart-message-request-headers>
          <unfold>true</unfold>
        </http-multipart-message-request-headers>
        <http-configured-request-headers>
          <headers>
            <key-value-pair>
              <key>X-Client-Id</key>
              <value>Some-Client-Id</value>
            </key-value-pair>
          </headers>
        </http-configured-request-headers>
      </request-header-provider>
      <request-body class="multipart-message-stream-input-parameter"/>
      <authenticator class="http-no-authentication"/>
    </producer>
  </standalone-requestor>
```

Then you will need an endpoint to which you can upload a multipart/form-data file with the name file.
That can be an endpoint you already have, a webapp, springboot app or even interlok with something like this:

```xml
<channel>
  <consume-connection class="jetty-embedded-connection">
    <unique-id>jetty-connection</unique-id>
  </consume-connection>
  <produce-connection class="null-connection">
    <unique-id>nostalgic-brahmagupta</unique-id>
  </produce-connection>
  <workflow-list>
    <standard-workflow>
      <consumer class="jetty-message-consumer">
        <message-factory class="default-message-factory"/>
        <unique-id>/api/files</unique-id>
        <destination class="configured-consume-destination">
          <configured-thread-name>/api/files</configured-thread-name>
          <destination>/api/files</destination>
        </destination>
        <parameter-handler class="jetty-http-parameters-as-metadata"/>
        <header-handler class="jetty-http-headers-as-metadata"/>
      </consumer>
      <service-collection class="service-list">
        <unique-id>agitated-austin</unique-id>
        <services>
          <mime-part-selector-service>
            <unique-id>get-file-from-payload</unique-id>
            <selector class="mime-select-by-header">
              <header-name>Content-Disposition</header-name>
              <header-value-reg-exp>form-data; name=&quot;file&quot;</header-value-reg-exp>
            </selector>
          </mime-part-selector-service>
          <jetty-response-service>
            <unique-id>jetty-response</unique-id>
            <http-status>200</http-status>
            <content-type>text/plain</content-type>
            <response-header-provider class="jetty-no-response-headers"/>
          </jetty-response-service>
        </services>
      </service-collection>
      <producer class="fs-producer">
        <unique-id>write-file</unique-id>
        <destination class="configured-destination">
          <destination>file:/path/to/where/you/want/to/save/file</destination>
        </destination>
        <fs-worker class="fs-nio-worker"/>
        <filename-creator class="formatted-filename-creator">
          <filename-format>pdf-file.pdf</filename-format>
        </filename-creator>
      </producer>
      <produce-exception-handler class="null-produce-exception-handler"/>
      <unique-id>http</unique-id>
    </standard-workflow>
  </workflow-list>
  <unique-id>http</unique-id>
</channel>
```
Then you can check that the pdf file has been saved correctly in your file system.
