### PR TITLE
ci(circleci): Bump ubuntu image to 2204

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,110 +5,9 @@
 version: 2
 
 jobs:
-  publish:
-    machine:
-      image: ubuntu-2004:202201-02
-
-    working_directory: ~/interlok
-
-    environment:
-      JAVA_TOOL_OPTIONS: -Xmx2G
-      TERM: dumb
-      DEBIAN_FRONTEND: noninteractive
-
-    steps:
-      - checkout
-
-      - run:
-          name: Configure
-          command: |
-            sudo -E apt-get -y -q update
-            sudo -E apt-get -y -q install haveged openjdk-8-jdk graphviz
-            sudo -E systemctl restart haveged
-            mkdir -p ~/.gradle
-            echo "org.gradle.warning.mode=none" > ~/.gradle/gradle.properties
-            echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}-{{ checksum "interlok-core/build.gradle" }}-{{ checksum "interlok-common/build.gradle"}}
-            - dependencies-{{ checksum "build.gradle" }}-{{ checksum "interlok-core/build.gradle" }}-{{ checksum "interlok-common/build.gradle"}}
-            - dependencies-{{ checksum "build.gradle" }}
-
-      # run tests!
-      - run:
-          name: publish
-          command: |
-            chmod +x ./gradlew
-            ./gradlew -PverboseTests=true clean publish
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-            - ~/.gradle/wrapper
-          key: dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}-{{ checksum "interlok-core/build.gradle" }}-{{ checksum "interlok-common/build.gradle"}}
-
-  build:
-    machine:
-      image: ubuntu-1604:201903-01
-
-    working_directory: ~/interlok
-
-    environment:
-      JAVA_TOOL_OPTIONS: -Xmx2G
-      TERM: dumb
-      DEBIAN_FRONTEND: noninteractive
-
-    steps:
-      - checkout
-
-      - run:
-          name: Configure
-          command: |
-            sudo -E apt-get -y -q update
-            sudo -E apt-get -y -q install haveged openjdk-8-jdk
-            sudo -E systemctl restart haveged
-            mkdir -p ~/.gradle
-            echo "org.gradle.warning.mode=none" > ~/.gradle/gradle.properties
-            echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
-            echo "default.jdbc.storedproc.tests.enabled=false" >> interlok-core/build.properties
-            echo "default.ftp.tests.enabled=false" >> interlok-core/build.properties
-            echo "junit.jms.tests.enabled=false" >> interlok-core/build.properties
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}-{{ checksum "interlok-core/build.gradle" }}-{{ checksum "interlok-common/build.gradle"}}
-            - dependencies-{{ checksum "build.gradle" }}-{{ checksum "interlok-core/build.gradle" }}-{{ checksum "interlok-common/build.gradle"}}
-            - dependencies-{{ checksum "build.gradle" }}
-
-      # run tests!
-      - run:
-          name: Run Tests
-          command: |
-            chmod +x ./gradlew
-            ./gradlew -PverboseTests=true test jacocoTestReport
-
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
-          when: always
-
-      - store_test_results:
-          path: ~/test-results
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-            - ~/.gradle/wrapper
-          key: dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}-{{ checksum "interlok-core/build.gradle" }}-{{ checksum "interlok-common/build.gradle"}}
-
   buildjava11:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2204:current
 
     working_directory: ~/interlok
 
@@ -123,8 +22,8 @@ jobs:
       - run:
           name: Configure
           command: |
-            sudo -E apt-get -y -q update
-            sudo -E apt-get -y -q install haveged openjdk-11-jdk
+            sudo -E apt-get -y -qq update
+            sudo -E apt-get -y -qq install haveged openjdk-11-jdk
             sudo -E systemctl restart haveged
             mkdir -p ~/.gradle
             echo "org.gradle.warning.mode=none" > ~/.gradle/gradle.properties


### PR DESCRIPTION
## Motivation

ubuntu-2604 is unavailable as of 2022-05-31 so we bump to 2204.1
Remove redundant circleci jobs that were for 3.x

## Modification

Switch to ubuntu-2204:current as the image tag.

## PR Checklist

- [x] been self-reviewed.

## Result

- No visible change to the user.
- https://app.circleci.com/pipelines/github/adaptris/interlok/3298/workflows/84c9f6b0-5162-40a7-b328-1ec8b365c661/jobs/3651 should no longer be an issue.

