### PR TITLE
owasp: exclude commons-net CVE from commons-jars

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -149,4 +149,20 @@
     <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-text@.*$</packageUrl>
     <cpe>cpe:/a:apache:commons_net</cpe>
   </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/commons\-collections/commons\-collections@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/commons\-digester/commons\-digester@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/commons\-lang/commons\-lang@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/commons\-validator/commons\-validator@.*$</packageUrl>
+    <cpe>cpe:/a:apache:commons_net</cpe>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
## Motivation

commons-net is already @ 3.9.0 which doesn't have the vuln, the other commons jar references seem to be a false positive regexp mismatch or something.

Some remaining commons jars from https://github.com/adaptris/interlok/pull/1056

## Modification

Updated owasp-exclude.xml

## PR Checklist

- [x] been self-reviewed.
