### PR TITLE
Interlok 521 add regex validation for offset field

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddTimestampMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddTimestampMetadataService.java
@@ -39,6 +39,7 @@ import com.adaptris.core.services.metadata.timestamp.OffsetTimestampGenerator;
 import com.adaptris.core.services.metadata.timestamp.TimestampGenerator;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -122,18 +123,14 @@ public class AddTimestampMetadataService extends ServiceImp {
 
   @Override
   public void start() throws CoreException {
-    if (timestampGenerator != null) {
-      timestampGenerator.start();
-    }
+    LifecycleHelper.start(timestampGenerator);
   }
 
 
   @Override
   protected void initService() throws CoreException {
     try {
-      if (timestampGenerator != null) {
-        timestampGenerator.init();
-      }
+      LifecycleHelper.init(timestampGenerator);
       Args.notBlank(getMetadataKey(), "metadata-key");
     } catch (IllegalArgumentException e) {
       throw ExceptionHelper.wrapCoreException(e);
@@ -142,16 +139,12 @@ public class AddTimestampMetadataService extends ServiceImp {
   
   @Override
   public void stop() {
-    if (timestampGenerator != null) {
-      timestampGenerator.stop();
-    }
+    LifecycleHelper.stop(timestampGenerator);
   }
 
   @Override
   protected void closeService() {
-    if (timestampGenerator != null) {
-      timestampGenerator.close();
-    }
+    LifecycleHelper.close(timestampGenerator);
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddTimestampMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddTimestampMetadataService.java
@@ -120,25 +120,39 @@ public class AddTimestampMetadataService extends ServiceImp {
     }
   }
 
+  @Override
+  public void start() throws CoreException {
+    if (timestampGenerator != null) {
+      timestampGenerator.start();
+    }
+  }
+
 
   @Override
   protected void initService() throws CoreException {
     try {
       if (timestampGenerator != null) {
-        AdaptrisMessage m = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-        timestampGenerator.generateTimestamp(m);
+        timestampGenerator.init();
       }
       Args.notBlank(getMetadataKey(), "metadata-key");
     } catch (IllegalArgumentException e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }
+  
+  @Override
+  public void stop() {
+    if (timestampGenerator != null) {
+      timestampGenerator.stop();
+    }
+  }
 
   @Override
   protected void closeService() {
-
+    if (timestampGenerator != null) {
+      timestampGenerator.close();
+    }
   }
-
 
   /**
    * @return the metadataKey

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddTimestampMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/AddTimestampMetadataService.java
@@ -31,6 +31,7 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
@@ -123,6 +124,10 @@ public class AddTimestampMetadataService extends ServiceImp {
   @Override
   protected void initService() throws CoreException {
     try {
+      if (timestampGenerator != null) {
+        AdaptrisMessage m = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+        timestampGenerator.generateTimestamp(m);
+      }
       Args.notBlank(getMetadataKey(), "metadata-key");
     } catch (IllegalArgumentException e) {
       throw ExceptionHelper.wrapCoreException(e);

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/LastMessageTimestampGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/LastMessageTimestampGenerator.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.metadata.timestamp;
 import java.util.Date;
 
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.metadata.AddTimestampMetadataService;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -39,6 +40,34 @@ public class LastMessageTimestampGenerator implements TimestampGenerator {
     Date timestamp = lastMsgDate;
     lastMsgDate = new Date();
     return timestamp;
+  }
+  
+  /**
+   * @see com.adaptris.core.AdaptrisComponent#init()
+   */
+  @Override
+  public void init() throws CoreException {
+  }
+  
+  /**
+   * @see com.adaptris.core.AdaptrisComponent#start()
+   */
+  @Override
+  public void start() throws CoreException {
+  }
+  
+  /**
+   * @see com.adaptris.core.AdaptrisComponent#stop()
+   */
+  @Override
+  public void stop() {
+  }
+  
+  /**
+   * @see com.adaptris.core.AdaptrisComponent#close()
+   */
+  @Override
+  public void close() {
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/OffsetTimestampGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/OffsetTimestampGenerator.java
@@ -31,6 +31,9 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.metadata.AddTimestampMetadataService;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Timestamp Generator implementation that mimics the default behaviour
  * available in {@link AddTimestampMetadataService}.
@@ -39,71 +42,11 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @see AddTimestampMetadataService
  * @since 3.5.0
  */
-
 @XStreamAlias("offset-timestamp-generator")
 public class OffsetTimestampGenerator implements TimestampGenerator {
 
   private static final String OFFSET_VALIDATION_REGEX = "^\\-?P(?=\\w*\\d)(?:\\d+Y|Y)?(?:\\d+M|M)?(?:\\d+D|D)?(?:T(?:\\d+H|H)?(?:\\d+M|M)?(?:\\d+(?:\\­.\\d{1,2})?S|S)?)?$";
   private static final String OFFSET_VALIDATION_MESSAGE = "Invalid offset pattern '%s', you must use the ISO8601 standard. I.e. 'P30D', '-P30D'";
-
-  @InputFieldHint(expression = true)
-  @Pattern(regexp = OFFSET_VALIDATION_REGEX, message = OFFSET_VALIDATION_MESSAGE)
-  private String offset;
-
-  public OffsetTimestampGenerator() {
-
-  }
-
-  public OffsetTimestampGenerator(String offset) {
-    this();
-    setOffset(offset);
-  }
-
-  @Override
-  public Date generateTimestamp(AdaptrisMessage msg) throws ServiceException {
-    Date timestamp = new Date();
-    try {
-      if (!isBlank(offset)) {
-        Duration duration;
-        duration = DatatypeFactory.newInstance().newDuration(msg.resolve(offset));
-        duration.addTo(timestamp);
-      }
-    } catch (Exception e) {
-      throw new ServiceException("Failed to parse " + offset + " using ISO8601", e);
-    }
-    return timestamp;
-  }
-  
-  @Override
-  public void init() throws CoreException {
-    if (!isBlank(offset)) {
-    java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(OFFSET_VALIDATION_REGEX);
-    Matcher matcher = pattern.matcher(offset);
-    if (!matcher.find()) {
-      throw new CoreException(String.format(OFFSET_VALIDATION_MESSAGE, offset));
-    }
-   }
-  }
-  
-  @Override
-  public void start() throws CoreException {
-  }
-  
-  @Override
-  public void stop() {
-  }
-  
-  @Override
-  public void close() {
-  }
-
-  /**
-   * @return the offset
-   */
-  public String getOffset() {
-    return offset;
-  }
-
 
   /**
    * Set the offset for the timestamp.
@@ -159,9 +102,59 @@ public class OffsetTimestampGenerator implements TimestampGenerator {
    *
    * @param offset the offset.
    */
-  public void setOffset(String offset) {
-    this.offset = offset;
+  @Getter
+  @Setter
+  @InputFieldHint(expression = true)
+  @Pattern(regexp = OFFSET_VALIDATION_REGEX, message = OFFSET_VALIDATION_MESSAGE)
+  private String offset;
+
+  public OffsetTimestampGenerator() {
   }
 
+  public OffsetTimestampGenerator(String offset) {
+    this();
+    setOffset(offset);
+  }
+
+  @Override
+  public Date generateTimestamp(AdaptrisMessage msg) throws ServiceException {
+    Date timestamp = new Date();
+    try {
+      if (!isBlank(offset)) {
+        Duration duration = DatatypeFactory.newInstance().newDuration(msg.resolve(offset));
+        duration.addTo(timestamp);
+      }
+    } catch (Exception e) {
+      throw new ServiceException("Failed to parse " + offset + " using ISO8601", e);
+    }
+    return timestamp;
+  }
+  
+  @Override
+  public void init() throws CoreException {
+    validateOffset();
+  }
+  
+  @Override
+  public void start() throws CoreException {
+  }
+  
+  @Override
+  public void stop() {
+  }
+  
+  @Override
+  public void close() {
+  }
+ 
+  private void validateOffset() throws CoreException {
+    if (!isBlank(offset)) {
+      java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(OFFSET_VALIDATION_REGEX);
+      Matcher matcher = pattern.matcher(offset);
+      if (!matcher.find()) {
+        throw new CoreException(String.format(OFFSET_VALIDATION_MESSAGE, offset));
+      }
+    }
+  }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/OffsetTimestampGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/OffsetTimestampGenerator.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.Pattern;
 
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.services.metadata.AddTimestampMetadataService;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -63,11 +64,6 @@ public class OffsetTimestampGenerator implements TimestampGenerator {
     Date timestamp = new Date();
     try {
       if (!isBlank(offset)) {
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(OFFSET_VALIDATION_REGEX);
-        Matcher matcher = pattern.matcher(offset);
-        if (!matcher.find()) {
-          throw new IllegalArgumentException(String.format(OFFSET_VALIDATION_MESSAGE, offset));
-        }
         Duration duration;
         duration = DatatypeFactory.newInstance().newDuration(msg.resolve(offset));
         duration.addTo(timestamp);
@@ -76,6 +72,29 @@ public class OffsetTimestampGenerator implements TimestampGenerator {
       throw new ServiceException("Failed to parse " + offset + " using ISO8601", e);
     }
     return timestamp;
+  }
+  
+  @Override
+  public void init() throws CoreException {
+    if (!isBlank(offset)) {
+    java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(OFFSET_VALIDATION_REGEX);
+    Matcher matcher = pattern.matcher(offset);
+    if (!matcher.find()) {
+      throw new CoreException(String.format(OFFSET_VALIDATION_MESSAGE, offset));
+    }
+   }
+  }
+  
+  @Override
+  public void start() throws CoreException {
+  }
+  
+  @Override
+  public void stop() {
+  }
+  
+  @Override
+  public void close() {
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/TimestampGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/TimestampGenerator.java
@@ -17,10 +17,11 @@ package com.adaptris.core.services.metadata.timestamp;
 
 import java.util.Date;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ComponentLifecycle;
 import com.adaptris.core.ServiceException;
 
 @FunctionalInterface
-public interface TimestampGenerator {
+public interface TimestampGenerator extends ComponentLifecycle{
 
   Date generateTimestamp(AdaptrisMessage msg) throws ServiceException;
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/AddTimestampMetadataServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/AddTimestampMetadataServiceTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -32,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.services.metadata.timestamp.LastMessageTimestampGenerator;
 import com.adaptris.core.services.metadata.timestamp.OffsetTimestampGenerator;
@@ -56,19 +56,22 @@ public class AddTimestampMetadataServiceTest extends MetadataServiceExample {
     initWithException(service);
     service.setMetadataKey(null);
     initWithException(service);
-
+    
+    service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, "invalid");
+    initWithException(service);
+    
+    service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, "P30D");
+    LifecycleHelper.init(service);
+    service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, new LastMessageTimestampGenerator());
+    LifecycleHelper.init(service);
     service = new AddTimestampMetadataService();
     LifecycleHelper.init(service);
   }
 
   private void initWithException(AddTimestampMetadataService s) {
-    try {
+    assertThrows(CoreException.class, ()->{
       LifecycleHelper.init(s);
-      fail("Should not initialise : " + s);
-    }
-    catch (CoreException e) {
-      ;
-    }
+    }, "Failed to initialise service");
   }
 
   @Test
@@ -160,6 +163,31 @@ public class AddTimestampMetadataServiceTest extends MetadataServiceExample {
     } catch (ParseException e) {
     }
   }
+  
+  @Test
+  public void testOffsetInThePast() throws Exception {
+    AdaptrisMessage m = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    Date now = new Date();
+    AddTimestampMetadataService service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, "-P30D");
+    execute(service, m);
+    assertTrue(m.headersContainsKey(KEY1));
+    SimpleDateFormat sdf = new SimpleDateFormat(DEFAULT_TS_FORMAT);
+    String date1 = m.getMetadataValue(KEY1);
+    try {
+      Date d = sdf.parse(date1);
+      assertTrue(d.before(now));
+    } catch (ParseException e) {
+    }
+  }
+  
+  @Test
+  public void testOffsetWithInvalidPattern() throws Exception {
+    AdaptrisMessage m = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    AddTimestampMetadataService service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, "invalid");
+    assertThrows(CoreException.class, ()->{
+      execute(service, m);
+    }, "Failed with an invalid offset pattern");
+  }
 
   @Test
   public void testLastMessage() throws Exception {
@@ -188,20 +216,6 @@ public class AddTimestampMetadataServiceTest extends MetadataServiceExample {
     execute(service, m);
     assertTrue(m.headersContainsKey(DEFAULT_METADATA_KEY));
     assertTrue(m.getMetadataValue(DEFAULT_METADATA_KEY) != null);
-  }
-
-  @Test
-  public void testInvalidOffset() throws Exception {
-    AdaptrisMessage m = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    Date now = new Date();
-    AddTimestampMetadataService service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, "BLAHBLAH");
-    try {
-      execute(service, m);
-      fail("Service success with BLAHBLAH as the offset");
-    }
-    catch (ServiceException expected) {
-      ;
-    }
   }
 
   @Test


### PR DESCRIPTION
## Motivation

So the offset field used by the AddTimestampMetadataService can be validated against a regex pattern that makes sure it adheres to the ISO8601 standard. This also includes validation in the UI and when the service is initialised.

## Modification

AddTimestampMetadataService class
AddTimestampMetadataServiceTest class
OffsetTimestampGenerator class

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

In the UI if the offset pattern they enter is not valid they will get an exception message telling them when they try to save.
If they edited the adapter xml directly with an invalid offset pattern they adapter will fail to start with the same exception message they would see in the UI.
If a message is sent through the service and the offset pattern is invalid they will also get an exception thrown(however this should not be possible due to the above two points)

## Testing

Load up a copy of interlok with the latest interlok-core.jar and add the following service
`<add-timestamp-metadata-service>
                <unique-id>offset-should-work</unique-id>
                <metadata-key>timestamp</metadata-key>
                <timestamp-generator class="offset-timestamp-generator">
                  <offset>invalid</offset>
                </timestamp-generator>
                <date-format-builder>
                  <format>yyyy-MM-dd&apos;T&apos;HH:mm:ssZ</format>
                </date-format-builder>
              </add-timestamp-metadata-service>`

Interlok should not start and throw the relevant exception.
To test in the UI do the same and try add the service and you should not even be able to save your changes as an exception should be thrown.

 **Also tested that this change did not break the service if 'LastMessageTimestampGenerator' is used.**