### PR TITLE
updated code to remove deprecated warnings

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/fs/IsFileFilter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/IsFileFilter.java
@@ -33,7 +33,7 @@ public class IsFileFilter implements FileFilter {
 
   @Override
   public boolean accept(File pathname) {
-    return FileFileFilter.FILE.accept(pathname);
+    return FileFileFilter.INSTANCE.accept(pathname);
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/StandardHttpProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/StandardHttpProducer.java
@@ -58,6 +58,7 @@ import com.adaptris.core.http.auth.NoAuthentication;
 import com.adaptris.core.http.client.RequestMethodProvider;
 import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
 import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.MessageHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
@@ -311,7 +312,7 @@ public class StandardHttpProducer extends HttpProducer<HttpURLConnection, HttpUR
     } else {
       if (getEncoder() != null) {
         AdaptrisMessage decodedReply = getEncoder().readMessage(http);
-        AdaptrisMessageImp.copyPayload(decodedReply, reply);
+        MessageHelper.copyPayload(decodedReply, reply);
         reply.getObjectHeaders().putAll(decodedReply.getObjectHeaders());
         reply.setMetadata(decodedReply.getMetadata());
       } else {

--- a/interlok-core/src/main/java/com/adaptris/security/certificate/CertRequestHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/security/certificate/CertRequestHandler.java
@@ -138,7 +138,7 @@ public final class CertRequestHandler {
     X509Certificate x509 = (X509Certificate)c;
     x509.getSigAlgName();
 
-        X500Name entityName = new X500Name(x509.getSubjectDN().getName());
+        X500Name entityName = new X500Name(x509.getSubjectX500Principal().getName());
         KeyPair entityPair = KeyPairGenerator.getInstance("RSA").genKeyPair();
         SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(x509.getPublicKey().getEncoded());
         // Generate the certificate signing request

--- a/interlok-core/src/main/java/com/adaptris/security/certificate/RevocationService.java
+++ b/interlok-core/src/main/java/com/adaptris/security/certificate/RevocationService.java
@@ -29,8 +29,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
+import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.DistributionPoint;
@@ -213,7 +213,7 @@ public abstract class RevocationService {
               if (dpn != null && dpn.getType() == DistributionPointName.FULL_NAME) {
                 for (GeneralName generalName : GeneralNames.getInstance(dpn.getName()).getNames()) {
                   if (generalName.getTagNo() == GeneralName.uniformResourceIdentifier) {
-                    crlUrls.add(DERIA5String.getInstance(generalName.getName()).getString());
+                    crlUrls.add(ASN1IA5String.getInstance(generalName.getName()).getString());
                   }
                 }
               }

--- a/interlok-core/src/main/java/com/adaptris/security/certificate/X509Handler.java
+++ b/interlok-core/src/main/java/com/adaptris/security/certificate/X509Handler.java
@@ -108,7 +108,7 @@ final class X509Handler implements CertificateHandler {
     try {
       CertificateFactory certFactory = CertificateFactory.getInstance("X.509", BouncyCastleProvider.PROVIDER_NAME);
       X509Certificate cert = (X509Certificate) certFactory.generateCertificate(input);
-      logR.trace("Handling [{}] SerialNumber: {}", cert.getSubjectDN().toString(), cert.getSerialNumber());
+      logR.trace("Handling [{}] SerialNumber: {}", cert.getSubjectX500Principal().toString(), cert.getSerialNumber());
       return cert;
       // X509CertParser x509parser = new X509CertParser();
       // x509parser.engineInit(input);
@@ -209,7 +209,7 @@ final class X509Handler implements CertificateHandler {
    * @see CertificateHandler#getIssuer()
    */
   public String getIssuer() {
-    return x509.getIssuerDN().getName();
+    return x509.getIssuerX500Principal().getName();
   }
 
   /**

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/FtpCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/FtpCase.java
@@ -376,7 +376,7 @@ public abstract class FtpCase extends FtpConsumerExample {
   protected void assertMessages(List<AdaptrisMessage> list, int count) {
     assertEquals("All files consumed/produced", count, list.size());
     for (AdaptrisMessage m : list) {
-      assertTrue(m.containsKey(CoreConstants.ORIGINAL_NAME_KEY));
+      assertTrue(m.headersContainsKey(CoreConstants.ORIGINAL_NAME_KEY));
       assertEquals(PAYLOAD, m.getContent().trim());
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/RelaxedFtpCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/RelaxedFtpCase.java
@@ -382,7 +382,7 @@ public abstract class RelaxedFtpCase extends FtpConsumerExample {
   protected void assertMessages(List<AdaptrisMessage> list, int count) {
     assertEquals("All files consumed/produced", count, list.size());
     for (AdaptrisMessage m : list) {
-      assertTrue(m.containsKey(CoreConstants.ORIGINAL_NAME_KEY));
+      assertTrue(m.headersContainsKey(CoreConstants.ORIGINAL_NAME_KEY));
       assertEquals(PAYLOAD, m.getContent().trim());
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/ftp/RelaxedFtpConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ftp/RelaxedFtpConsumerTest.java
@@ -72,7 +72,7 @@ public class RelaxedFtpConsumerTest extends RelaxedFtpConsumerCase {
   public void setUp() throws Exception {
     consumer = new RelaxedFtpConsumer();
 
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     consumeDestination = "myDestination";
     consumer.setFtpEndpoint(consumeDestination);

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/IfElseTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/IfElseTest.java
@@ -62,7 +62,7 @@ public class IfElseTest extends ConditionalServiceExample {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     thenService = new ThenService();
     elseService = new ElseService();

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/conditions/ConditionAndTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/conditions/ConditionAndTest.java
@@ -46,7 +46,7 @@ private ConditionAnd conditionAnd;
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     conditionAnd = new ConditionAnd().withConditions(mockConditionOne, mockConditionTwo, mockConditionThree);
     adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();

--- a/interlok-core/src/test/java/com/adaptris/core/services/conditional/conditions/ConditionOrTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/conditional/conditions/ConditionOrTest.java
@@ -46,7 +46,7 @@ public class ConditionOrTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     conditionOr = new ConditionOr();
     conditionOr.getConditions().add(mockConditionOne);

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/NamedParameterApplicatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/NamedParameterApplicatorTest.java
@@ -55,7 +55,7 @@ public class NamedParameterApplicatorTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     message = DefaultMessageFactory.getDefaultInstance().newMessage("SomePayload");
     parameterApplicator = new NamedParameterApplicator();

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/SequentialParameterApplicatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/SequentialParameterApplicatorTest.java
@@ -49,7 +49,7 @@ public class SequentialParameterApplicatorTest {
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     message = DefaultMessageFactory.getDefaultInstance().newMessage("SomePayload");
     parameterApplicator = new SequentialParameterApplicator();

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ByteArrayColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ByteArrayColumnTranslatorTest.java
@@ -72,7 +72,7 @@ public class ByteArrayColumnTranslatorTest {
   @Test
   public void testByteIncorrectObject() throws Exception {
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Integer(10), Types.ARRAY);
+    row.setFieldValue("testField", Integer.valueOf(10), Types.ARRAY);
 
     try {
       translator.translate(row, "testField");

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ClobColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/ClobColumnTranslatorTest.java
@@ -73,7 +73,7 @@ public class ClobColumnTranslatorTest {
   @Test
   public void testClobIncorrectType() throws Exception {
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Integer(999), Types.CLOB);
+    row.setFieldValue("testField", Integer.valueOf(999), Types.CLOB);
 
     try {
       translator.translate(row, 0);
@@ -86,7 +86,7 @@ public class ClobColumnTranslatorTest {
   @Test
   public void testClobIncorrectTypeColumnName() throws Exception {
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Integer(999), Types.CLOB);
+    row.setFieldValue("testField", Integer.valueOf(999), Types.CLOB);
 
     try {
       translator.translate(row, "testField");

--- a/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/StringColumnTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jdbc/types/StringColumnTranslatorTest.java
@@ -41,7 +41,7 @@ public class StringColumnTranslatorTest {
   @Test
   public void testAsIntegerTranslator() throws Exception {
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Integer(111), Types.VARCHAR);
+    row.setFieldValue("testField", Integer.valueOf(111), Types.VARCHAR);
 
     {
       String translated = translator.translate(row, 0);
@@ -56,7 +56,7 @@ public class StringColumnTranslatorTest {
   @Test
   public void testAsDoubleTranslator() throws Exception {
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Double(111), Types.VARCHAR);
+    row.setFieldValue("testField", Double.valueOf(111), Types.VARCHAR);
 
     {
       String translated = translator.translate(row, 0);
@@ -71,7 +71,7 @@ public class StringColumnTranslatorTest {
   @Test
   public void testAsFloatTranslator() throws Exception {
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Float(111), Types.VARCHAR);
+    row.setFieldValue("testField", Float.valueOf(111), Types.VARCHAR);
 
     {
       String translated = translator.translate(row, 0);
@@ -116,7 +116,7 @@ public class StringColumnTranslatorTest {
   public void testAsFormattedDoubleTranslator() throws Exception {
     translator.setFormat("%f");
     JdbcResultRow row = new JdbcResultRow();
-    row.setFieldValue("testField", new Double(111), Types.VARCHAR);
+    row.setFieldValue("testField", Double.valueOf(111), Types.VARCHAR);
     {
       String translated = translator.translate(row, 0);
       assertEquals("111.000000", translated);

--- a/interlok-core/src/test/java/com/adaptris/core/services/jmx/JmxOperationCallServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jmx/JmxOperationCallServiceTest.java
@@ -61,7 +61,7 @@ public class JmxOperationCallServiceTest
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     callService = new JmxOperationCallService();
     callService.setInvoker(mockInvoker);

--- a/interlok-core/src/test/java/com/adaptris/core/services/jmx/JmxWaitServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jmx/JmxWaitServiceTest.java
@@ -51,7 +51,7 @@ public class JmxWaitServiceTest
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/jmx/TestDynamicJmxOperationalService.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/jmx/TestDynamicJmxOperationalService.java
@@ -67,7 +67,7 @@ public class TestDynamicJmxOperationalService
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/SimpleSequenceNumberTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/SimpleSequenceNumberTest.java
@@ -134,7 +134,7 @@ public class SimpleSequenceNumberTest extends SequenceNumberServiceExample {
     service.setMaximumSequenceNumber(null);
     assertNull(service.getMaximumSequenceNumber());
     service.setMaximumSequenceNumber(12L);
-    assertEquals(new Long(12L), service.getMaximumSequenceNumber());
+    assertEquals(Long.valueOf(12L), service.getMaximumSequenceNumber());
   }
 
   @Test


### PR DESCRIPTION
# DRAFT PR - STILL A WIP

## Motivation

To remove deprecated warnings from code as we move to java 17

## Modification

Where I could, located warnings using eclipse set to java 17, and replaced code with suggested code from latest javadocs.

## PR Checklist

- [x] been self-reviewed.

## Result

should be no or little deprecated warnings in eclipse, project should still build/run/test

## Testing

please review code changes and run tests etc
