### PR TITLE
Interlok 4071 expose timeout options

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpRequestServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/client/net/HttpRequestServiceImpl.java
@@ -40,6 +40,10 @@ import com.adaptris.core.http.client.RequestHeaderProvider;
 import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
 import com.adaptris.core.http.client.ResponseHeaderHandler;
 import com.adaptris.core.util.Args;
+import com.adaptris.util.TimeInterval;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Direct HTTP support as a service rather than wrapped via {@link StandaloneProducer} or {@link StandaloneRequestor}.
@@ -88,6 +92,25 @@ public abstract class HttpRequestServiceImpl extends ServiceImp {
   @NotNull
   @AutoPopulated
   private HttpAuthenticator authenticator = new NoAuthentication();
+  
+  @Valid
+  @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
+  private TimeInterval connectTimeout;
+  /**
+   * Set the read timeout.
+   * <p>
+   * Note that any read timeout will be overridden by the timeout value passed in via the
+   * {{@link #request(AdaptrisMessage, long)} method; if it is not the same as
+   * {@value com.adaptris.core.http.HttpConstants#DEFAULT_SOCKET_TIMEOUT}
+   * </p>
+   */
+  @Valid
+  @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
+  private TimeInterval readTimeout;
 
   public HttpRequestServiceImpl() {
     super();
@@ -124,6 +147,8 @@ public abstract class HttpRequestServiceImpl extends ServiceImp {
     p.setRequestHeaderProvider(getRequestHeaderProvider());
     p.setResponseHeaderHandler(getResponseHeaderHandler());
     p.registerConnection(new NullConnection());
+    p.setConnectTimeout(getConnectTimeout());
+    p.setReadTimeout(getReadTimeout());
     return p;
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/http/client/net/HttpRequestServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/client/net/HttpRequestServiceTest.java
@@ -21,10 +21,12 @@ import static com.adaptris.core.http.jetty.JettyHelper.createConsumer;
 import static com.adaptris.core.http.jetty.JettyHelper.createWorkflow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,9 +53,11 @@ import com.adaptris.core.http.jetty.SecurityConstraint;
 import com.adaptris.core.http.jetty.StandardResponseProducer;
 import com.adaptris.core.http.server.HttpStatusProvider.HttpStatus;
 import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.adaptris.core.services.WaitService;
 import com.adaptris.core.services.metadata.PayloadFromTemplateService;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.TimeInterval;
 
 public class HttpRequestServiceTest extends HttpServiceExample {
   private static final String TEXT = "ABCDEFG";
@@ -97,6 +101,29 @@ public class HttpRequestServiceTest extends HttpServiceExample {
     AdaptrisMessage m2 = mock.getMessages().get(0);
     assertTrue(m2.headersContainsKey("Content-Type"));
     assertEquals("text/complicated", m2.getMetadataValue("Content-Type"));
+  }
+  
+  @Test
+  public void testService_Fails_WithReadTimeout() throws Exception {
+    MockMessageProducer mock = new MockMessageProducer();
+    HttpConnection jc = HttpHelper.createConnection();
+    JettyMessageConsumer mc = createConsumer(HttpHelper.URL_TO_POST_TO);
+    Channel c = createChannel(jc,
+        createWorkflow(mc, mock, new ServiceList(new Service[] {new WaitService(new TimeInterval(2L, TimeUnit.SECONDS))})));
+    HttpRequestService service =
+        new HttpRequestService(HttpHelper.createProduceDestination(c))
+            .withMethod("GET");
+    service.setReadTimeout(new TimeInterval(1L, TimeUnit.SECONDS));
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    try {
+      assertThrows(CoreException.class, ()->{
+        start(c);
+        execute(service, msg);
+      }, "Failed with read timeout");
+    }
+    finally {
+      HttpHelper.stopChannelAndRelease(c);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Motivation

So we can expose the timeout options that are available in the standard http producer.

## Modification

Updated the class HttpRequestServiceImp so it gives the timeout options in the UI and when creating a StandardHttpProducer object we pass in the timeout values that have been set.

Also added a new unit test that tests that the read timeout will throw an exception if it is exceeded.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

The end user is now able to choose and swet connect and read timeout durations when using this service.

## Testing

You can create a channel->workflow that creates a request using a polling consumer and the HttpRequestService(making sure you have the read timeout set) then create a second channel->workflow that can mock a http endpoint by using a Jetty connection and consumers. Within that workflow include a wait service followed by a jetty response service. Make sure the wait service time period is longer than whatever the read timeout is.