### PR TITLE
Pooling workflows and Shared connections fun.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
@@ -18,7 +18,7 @@ package com.adaptris.core;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.WeakHashMap;
 
 import javax.validation.Valid;
 
@@ -60,9 +60,12 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
    * </p>
    */
   public AdaptrisConnectionImp() {
-    consumers = Collections.newSetFromMap(new ConcurrentHashMap<AdaptrisMessageConsumer, Boolean>());
-    producers = Collections.newSetFromMap(new ConcurrentHashMap<AdaptrisMessageProducer, Boolean>());
-    listeners = Collections.newSetFromMap(new ConcurrentHashMap<StateManagedComponent, Boolean>());
+    consumers = Collections.newSetFromMap(
+        Collections.synchronizedMap(new WeakHashMap<AdaptrisMessageConsumer, Boolean>()));
+    producers = Collections.newSetFromMap(
+        Collections.synchronizedMap(new WeakHashMap<AdaptrisMessageProducer, Boolean>()));
+    listeners = Collections.newSetFromMap(
+        Collections.synchronizedMap(new WeakHashMap<StateManagedComponent, Boolean>()));
     state = ClosedState.getInstance();
   }
 


### PR DESCRIPTION
## Motivation

If you have a pooling workflow that has references to a shared connection, then upon init/start you can get into a situation where multiple threads (each being a worker for the pooling workflow) attempt to register themselves as listeners to the shared connection.
This list of listeners in the shared connection was not thread safe and could cause an infinite loop resulting in Interlok app[earling to hang.

## Modification

Simple changed the maps holding the consumers/producers and listeners to be thread safe versions.

## Result

Interlok no longer hangs on startup when using a pooling workflow that references shared connections.

