### PR TITLE
OWASP: jettison CVEs

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -100,7 +100,9 @@
    <packageUrl regex="true">^pkg:maven/org\.codehaus\.jettison/jettison@.*$</packageUrl>
    <cve>CVE-2022-40149</cve>
    <cve>CVE-2022-40150</cve>
-</suppress>
+   <cve>CVE-2022-45685</cve>
+   <cve>CVE-2022-45693</cve>
+  </suppress>
   <suppress>
     <notes><![CDATA[
     file name: xstream-1.4.19.jar


### PR DESCRIPTION
## Motivation

CVE-2022-45685 / CVE-2022-45693 need to be excluded because jettison is required by XStream to round trip JSON, and we may not be upgraded to jettison-1.5.3

## Modification

Updated owasp-exclude.xml

## PR Checklist

- [x] been self-reviewed.

## Result

dependencyCheckAnalyze should now pass if you are referring to 4.6.0-RELEASE

## Testing

Run dependencyCheckAnalyze on a project that uses interlok-build-parent before merging this branch; it should fail, because we refer to jettison-1.2 in the dependencies && interlok-core:4.6.0-RELEASE

Modify your local build.gradle
```
dependencyCheck.suppressionFiles.add("https://raw.githubusercontent.com/adaptris/interlok/jettison-cve/gradle/owasp-exclude.xml")
```

dependencyCheckAnalyze should now pass.



