### PR TITLE
build: mark CVE-2022-33915 as a false positive

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -76,4 +76,12 @@
     <cve>CVE-2021-21350</cve>
     <cve>CVE-2021-21351</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: log4j-1.2-*.jar
+    This CVE matches a AWS CVE for a hotfix they patched a JVM with. This is a false positive
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j.*$</packageUrl>
+    <cve>CVE-2022-33915</cve>
+  </suppress>  
 </suppressions>


### PR DESCRIPTION

## Motivation

CVE-2022-33915 refers specifically to a hotfix produced by AWS for log4j. Basically their mitigation for log4jshell is broken.  I don't see why they can't narrow the regexp to match log4j-cve-2021-44228-hotpatch-1.3-5
directly


## Modification

Add suppression to ./gradle/owasp-exclude.xml


## PR Checklist

- [x] been self-reviewed.

## Result

Downstream builds are no longer broken if they have a dependency on log4j.

## Testing

`./gradlew dependencyCheckAnalyze` without the suppression.
`./gradlew dCAn` with the suppression.

