### PR TITLE
owasp: exclude commons-net CVE from commons jars

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -18,34 +18,34 @@
   <suppress>
     <notes><![CDATA[
     file name: javax.security.auth.message-1.0.0.v201108011116.jar, isn't geronimo!
-    ]]></notes>
+    ]]>    </notes>
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.orbit/javax\.security\.auth\.message@.*$</packageUrl>
     <cpe>cpe:/a:apache:geronimo</cpe>
   </suppress>
   <suppress>
     <notes><![CDATA[
     javax.websocket-api != Java-WebSocket (INTERLOK-3284)
-    ]]></notes>
+    ]]>    </notes>
     <packageUrl regex="true">^pkg:maven/javax\.websocket/javax\.websocket\-api@.*$</packageUrl>
     <cve>CVE-2020-11050</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
     javax.websocket-client-api != Java-WebSocket (INTERLOK-3284)
-    ]]></notes>
+    ]]>    </notes>
     <packageUrl regex="true">^pkg:maven/javax\.websocket/javax\.websocket\-client\-api@.*$</packageUrl>
     <cve>CVE-2020-11050</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
     This CVE is a ruby CVE : https://nvd.nist.gov/vuln/detail/CVE-2020-10663
-    ]]></notes>
+    ]]>    </notes>
     <cve>CVE-2020-10663</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
     This CVE is a NPM Node/CVE... https://nvd.nist.gov/vuln/detail/CVE-2020-7712
-    ]]></notes>
+    ]]>    </notes>
     <cve>CVE-2020-7712</cve>
   </suppress>
   <suppress>
@@ -56,7 +56,7 @@
       <packageUrl regex="true">^pkg:maven/io\.github\.x\-stream/mxparser@.*$</packageUrl>
       <cpe>cpe:/a:xstream_project:xstream</cpe>
       Because this causes it to have a low-confidence match against some oracle crap so just exclude the explicit CVEs
-    ]]></notes>
+    ]]>    </notes>
     <packageUrl regex="true">^pkg:maven/io\.github\.x\-stream/mxparser@.*$</packageUrl>
     <cve>CVE-2013-7285</cve>
     <cve>CVE-2016-3674</cve>
@@ -80,35 +80,35 @@
     <notes><![CDATA[
     file name: log4j-1.2-*.jar
     This CVE matches a AWS CVE for a hotfix they patched a JVM with. This is a false positive
-    ]]></notes>
+    ]]>    </notes>
     <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j.*$</packageUrl>
     <cve>CVE-2022-33915</cve>
   </suppress>
   <suppress>
-     <notes><![CDATA[
+    <notes><![CDATA[
      file name: jetty-io-9.4.48.v20220622.jar
 	 Only Jetty versions 10.0.0 thru 10.0.9, and 11.0.0 thru 11.0.9 versions are affected
-     ]]></notes>
-     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-io@.*$</packageUrl>
-     <vulnerabilityName>CVE-2022-2191</vulnerabilityName>
+     ]]>    </notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-io@.*$</packageUrl>
+    <vulnerabilityName>CVE-2022-2191</vulnerabilityName>
   </suppress>
   <suppress>
-   <notes><![CDATA[
+    <notes><![CDATA[
    file name: jettison-1.2.jar
    XStream has to use jettison-1.2 according to their docs, so an upgrade to 1.4 may not be possible
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.codehaus\.jettison/jettison@.*$</packageUrl>
-   <cve>CVE-2022-40149</cve>
-   <cve>CVE-2022-40150</cve>
-   <cve>CVE-2022-45685</cve>
-   <cve>CVE-2022-45693</cve>
+   ]]>    </notes>
+    <packageUrl regex="true">^pkg:maven/org\.codehaus\.jettison/jettison@.*$</packageUrl>
+    <cve>CVE-2022-40149</cve>
+    <cve>CVE-2022-40150</cve>
+    <cve>CVE-2022-45685</cve>
+    <cve>CVE-2022-45693</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
     file name: xstream-1.4.19.jar
     XStream denial of service attack is a possibility, but it's the foundation of config so unavoidable
     until they patch it.
-    ]]></notes>
+    ]]>    </notes>
     <packageUrl regex="true">^pkg:maven/com\.thoughtworks\.xstream/xstream@.*$</packageUrl>
     <cve>CVE-2022-40151</cve>
     <cve>CVE-2022-40152</cve>
