### PR TITLE
INTERLOK-3904 Resolve service added.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/ResolveExpressionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/ResolveExpressionService.java
@@ -1,0 +1,50 @@
+package com.adaptris.core.services;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@XStreamAlias("resolve-expression-service")
+@AdapterComponent
+@ComponentProfile(summary = "Will perform an expression resolve on any input and put the result into the output.", tag = "service,resolve,expression")
+public class ResolveExpressionService extends ServiceImp {
+
+  @Getter
+  @Setter
+  private DataInputParameter<String> input;
+  
+  @Getter
+  @Setter
+  private DataOutputParameter<String> output;
+  
+  @Override
+  public void doService(AdaptrisMessage message) throws ServiceException {
+    try {
+      getOutput().insert(message.resolve(getInput().extract(message)), message);
+    } catch (Throwable e) {
+      throw new ServiceException(e);
+    }
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/ResolveExpressionServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/ResolveExpressionServiceTest.java
@@ -1,0 +1,77 @@
+package com.adaptris.core.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.MetadataDataOutputParameter;
+import com.adaptris.core.util.LifecycleHelper;
+
+public class ResolveExpressionServiceTest {
+  
+  private ResolveExpressionService service;
+  
+  private AdaptrisMessage message;
+  
+  @Before
+  public void setUp() throws Exception {
+    message = DefaultMessageFactory.getDefaultInstance().newMessage();
+    service = new ResolveExpressionService();
+    
+    service.setOutput(new MetadataDataOutputParameter("result"));
+    
+    LifecycleHelper.prepare(service);
+    LifecycleHelper.initAndStart(service);
+  }
+  
+  @After
+  public void tearDown() {
+    LifecycleHelper.stopAndClose(service);
+  }
+  
+  @Test
+  public void testResolveAMetadataKey() throws Exception {
+    message.addMessageHeader("key", "value1");
+    
+    service.setInput(new ConstantDataInputParameter("%message{key}"));
+    service.doService(message);
+    
+    assertEquals("Should be value1", "value1", message.getMetadataValue("result"));
+  }
+  
+  @Test
+  public void testResolveToAppendToMetadata() throws Exception {
+    message.addMessageHeader("result", "AB");
+    
+    service.setInput(new ConstantDataInputParameter("%message{result}C"));
+    service.doService(message);
+    
+    assertEquals("Should be ABC", "ABC", message.getMetadataValue("result"));
+  }
+  
+  @Test
+  public void testResolveAMetadataKeyDoesNotExist() throws Exception {    
+    service.setInput(new ConstantDataInputParameter("%message{key}"));
+    try {
+      service.doService(message);
+      fail("Should fail with no metadata found.");
+    } catch (ServiceException ex) {
+      // expected.
+    }
+  }
+  
+  @Test
+  public void testResolveAMetadataKeyWithNoExpression() throws Exception {    
+    service.setInput(new ConstantDataInputParameter("NoExpression"));
+    service.doService(message);
+    
+    assertEquals("Should be NoExpression", "NoExpression", message.getMetadataValue("result"));
+  }
+}


### PR DESCRIPTION
## Motivation

Interlok has never handled basic string manipulation very well.  It's also one of the most requested features. 

## Modification

I've added a service that will allow you to specify a string which may include resolvable expressions which will be calculated at runtime.

## PR Checklist

- [x] been self-reviewed.

