### PR TITLE
owasp: add exclusion for jettison / xstream

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -92,4 +92,27 @@
      <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-io@.*$</packageUrl>
      <vulnerabilityName>CVE-2022-2191</vulnerabilityName>
   </suppress>
+  <suppress>
+   <notes><![CDATA[
+   file name: jettison-1.2.jar
+   XStream has to use jettison-1.2 according to their docs, so an upgrade to 1.4 may not be possible
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.codehaus\.jettison/jettison@.*$</packageUrl>
+   <cve>CVE-2022-40149</cve>
+   <cve>CVE-2022-40150</cve>
+</suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: xstream-1.4.19.jar
+    XStream denial of service attack is a possibility, but it's the foundation of config so unavoidable
+    until they patch it.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.thoughtworks\.xstream/xstream@.*$</packageUrl>
+    <cve>CVE-2022-40151</cve>
+    <cve>CVE-2022-40152</cve>
+    <cve>CVE-2022-40153</cve>
+    <cve>CVE-2022-40154</cve>
+    <cve>CVE-2022-40155</cve>
+    <cve>CVE-2022-40156</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
## Motivation

Jettison-1.2 & XStream-1.4.19 marked with HIGH vulns > 7.5

Jettison is required because we use XStream to round-trip JSON but 1.3+ is marked as incompatible with XStream.

XStream is the cornerstone of config, so we have to suppress their DoS CVEs

Ref: http://x-stream.github.io/json-tutorial.html
Ref: http://x-stream.github.io/download.html#optional-deps


## Modification

- Add exclusions in for CVE-2022-40149 + CVE-2022-40150 for jettison
- Add exclusions for CVE-2022-40151 -> CVE-2022-40156 for xstream


## PR Checklist

- [x] been self-reviewed.

## Result

- `gradle dependencyCheckAnalyze` now works
- `gradle dependencyCheckAnalyze` now works for build-parent.

## Testing

- Run `gradle dCAnalyze` without the exclusions
- Run `gradle dCAnalyze` with the exclusions
