### PR TITLE
INTERLOK-3924 Bump slf4j to 2.0.0

### DIFF
--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -3,7 +3,7 @@ ext {
   componentDesc="Common components for Interlok"
 
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  slf4jVersion = '1.7.36'
+  slf4jVersion = '2.0.0'
   log4j2Version = "2.18.0"
   mockitoVersion = '4.8.0'
 }
@@ -25,10 +25,10 @@ dependencies {
 
   implementation "org.apache.logging.log4j:log4j-api:$log4j2Version", optional
   implementation "org.apache.logging.log4j:log4j-core:$log4j2Version", optional
-  implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4j2Version", optional
   implementation "org.apache.logging.log4j:log4j-1.2-api:$log4j2Version", optional
   implementation "org.slf4j:jul-to-slf4j:$slf4jVersion", optional
   implementation "org.slf4j:jcl-over-slf4j:$slf4jVersion", optional
+  implementation "org.slf4j:slf4j-reload4j:$slf4jVersion", optional
 
   annotationProcessor project(':interlok-core-apt')
   testAnnotationProcessor project(':interlok-core-apt')

--- a/interlok-common/src/main/java/com/adaptris/interlok/util/FileFilterBuilder.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/util/FileFilterBuilder.java
@@ -1,18 +1,18 @@
 package com.adaptris.interlok.util;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.FileFilter;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
+
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang3.BooleanUtils;
-import lombok.extern.slf4j.Slf4j;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-@Slf4j
 public abstract class FileFilterBuilder {
 
   // Since we declare commons-io in our dependency tree; we can just use the class.getCanonicalName()

--- a/interlok-common/src/test/java/com/adaptris/interlok/util/FileFilterBuilderTest.java
+++ b/interlok-common/src/test/java/com/adaptris/interlok/util/FileFilterBuilderTest.java
@@ -12,15 +12,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 package com.adaptris.interlok.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.FileFilter;
 import java.util.Map;
 import java.util.function.Function;
+
 import org.apache.commons.io.filefilter.DelegateFileFilter;
 import org.apache.commons.io.filefilter.FileFileFilter;
 import org.apache.commons.io.filefilter.SizeFileFilter;
@@ -50,7 +52,7 @@ public class FileFilterBuilderTest extends FileFilterBuilder {
 
   @Test(expected = RuntimeException.class)
   public void testNonPrimitiveConstructor() throws Exception {
-    FileFilter f = build("*test*.java~*~", DelegateFileFilter.class.getCanonicalName());
+    build("*test*.java~*~", DelegateFileFilter.class.getCanonicalName());
   }
 
   @Test
@@ -76,7 +78,7 @@ public class FileFilterBuilderTest extends FileFilterBuilder {
   @Test(expected = RuntimeException.class)
   public void testInvalidNoArgsConstructor() throws Exception {
     // Since FileFileFilter doesn't have a public noargs constructor.
-    FileFilter f = build("", FileFileFilter.class.getCanonicalName());
+    build("", FileFileFilter.class.getCanonicalName());
   }
 
 }

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -6,7 +6,7 @@ ext {
   activeMqVersion='5.17.2'
   bouncyCastleVersion='1.70'
   mysqlDriverVersion='8.0.30'
-  slf4jVersion = '1.7.36'
+  slf4jVersion = '2.0.0'
   mockitoVersion = '4.8.0'
   jschVersion = '0.2.4'
   mssqlDriverVersion = '9.2.1.jre8'

--- a/interlok-core/src/test/java/com/adaptris/core/fs/CompositeFileFilterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/CompositeFileFilterTest.java
@@ -12,18 +12,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.fs;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.stubs.TempFileUtils;
 
 /**
@@ -31,7 +32,6 @@ import com.adaptris.core.stubs.TempFileUtils;
  * @author $Author: lchan $
  */
 public class CompositeFileFilterTest {
-  protected transient Log logR = LogFactory.getLog(this.getClass());
   private static final String FILTER_SIZE = "SizeGT=1024__@@__Regex=.*\\.xml";
   private static final String FILTER_CUSTOM = "SizeGT=1024__@@__Regex=.*\\.xml__@@__com.adaptris.core.fs.YesOrNo=false";
   private static final String FILTER_NO_CLASSDEF = "SizeGT=1024__@@__Regex=.*\\.xml__@@__com.adaptris.core.fs.Blah=false";
@@ -50,13 +50,13 @@ public class CompositeFileFilterTest {
   @Test
   public void testCreate() throws Exception {
     for (String filter : FILTER_STRINGS) {
-      CompositeFileFilter df = new CompositeFileFilter(filter, true);
+      new CompositeFileFilter(filter, true);
     }
   }
 
   @Test(expected = RuntimeException.class)
   public void testCreate_Invalid() throws Exception {
-    CompositeFileFilter df = new CompositeFileFilter("IWon'tWork", true);
+    new CompositeFileFilter("IWon'tWork", true);
   }
 
   @Test
@@ -85,7 +85,7 @@ public class CompositeFileFilterTest {
 
   @Test(expected = RuntimeException.class)
   public void testCustomFilterNoClassDef() throws Exception {
-    CompositeFileFilter df = new CompositeFileFilter(FILTER_NO_CLASSDEF);
+    new CompositeFileFilter(FILTER_NO_CLASSDEF);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/fs/ItemCacheCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/ItemCacheCase.java
@@ -20,15 +20,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import java.util.Random;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.interlok.junit.scaffolding.BaseCase;
 
 public abstract class ItemCacheCase extends BaseCase {
-
-  protected transient Log logR = LogFactory.getLog(this.getClass());
 
   protected static final String CACHE_PREFIX = "CacheEntry_";
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/FailoverPasConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/FailoverPasConsumerTest.java
@@ -17,14 +17,10 @@
 package com.adaptris.core.jms;
 
 import static com.adaptris.core.jms.FailoverPtpProducerTest.createFailoverConfigExample;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import com.adaptris.core.StandaloneConsumer;
 
 public class FailoverPasConsumerTest extends FailoverJmsConsumerCase {
-
-  private static final Log LOG = LogFactory
-      .getLog(FailoverPasConsumerTest.class);
 
   @Override
   protected Object retrieveObjectForSampleConfig() {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/FailoverPtpConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/FailoverPtpConsumerTest.java
@@ -17,14 +17,10 @@
 package com.adaptris.core.jms;
 
 import static com.adaptris.core.jms.FailoverPtpProducerTest.createFailoverConfigExample;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import com.adaptris.core.StandaloneConsumer;
 
 public class FailoverPtpConsumerTest extends FailoverJmsConsumerCase {
-
-  private static final Log LOG = LogFactory
-      .getLog(FailoverPtpConsumerTest.class);
 
   @Override
   protected Object retrieveObjectForSampleConfig() {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/FailoverPtpProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/FailoverPtpProducerTest.java
@@ -16,18 +16,16 @@
 
 package com.adaptris.core.jms;
 import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
 
 public class FailoverPtpProducerTest extends FailoverJmsProducerCase {
-
-  private static final Log LOG = LogFactory.getLog(FailoverPtpProducerTest.class);
-
 
   @Test
   public void testBug845() throws Exception {
@@ -52,7 +50,7 @@ public class FailoverPtpProducerTest extends FailoverJmsProducerCase {
 
   static FailoverJmsConnection createFailoverConfigExample(boolean isPtp) {
     FailoverJmsConnection result = null;
-    result = new FailoverJmsConnection(new ArrayList<JmsConnection>(Arrays.asList(new JmsConnection[]
+    result = new FailoverJmsConnection(new ArrayList<>(Arrays.asList(new JmsConnection[]
     {
         new JmsConnection(new BasicActiveMqImplementation("tcp://SomeUnclusteredBroker:9999")),
         new JmsConnection(new BasicActiveMqImplementation("tcp://SomeUnclusteredBroker:9998"))

--- a/interlok-core/src/test/java/com/adaptris/core/jms/MetadataCorrelationIdSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/MetadataCorrelationIdSourceTest.java
@@ -1,48 +1,46 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.jms;
 
-import static com.adaptris.core.BaseCase.start;
-import static com.adaptris.core.BaseCase.stop;
+import static com.adaptris.interlok.junit.scaffolding.BaseCase.start;
+import static com.adaptris.interlok.junit.scaffolding.BaseCase.stop;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import javax.jms.Session;
 import javax.jms.TextMessage;
+
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
 
-@SuppressWarnings("deprecation")
 public class MetadataCorrelationIdSourceTest {
 
   private static final String CORRELATIONID_KEY = "correlationid_key";
   private static final String TEXT = "The quick brown fox";
   private static final String TEXT2 = "jumps over the lazy dog";
-
-  protected transient Log log = LogFactory.getLog(this.getClass());
 
   private static EmbeddedActiveMq activeMqBroker;
 
@@ -51,13 +49,14 @@ public class MetadataCorrelationIdSourceTest {
     activeMqBroker = new EmbeddedActiveMq();
     activeMqBroker.start();
   }
-  
+
   @AfterClass
   public static void tearDownAll() throws Exception {
-    if(activeMqBroker != null)
+    if(activeMqBroker != null) {
       activeMqBroker.destroy();
+    }
   }
-  
+
   @Test
   public void testAdaptrisMessageMetadataToJmsCorrelationId() throws Exception {
     JmsConnection conn = activeMqBroker.getJmsConnection();
@@ -163,7 +162,7 @@ public class MetadataCorrelationIdSourceTest {
       TextMessage jmsMsg = session.createTextMessage();
       MetadataCorrelationIdSource mcs = new MetadataCorrelationIdSource(CORRELATIONID_KEY);
       mcs.processCorrelationId(jmsMsg, adpMsg);
-      assertFalse(adpMsg.containsKey(CORRELATIONID_KEY));
+      assertFalse(adpMsg.headersContainsKey(CORRELATIONID_KEY));
       session.close();
     }
     finally {

--- a/interlok-core/src/test/java/com/adaptris/core/management/ManagementComponentFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/ManagementComponentFactoryTest.java
@@ -17,18 +17,17 @@
 package com.adaptris.core.management;
 
 import static org.junit.Assert.assertEquals;
+
 import java.util.List;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.ClosedState;
 import com.adaptris.core.management.jetty.ServerBuilder;
 import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.interlok.junit.scaffolding.util.PortManager;
 
 public class ManagementComponentFactoryTest extends BaseCase {
-
-  protected transient Log logR = LogFactory.getLog(this.getClass());
 
   @Test
   public void testCreateJsr160Component() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/MessagesInFlightTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/MessagesInFlightTest.java
@@ -1,30 +1,32 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.runtime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.TimeUnit;
+
 import javax.management.JMX;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.Channel;
@@ -37,11 +39,8 @@ import com.adaptris.util.TimeInterval;
 
 public class MessagesInFlightTest extends ComponentManagerCase {
 
-  protected transient Log logR = LogFactory.getLog(this.getClass());
-
   public MessagesInFlightTest() {
   }
-
 
   @Test
   public void testInFlightMessageCount() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/StandardMessageErrorDigestTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/StandardMessageErrorDigestTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.runtime;
 
@@ -24,18 +24,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.management.JMX;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileDeleteStrategy;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
+
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -48,15 +50,12 @@ import com.adaptris.core.Workflow;
 import com.adaptris.core.services.exception.ConfiguredException;
 import com.adaptris.core.services.exception.ThrowExceptionService;
 
-@SuppressWarnings("deprecation")
 public class StandardMessageErrorDigestTest extends ComponentManagerCase {
 
-  protected transient Log logR = LogFactory.getLog(this.getClass());
   private static FileCleaningTracker cleaner = new FileCleaningTracker();
 
   public StandardMessageErrorDigestTest() {
   }
-
 
   @Test
   public void testSetMaxCount() throws Exception {
@@ -139,7 +138,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
       StandardMessageErrorDigesterJmxMBean errDigester = JMX.newMBeanProxy(mBeanServer, digesterObj,
           StandardMessageErrorDigesterJmxMBean.class);
-      AdapterManagerMBean adapterManager = JMX.newMBeanProxy(mBeanServer, adapterObj, AdapterManagerMBean.class);
+      JMX.newMBeanProxy(mBeanServer, adapterObj, AdapterManagerMBean.class);
       assertNotNull(errDigester.getParentObjectName());
       assertEquals(adapterObj, errDigester.getParentObjectName());
     }
@@ -159,7 +158,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     try {
       start(adapter);
       register(mBeans);
-      ObjectName adapterObj = createAdapterObjectName(adapterName);
+      createAdapterObjectName(adapterName);
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
       StandardMessageErrorDigesterJmxMBean errDigester = JMX.newMBeanProxy(mBeanServer, digesterObj,
           StandardMessageErrorDigesterJmxMBean.class);
@@ -194,7 +193,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     try {
       start(adapter);
       register(mBeans);
-      ObjectName adapterObj = createAdapterObjectName(adapterName);
+      createAdapterObjectName(adapterName);
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
       StandardMessageErrorDigesterJmxMBean errDigester = JMX.newMBeanProxy(mBeanServer, digesterObj,
           StandardMessageErrorDigesterJmxMBean.class);
@@ -227,7 +226,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     try {
       start(adapter);
       register(mBeans);
-      ObjectName adapterObj = createAdapterObjectName(adapterName);
+      createAdapterObjectName(adapterName);
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
       StandardMessageErrorDigesterJmxMBean errDigesterBean = JMX.newMBeanProxy(mBeanServer, digesterObj,
           StandardMessageErrorDigesterJmxMBean.class);
@@ -258,7 +257,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     try {
       start(adapter);
       register(mBeans);
-      ObjectName adapterObj = createAdapterObjectName(adapterName);
+      createAdapterObjectName(adapterName);
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
       StandardMessageErrorDigesterJmxMBean errDigesterBean = JMX.newMBeanProxy(mBeanServer, digesterObj,
           StandardMessageErrorDigesterJmxMBean.class);
@@ -285,7 +284,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     Adapter adapter = createAdapter(adapterName);
     adapter.setMessageErrorDigester(new StandardMessageErrorDigester(getName()));
     AdapterManager adapterManager = new AdapterManager(adapter);
-    List<BaseComponentMBean> mBeans = new ArrayList<BaseComponentMBean>();
+    List<BaseComponentMBean> mBeans = new ArrayList<>();
     mBeans.add(adapterManager);
     mBeans.addAll(adapterManager.getAllDescendants());
     try {
@@ -314,7 +313,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     try {
       start(adapter);
       register(mBeans);
-      ObjectName adapterObj = createAdapterObjectName(adapterName);
+      createAdapterObjectName(adapterName);
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
 
       StandardMessageErrorDigesterJmxMBean errDigester = JMX.newMBeanProxy(mBeanServer, digesterObj,
@@ -326,7 +325,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
       assertNotNull(errDigester.getDigest());
       assertEquals(5, errDigester.getDigest().size());
       assertEquals(5, errDigester.getTotalErrorCount());
-      errDigester.remove(new MessageDigestErrorEntry(msgs.get(0).getUniqueId(), null));
+      errDigester.remove(new MessageDigestErrorEntry(msgs.get(0).getUniqueId(), null), false);
       assertEquals(4, errDigester.getDigest().size());
       assertEquals(5, errDigester.getTotalErrorCount());
     }
@@ -349,7 +348,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     try {
       start(adapter);
       register(mBeans);
-      ObjectName adapterObj = createAdapterObjectName(adapterName);
+      createAdapterObjectName(adapterName);
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
 
       StandardMessageErrorDigesterJmxMBean errDigester = JMX.newMBeanProxy(mBeanServer, digesterObj,
@@ -380,7 +379,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     try {
       start(adapter);
       register(mBeans);
-      ObjectName adapterObj = createAdapterObjectName(adapterName);
+      createAdapterObjectName(adapterName);
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
 
       StandardMessageErrorDigesterJmxMBean errDigester = JMX.newMBeanProxy(mBeanServer, digesterObj,
@@ -392,7 +391,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
       assertNotNull(errDigester.getDigest());
       assertEquals(5, errDigester.getDigest().size());
       assertEquals(5, errDigester.getTotalErrorCount());
-      errDigester.remove(msgs.get(0).getUniqueId());
+      errDigester.remove(msgs.get(0).getUniqueId(), false);
       assertEquals(4, errDigester.getDigest().size());
       assertEquals(5, errDigester.getTotalErrorCount());
     }
@@ -415,7 +414,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
     try {
       start(adapter);
       register(mBeans);
-      ObjectName adapterObj = createAdapterObjectName(adapterName);
+      createAdapterObjectName(adapterName);
       ObjectName digesterObj = createMessageErrorDigestObjectName(adapterName, getName());
 
       StandardMessageErrorDigesterJmxMBean errDigester = JMX.newMBeanProxy(mBeanServer, digesterObj,
@@ -476,7 +475,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
   }
 
   private List<AdaptrisMessage> createMessages(int size, int start) {
-    List<AdaptrisMessage> errors = new ArrayList<AdaptrisMessage>();
+    List<AdaptrisMessage> errors = new ArrayList<>();
     for (int i = 0; i < size; i++) {
       AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
       msg.addMetadata(Workflow.WORKFLOW_ID_KEY, "workflow" + (i + start));
@@ -486,7 +485,7 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
   }
 
   private List<AdaptrisMessage> createListOfErrors(int size, int start, String errorMsg, String fsLocation) {
-    List<AdaptrisMessage> errors = new ArrayList<AdaptrisMessage>();
+    List<AdaptrisMessage> errors = new ArrayList<>();
     for (int i = 0; i < size; i++) {
       errors.add(createMessageWithErrors("workflow" + (i + start), errorMsg, fsLocation));
     }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/XpathQueryCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/xpath/XpathQueryCase.java
@@ -21,22 +21,22 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.CoreException;
 
 public abstract class XpathQueryCase {
-
-  private static Log log = LogFactory.getLog(XpathQueryCase.class);
 
   public static final String XML = "<?xml version=\"1.0\"?><message><message-type>order"
       + "</message-type><source-id>partnera</source-id><destination-id>" + "partnerb</destination-id><body>...</body>"
@@ -112,7 +112,7 @@ public abstract class XpathQueryCase {
     private final Map<String, Set<String>> nsMap;
 
     public StaticNamespaceContext() {
-      Map<String, String> map = new HashMap<String, String>();
+      Map<String, String> map = new HashMap<>();
       map.put("svrl", "http://purl.oclc.org/dsdl/svrl");
       map.put("xsd", "http://www.w3.org/2001/XMLSchema");
       map.put("xs", "http://www.w3.org/2001/XMLSchema");
@@ -130,7 +130,7 @@ public abstract class XpathQueryCase {
 
 
     private Map<String, String> createPrefixMap(Map<String, String> source) {
-      Map<String, String> result = new HashMap<String, String>(source);
+      Map<String, String> result = new HashMap<>(source);
       addDefault(result, XMLConstants.XML_NS_PREFIX, XMLConstants.XML_NS_URI);
       addDefault(result, XMLConstants.XMLNS_ATTRIBUTE, XMLConstants.XMLNS_ATTRIBUTE_NS_URI);
       return Collections.unmodifiableMap(result);
@@ -144,12 +144,12 @@ public abstract class XpathQueryCase {
     }
 
     private Map<String, Set<String>> createNamespaceMap(Map<String, String> prefixMap) {
-      Map<String, Set<String>> result = new HashMap<String, Set<String>>();
+      Map<String, Set<String>> result = new HashMap<>();
       for (Map.Entry<String, String> entry : prefixMap.entrySet()) {
         String nsURI = entry.getValue();
         Set<String> existingPrefixes = result.get(nsURI);
         if (isNull(existingPrefixes)) {
-          existingPrefixes = new HashSet<String>();
+          existingPrefixes = new HashSet<>();
           result.put(nsURI, existingPrefixes);
         }
         existingPrefixes.add(entry.getKey());

--- a/interlok-core/src/test/java/com/adaptris/core/services/routing/RegexpSyntaxIdentifierTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/routing/RegexpSyntaxIdentifierTest.java
@@ -17,9 +17,9 @@
 package com.adaptris.core.services.routing;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.ServiceException;
 
 public class RegexpSyntaxIdentifierTest extends SyntaxIdentifierCase {
@@ -29,9 +29,6 @@ public class RegexpSyntaxIdentifierTest extends SyntaxIdentifierCase {
   public static final String MATCHING_2 = ".+lazy.+";
   public static final String UNMATCHED_1 = ".+ZZZZ.+";
   public static final String UNMATCHED_2 = ".+YYYY.+";
-
-  private static Log logR = LogFactory.getLog(RegexpSyntaxIdentifierTest.class);
-
 
   @Override
   public RegexpSyntaxIdentifier createIdentifier() {

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/LineCountSplitterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/LineCountSplitterTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.splitter;
 
@@ -21,29 +21,27 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.io.Reader;
 import java.util.Iterator;
 import java.util.List;
+
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.Service;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.stubs.StubMessageFactory;
 import com.adaptris.interlok.util.CloseableIterable;
 
 public class LineCountSplitterTest extends SplitterCase {
 
-  private static Log logR = LogFactory.getLog(LineCountSplitterTest.class);
-
   private AdaptrisMessage msg;
   private MockMessageProducer producer;
   private BasicMessageSplitterService service;
-
-
 
   @Before
   public void setUp() throws Exception {
@@ -180,9 +178,9 @@ public class LineCountSplitterTest extends SplitterCase {
     final String HEADER_TEXT = "HEADER LINE 1";
     List<AdaptrisMessage> result = toList(s.splitMessage(
         createLineCountMessageInputWithHeader(new String[] {HEADER_TEXT})));
-    
+
     assertEquals("50 split messages", 50, result.size());
-    
+
     for(AdaptrisMessage m: result) {
       List<String> lines = IOUtils.readLines(m.getReader());
       assertEquals("2 lines per message", 2, lines.size());
@@ -202,9 +200,9 @@ public class LineCountSplitterTest extends SplitterCase {
     final String HEADER_LINE_2 = "HEADER LINE 2";
     List<AdaptrisMessage> result = toList(s.splitMessage(
         createLineCountMessageInputWithHeader(new String[] {HEADER_LINE_1, HEADER_LINE_2})));
-    
+
     assertEquals("5 split messages", 5, result.size());
-    
+
     for(AdaptrisMessage m: result) {
       try (Reader reader = m.getReader()) {
         List<String> lines = IOUtils.readLines(reader);
@@ -222,15 +220,15 @@ public class LineCountSplitterTest extends SplitterCase {
   public void testIterator_DoubleProtection() throws Exception {
     MessageSplitterImp splitter = new LineCountSplitter(1);
     try (CloseableIterable<AdaptrisMessage> iterable = CloseableIterable.ensureCloseable(splitter.splitMessage(msg))) {
-      Iterator<AdaptrisMessage> first = iterable.iterator();
+      iterable.iterator();
       try {
-        Iterator<AdaptrisMessage> second = iterable.iterator();
+        iterable.iterator();
         fail();
       } catch (IllegalStateException expected) {
-        
+
       }
     }
-    
+
   }
 
   @Test
@@ -240,7 +238,9 @@ public class LineCountSplitterTest extends SplitterCase {
         .ensureCloseable(splitter.splitMessage(msg))) {
       Iterator<AdaptrisMessage> first = iterable.iterator();
       try {
-        if (first.hasNext()) first.next();
+        if (first.hasNext()) {
+          first.next();
+        }
         first.remove();
         fail();
       }
@@ -260,7 +260,7 @@ public class LineCountSplitterTest extends SplitterCase {
       assertTrue(first.hasNext());
     }
   }
-  
+
   @Override
   protected String createBaseFileName(Object object) {
     return super.createBaseFileName(object) + "-LineCountSplitter";
@@ -272,7 +272,7 @@ public class LineCountSplitterTest extends SplitterCase {
   }
 
   @Override
-  protected List retrieveObjectsForSampleConfig() {
+  protected List<Service> retrieveObjectsForSampleConfig() {
     return createExamples(new LineCountSplitter(100));
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/MetadataDocumentCopierTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/MetadataDocumentCopierTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.splitter;
 
@@ -21,12 +21,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.util.List;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.Service;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.interlok.util.CloseableIterable;
@@ -37,9 +39,6 @@ public class MetadataDocumentCopierTest extends SplitterCase {
   private static final String METADATA_KEY_INDEX = "MyMetadataKeyIndex";
 
   private static final String METADATA_KEY = "MyMetadataKey";
-
-  private static Log logR = LogFactory.getLog(MetadataDocumentCopierTest.class);
-
 
   @Override
   protected String createBaseFileName(Object object) {
@@ -52,7 +51,7 @@ public class MetadataDocumentCopierTest extends SplitterCase {
   }
 
   @Override
-  protected List retrieveObjectsForSampleConfig() {
+  protected List<Service> retrieveObjectsForSampleConfig() {
     return createExamples(new MetadataDocumentCopier(METADATA_KEY));
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/MimePartSplitterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/MimePartSplitterTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.splitter;
 
@@ -21,18 +21,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import java.util.List;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.Service;
 
-@SuppressWarnings("deprecation")
 public class MimePartSplitterTest extends SplitterCase {
-
-  private static Log logR = LogFactory.getLog(MimePartSplitterTest.class);
-
-
 
   @Override
   protected MimePartSplitter createSplitterForTests() {
@@ -89,8 +86,8 @@ public class MimePartSplitterTest extends SplitterCase {
     List<AdaptrisMessage> result = m.splitMessage(msg);
     assertEquals(3, result.size());
     for (AdaptrisMessage smsg : result) {
-      assertTrue(smsg.containsKey("Content-Id"));
-      assertTrue(smsg.containsKey("Content-Transfer-Encoding"));
+      assertTrue(smsg.headersContainsKey("Content-Id"));
+      assertTrue(smsg.headersContainsKey("Content-Transfer-Encoding"));
     }
   }
 
@@ -105,10 +102,8 @@ public class MimePartSplitterTest extends SplitterCase {
   }
 
   @Override
-  protected List retrieveObjectsForSampleConfig() {
+  protected List<Service> retrieveObjectsForSampleConfig() {
     return createExamples(new MimePartSplitter());
   }
-
-
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitByMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitByMetadataTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.splitter;
 
@@ -20,21 +20,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.util.List;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.Service;
 import com.adaptris.core.stubs.MockMessageProducer;
 
-@SuppressWarnings("deprecation")
 public class SplitByMetadataTest extends SplitterCase {
 
   private static final String A_B_C_D = "a,b,c,d";
   private static final String SPLIT_ON_METADATA_KEY = "metadataKey";
   private static final String SPLIT_METADATA_KEY = "key";
-  private static Log logR = LogFactory.getLog(SplitByMetadataTest.class);
 
 
   @Override
@@ -56,30 +56,30 @@ public class SplitByMetadataTest extends SplitterCase {
       assertFalse("No Object Metadata", m.getObjectHeaders().containsKey(obj));
       // May as well explicitly test the indexes.
       switch(count) {
-      case 0: {
-        assertEquals("a", m.getMetadataValue(SPLIT_METADATA_KEY));
-        break;
-      }
-      case 1: {
-        assertEquals("b", m.getMetadataValue(SPLIT_METADATA_KEY));
-        break;
-      }
-      case 2: {
-        assertEquals("c", m.getMetadataValue(SPLIT_METADATA_KEY));
-        break;
-      }
-      case 3: {
-        assertEquals("d", m.getMetadataValue(SPLIT_METADATA_KEY));
-        break;
-      }
-      default : {
-        fail();
-      }
+        case 0: {
+          assertEquals("a", m.getMetadataValue(SPLIT_METADATA_KEY));
+          break;
+        }
+        case 1: {
+          assertEquals("b", m.getMetadataValue(SPLIT_METADATA_KEY));
+          break;
+        }
+        case 2: {
+          assertEquals("c", m.getMetadataValue(SPLIT_METADATA_KEY));
+          break;
+        }
+        case 3: {
+          assertEquals("d", m.getMetadataValue(SPLIT_METADATA_KEY));
+          break;
+        }
+        default : {
+          fail();
+        }
       };
       count ++;
       doStandardAssertions(m);
     }
-  
+
   }
 
   @Test
@@ -121,13 +121,13 @@ public class SplitByMetadataTest extends SplitterCase {
     execute(service, msg);
     assertEquals("Number of messages", 1, producer.getMessages().size());
     for (AdaptrisMessage m : producer.getMessages()) {
-      assertFalse(m.containsKey(SPLIT_METADATA_KEY));
+      assertFalse(m.headersContainsKey(SPLIT_METADATA_KEY));
       assertEquals(XML_MESSAGE, m.getContent());
     }
   }
 
   private void doStandardAssertions(AdaptrisMessage msg) {
-    assertTrue(msg.containsKey(SPLIT_METADATA_KEY));
+    assertTrue(msg.headersContainsKey(SPLIT_METADATA_KEY));
     String s = msg.getMetadataValue(SPLIT_METADATA_KEY);
     assertTrue(s.matches("[abcd]{1}"));
     assertEquals(A_B_C_D, msg.getMetadataValue(SPLIT_ON_METADATA_KEY));
@@ -145,7 +145,7 @@ public class SplitByMetadataTest extends SplitterCase {
   }
 
   @Override
-  protected List retrieveObjectsForSampleConfig() {
+  protected List<Service> retrieveObjectsForSampleConfig() {
     return createExamples(new SplitByMetadata(SPLIT_ON_METADATA_KEY, "splitMetadataKey"));
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitterCase.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.splitter;
 
@@ -21,12 +21,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.DefaultMessageFactory;
@@ -61,15 +64,15 @@ public abstract class SplitterCase extends SplitterServiceExample {
   }
 
   static AdvancedMessageSplitterService createAdvanced(MessageSplitter ms,
-                                                       StandaloneProducer p) {
+      StandaloneProducer p) {
     return createAdvanced(ms, new Service[]
-    {
-      p
-    });
+        {
+            p
+        });
   }
 
   static AdvancedMessageSplitterService createAdvanced(MessageSplitter ms,
-                                                       Service... services) {
+      Service... services) {
     AdvancedMessageSplitterService service = new AdvancedMessageSplitterService();
     ServiceList sl = new ServiceList(services);
     service.setSplitter(ms);
@@ -87,7 +90,7 @@ public abstract class SplitterCase extends SplitterServiceExample {
   }
 
   static List<Service> createExamples(MessageSplitter ms) {
-    List<Service> services = new ArrayList<Service>();
+    List<Service> services = new ArrayList<>();
     services.add(createBasic(ms));
     services.add(createAdvanced(ms, new WaitService(), new StandaloneProducer()));
     services.add(createPooling(ms, new WaitService(), new StandaloneProducer()));
@@ -105,7 +108,7 @@ public abstract class SplitterCase extends SplitterServiceExample {
     return AdaptrisMessageFactory.getDefaultInstance().newMessage(
         out.toByteArray());
   }
-  
+
   public static AdaptrisMessage createLineCountMessageInputWithHeader(String[] header) {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     PrintWriter print = new PrintWriter(out);
@@ -169,16 +172,16 @@ public abstract class SplitterCase extends SplitterServiceExample {
   }
 
   protected abstract MessageSplitterImp createSplitterForTests();
-  
+
   /**
-   * Convert the Iterable into a List. If it's already a list, just return it. If not, 
+   * Convert the Iterable into a List. If it's already a list, just return it. If not,
    * it will be iterated and the resulting list returned.
    */
   protected List<AdaptrisMessage> toList(Iterable<AdaptrisMessage> iter) {
     if(iter instanceof List) {
       return (List<AdaptrisMessage>)iter;
     }
-    List<AdaptrisMessage> result = new ArrayList<AdaptrisMessage>();
+    List<AdaptrisMessage> result = new ArrayList<>();
     try (CloseableIterable<AdaptrisMessage> messages = CloseableIterable.ensureCloseable(iter)) {
       for(AdaptrisMessage msg: messages) {
         result.add(msg);
@@ -189,7 +192,7 @@ public abstract class SplitterCase extends SplitterServiceExample {
     return result;
   }
 
-  protected List splitToList(MessageSplitterImp splitter, AdaptrisMessage msg) throws Exception {
+  protected List<AdaptrisMessage> splitToList(MessageSplitterImp splitter, AdaptrisMessage msg) throws Exception {
     return toList(splitter.splitMessage(msg));
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathDocumentCopierTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathDocumentCopierTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.splitter;
 
@@ -21,14 +21,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.util.List;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
+import com.adaptris.core.Service;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.KeyValuePair;
@@ -37,7 +39,6 @@ public class XpathDocumentCopierTest extends SplitterCase {
 
   static final String XPATH_DOCUMENT_COUNT = "count(/envelope/document)";
 
-  private static Log logR = LogFactory.getLog(XpathDocumentCopierTest.class);
   private MockMessageProducer producer;
   private BasicMessageSplitterService service;
 
@@ -61,7 +62,7 @@ public class XpathDocumentCopierTest extends SplitterCase {
   }
 
   @Override
-  protected List retrieveObjectsForSampleConfig() {
+  protected List<Service> retrieveObjectsForSampleConfig() {
     return createExamples(new XpathDocumentCopier(XPATH_DOCUMENT_COUNT));
   }
 
@@ -140,7 +141,7 @@ public class XpathDocumentCopierTest extends SplitterCase {
     msg.setContent(XML_MESSAGE, msg.getContentEncoding());
     XpathDocumentCopier splitter = new XpathDocumentCopier("/document/envelope[");
     try {
-      List<AdaptrisMessage> result = splitToList(splitter, msg);
+      splitToList(splitter, msg);
       fail();
     }
     catch (CoreException expected) {
@@ -157,7 +158,7 @@ public class XpathDocumentCopierTest extends SplitterCase {
     builder.getFeatures().add(new KeyValuePair("http://apache.org/xml/features/disallow-doctype-decl", "true"));
     splitter.setXmlDocumentFactoryConfig(builder);
     try {
-      List<AdaptrisMessage> result = splitToList(splitter, msg);
+      splitToList(splitter, msg);
       fail();
     } catch (CoreException expected) {
       assertTrue(expected.getMessage().contains("DOCTYPE is disallowed"));

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathSplitterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathSplitterTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core.services.splitter;
 
@@ -22,20 +22,23 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream;
 import java.util.List;
+
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
+import com.adaptris.core.Service;
 import com.adaptris.core.services.metadata.XpathMetadataServiceTest;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.MessageHelper;
@@ -60,10 +63,8 @@ public class XpathSplitterTest extends SplitterCase {
   private static final String ISSUE_2658_SRC_XPATH = "/root/segment_shipto_line/record_[1]/Street";
   private static final String ISSUE_2658_DEST_XPATH = "/record_/Street";
 
-  private static Log logR = LogFactory.getLog(XpathSplitterTest.class);
   private MockMessageProducer producer;
   private BasicMessageSplitterService service;
-
 
 
   @Before
@@ -84,7 +85,7 @@ public class XpathSplitterTest extends SplitterCase {
   }
 
   @Override
-  protected List retrieveObjectsForSampleConfig() {
+  protected List<Service> retrieveObjectsForSampleConfig() {
     return createExamples(new XpathMessageSplitter(ENVELOPE_DOCUMENT, ENCODING_UTF8));
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/CheckComponentStateService.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/CheckComponentStateService.java
@@ -18,9 +18,6 @@ package com.adaptris.core.stubs;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.Service;
 import com.adaptris.core.ServiceException;
@@ -28,22 +25,20 @@ import com.adaptris.core.StartedState;
 
 public class CheckComponentStateService extends MockStateManagedComponent implements Service {
   private String uniqueId;
-  private boolean isBranching;
-  private Boolean continueOnFail;
   private Boolean isTrackingEndpoint;
   private Boolean isConfirmation;
   private String lookupName;
-
-  private transient Log logR = LogFactory.getLog(this.getClass());
 
   public CheckComponentStateService() {
     super();
   }
 
+  @Override
   public boolean continueOnFailure() {
     return false;
   }
 
+  @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     if (retrieveComponentState() != StartedState.getInstance()) {
       throw new ServiceException("Internal state out of step, expected StartedState but was " + retrieveComponentState().toString());
@@ -55,10 +50,12 @@ public class CheckComponentStateService extends MockStateManagedComponent implem
     return defaultIfEmpty(getUniqueId(), "");
   }
 
+  @Override
   public boolean isBranching() {
     return false;
   }
 
+  @Override
   public void setUniqueId(String id) {
     uniqueId = id;
   }
@@ -68,6 +65,7 @@ public class CheckComponentStateService extends MockStateManagedComponent implem
     return uniqueId;
   }
 
+  @Override
   public String createName() {
     return this.getClass().getName();
   }
@@ -76,6 +74,7 @@ public class CheckComponentStateService extends MockStateManagedComponent implem
     return false;
   }
 
+  @Override
   public boolean isTrackingEndpoint() {
     return false;
   }
@@ -90,7 +89,6 @@ public class CheckComponentStateService extends MockStateManagedComponent implem
 
   public void setIsConfirmation(Boolean b) {
     isConfirmation = b;
-
   }
 
   public void setIsTrackingEndpoint(Boolean b) {

--- a/interlok-core/src/test/java/com/adaptris/fs/FsCase.java
+++ b/interlok-core/src/test/java/com/adaptris/fs/FsCase.java
@@ -20,12 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 public class FsCase {
-
-  protected transient Log logR = LogFactory.getLog(this.getClass());
 
   protected static Properties PROPERTIES;
   private static final String PROPERTIES_RESOURCE = "unit-tests.properties";

--- a/interlok-core/src/test/java/com/adaptris/fs/StandardWorkerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/fs/StandardWorkerTest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.fs;
 
@@ -74,7 +74,7 @@ public class StandardWorkerTest extends FsCase {
   // write test files to file system
   protected String[] createTestFiles() throws Exception {
     GuidGenerator guid = new GuidGenerator();
-    List<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     for (int i = 0; i < FILE_CREATION_COUNT; i++) {
       String fname = guid.safeUUID();
       File file = new File(baseDir, fname);
@@ -87,7 +87,7 @@ public class StandardWorkerTest extends FsCase {
   }
 
   protected Set<File> asFileArray(String[] files) {
-    Set<File> result = new HashSet<File>();
+    Set<File> result = new HashSet<>();
     for (String f : files) {
       result.add(new File(baseDir, f));
     }
@@ -108,7 +108,7 @@ public class StandardWorkerTest extends FsCase {
     File dir = Mockito.mock(File.class);
     Mockito.when(dir.canWrite()).thenReturn(true);
     Mockito.when(dir.exists()).thenReturn(true);
-    Mockito.when(dir.canRead()).thenReturn(true);    
+    Mockito.when(dir.canRead()).thenReturn(true);
     Mockito.when(dir.isDirectory()).thenReturn(true);
     Mockito.when(dir.listFiles((FileFilter) Mockito.any())).thenReturn(files);
     StandardWorker worker = createWorker();
@@ -118,7 +118,7 @@ public class StandardWorkerTest extends FsCase {
       worker.listFiles(null);
       fail();
     } catch (FsException | IllegalArgumentException expected) {
-      
+
     }
   }
 
@@ -167,7 +167,7 @@ public class StandardWorkerTest extends FsCase {
   @Test
   public void testPutFile() throws Exception {
     FsWorker worker = createWorker();
-    String[] testFiles = createTestFiles();
+    createTestFiles();
     String newFilename = new GuidGenerator().safeUUID();
     worker.put(DATA.getBytes(), new File(baseDir, newFilename));
     byte[] result = worker.get(new File(baseDir, newFilename));
@@ -205,7 +205,7 @@ public class StandardWorkerTest extends FsCase {
 
     worker.rename(new File(baseDir, testFiles[0]), new File(baseDir, newFilename));
     File[] files = worker.listFiles(baseDir);
-    Set set = new HashSet(Arrays.asList(files));
+    Set<File> set = new HashSet<>(Arrays.asList(files));
     assertTrue(set.contains(new File(FsHelper.createFileReference(baseUrl), newFilename)));
     try {
       worker.rename(new File(baseDir, testFiles[0]), new File(baseDir, testFiles[1]));
@@ -229,7 +229,7 @@ public class StandardWorkerTest extends FsCase {
     worker.delete(new File(baseDir, testFiles[0]));
 
     File[] files = worker.listFiles(baseDir);
-    Set set = new HashSet(Arrays.asList(files));
+    Set<File> set = new HashSet<>(Arrays.asList(files));
     assertTrue(!set.contains(new File(baseDir, testFiles[0])));
     worker.delete(new File(baseDir, "sthgelse"));
     try {
@@ -313,7 +313,7 @@ public class StandardWorkerTest extends FsCase {
     }
 
   }
-  
+
   @Test
   public void testCheckExists() throws Exception {
     File nonExistent = Mockito.mock(File.class);
@@ -367,7 +367,7 @@ public class StandardWorkerTest extends FsCase {
     Mockito.when(readable.exists()).thenReturn(true);
     FsWorker.checkReadable(readable);
   }
-  
+
   @Test
   public void testIsDirectory() throws Exception {
     File isFile = Mockito.mock(File.class);
@@ -385,7 +385,7 @@ public class StandardWorkerTest extends FsCase {
     Mockito.when(dir.exists()).thenReturn(true);
     FsWorker.isDirectory(dir);
   }
-  
+
   @Test
   public void testIsFile() throws Exception {
     File isDirectory = Mockito.mock(File.class);
@@ -403,8 +403,9 @@ public class StandardWorkerTest extends FsCase {
     Mockito.when(file.exists()).thenReturn(true);
     FsWorker.isFile(file);
   }
-  
+
   private class TmpFilter implements java.io.FileFilter {
+    @Override
     public boolean accept(File file) {
       if (file.getName().endsWith(DEFAULT_FILTER_SUFFIX)) {
         return true;

--- a/interlok-core/src/test/java/com/adaptris/http/HttpRequest.java
+++ b/interlok-core/src/test/java/com/adaptris/http/HttpRequest.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.http;
 
@@ -43,12 +43,12 @@ import com.adaptris.util.stream.UnbufferedLineInputStream;
  *  </pre></code>
  */
 public final class HttpRequest implements DataTransfer {
-  
+
   private String method, version, uri;
   private transient Log logR;
-  
+
   /** @see Object#Object()
-   * 
+   *
    *
    */
   public HttpRequest() {
@@ -62,9 +62,9 @@ public final class HttpRequest implements DataTransfer {
    * e.g. POST GET PUT
    */
   public void setMethod(String s) {
-    this.method = s;
+    method = s;
   }
-  
+
   /** Set the uri.
    * <p>e.g. /directory/index.html, or
    * /index.jsp?param1=x&param2=y&param3=z</p>
@@ -74,7 +74,7 @@ public final class HttpRequest implements DataTransfer {
   public void setURI(String uri) {
     this.uri = uri;
   }
-  
+
   /** Return the http Version
    * @return the http Version associated with this set of HTTP headers
    * generally HTTP/1.0
@@ -82,39 +82,40 @@ public final class HttpRequest implements DataTransfer {
   public String getVersion() {
     return version;
   }
-  
+
   /** Return the Method associated with this set of headers
    * @return the http method associated with this set of HTTP headers
    */
   public String getMethod() {
     return method;
   }
-  
+
   /** Return the URI.
    * @return the URI associated with this set of HTTP headers
    */
   public String getURI() {
     return uri;
   }
-  
+
   /** Set the Version.
-   * @param version set the version to be associated with this set of HTTP 
+   * @param version set the version to be associated with this set of HTTP
    * headers
    * generally HTTP/1.0 or HTTP/1.1
    */
   public void setVersion(String version) {
     this.version = version;
   }
-  
+
   /** Write the request line to the supplied outputstream.
    *  @param out the outputstream
    *  @throws HttpException on error.
    *  @see DataTransfer#writeTo(OutputStream)
    */
+  @Override
   public void writeTo(OutputStream out)
-  throws HttpException {
+      throws HttpException {
     try {
-      logR.trace("Writing Request:- " + toString());      
+      logR.trace("Writing Request:- " + toString());
       PrintStream p = new PrintStream(out);
       p.print(toString());
       p.print(Http.CRLF);
@@ -123,17 +124,18 @@ public final class HttpRequest implements DataTransfer {
       throw new HttpException(e);
     }
   }
-  
+
   /** Parse an inputstream that contains a request.
    *  @see DataTransfer#load(InputStream)
    */
+  @Override
   public void load(InputStream in) throws HttpException {
     UnbufferedLineInputStream unbuffered = new UnbufferedLineInputStream(in);
     String line;
     try {
       synchronized (in) {
         line = unbuffered.readLine();
-        
+
         StringTokenizer st = new StringTokenizer(line);
         if (line.startsWith("HTTP/")) {
           throw new HttpException("Input is not a HttpRequest");
@@ -151,11 +153,12 @@ public final class HttpRequest implements DataTransfer {
     }
     return;
   }
-  
+
   /** @see Object#toString()
    */
+  @Override
   public String toString() {
-    
+
     StringBuffer sb = new StringBuffer();
     sb.append(method);
     sb.append(Http.SPACE);
@@ -164,18 +167,18 @@ public final class HttpRequest implements DataTransfer {
     sb.append(version);
     return sb.toString();
   }
-  
+
   /**
    * <p>
-   * Returns the file element of the URI, where the file element is the URI up 
-   * to but not including any paramters or references.  If no parameters or 
+   * Returns the file element of the URI, where the file element is the URI up
+   * to but not including any paramters or references.  If no parameters or
    * references exist the URI is returned.
    * </p>
    * @return the file element of the URI
    */
   public String getFile() {
-    String result = this.getURI();
-    
+    String result = getURI();
+
     if (uri.indexOf("?") > -1) {
       result = uri.substring(0, uri.indexOf("?"));
     }
@@ -184,46 +187,46 @@ public final class HttpRequest implements DataTransfer {
         result = uri.substring(0, uri.indexOf("#"));
       }
     }
-    
+
     logR.debug("file element of URI [" + result + "]");
-    
+
     return result;
   }
-  
+
   /**
    * <p>
-   * Returns a <code>Map</code> of the query parameters.  This implementation 
+   * Returns a <code>Map</code> of the query parameters.  This implementation
    * doesn't handle URL encoding (e.g. spaces) due to lack of time.
    * </p>
    * @return a <code>Map</code> of the query parameters
    */
-  public Map getParameters() {
-    Map result = new HashMap();
-    
+  public Map<String, String> getParameters() {
+    Map<String, String> result = new HashMap<>();
+
     if (uri.indexOf("?") > -1) {  // uri contains params
       int start = uri.indexOf("?") + 1;
       int end = uri.indexOf("#");
-      
+
       if (end == -1) {  // uri doesn't contain reference
         end = uri.length();
       }
-      
-      StringTokenizer params 
-        = new StringTokenizer(uri.substring(start, end), "&");
-      
+
+      StringTokenizer params
+      = new StringTokenizer(uri.substring(start, end), "&");
+
       while (params.hasMoreTokens()) {
         String param = params.nextToken();
-        
-        // at least three chars... 
+
+        // at least three chars...
         if (param.length() > 2) {
           // and contain equals but not first or last char
-          if (param.indexOf("=") > -1  
-            && param.indexOf("=") != 0  
-            && param.indexOf("=") != param.length() - 1) {
-            
+          if (param.indexOf("=") > -1
+              && param.indexOf("=") != 0
+              && param.indexOf("=") != param.length() - 1) {
+
             String key = param.substring(0, param.indexOf("="));
             String value = param.substring(param.indexOf("=") + 1);
-            
+
             result.put(key, value);
           }
         }
@@ -233,7 +236,7 @@ public final class HttpRequest implements DataTransfer {
         }
       }
     }
-    
+
     return result;
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/http/HttpsListener.java
+++ b/interlok-core/src/test/java/com/adaptris/http/HttpsListener.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.http;
 
@@ -44,7 +44,7 @@ import com.adaptris.security.util.AlwaysTrustManager;
  * the listener have not been invoked. The private key password must always
  * exist in this file and cannot be set programmatically.
  * </p>
- * 
+ *
  * @see HttpListener
  */
 public class HttpsListener extends HttpListener {
@@ -70,8 +70,9 @@ public class HttpsListener extends HttpListener {
 
   /**
    * Require a client to present a certificat.
-   * 
-   * @param b true if clients must always present a certificate
+   *
+   * @param b
+   *          true if clients must always present a certificate
    */
   public void setRequireClientAuth(boolean b) {
     requireClientAuth = b;
@@ -79,7 +80,7 @@ public class HttpsListener extends HttpListener {
 
   /**
    * Get the require authorisation flag.
-   * 
+   *
    * @return true or false, depending
    */
   public boolean getRequireClientAuth() {
@@ -98,7 +99,7 @@ public class HttpsListener extends HttpListener {
    * <p>
    * Regardless of the flag setting, the actual data communication is encrypted
    * </p>
-   * 
+   *
    * @param b true of false
    */
   public void setAlwaysTrust(boolean b) {
@@ -107,7 +108,7 @@ public class HttpsListener extends HttpListener {
 
   /**
    * Get the always trust flag.
-   * 
+   *
    * @return the flag true or false
    */
   public boolean getAlwaysTrust() {
@@ -117,6 +118,7 @@ public class HttpsListener extends HttpListener {
   /**
    * @see HttpListener#initialise()
    */
+  @Override
   public void initialise() throws HttpException {
     try {
       if (initialised) {
@@ -149,7 +151,7 @@ public class HttpsListener extends HttpListener {
     if (alwaysTrust) {
       // Always trust the certificate ! - quite dangerous ;)
       TrustManager[] tm = new TrustManager[1];
-      tm[0] = (TrustManager) new AlwaysTrustManager();
+      tm[0] = new AlwaysTrustManager();
       sslContext.init(kmf.getKeyManagers(), tm, null);
     }
     else {
@@ -181,7 +183,7 @@ public class HttpsListener extends HttpListener {
 
   /**
    * Register the keystore to use when listening for connections.
-   * 
+   *
    * @param keystoreProxy the keystoreProxy to set
    */
   public void registerKeystore(KeystoreProxy keystoreProxy) {
@@ -190,7 +192,7 @@ public class HttpsListener extends HttpListener {
 
   /**
    * Register a private key password.
-   * 
+   *
    * @param pkpw
    */
   public void registerPrivateKeyPassword(char[] pkpw) {

--- a/interlok-core/src/test/java/com/adaptris/http/MessageImp.java
+++ b/interlok-core/src/test/java/com/adaptris/http/MessageImp.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.http;
 
@@ -21,15 +21,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.MessageDigest;
+import java.util.Base64;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.adaptris.util.text.Conversion;
 import com.adaptris.util.text.HexDump;
 
 /** Abstract implementation of HttpMessage.
- *  <p>This class provides default implementations of the DataSource 
+ *  <p>This class provides default implementations of the DataSource
  * components required
  *  by the interface.
  */
@@ -44,52 +44,59 @@ abstract class MessageImp implements HttpMessage {
 
   protected MessageImp() {
     logR = LogFactory.getLog(this.getClass());
-    output = new ByteArrayOutputStream();    
+    output = new ByteArrayOutputStream();
     header = new HttpHeaders();
     try {
-      md5 = MessageDigest.getInstance("MD5");      
+      md5 = MessageDigest.getInstance("MD5");
     } catch (Exception ignoredIntentionally) {
       ;
     }
   }
 
   /** @see javax.activation.DataSource#getInputStream() */
+  @Override
   public InputStream getInputStream() throws java.io.IOException {
     return input;
   }
 
   /** @see javax.activation.DataSource#getOutputStream() */
+  @Override
   public OutputStream getOutputStream() throws java.io.IOException {
     return output;
   }
 
   /** @see javax.activation.DataSource#getName()
    */
+  @Override
   public String getName() {
     return getHeaders().get(Http.HEADER_MESSAGE_ID);
   }
 
   /** @see javax.activation.DataSource#getContentType()
    */
+  @Override
   public String getContentType() {
     return getHeaders().get(Http.CONTENT_TYPE);
   }
 
   /** @see HttpMessage#getHeaders()
    */
+  @Override
   public HttpHeaders getHeaders() {
     return header;
   }
 
   /** @see HttpMessage#setHeaders(HttpHeaders)
    */
+  @Override
   public void setHeaders(HttpHeaders h) {
     header = h;
   }
 
   /** @see Object#toString()
-   * 
+   *
    */
+  @Override
   public String toString() {
     StringBuffer sb = new StringBuffer();
     try {
@@ -102,18 +109,18 @@ abstract class MessageImp implements HttpMessage {
     }
     return sb.toString();
   }
-  
+
   protected void logMessageInfo() {
     Log socketLogger = Http.getSocketLogger();
     if (socketLogger.isTraceEnabled()) {
       socketLogger.trace(toVerboseString());
     } else {
       logR.trace(toString());
-    }    
+    }
   }
 
   /** Provide some way of getting extended information of this object.
-   * 
+   *
    */
   private String toVerboseString() {
     StringBuffer sb = new StringBuffer();
@@ -123,16 +130,16 @@ abstract class MessageImp implements HttpMessage {
       sb.append(getHeaders());
       sb.append("\nData :\n");
       output.writeTo(out);
-      sb.append(HexDump.parse(out.toByteArray()));      
+      sb.append(HexDump.parse(out.toByteArray()));
     } catch (Exception e) {
       ;
     }
     return sb.toString();
   }
-  
+
   private String getHash() {
     md5.reset();
     byte[] digest = md5.digest(output.toByteArray());
-    return (Conversion.byteArrayToBase64String(digest));        
+    return Base64.getEncoder().encodeToString(digest);
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/http/RequestDispatcher.java
+++ b/interlok-core/src/test/java/com/adaptris/http/RequestDispatcher.java
@@ -1,18 +1,18 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.http;
 
@@ -36,62 +36,63 @@ final class RequestDispatcher implements Runnable {
    */
   private static final String[] COMMON_RESPONSE_CODES =
     {
-      Integer.toString(HttpURLConnection.HTTP_OK),
-      Integer.toString(HttpURLConnection.HTTP_BAD_METHOD),
-      Integer.toString(HttpURLConnection.HTTP_FORBIDDEN),
-      Integer.toString(HttpURLConnection.HTTP_LENGTH_REQUIRED),
-      Integer.toString(HttpURLConnection.HTTP_INTERNAL_ERROR),
-      Integer.toString(HttpURLConnection.HTTP_NOT_IMPLEMENTED),
-      Integer.toString(HttpURLConnection.HTTP_NOT_FOUND),
-      Integer.toString(HttpURLConnection.HTTP_VERSION)};
+        Integer.toString(HttpURLConnection.HTTP_OK),
+        Integer.toString(HttpURLConnection.HTTP_BAD_METHOD),
+        Integer.toString(HttpURLConnection.HTTP_FORBIDDEN),
+        Integer.toString(HttpURLConnection.HTTP_LENGTH_REQUIRED),
+        Integer.toString(HttpURLConnection.HTTP_INTERNAL_ERROR),
+        Integer.toString(HttpURLConnection.HTTP_NOT_IMPLEMENTED),
+        Integer.toString(HttpURLConnection.HTTP_NOT_FOUND),
+        Integer.toString(HttpURLConnection.HTTP_VERSION)};
   /** some generic response messages to be stored in a hashmap.
    */
   private static final String[] COMMON_RESPONSE_MESSAGES =
     {
-      "OK",
-      "Bad Method",
-      "Bad username/password",
-      "Length Required",
-      "Internal Server Error",
-      "Not implemented",
-      "Workflow Not Found",
-      "HTTP Version not supported" };
+        "OK",
+        "Bad Method",
+        "Bad username/password",
+        "Length Required",
+        "Internal Server Error",
+        "Not implemented",
+        "Workflow Not Found",
+    "HTTP Version not supported" };
   /** The generic response hashmap.
    */
-  private static HashMap commonResponseHashMap;
+  private static HashMap<String, String> commonResponseHashMap;
   // Default poll for the LinkedQueue timeout. 100 ms
   private static final int DEFAULT_QUEUE_POLL_TIMEOUT = 100;
 
   static {
-    commonResponseHashMap = new HashMap();
+    commonResponseHashMap = new HashMap<>();
     for (int i = 0; i < COMMON_RESPONSE_CODES.length; i++) {
       commonResponseHashMap.put(
-        COMMON_RESPONSE_CODES[i],
-        COMMON_RESPONSE_MESSAGES[i]);
+          COMMON_RESPONSE_CODES[i],
+          COMMON_RESPONSE_MESSAGES[i]);
     }
   }
 
   private Socket socket;
   private transient Log logR;
-  private Map requestProcessors;
+  private Map<String, LinkedBlockingQueue<RequestProcessor>> requestProcessors;
   private String threadName;
-  
+
   private RequestDispatcher() {
     logR = LogFactory.getLog(this.getClass());
     threadName = getThreadName();
   }
 
-  RequestDispatcher(Socket s, Map requests, Listener parent) {
+  RequestDispatcher(Socket s, Map<String, LinkedBlockingQueue<RequestProcessor>> requests, Listener parent) {
     this();
     socket = s;
     requestProcessors = requests;
     this.parent = parent;
   }
 
+  @Override
   public void run() {
     RequestProcessor rp = null;
     HttpSession session = null;
-    LinkedBlockingQueue queue = null;
+    LinkedBlockingQueue<RequestProcessor> queue = null;
     String oldName = Thread.currentThread().getName();
     Thread.currentThread().setName(threadName);
     do {
@@ -102,14 +103,14 @@ final class RequestDispatcher implements Runnable {
 
         session = new ServerSession();
         session.setSocket(socket);
-//        String uri = session.getRequestLine().getURI();
+        //        String uri = session.getRequestLine().getURI();
 
         String file = session.getRequestLine().getFile();
-        queue = (LinkedBlockingQueue) requestProcessors.get(file);
+        queue = requestProcessors.get(file);
 
         if (queue == null) {
           // Get a default one, if any
-          queue = (LinkedBlockingQueue) requestProcessors.get("*");
+          queue = requestProcessors.get("*");
           if (queue == null) {
             doResponse(session, HttpURLConnection.HTTP_NOT_FOUND);
             break;
@@ -123,7 +124,7 @@ final class RequestDispatcher implements Runnable {
         rp.processRequest(session);
         session.commit();
       } catch (Exception e) {
-        // if an exception occurs, then it's pretty much a fatal error for 
+        // if an exception occurs, then it's pretty much a fatal error for
         // this session
         // we ignore any output that it might have setup, and use our own
         try {
@@ -153,15 +154,15 @@ final class RequestDispatcher implements Runnable {
 
   // Block on a request processor for ever, or until we are are shutdown.
   //
-  private RequestProcessor waitForRequestProcessor(LinkedBlockingQueue queue)
-    throws HttpException {
+  private RequestProcessor waitForRequestProcessor(LinkedBlockingQueue<RequestProcessor> queue)
+      throws HttpException {
     RequestProcessor rp = null;
     do {
       if (logR.isTraceEnabled()) {
         logR.trace("Waiting for an available processor from " + queue);
       }
       try {
-        rp = (RequestProcessor) queue.poll(DEFAULT_QUEUE_POLL_TIMEOUT, TimeUnit.MILLISECONDS);
+        rp = queue.poll(DEFAULT_QUEUE_POLL_TIMEOUT, TimeUnit.MILLISECONDS);
         if (rp != null) {
           if (logR.isTraceEnabled()) {
             logR.trace("Got RequestProcessor " + rp);
@@ -178,17 +179,17 @@ final class RequestDispatcher implements Runnable {
   /** Perform some generic response to the remote party
    */
   private static void doResponse(HttpSession currentSession, int code)
-    throws HttpException {
+      throws HttpException {
 
     HttpResponse response = currentSession.getResponseLine();
     response.setResponseCode(code);
     response.setResponseMessage(
-      (String) commonResponseHashMap.get(Integer.toString(code)));
+        commonResponseHashMap.get(Integer.toString(code)));
     HttpMessage msg = currentSession.getResponseMessage();
     msg.getHeaders().put(Http.CONNECTION, Http.CLOSE);
     currentSession.commit();
   }
-  
+
   private String getThreadName() {
     String className = this.getClass().getName();
     int dot = className.lastIndexOf(".");

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/BaseCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/BaseCase.java
@@ -12,12 +12,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.interlok.junit.scaffolding;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -29,10 +30,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
@@ -40,6 +43,7 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ComponentLifecycle;
 import com.adaptris.core.ComponentState;
@@ -93,7 +97,7 @@ public abstract class BaseCase {
     if (this instanceof UpgradedToJunit4) {
       if (!((UpgradedToJunit4) this).isAnnotatedForJunit4()) {
         throw new RuntimeException(this.getClass().getCanonicalName()
-          + ": isAnnotatedForJunit4() method returned false, please add annotations, and override the method.");
+            + ": isAnnotatedForJunit4() method returned false, please add annotations, and override the method.");
       }
     }
   }
@@ -108,7 +112,7 @@ public abstract class BaseCase {
   }
 
   public static void execute(StandaloneConsumer c, StandaloneProducer p, AdaptrisMessage m, int count, long wait,
-                             MockMessageListener stub) throws Exception {
+      MockMessageListener stub) throws Exception {
     start(c);
     start(p);
     try {
@@ -271,7 +275,7 @@ public abstract class BaseCase {
 
   protected Set<ConstraintViolation<Object>> validate(Validator v, Object o) {
     if (o == null) {
-      return Collections.EMPTY_SET;
+      return Collections.emptySet();
     }
     Validator validator = ObjectUtils.defaultIfNull(v, vFactory.getValidator());
     return validator.validate(o);

--- a/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/jms/MessageTypeTranslatorCase.java
+++ b/interlok-core/src/test/java/com/adaptris/interlok/junit/scaffolding/jms/MessageTypeTranslatorCase.java
@@ -12,40 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.interlok.junit.scaffolding.jms;
-
-import com.adaptris.core.AdaptrisMarshaller;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.BaseCase;
-import com.adaptris.core.DefaultMarshaller;
-import com.adaptris.core.DefaultMessageFactory;
-import com.adaptris.core.MetadataElement;
-import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.jms.AutoConvertMessageTranslator;
-import com.adaptris.core.jms.JmsConnection;
-import com.adaptris.core.jms.JmsConstants;
-import com.adaptris.core.jms.MessageTypeTranslator;
-import com.adaptris.core.jms.MessageTypeTranslatorImp;
-import com.adaptris.core.jms.PasProducer;
-import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
-import com.adaptris.core.metadata.NoOpMetadataFilter;
-import com.adaptris.core.metadata.RegexMetadataFilter;
-import com.adaptris.core.metadata.RemoveAllMetadataFilter;
-import com.adaptris.core.util.LifecycleHelper;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.Session;
 
 import static com.adaptris.core.jms.JmsConstants.JMS_CORRELATION_ID;
 import static com.adaptris.core.jms.JmsConstants.JMS_DELIVERY_MODE;
@@ -64,9 +33,38 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import com.adaptris.core.AdaptrisMarshaller;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.MetadataElement;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.jms.AutoConvertMessageTranslator;
+import com.adaptris.core.jms.JmsConnection;
+import com.adaptris.core.jms.JmsConstants;
+import com.adaptris.core.jms.MessageTypeTranslator;
+import com.adaptris.core.jms.MessageTypeTranslatorImp;
+import com.adaptris.core.jms.PasProducer;
+import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
+import com.adaptris.core.metadata.NoOpMetadataFilter;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.adaptris.core.metadata.RemoveAllMetadataFilter;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+
 /**
  */
-@SuppressWarnings("deprecation")
 public abstract class MessageTypeTranslatorCase {
 
 
@@ -79,10 +77,9 @@ public abstract class MessageTypeTranslatorCase {
   public static final String TEXT = "The quick brown fox";
   public static final String TEXT2 = "jumps over the lazy dog";
 
-  protected transient Log log = LogFactory.getLog(this.getClass());
   @Rule
   public TestName testName = new TestName();
-  
+
   protected static EmbeddedActiveMq activeMqBroker;
 
   @BeforeClass
@@ -90,11 +87,12 @@ public abstract class MessageTypeTranslatorCase {
     activeMqBroker = new EmbeddedActiveMq();
     activeMqBroker.start();
   }
-  
+
   @AfterClass
   public static void tearDownAll() throws Exception {
-    if(activeMqBroker != null)
+    if(activeMqBroker != null) {
       activeMqBroker.destroy();
+    }
   }
 
   protected abstract MessageTypeTranslatorImp createTranslator() throws Exception;
@@ -112,7 +110,7 @@ public abstract class MessageTypeTranslatorCase {
   public void testRoundTrip() throws Exception {
     MessageTypeTranslatorImp translator =
         createTranslator().withMoveJmsHeaders(true).withMetadataFilter(new NoOpMetadataFilter())
-            .withReportAllErrors(true);
+        .withReportAllErrors(true);
     StandaloneProducer p1 = createProducer(translator);
     StandaloneProducer p2 = roundTrip(p1);
     BaseCase.assertRoundtripEquality(p1, p2);
@@ -193,15 +191,15 @@ public abstract class MessageTypeTranslatorCase {
       addProperties(jmsMsg);
       start(trans, session);
       AdaptrisMessage msg = trans.translate(jmsMsg);
-      assertFalse(msg.containsKey(INTEGER_METADATA));
-      assertFalse(msg.containsKey(STRING_METADATA));
-      assertFalse(msg.containsKey(BOOLEAN_METADATA));
+      assertFalse(msg.headersContainsKey(INTEGER_METADATA));
+      assertFalse(msg.headersContainsKey(STRING_METADATA));
+      assertFalse(msg.headersContainsKey(BOOLEAN_METADATA));
     }
     finally {
       stop(trans);
     }
   }
-  
+
   @Test
   public void testTranslatorNullMessage() throws Exception {
     Message nullMessage = null;
@@ -222,7 +220,7 @@ public abstract class MessageTypeTranslatorCase {
       AdaptrisMessage msg = trans.translate(jmsMsg);
       assertMetadata(msg, new MetadataElement(STRING_METADATA, STRING_VALUE));
       assertMetadata(msg, new MetadataElement(BOOLEAN_METADATA, BOOLEAN_VALUE));
-      assertFalse(msg.containsKey(INTEGER_METADATA));
+      assertFalse(msg.headersContainsKey(INTEGER_METADATA));
     }
     finally {
       stop(trans);
@@ -379,7 +377,7 @@ public abstract class MessageTypeTranslatorCase {
   }
 
   protected static void assertMetadata(AdaptrisMessage msg, MetadataElement e) {
-    assertTrue(msg.containsKey(e.getKey()));
+    assertTrue(msg.headersContainsKey(e.getKey()));
     assertEquals(e.getValue(), msg.getMetadataValue(e.getKey()));
   }
 
@@ -399,10 +397,10 @@ public abstract class MessageTypeTranslatorCase {
 
   public static void addRedundantJmsHeaders(AdaptrisMessage msg) {
     String[] RESERVED_JMS =
-    {
-        JMS_CORRELATION_ID, JMS_TYPE, JMS_TIMESTAMP, JMS_REPLY_TO, JMS_REDELIVERED, JMS_PRIORITY, JMS_MESSAGE_ID, JMS_EXPIRATION,
-        JMS_DELIVERY_MODE, JMS_DESTINATION
-    };
+      {
+          JMS_CORRELATION_ID, JMS_TYPE, JMS_TIMESTAMP, JMS_REPLY_TO, JMS_REDELIVERED, JMS_PRIORITY, JMS_MESSAGE_ID, JMS_EXPIRATION,
+          JMS_DELIVERY_MODE, JMS_DESTINATION
+      };
     for (String key : RESERVED_JMS) {
       msg.addMetadata(key, "XXX");
     }

--- a/interlok-core/src/test/java/com/adaptris/security/Config.java
+++ b/interlok-core/src/test/java/com/adaptris/security/Config.java
@@ -21,12 +21,12 @@ import java.io.IOException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.util.Properties;
+
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x509.X509ObjectIdentifiers;
+
 import com.adaptris.core.util.PropertyHelper;
 import com.adaptris.security.certificate.CertificateBuilder;
 import com.adaptris.security.certificate.CertificateBuilderFactory;
@@ -101,12 +101,10 @@ public class Config {
 
   private static Config instance = null;
 
-  private transient Log logR;
   private Properties config = null;
 
   private Config() {
     try {
-      logR = LogFactory.getLog(Config.class);
       config = PropertyHelper.loadQuietly(() -> {
         return this.getClass().getClassLoader().getResourceAsStream(SECURITY_PROPERTIES);
       });

--- a/interlok-core/src/test/java/com/adaptris/security/password/PasswordTest.java
+++ b/interlok-core/src/test/java/com/adaptris/security/password/PasswordTest.java
@@ -12,44 +12,30 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.security.password;
 
 import static org.junit.Assert.assertEquals;
 
-import com.adaptris.security.exc.PasswordException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-import com.adaptris.interlok.junit.scaffolding.util.Os;
-
 import java.util.Properties;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import com.adaptris.interlok.junit.scaffolding.util.Os;
+import com.adaptris.security.exc.PasswordException;
 
 public class PasswordTest {
 
   private static final String TEXT = "MYPASSWORD";
 
-  private static Log logR = LogFactory.getLog(PasswordTest.class);
-
-  @Before
-  public void setUp() throws Exception {
-    logR = LogFactory.getLog(this.getClass());
-  }
-
-  @After
-  public void tearDown() throws Exception {
-  }
-
   @Test
   public void testMainClass() throws Exception {
     String[] args =
-    {
-        Password.PORTABLE_PASSWORD, TEXT
-    };
+      {
+          Password.PORTABLE_PASSWORD, TEXT
+      };
     Password.generatePassword(args);
     Password.generatePassword(null);
     Password.generatePassword(new String[0]);

--- a/interlok-core/src/test/java/com/adaptris/util/ByteArrayDataSourceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/ByteArrayDataSourceTest.java
@@ -18,18 +18,17 @@ package com.adaptris.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.io.ByteArrayOutputStream;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
+
 import com.adaptris.util.text.mime.ByteArrayDataSource;
 
 public class ByteArrayDataSourceTest {
 
   private static final String EXAMPLE_XML = "<document>" + "<root>"
       + "<data>abcdefg</data>" + "</root>" + "</document>";
-
-  private transient Log logR = LogFactory.getLog(this.getClass());;
 
   @Test
   public void testInputStream() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/util/FifoMutexLockTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/FifoMutexLockTest.java
@@ -18,14 +18,12 @@ package com.adaptris.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Before;
 import org.junit.Test;
 
 public class FifoMutexLockTest {
 
-  protected transient Log log = LogFactory.getLog(this.getClass().getName());
   private FifoMutexLock lock;
   private int locksAcquired = 0;
   private int locksInterrupted = 0;

--- a/interlok-core/src/test/java/com/adaptris/util/TestMultipartOutput.java
+++ b/interlok-core/src/test/java/com/adaptris/util/TestMultipartOutput.java
@@ -18,11 +18,12 @@ package com.adaptris.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.io.ByteArrayOutputStream;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import com.adaptris.util.text.mime.ByteArrayIterator;
 import com.adaptris.util.text.mime.MimeConstants;
 import com.adaptris.util.text.mime.MultiPartOutput;
@@ -36,8 +37,6 @@ public class TestMultipartOutput implements MimeConstants {
   private static final String PAYLOAD_2 = "Sixty zippers were quickly picked "
       + "from the woven jute bag";
   private GuidGenerator guid;
-  static final Log logR = LogFactory.getLog(TestMultipartOutput.class);
-
 
   @Before
   public void setUp() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/util/TestURLName.java
+++ b/interlok-core/src/test/java/com/adaptris/util/TestURLName.java
@@ -17,14 +17,12 @@
 package com.adaptris.util;
 
 import static org.junit.Assert.assertEquals;
+
 import javax.mail.URLName;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
 
 public class TestURLName {
-
-  private static Log logR = LogFactory.getLog(TestURLName.class);
 
   private static String testUrl = "smtp://user%40btinternet.com:password@mail.btinternet.com/";
   private static String username = "user@btinternet.com";

--- a/interlok-core/src/test/java/com/adaptris/util/datastore/TestSimpleDataStore.java
+++ b/interlok-core/src/test/java/com/adaptris/util/datastore/TestSimpleDataStore.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,8 +36,6 @@ public class TestSimpleDataStore {
   private static String type = "type";
   private static String id = "id";
   private static String data = "This is the data part";
-  private boolean initialised = false;
-  private static Log logR = LogFactory.getLog(TestSimpleDataStore.class);
 
   private DataStore dataStore = null;
   private Properties dataStoreProperties;

--- a/interlok-core/src/test/java/com/adaptris/util/stream/Slf4jLoggingOutputStreamTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/stream/Slf4jLoggingOutputStreamTest.java
@@ -19,10 +19,6 @@ package com.adaptris.util.stream;
 import java.io.IOException;
 import java.io.PrintStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.adaptris.util.stream.LoggingOutputStreamImpl.LogLevel;
@@ -30,17 +26,6 @@ import com.adaptris.util.stream.LoggingOutputStreamImpl.LogLevel;
 public class Slf4jLoggingOutputStreamTest {
 
   private static final String TEXT = "The Quick Brown fox jumps over the lazy dog.";
-
-  private static Log logR = LogFactory.getLog(Slf4jLoggingOutputStreamTest.class);
-
-  @Before
-  public void setUp() throws Exception {
-    logR = LogFactory.getLog(this.getClass());
-  }
-
-  @After
-  public void tearDown() throws Exception {
-  }
 
   @Test
   public void testLogTrace() throws Exception {

--- a/interlok-core/src/test/java/com/adaptris/util/stream/StreamUtilTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/stream/StreamUtilTest.java
@@ -29,26 +29,11 @@ import java.io.OutputStreamWriter;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class StreamUtilTest extends StreamUtil {
 
   private static final String TEXT = "The Quick Brown fox jumps over the lazy dog.";
-
-  private transient Log logR;
-
-  @Before
-  public void setUp() throws Exception {
-    logR = LogFactory.getLog(this.getClass());
-  }
-
-  @After
-  public void tearDown() throws Exception {
-  }
 
   @Test
   public void testCreateFile() throws Exception {


### PR DESCRIPTION
## Motivation

Upgrade to slf4j 2.0.0

## Modification

- Bump slf4j to 2.0.0
- Add dependency on reload4j
- Remove dependency on slf4j-simple
- Refactoring
- Remove compile warnings

## PR Checklist

- [x] been self-reviewed.

## Result

It should be seamless to the end user

## Testing

The build should be successful.
 In a nightly build, change slf4j-api.jar by slf4j-api-2.0.0.jar, add slf4j-reload4j-2.0.0.jar. Remove log4j-slf4j-impl.jar and makre sure the logging works fine,
