### PR TITLE
deps: switch to jakarta.el dependency

### DIFF
--- a/interlok-core-apt/build.gradle
+++ b/interlok-core-apt/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
   testImplementation("junit:junit:4.13.2")
   testImplementation("org.hibernate.validator:hibernate-validator:6.1.7.Final")
-  testImplementation("org.glassfish:javax.el:3.0.1-b12")
+  testImplementation("org.glassfish:jakarta.el:3.0.4")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -70,7 +70,7 @@ dependencies {
   // Transitive from jetty.
   // api ("jakarta.transaction:jakarta.transaction-api:1.3.3")
   api ("org.hibernate.validator:hibernate-validator:6.1.7.Final")
-  api ("org.glassfish:javax.el:3.0.1-b12")
+  api ("org.glassfish:jakarta.el:3.0.4")
   api ("commons-io:commons-io:2.11.0")
   api ("org.apache.commons:commons-lang3:3.12.0")
   api ("commons-net:commons-net:3.9.0")


### PR DESCRIPTION
## Motivation

javax.el 3.0.1 reports CVE-2021-28170; it's a medium vuln but is sometimes reported

- 4.0.2 only contains the com.sun classes and no javax.el clases. 
- 5.0.0M1 is a likely switch to jakarta.el namespace.

## Modification

Bump the dependency

## PR Checklist

- [x] been self-reviewed.
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

No change, tests pass

## Testing

No change for the user.
