### PR TITLE
Control the default message factory and UID associated with messages via system properties.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageFactory.java
@@ -1,23 +1,24 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.Valid;
@@ -25,6 +26,9 @@ import javax.validation.Valid;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.IdGenerator;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * <p>
@@ -32,11 +36,38 @@ import com.adaptris.util.IdGenerator;
  * <code>AdaptrisMessage</code>.
  * </p>
  */
+@Slf4j
+@NoArgsConstructor
 public abstract class AdaptrisMessageFactory {
 
-  private static DefaultMessageFactory DEFAULT_INSTANCE = new DefaultMessageFactory();
+  /**
+   * If set as as system property then the fully qualified classname is used as the default message factory.
+   */
+  public static final String OVERRIDE_DEFAULT_MSG_FACTORY_PROP = "interlok.default.message.factory";
 
-  private static final IdGenerator DEFAULT_GENERATOR = new GuidGenerator();
+  /**
+   * If set as an env var then the fully qualified classname is used as the default message factory.
+   * <p>This will take precedence over the system property</p>
+   *
+   * @see #OVERRIDE_DEFAULT_MSG_FACTORY_PROP
+   */
+  public static final String OVERRIDE_DEFAULT_MSG_FACTORY_ENV = "INTERLOK_DEFAULT_MSG_FACTORY";
+
+  /**
+   * If set as as system property then the fully qualified classname is used as the default ID generator.
+   */
+  public static final String OVERRIDE_DEFAULT_MSGID_GEN_PROP = "interlok.default.msgid.generator";
+  /**
+   * If set as an env var then the fully qualified classname is used as the default ID Generator
+   * <p>This will take precedence over the system property</p>
+   *
+   * @see #OVERRIDE_DEFAULT_MSGID_GEN_PROP
+   */
+  public static final String OVERRIDE_DEFAULT_MSGID_GEN_KEY = "INTERLOK_DEFAULT_MSGID_GENERATOR";
+
+  private static final AdaptrisMessageFactory DEFAULT_INSTANCE = createDefaultFactory();
+
+  private static final IdGenerator DEFAULT_GENERATOR = createDefaultIdGenerator();
 
   @AdvancedConfig
   @Valid
@@ -46,9 +77,8 @@ public abstract class AdaptrisMessageFactory {
    * Get the default implementationion of AdaptrisMessageFactory.
    *
    * <p>
-   * Generally speaking, the appropriate message factory should be already be
-   * configured explicitly and available to be used. This method is simply here
-   * for those instances where no AdaptrisMessageFactory is available.
+   * Generally speaking, the appropriate message factory should be already be configured explicitly and available to be
+   * used. This method is simply here for those instances where no AdaptrisMessageFactory is available.
    * </p>
    *
    * @return a AdaptrisMessageFactory implementation
@@ -62,13 +92,12 @@ public abstract class AdaptrisMessageFactory {
 
   /**
    * Convenience method for null protection.
-   * 
+   *
    * @param f the configured message factory.
    * @return the configured message factory or the default instance if it is null.
-   *
    */
   public static AdaptrisMessageFactory defaultIfNull(AdaptrisMessageFactory f) {
-    return f == null ? DEFAULT_INSTANCE : f;
+    return Optional.ofNullable(f).orElse(DEFAULT_INSTANCE);
   }
 
   /**
@@ -76,16 +105,16 @@ public abstract class AdaptrisMessageFactory {
    * Returns a new <code>AdaptrisMessage</code> with the specified payload and metadata.
    * </p>
    *
-   * @param payload the <code>byte[]</code> payload
+   * @param payload  the <code>byte[]</code> payload
    * @param metadata a <code>Set</code> of <code>MetadataElement</code>s
    * @return a new <code>AdaptrisMessage</code>
    */
+  @SuppressWarnings("rawtypes")
   public abstract AdaptrisMessage newMessage(byte[] payload, Set metadata);
 
   /**
    * <p>
-   * Returns a new <code>AdaptrisMessage</code> with the specified payload and
-   * metadata.
+   * Returns a new <code>AdaptrisMessage</code> with the specified payload and metadata.
    * </p>
    *
    * @param payload the <code>byte[]</code> payload
@@ -95,20 +124,21 @@ public abstract class AdaptrisMessageFactory {
 
   /**
    * <p>
-   * Returns a new <code>AdaptrisMessage</code> with the specified payload and
-   * metadata. Uses default platform character encoding.
+   * Returns a new <code>AdaptrisMessage</code> with the specified payload and metadata. Uses default platform character
+   * encoding.
    * </p>
    *
-   * @param payload the <code>String</code> payload
+   * @param payload  the <code>String</code> payload
    * @param metadata a <code>Set</code> of <code>MetadataElement</code>s
    * @return a new <code>AdaptrisMessage</code>
    */
+  @SuppressWarnings("rawtypes")
   public abstract AdaptrisMessage newMessage(String payload, Set metadata);
 
   /**
    * <p>
-   * Returns a new <code>AdaptrisMessage</code> with the specified payload and
-   * metadata. Uses default platform character encoding.
+   * Returns a new <code>AdaptrisMessage</code> with the specified payload and metadata. Uses default platform character
+   * encoding.
    * </p>
    *
    * @param payload the <code>String</code> payload
@@ -118,46 +148,43 @@ public abstract class AdaptrisMessageFactory {
 
   /**
    * <p>
-   * Returns a new <code>AdaptrisMessage</code> with the specified payload and
-   * metadata. Uses default platform character encoding.
+   * Returns a new <code>AdaptrisMessage</code> with the specified payload and metadata. Uses default platform character
+   * encoding.
    * </p>
    *
-   * @param payload the <code>String</code> payload
-   * @param metadata a <code>Set</code> of <code>MetadataElement</code>s
+   * @param payload      the <code>String</code> payload
+   * @param metadata     a <code>Set</code> of <code>MetadataElement</code>s
    * @param charEncoding the <code>String</code>'s character encoding
    * @return a new <code>AdaptrisMessage</code>
-   * @throws UnsupportedEncodingException if the passed character encoding is
-   *           not supported
+   * @throws UnsupportedEncodingException if the passed character encoding is not supported
    */
+  @SuppressWarnings("rawtypes")
   public abstract AdaptrisMessage newMessage(String payload,
-                                             String charEncoding, Set metadata)
+      String charEncoding, Set metadata)
       throws UnsupportedEncodingException;
 
   /**
    * <p>
-   * Returns a new <code>AdaptrisMessage</code> with the specified payload and
-   * metadata. Uses default platform character encoding.
+   * Returns a new <code>AdaptrisMessage</code> with the specified payload and metadata. Uses default platform character
+   * encoding.
    * </p>
    *
-   * @param payload the <code>String</code> payload
+   * @param payload      the <code>String</code> payload
    * @param charEncoding the <code>String</code>'s character encoding
    * @return a new <code>AdaptrisMessage</code>
-   * @throws UnsupportedEncodingException if the passed character encoding is
-   *           not supported
+   * @throws UnsupportedEncodingException if the passed character encoding is not supported
    */
   public abstract AdaptrisMessage newMessage(String payload, String charEncoding)
       throws UnsupportedEncodingException;
 
   /**
-   * Returns a new <code>AdaptrisMessage</code> with an empty payload but with
-   * selected metadata from the source.
+   * Returns a new <code>AdaptrisMessage</code> with an empty payload but with selected metadata from the source.
    * <p>
-   * The new AdaptrisMessage will have the same message id and
-   * MessageLifecycleEvent will be cloned from the original. Object metadata
-   * will also be preserved.
+   * The new AdaptrisMessage will have the same message id and MessageLifecycleEvent will be cloned from the original.
+   * Object metadata will also be preserved.
    * </p>
    *
-   * @param source the original AdaptrisMessage
+   * @param source                 the original AdaptrisMessage
    * @param metadataKeysToPreserve a list of keys to transfer to the new Message; if null, then all keys.
    * @return a new {@code AdaptrisMessage}
    * @throws CloneNotSupportedException if the MleMarkers could not be cloned.
@@ -173,16 +200,16 @@ public abstract class AdaptrisMessageFactory {
   public abstract String getDefaultCharEncoding();
 
   /**
-   * Set the default character encoding to be applied to the message upon
-   * creation.
+   * Set the default character encoding to be applied to the message upon creation.
    * <p>
-   * If not explicitly configured, then the platform default character encoding
-   * should be used.
+   * If not explicitly configured, then the platform default character encoding should be used.
    * </p>
    *
    * @param s the defaultCharEncoding to set
    * @see AdaptrisMessage#setCharEncoding(String)
+   * @see AdaptrisMessage#setContentEncoding(String)
    */
+  @SuppressWarnings("deprecation")
   public abstract void setDefaultCharEncoding(String s);
 
   /**
@@ -190,8 +217,7 @@ public abstract class AdaptrisMessageFactory {
    * Returns a new <code>AdaptrisMessage</code>. Payload and metadata are null.
    * </p>
    *
-   * @return a new <code>AdaptrisMessage</code> with the specified payload and
-   *         metadata
+   * @return a new <code>AdaptrisMessage</code> with the specified payload and metadata
    */
   public abstract AdaptrisMessage newMessage();
 
@@ -205,11 +231,11 @@ public abstract class AdaptrisMessageFactory {
   /**
    * Set the unique id generator used for messages.
    * <p>
-   * In some situations you may not want to use the default {@link GuidGenerator} instance when assigning unique ids to messages.
-   * This allows you to change the {@link IdGenerator} used both for message ids unique ids associated with
+   * In some situations you may not want to use the default {@link GuidGenerator} instance when assigning unique ids to
+   * messages. This allows you to change the {@link IdGenerator} used both for message ids unique ids associated with
    * {@link MessageLifecycleEvent}.
    * </p>
-   * 
+   *
    * @param s the uniqueIdGenerator to set
    */
   public void setUniqueIdGenerator(IdGenerator s) {
@@ -217,7 +243,44 @@ public abstract class AdaptrisMessageFactory {
   }
 
   protected IdGenerator uniqueIdGenerator() {
-    return getUniqueIdGenerator() != null ? getUniqueIdGenerator() : DEFAULT_GENERATOR;
+    return Optional.ofNullable(getUniqueIdGenerator()).orElse(DEFAULT_GENERATOR);
+  }
+
+  protected static IdGenerator createDefaultIdGenerator() {
+    IdGenerator guid = create(resolve(OVERRIDE_DEFAULT_MSGID_GEN_KEY, OVERRIDE_DEFAULT_MSGID_GEN_PROP,
+        GuidGenerator.class.getCanonicalName()));
+    log.debug("Using {} as default ID Generator for messages", guid.getClass().getCanonicalName());
+    return guid;
+  }
+
+  protected static AdaptrisMessageFactory createDefaultFactory() {
+    AdaptrisMessageFactory f = create(resolve(OVERRIDE_DEFAULT_MSG_FACTORY_ENV, OVERRIDE_DEFAULT_MSG_FACTORY_PROP,
+        DefaultMessageFactory.class.getCanonicalName()));
+    log.debug("Using {} as default MessageFactory Implementation", f.getClass().getCanonicalName());
+    return f;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T create(String name) {
+    try {
+      return (T) Class.forName(name).getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Resolve a value from an environment variable or system property.
+   *
+   * @param envKey       the environment variable, this takes precedence over system properties.
+   * @param sysPropKey   the system property.
+   * @param defaultValue the default value if neither keys exist.
+   * @return the resolved value.
+   */
+  protected static String resolve(String envKey, String sysPropKey, String defaultValue) {
+    String envValue = System.getenv(envKey);
+    return StringUtils.defaultIfBlank(
+        Optional.ofNullable(envValue).orElse(System.getProperty(sysPropKey, defaultValue)), defaultValue);
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageFactoryTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,11 +16,26 @@
 
 package com.adaptris.core;
 
+import static com.adaptris.core.AdaptrisMessageFactory.OVERRIDE_DEFAULT_MSGID_GEN_PROP;
+import static com.adaptris.core.AdaptrisMessageFactory.OVERRIDE_DEFAULT_MSG_FACTORY_PROP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 
+import com.adaptris.core.stubs.StubMessageFactory;
+import com.adaptris.util.GuidGenerator;
+import com.adaptris.util.IdGenerator;
+import com.adaptris.util.PseudoRandomIdGenerator;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
+// Force the order of the tests.
+// Because system properties.
+// Also, upgrading to junit-jupiter with junit-pioneer (for setEnvironmentVariable) has
+// some side-effects seem hard to explain, but potentially due to test ordering.
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class AdaptrisMessageFactoryTest {
 
   @Test
@@ -31,6 +46,61 @@ public class AdaptrisMessageFactoryTest {
     AdaptrisMessageFactory m2 = AdaptrisMessageFactory.getDefaultInstance();
     assertNotNull(m2);
     assertEquals(m1, m2);
+  }
+
+  @Test
+  public void testResolve_FromEnv() {
+    String resolved_1 = AdaptrisMessageFactory.resolve("PATH", "testSystemPropertyKey", "myDefaultValue");
+    assertNotSame("myDefaultValue", resolved_1);
+  }
+
+  @Test
+  public void testResolve_FromSysProp() {
+    GuidGenerator guid = new GuidGenerator();
+    String propertyKey = guid.safeUUID();
+    System.setProperty(propertyKey, "testSystemPropertyValue");
+    String resolved = AdaptrisMessageFactory.resolve("NON_EXISTENT_VAR", propertyKey, "myDefaultValue");
+    assertEquals("testSystemPropertyValue", resolved);
+  }
+
+  @Test
+  public void testResolve_UsesDefault() {
+    String resolved = AdaptrisMessageFactory.resolve("NON_EXISTENT_VAR", new GuidGenerator().safeUUID(), "myDefaultValue");
+    assertEquals("myDefaultValue", resolved);
+  }
+
+  @Test
+  public void test_10_CreateMessageFactory_Override() {
+    System.setProperty(OVERRIDE_DEFAULT_MSG_FACTORY_PROP, StubMessageFactory.class.getCanonicalName());
+    AdaptrisMessageFactory factory = AdaptrisMessageFactory.createDefaultFactory();
+    assertEquals(StubMessageFactory.class, factory.getClass());
+    // Because system properties, set it to a sensible default
+    System.setProperty(OVERRIDE_DEFAULT_MSG_FACTORY_PROP, DefaultMessageFactory.class.getCanonicalName());
+  }
+
+  @Test
+  public void test_20_CreateMessageFactory_NonExistent() {
+    System.setProperty(OVERRIDE_DEFAULT_MSG_FACTORY_PROP,"does.not.exist.MessageFactory");
+    assertThrows(RuntimeException.class, AdaptrisMessageFactory::createDefaultFactory);
+    // Because system properties, set it to a sensible default
+    System.setProperty(OVERRIDE_DEFAULT_MSG_FACTORY_PROP, DefaultMessageFactory.class.getCanonicalName());
+  }
+
+  @Test
+  public void test_30_CreateUidGenerator_Override() {
+    System.setProperty(OVERRIDE_DEFAULT_MSGID_GEN_PROP, PseudoRandomIdGenerator.class.getCanonicalName());
+    IdGenerator guid = AdaptrisMessageFactory.createDefaultIdGenerator();
+    assertEquals(PseudoRandomIdGenerator.class, guid.getClass());
+    // Because system properties, set it to a sensible default
+    System.setProperty(OVERRIDE_DEFAULT_MSGID_GEN_PROP, GuidGenerator.class.getCanonicalName());
+  }
+
+  @Test
+  public void test_40_CreateUidGenerator_NonExistent() {
+    System.setProperty(OVERRIDE_DEFAULT_MSGID_GEN_PROP,"does.not.exist.guid.Generator");
+    assertThrows(RuntimeException.class, AdaptrisMessageFactory::createDefaultIdGenerator);
+    // Because system properties, set it to a sensible default
+    System.setProperty(OVERRIDE_DEFAULT_MSGID_GEN_PROP, GuidGenerator.class.getCanonicalName());
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/security/TestPassword.java
+++ b/interlok-core/src/test/java/com/adaptris/security/TestPassword.java
@@ -21,6 +21,7 @@ import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 
 import com.adaptris.security.password.SeededAesPbeCrypto;
+import org.junit.Assume;
 import org.junit.Test;
 import com.adaptris.interlok.junit.scaffolding.util.Os;
 import com.adaptris.security.certificate.CertificateBuilder;
@@ -47,26 +48,18 @@ public class TestPassword {
 
   @Test
   public void testMicrosoftCrypto() throws Exception {
-    if (Os.isFamily(Os.WINDOWS_NT_FAMILY)) {
-      specificMicrosoftSetup();
-      PasswordCodec pw = Password.create(Password.MSCAPI_STYLE);
-      assertEquals(PW, pw.decode(pw.encode(PW)));
-    }
-    else {
-      System.out.println("Not a MS platform! for testMicrosoftCrypto()");
-    }
+    Assume.assumeTrue(Os.isFamily(Os.WINDOWS_NT_FAMILY));
+    specificMicrosoftSetup();
+    PasswordCodec pw = Password.create(Password.MSCAPI_STYLE);
+    assertEquals(PW, pw.decode(pw.encode(PW)));
   }
 
   @Test
   public void testMicrosoftCryptoWithCharset() throws Exception {
-    if (Os.isFamily(Os.WINDOWS_NT_FAMILY)) {
-      specificMicrosoftSetup();
-      PasswordCodec pw = Password.create(Password.MSCAPI_STYLE);
-      assertEquals(PW, pw.decode(pw.encode(PW, CHARSET), CHARSET));
-    }
-    else {
-      System.out.println("Not a MS platform! for testMicrosoftCryptoWithCharset()");
-    }
+    Assume.assumeTrue(Os.isFamily(Os.WINDOWS_NT_FAMILY));
+    specificMicrosoftSetup();
+    PasswordCodec pw = Password.create(Password.MSCAPI_STYLE);
+    assertEquals(PW, pw.decode(pw.encode(PW, CHARSET), CHARSET));
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/security/password/PasswordTest.java
+++ b/interlok-core/src/test/java/com/adaptris/security/password/PasswordTest.java
@@ -18,13 +18,9 @@ package com.adaptris.security.password;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Properties;
-
+import com.adaptris.interlok.junit.scaffolding.util.Os;
 import org.junit.Assume;
 import org.junit.Test;
-
-import com.adaptris.interlok.junit.scaffolding.util.Os;
-import com.adaptris.security.exc.PasswordException;
 
 public class PasswordTest {
 
@@ -58,35 +54,6 @@ public class PasswordTest {
     Assume.assumeTrue(Os.isFamily(Os.WINDOWS_NT_FAMILY));
     String encoded = Password.encode(TEXT, Password.MSCAPI_STYLE);
     assertEquals(TEXT, Password.decode(encoded));
-  }
-
-  @Test
-  public void testSeeded()throws Exception {
-    System.setProperty(SeededAesPbeCrypto.SYSTEM_PROPERTY, System.getProperty("user.dir") + "/build.gradle");
-    String encoded = Password.encode(TEXT, Password.SEEDED_BATCH);
-    assertEquals(TEXT, Password.decode(encoded));
-  }
-
-  @Test(expected = PasswordException.class)
-  public void testSeededEncodeException()throws Exception {
-    Properties p = System.getProperties();
-    if (p.contains(SeededAesPbeCrypto.SYSTEM_PROPERTY)) {
-      p.remove(SeededAesPbeCrypto.SYSTEM_PROPERTY);
-    }
-    System.setProperties(p);
-
-    Password.encode(TEXT, Password.SEEDED_BATCH);
-  }
-
-  @Test(expected = PasswordException.class)
-  public void testSeededDecodeException()throws Exception {
-    Properties p = System.getProperties();
-    if (p.contains(SeededAesPbeCrypto.SYSTEM_PROPERTY)) {
-      p.remove(SeededAesPbeCrypto.SYSTEM_PROPERTY);
-    }
-    System.setProperties(p);
-
-    Password.decode(Password.SEEDED_BATCH + TEXT); // doesn't matter what we try to decode, lack of seed file
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/security/password/SeededAesPbeCryptoTest.java
+++ b/interlok-core/src/test/java/com/adaptris/security/password/SeededAesPbeCryptoTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.security.password;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.adaptris.security.exc.PasswordException;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.junit.Test;
+
+public class SeededAesPbeCryptoTest {
+
+  private static final String TEXT = "MYPASSWORD";
+
+  private static final String SEED_FILE = System.getProperty("user.dir") + "/build.gradle";
+  private static final String NON_EXISTENT_FILE = "/surely/this/file/does/not/exist";
+
+  @Test
+  public void testResolveFromProperties() throws Exception {
+    Properties p = new Properties();
+    p.setProperty("file-exists", SEED_FILE);
+    p.setProperty("non-existent-file", NON_EXISTENT_FILE);
+    assertEquals(SEED_FILE, SeededAesPbeCrypto.fromProperties("file-exists", p));
+    assertThrows(Exception.class, () -> SeededAesPbeCrypto.fromProperties("non-existent-file", p));
+    assertThrows(Exception.class, () -> SeededAesPbeCrypto.fromProperties("no-key", p));
+  }
+
+  // Technically it's a slightly dodgy test because of the way ServiceLoaders work, so we can't
+  // use the Password static functions, we have to use SeededAesPbeCrypto directly.
+  @Test
+  public void testSeeded() throws Exception {
+    SeededAesPbeCrypto passworder = new SeededAesPbeCrypto(SEED_FILE);
+    String encoded = passworder.encode(TEXT, StandardCharsets.UTF_8.name());
+    assertEquals(TEXT, passworder.decode(encoded));
+  }
+
+  @Test
+  public void testSeededEncodeException() throws Exception {
+    assertThrows(PasswordException.class, () -> new SeededAesPbeCrypto(NON_EXISTENT_FILE).encode(TEXT));
+  }
+
+  @Test
+  public void testSeededDecodeException() throws Exception {
+    assertThrows(PasswordException.class, () -> new SeededAesPbeCrypto(NON_EXISTENT_FILE).decode(TEXT));
+  }
+}


### PR DESCRIPTION
## Motivation

In the event that you wish to enforce certain default behaviours (i.e. storing the message in an opaque blob where `getInputStream()/getOutputStream()` returns a pointer to a remote blob (perhaps an S3 location) you have to explicitly configure a message factory on _every consumer_ in _every workflow_.

All consumers ultimately delegate to `AdaptrisMessageFactory.defaultIfNull(AMF)` to find the correct message factory to use which means that we can control the default message factory by injecting the correct thing into that static method.

- No additional configuration is done to the message factory, so it assumes that it is pre-configured (e.g. if you had an s3-message-factory it would already be configured with the correct credentials etc).
- The side effect of no config is that if you switched to FileBacked then you would see a bunch of files littering `java.io.tmpdir` after a while (since you can't explicitly configure the temp-directory...)
- The side effect of not being able to "configure" it in adapter.xml is that you might end up with a situation where you "forget to pass in the ENV var, and things break, because you're using DefaultMessageFactory and not MyRemoteBlobberMessageFactory.

## Modification

Added the ability to change the message-factory from its default impl via a system property (or environment variable) `-Dinterlok.default.message.factory` or `INTERLOK_DEFAULT_MSG_FACTORY`

It means that we don't have to explicitly configure the message factory on every consumer in every workflow if we wanted to change all the message factories.

Similarly, added `-Dinterlok.default.msgid.generator` or `INTERLOK_DEFAULT_MSGID_GENERATOR` which allows us to switch the default guid generator rather than having to configure a message factory everywhere.

Both values should be the fully qualified class name.

Also did a refactor on SeededAesPbeCrypto so that it becomes less dependent on "ordering". We avoid an upgrade to junit-jupiter + junit-pioneer (which gives additional annotations) since this has some side effects in the unit tests (previous tests started failing).

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Checked that javadoc generation doesn't report errors

## Result

No change for the end user unless they have the specific use-case as described.

## Testing

- Build this branch / PR and you will see addcitional logging at DEBUG level about the default message factory + UID generator.

```console
$ java -jar lib/interlok-boot.jar
NOTE: Picked up JDK_JAVA_OPTIONS: -Dpolyglot.js.nashorn-compat=true  -Dpolyglot.engine.WarnInterpreterOnly=false  -Dlog4j2.Script.enableLanguages=javascript
TRACE [main] [c.a.c.m.BootstrapProperties.createProperties()] [{}] Properties resource is [bootstrap.properties]
Bootstrap of Interlok 4.6-SNAPSHOT(2022-10-07:message-factory-from-system-property) complete
TRACE [main] [c.a.c.m.p.PropertyResolver.init()] [{}] Parsing PropertyResolver URL [jar:file:/C:/storage/work/runtime/interlok/sandbox/build/distribution/lib/interlok-core.jar!/META-INF/com/adaptris/core/management/properties/resolver]
TRACE [main] [c.a.c.m.p.PropertyResolver.init()] [{}] Registered Decoders : {password=com.adaptris.core.management.properties.PasswordDecoder}
TRACE [main] [c.a.c.m.BootstrapProperties.addSystemProperties()] [{}] Adding polyglot.js.nashorn-compat=true to system properties
TRACE [main] [c.a.c.m.BootstrapProperties.addSystemProperties()] [{}] Adding org.jboss.logging.provider=slf4j to system properties
TRACE [main] [c.a.c.m.v.RuntimeVersionControlLoader.loadFirst()] [{}] Version control system found: [None]
#### Here
DEBUG [main] [c.a.c.AdaptrisMessageFactory.createDefaultFactory()] [{}] Using com.adaptris.core.DefaultMessageFactory as default MessageFactory Implementation
DEBUG [main] [c.a.c.AdaptrisMessageFactory.createDefaultIdGenerator()] [{}] Using com.adaptris.util.GuidGenerator as default ID Generator for messages
####
TRACE [main] [c.a.c.m.v.RuntimeVersionControlLoader.loadFirst()] [{}] Version control system found: [None]
TRACE [main] [c.a.c.c.DefaultPreProcessorLoader.createInstance()] [{}] Loading pre-processor: xinclude
```

And then you can control the default using and check that when you submit a message to the workflow it changes is the right type (e.g. switching to FileBackedMessageFactory / Different GuidGenerator could be done like this).

```console
$ java -Dinterlok.default.msgid.generator=com.adaptris.util.GuidGeneratorWithTime -Dinterlok.default.message.factory=com.adaptris.core.lms.FileBackedMessageFactory -jar lib/interlok-boot.jar
NOTE: Picked up JDK_JAVA_OPTIONS: -Dpolyglot.js.nashorn-compat=true  -Dpolyglot.engine.WarnInterpreterOnly=false  -Dlog4j2.Script.enableLanguages=javascript
TRACE [main] [c.a.c.m.BootstrapProperties.createProperties()] [{}] Properties resource is [bootstrap.properties]
Bootstrap of Interlok 4.6-SNAPSHOT(2022-10-07:message-factory-from-system-property) complete
TRACE [main] [c.a.c.m.p.PropertyResolver.init()] [{}] Parsing PropertyResolver URL [jar:file:/C:/storage/work/runtime/interlok/sandbox/build/distribution/lib/interlok-core.jar!/META-INF/com/adaptris/core/management/properties/resolver]
TRACE [main] [c.a.c.m.p.PropertyResolver.init()] [{}] Registered Decoders : {password=com.adaptris.core.management.properties.PasswordDecoder}
TRACE [main] [c.a.c.m.BootstrapProperties.addSystemProperties()] [{}] Adding polyglot.js.nashorn-compat=true to system properties
TRACE [main] [c.a.c.m.BootstrapProperties.addSystemProperties()] [{}] Adding org.jboss.logging.provider=slf4j to system properties
TRACE [main] [c.a.c.m.v.RuntimeVersionControlLoader.loadFirst()] [{}] Version control system found: [None]
#### Here
DEBUG [main] [c.a.c.AdaptrisMessageFactory.createDefaultFactory()] [{}] Using com.adaptris.core.lms.FileBackedMessageFactory as default MessageFactory Implementation
DEBUG [main] [c.a.c.AdaptrisMessageFactory.createDefaultIdGenerator()] [{}] Using com.adaptris.util.GuidGeneratorWithTime as default ID Generator for messages
#### 
TRACE [main] [c.a.c.m.v.RuntimeVersionControlLoader.loadFirst()] [{}] Version control system found: [None]
TRACE [main] [c.a.c.c.DefaultPreProcessorLoader.createInstance()] [{}] Loading pre-processor: xinclude
```


