### PR TITLE
feat: add Add-Opens shim to provider interim support for Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'nebula.optional-base' version '7.0.0' apply false
   id 'com.github.spotbugs' version '5.0.13' apply false
   id "org.sonarqube" version '3.4.0.2513' apply false
-  id 'org.owasp.dependencycheck' version '7.2.1' apply false
+  id 'org.owasp.dependencycheck' version '7.4.4' apply false
   id "io.freefair.lombok" version "6.5.1" apply false
   // id 'org.kordamp.gradle.jdeps' version '0.12.0' apply false
   id "org.gradle.test-retry" version "1.4.1" apply false

--- a/interlok-boot/build.gradle
+++ b/interlok-boot/build.gradle
@@ -47,6 +47,8 @@ jar {
                "Implementation-Version": project.version,
                "Implementation-Vendor-Id": project.group,
                "Implementation-Vendor": organizationName,
+               // This is an intermediate "shim" to allow XStream work with with Java17+
+               "Add-Opens": "java.base/java.lang java.base/java.util",
                "Main-Class": "com.adaptris.interlok.boot.InterlokLauncher")
   }
   from ("$project.buildDir/spring-boot-loader") {


### PR DESCRIPTION
## Motivation

https://openjdk.org/jeps/261#Packaging:-Modular-JAR-files

This is is actually BAD but may allow us to run Interlok-4.x in Java17 with some additional flags.


## Modification

- Add `Add-Opens` to the manifest.mf file for interlok-boot.jar, only java.lang && java.util (collections) exposed right now
- You have to start interlok `-Dinterlok.xstream.jdk.stax=false` to _force it to use an any STAX implementation rather than the com.sun one_

> INTERLOK-2865 allowed us to switch between the internal JVM stax impl vs something else; but I can't remember the reasons why.

## PR Checklist

- [x] been self-reviewed.

## Result

- You _can_ potentially run interlok-4.x in Java 17; provided you force XStream to use an available Stax implementation 
- `java -Dinterlok.xstream.debug=true -Dinterlok.xstream.jdk.stax=false -jar lib/interlok-boot.jar`
- You _cannot build & test interlok with java17 from source_
- Only works with `java -jar` execution since the manifest is not read otherwise

## Testing

- build this branch using java11; you only need to build interlok-boot.jar
- Build https://github.com/adaptris-labs/build-parent-json-csv
- Make sure config/bootstrap.properties contains `startAdapterQuietly=false`
- Replace interlok-boot.jar with the built version
- Confirm that execution with java11 still works
- Switch to java 17
- `java -jar lib/interlok-boot.jar` -> will ultimately fail with 
```
Caused by: java.lang.IllegalAccessException: class com.thoughtworks.xstream.io.xml.StandardStaxDriver cannot access class com.sun.xml.internal.stream.XMLInputFactoryImpl (in module java.xml) because 
module java.xml does not export com.sun.xml.internal.stream to unnamed module @41fbdac4
```
- `java -Dinterlok.xstream.jdk.stax=false -jar lib/interlok-boot.jar` will startup, and a test execution using curl appears to work.