@@ -116,5 +116,37 @@
     <cve>CVE-2022-40154</cve>
     <cve>CVE-2022-40155</cve>
     <cve>CVE-2022-40156</cve>
+  </suppress>
+  <!-- These commons-* jars seem to be a false positive;
+       we are already at the correct commons-net version (3.9.0)
+       and it's likely to be a regexp failure.
+  -->
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/commons\-beanutils/commons\-beanutils@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/commons\-codec/commons\-codec@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-exec@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/commons\-io/commons\-io@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/commons\-pool/commons\-pool@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-pool2@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-text@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
   </suppress>
 </suppressions>


### PR DESCRIPTION
## Motivation

commons-net is already @ 3.9.0 which doesn't have the vuln (CVE-2021-37533), the other commons jar references seem to be a false positive regexp mismatch or something.

## Modification

Updated owasp-exclude.xml

## PR Checklist

- [x] been self-reviewed.

## Result

Removes this logging when you run dependencyCheckAnalyze.

```
commons-beanutils-1.9.4.jar (pkg:maven/commons-beanutils/commons-beanutils@1.9.4, cpe:2.3:a:apache:commons_beanutils:1.9.4:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_net:1.9.4:*:*:*:*:*:*:*) : CVE-2021-37533
commons-codec-1.15.jar (pkg:maven/commons-codec/commons-codec@1.15, cpe:2.3:a:apache:commons_net:1.15:*:*:*:*:*:*:*) : CVE-2021-37533
commons-collections-3.2.2.jar (pkg:maven/commons-collections/commons-collections@3.2.2, cpe:2.3:a:apache:commons_collections:3.2.2:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_net:3.2.2:*:*:*:*:*:*:*) : CVE-2021-37533
commons-digester-2.1.jar (pkg:maven/commons-digester/commons-digester@2.1, cpe:2.3:a:apache:commons_net:2.1:*:*:*:*:*:*:*) : CVE-2021-37533
commons-exec-1.3.jar (pkg:maven/org.apache.commons/commons-exec@1.3, cpe:2.3:a:apache:commons_net:1.3:*:*:*:*:*:*:*) : CVE-2021-37533
commons-io-2.11.0.jar (pkg:maven/commons-io/commons-io@2.11.0, cpe:2.3:a:apache:commons_io:2.11.0:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_net:2.11.0:*:*:*:*:*:*:*) : CVE-2021-37533
commons-lang-2.5.jar (pkg:maven/commons-lang/commons-lang@2.5, cpe:2.3:a:apache:commons_net:2.5:*:*:*:*:*:*:*) : CVE-2021-37533
commons-pool-1.6.jar (pkg:maven/commons-pool/commons-pool@1.6, cpe:2.3:a:apache:commons_net:1.6:*:*:*:*:*:*:*) : CVE-2021-37533
commons-pool2-2.11.1.jar (pkg:maven/org.apache.commons/commons-pool2@2.11.1, cpe:2.3:a:apache:commons_net:2.11.1:*:*:*:*:*:*:*) : CVE-2021-37533
commons-text-1.10.0.jar (pkg:maven/org.apache.commons/commons-text@1.10.0, cpe:2.3:a:apache:commons_net:1.10.0:*:*:*:*:*:*:*, cpe:2.3:a:apache:commons_text:1.10.0:*:*:*:*:*:*:*) : CVE-2021-37533
commons-validator-1.7.jar (pkg:maven/commons-validator/commons-validator@1.7, cpe:2.3:a:apache:commons_net:1.7:*:*:*:*:*:*:*) : CVE-2021-37533
```

