### PR TITLE
INTERLOK-4081 Upgraded to jetty10

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -203,4 +203,18 @@
     <packageUrl regex="true">^pkg:maven/com\.bazaarvoice\.jolt/json\-utils@.*$</packageUrl>
     <cve>CVE-2023-2972</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: jetty-javax-websocket-api-1.1.2.jar and jetty-servlet-api-4.0.6.jar
+    False positive, the CVEs are for org.eclipse.jetty components and less than 10.0.15 and not org.eclipse.jetty.toolchain components
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-.*\-api@.*$</packageUrl>
+    <cve>CVE-2017-7657</cve>
+    <cve>CVE-2017-7658</cve>
+    <cve>CVE-2009-5045</cve>
+    <cve>CVE-2017-7656</cve>
+    <cve>CVE-2017-9735</cve>
+    <cve>CVE-2022-2048</cve>
+    <cve>CVE-2020-27216</cve>
+   </suppress>
 </suppressions>

--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -6,6 +6,7 @@ ext {
   slf4jVersion = '2.0.6'
   log4j2Version = "2.20.0"
   mockitoVersion = '4.9.0'
+  jettyVersion= '10.0.15'
 }
 
 // In this section you declare the dependencies for your production and test code
@@ -21,7 +22,31 @@ dependencies {
 
   api ("org.slf4j:slf4j-api:$slf4jVersion")
   api ("javax.servlet:javax.servlet-api:4.0.1")
-  api ("org.eclipse.jetty.aggregate:jetty-all:9.4.51.v20230217")
+
+  api ("org.eclipse.jetty:jetty-alpn-client:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-annotations:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-client:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-deploy:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-http:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-io:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-jaspi:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-jmx:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-jndi:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-plus:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-quickstart:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-rewrite:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-security:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-server:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-servlet:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-servlets:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-util-ajax:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-util:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-webapp:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-xml:$jettyVersion")
+  api ("org.eclipse.jetty.http2:http2-hpack:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty.http2:http2-common:$jettyVersion")
+  api ("org.eclipse.jetty.http2:http2-server:$jettyVersion")
+  api ("org.eclipse.jetty.http2:http2-client:$jettyVersion")
 
   implementation "org.apache.logging.log4j:log4j-api:$log4j2Version", optional
   implementation "org.apache.logging.log4j:log4j-core:$log4j2Version", optional

--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -24,6 +24,9 @@ dependencies {
   api ("javax.servlet:javax.servlet-api:4.0.1")
 
   api ("org.eclipse.jetty:jetty-alpn-client:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-alpn-java-client:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-alpn-server:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-alpn-java-server:$jettyVersion")
   api ("org.eclipse.jetty:jetty-annotations:$jettyVersion")
   api ("org.eclipse.jetty:jetty-client:$jettyVersion")
   api ("org.eclipse.jetty:jetty-deploy:$jettyVersion")
@@ -47,6 +50,8 @@ dependencies {
   api ("org.eclipse.jetty.http2:http2-common:$jettyVersion")
   api ("org.eclipse.jetty.http2:http2-server:$jettyVersion")
   api ("org.eclipse.jetty.http2:http2-client:$jettyVersion")
+  api ("org.eclipse.jetty.websocket:websocket-javax-server:$jettyVersion")
+  api ("org.eclipse.jetty.websocket:websocket-javax-client:$jettyVersion")
 
   implementation "org.apache.logging.log4j:log4j-api:$log4j2Version", optional
   implementation "org.apache.logging.log4j:log4j-core:$log4j2Version", optional

--- a/interlok-common/src/main/java/com/adaptris/core/management/webserver/JettyServerManager.java
+++ b/interlok-common/src/main/java/com/adaptris/core/management/webserver/JettyServerManager.java
@@ -26,13 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+
 import javax.servlet.Servlet;
-import javax.servlet.ServletContext;
-import org.eclipse.jetty.security.Authenticator;
-import org.eclipse.jetty.security.Authenticator.AuthConfiguration;
+
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.security.IdentityService;
-import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -47,7 +44,9 @@ import org.eclipse.jetty.servlet.ServletMapping;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
+
 import com.adaptris.interlok.util.Args;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Synchronized;
@@ -56,15 +55,15 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Implementation of the {@link ServerManager} interface for managing Jetty servers.
  * <p>
- * This class only deals with a specific handler structure. The uppermost handler must be a HandlerCollection and we add the
- * deployment to all of it's appropriate childhandlers.
+ * This class only deals with a specific handler structure. The uppermost handler must be a HandlerCollection and we add the deployment to
+ * all of it's appropriate childhandlers.
  * </p>
  *
  * @author gcsiki
  *
  */
 @Slf4j
-@SuppressWarnings({"removal"})
+@SuppressWarnings({ "removal" })
 public final class JettyServerManager implements ServerManager {
 
   public static final String DEFAULT_DESCRIPTOR_XML = "com/adaptris/core/management/webserver/jetty-webdefault-failsafe.xml";
@@ -87,16 +86,14 @@ public final class JettyServerManager implements ServerManager {
   public static final String SECURITY_CONSTRAINTS = "securityConstraints";
 
   /**
-   * Enable additional debug logging by specifying the system property {@code interlok.jetty.debug}
-   * to true.
+   * Enable additional debug logging by specifying the system property {@code interlok.jetty.debug} to true.
    *
    */
-  public static final boolean JETTY_DEBUG =
-      Boolean.getBoolean("adp.jetty.debug") || Boolean.getBoolean("interlok.jetty.debug");
+  public static final boolean JETTY_DEBUG = Boolean.getBoolean("adp.jetty.debug") || Boolean.getBoolean("interlok.jetty.debug");
 
   /**
-   * This string is for adding a attribute to the ContextHandler for servlets, because if we set the contextPath on the handler and
-   * not on the ServletHolder then the tests fail. (Absolutely no idea why...)
+   * This string is for adding a attribute to the ContextHandler for servlets, because if we set the contextPath on the handler and not on
+   * the ServletHolder then the tests fail. (Absolutely no idea why...)
    */
   private static final String SERVLET_CONTEXT_PATH_ATTRIBUTE = "servletContextPathAttribute";
 
@@ -118,8 +115,10 @@ public final class JettyServerManager implements ServerManager {
     return INSTANCE;
   }
 
-  /** Add a server.
-   *  @deprecated since 4.3.0; use addServer(String, Server) instead.
+  /**
+   * Add a server.
+   *
+   * @deprecated since 4.3.0; use addServer(String, Server) instead.
    */
   @Deprecated(since = "4.3.0")
   public void addServer(Server server) {
@@ -128,8 +127,10 @@ public final class JettyServerManager implements ServerManager {
     addServer(key, server);
   }
 
-  /** Remove a server
-   *  @deprecated since 4.3.0; use removeServer(String) instead.
+  /**
+   * Remove a server
+   *
+   * @deprecated since 4.3.0; use removeServer(String) instead.
    */
   @Deprecated(since = "4.3.0")
   public void removeServer(Server server) {
@@ -143,18 +144,23 @@ public final class JettyServerManager implements ServerManager {
     removeServer(key);
   }
 
-  /** Add a server.
+  /**
+   * Add a server.
    *
-   * @param key the key
-   * @param server the underlying jetty server
+   * @param key
+   *          the key
+   * @param server
+   *          the underlying jetty server
    */
   public void addServer(String key, Server server) {
     servers.put(Args.notNull(key, "server-id"), server);
   }
 
-  /** Remove a server
+  /**
+   * Remove a server
    *
-   * @param key the key.
+   * @param key
+   *          the key.
    */
   public void removeServer(String key) {
     servers.remove(key);
@@ -182,14 +188,12 @@ public final class JettyServerManager implements ServerManager {
   /**
    * This will add the servlet to all underlying server instances and is discouraged.
    *
-   * @deprecated since 4.3.0 use {@link #addServlet(String, ServletHolder, Map)}
-   *             instead. This will be removed without warning.
+   * @deprecated since 4.3.0 use {@link #addServlet(String, ServletHolder, Map)} instead. This will be removed without warning.
    */
-  @Deprecated(since="4.3.0")
+  @Deprecated(since = "4.3.0")
   @Synchronized("locker")
   // Note, only used by EmbeddedConnection so this can be removed at any time.
-  public void addServlet(ServletHolder servlet, HashMap<String, Object> props)
-      throws Exception {
+  public void addServlet(ServletHolder servlet, HashMap<String, Object> props) throws Exception {
     int timesAdded = 0;
     for (Server server : servers.values()) {
       timesAdded += addServlet(server, servlet, props) ? 1 : 0;
@@ -199,24 +203,32 @@ public final class JettyServerManager implements ServerManager {
     }
   }
 
-  /** Add a servlet to the corresponding server instance.
+  /**
+   * Add a servlet to the corresponding server instance.
    *
-   * @param serverId the id of the {@code Server} instance.
-   * @param servlet the servlet
-   * @param additionalProperties and additional properties to assist deployment
-   * @throws Exception on exception
+   * @param serverId
+   *          the id of the {@code Server} instance.
+   * @param servlet
+   *          the servlet
+   * @param additionalProperties
+   *          and additional properties to assist deployment
+   * @throws Exception
+   *           on exception
    * @see #addServlet(String, ServletHolder, Map)
    */
-  public void addServlet(String serverId, Servlet servlet, Map<String, Object> additionalProperties)
-      throws Exception {
+  public void addServlet(String serverId, Servlet servlet, Map<String, Object> additionalProperties) throws Exception {
     addServlet(serverId, new ServletHolder(servlet), additionalProperties);
   }
 
   /**
-   * @param serverId the id of the {@code Server} instance.
-   * @param servlet the servlet
-   * @param props and additional properties to assist deployment
-   * @throws Exception on exception
+   * @param serverId
+   *          the id of the {@code Server} instance.
+   * @param servlet
+   *          the servlet
+   * @param props
+   *          and additional properties to assist deployment
+   * @throws Exception
+   *           on exception
    * @return true if the servlet was added
    */
   @Synchronized("locker")
@@ -234,11 +246,15 @@ public final class JettyServerManager implements ServerManager {
     }
   }
 
-  /** Remove a deployment from the corresponding {@code Server} instance.
+  /**
+   * Remove a deployment from the corresponding {@code Server} instance.
    *
-   * @param serverId the id of the {@code Server} instance.
-   * @param contextPath the path
-   * @throws Exception on exception
+   * @param serverId
+   *          the id of the {@code Server} instance.
+   * @param contextPath
+   *          the path
+   * @throws Exception
+   *           on exception
    */
   @Synchronized("locker")
   public void removeDeployment(String serverId, String contextPath) throws Exception {
@@ -247,26 +263,30 @@ public final class JettyServerManager implements ServerManager {
   }
 
   /**
-   * This will remove the servlet from all underlying server instances and is discouraged (but not
-   * as much as adding the servlet to all instances).
+   * This will remove the servlet from all underlying server instances and is discouraged (but not as much as adding the servlet to all
+   * instances).
    *
-   * @deprecated since 4.3.0 use {@link #removeDeployment(String, ServletHolder, String)} instead.
-   *             This will be removed without warning.
+   * @deprecated since 4.3.0 use {@link #removeDeployment(String, ServletHolder, String)} instead. This will be removed without warning.
    */
   // Note, only used by EmbeddedConnection so this can be removed at any time.
-  @Deprecated(since="4.3.0")
+  @Deprecated(since = "4.3.0")
   public void removeDeployment(ServletHolder holder, String path) throws Exception {
     for (String serverId : getServers().keySet()) {
       removeDeployment(serverId, holder, path);
     }
   }
 
-  /** Remove a deployment.
+  /**
+   * Remove a deployment.
    *
-   * @param serverId the id of the {@code Server} instance.
-   * @param holder the servlet to remove
-   * @param path the path
-   * @throws Exception on exception
+   * @param serverId
+   *          the id of the {@code Server} instance.
+   * @param holder
+   *          the servlet to remove
+   * @param path
+   *          the path
+   * @throws Exception
+   *           on exception
    */
   @Synchronized("locker")
   public void removeDeployment(String serverId, ServletHolder holder, String path) throws Exception {
@@ -277,7 +297,6 @@ public final class JettyServerManager implements ServerManager {
     }
   }
 
-
   @Override
   @Deprecated
   public void startDeployment(String contextPath) throws Exception {
@@ -286,11 +305,15 @@ public final class JettyServerManager implements ServerManager {
     }
   }
 
-  /** Start a deployment
+  /**
+   * Start a deployment
    *
-   * @param serverId the id of the {@code Server} instance.
-   * @param contextPath the path
-   * @throws Exception on exception
+   * @param serverId
+   *          the id of the {@code Server} instance.
+   * @param contextPath
+   *          the path
+   * @throws Exception
+   *           on exception
    */
   @Synchronized("locker")
   public void startDeployment(String serverId, String contextPath) throws Exception {
@@ -300,8 +323,6 @@ public final class JettyServerManager implements ServerManager {
     }
   }
 
-
-
   @Override
   @Deprecated
   public void stopDeployment(String contextPath) throws Exception {
@@ -310,12 +331,15 @@ public final class JettyServerManager implements ServerManager {
     }
   }
 
-
-  /** Stop a deployment
+  /**
+   * Stop a deployment
    *
-   * @param serverId the id of the {@code Server} instance.
-   * @param contextPath the path
-   * @throws Exception on exception
+   * @param serverId
+   *          the id of the {@code Server} instance.
+   * @param contextPath
+   *          the path
+   * @throws Exception
+   *           on exception
    */
   @Synchronized("locker")
   public void stopDeployment(String serverId, String contextPath) throws Exception {
@@ -329,7 +353,6 @@ public final class JettyServerManager implements ServerManager {
     }
   }
 
-
   private boolean addServlet(Server server, ServletHolder servlet, Map<String, Object> additionalProperties) throws Exception {
     // this will always create a rootWar
     WebAppContext rootWar = findRootContext(server, true);
@@ -339,10 +362,9 @@ public final class JettyServerManager implements ServerManager {
     return true;
   }
 
-  private void reconfigureWar(WebAppContext rootWar, ServletHolder servlet, Map<String, Object> props)
-      throws Exception {
+  private void reconfigureWar(WebAppContext rootWar, ServletHolder servlet, Map<String, Object> props) throws Exception {
     // Have to stop the WAR before we can reconfigure the security handler, not true if we just want
-    // to add a new servlet; but it's probaby good practice to.
+    // to add a new servlet; but it's probably good practice to.
     rootWar.stop();
     rootWar.setThrowUnavailableOnStartupException(THROW_UNAVAILABLE_ON_START);
     String pathSpec = (String) props.get(CONTEXT_PATH);
@@ -352,11 +374,12 @@ public final class JettyServerManager implements ServerManager {
     if (w != null) {
       rootWar.setSecurityHandler(w.createSecurityHandler());
     }
+    // It seems that we need to add the class loader to load jetty classes.
+    rootWar.setClassLoader(getClass().getClassLoader());
     rootWar.start();
   }
 
-  private WebAppContext findRootContext(Server server, boolean create)
-      throws Exception {
+  private WebAppContext findRootContext(Server server, boolean create) throws Exception {
     WebAppContext root = rootContextFromHandler(server.getHandler());
     if (root == null && create) {
       log.trace("No ROOT WebAppContext, creating one");
@@ -366,16 +389,12 @@ public final class JettyServerManager implements ServerManager {
       URL defaultsURL = findDefaultDescriptorXML();
       log.trace("Using default descriptor [{}]", defaultsURL);
       root.setDefaultsDescriptor(defaultsURL.toString());
-      root.setConfigurations(new Configuration[]
-          {
-              new WebXmlConfiguration() {
-              }
-          });
+      root.setConfigurations(new Configuration[] { new WebXmlConfiguration() {
+      } });
       ContextHandlerCollection c = firstContextHandler(server.getHandler());
       if (c != null) {
         c.addHandler(root);
-      }
-      else {
+      } else {
         // Well, we could go down a rabbit warren here, but screw it
         // We make our root the root.
         server.setHandler(root);
@@ -392,16 +411,7 @@ public final class JettyServerManager implements ServerManager {
   // getKnownAuthenticatorFactories()...
   static SecurityHandler defaultSecurityStub() {
     ConstraintSecurityHandler defaultSecurity = new ConstraintSecurityHandler();
-    defaultSecurity.setAuthenticatorFactory(new Authenticator.Factory() {
-
-      @Override
-      public Authenticator getAuthenticator(Server server, ServletContext context,
-          AuthConfiguration configuration, IdentityService identityService,
-          LoginService loginService) {
-        return null;
-      }
-
-    });
+    defaultSecurity.setAuthenticatorFactory((server, context, configuration, identityService, loginService) -> null);
     return defaultSecurity;
   }
 
@@ -424,8 +434,7 @@ public final class JettyServerManager implements ServerManager {
       if ("/".equals(ctx.getContextPath())) {
         result = ctx;
       }
-    }
-    else if (parent instanceof HandlerCollection) {
+    } else if (parent instanceof HandlerCollection) {
       Handler[] children = ((HandlerCollection) parent).getChildHandlers();
       for (Handler child : children) {
         result = rootContextFromHandler(child);
@@ -444,8 +453,7 @@ public final class JettyServerManager implements ServerManager {
     }
     if (parent instanceof ContextHandlerCollection) {
       result = (ContextHandlerCollection) parent;
-    }
-    else if (parent instanceof HandlerCollection) {
+    } else if (parent instanceof HandlerCollection) {
       Handler[] children = ((HandlerCollection) parent).getChildHandlers();
       for (Handler child : children) {
         result = firstContextHandler(child);
@@ -456,7 +464,6 @@ public final class JettyServerManager implements ServerManager {
     }
     return result;
   }
-
 
   private void removeServlet(WebAppContext webAppContext, ServletHolder toRemove, String pathSpec) throws Exception {
     log.trace("{}: Removing servlet mapped to {}", webAppContext.getWar(), pathSpec);
@@ -518,10 +525,7 @@ public final class JettyServerManager implements ServerManager {
     } else if (handler instanceof ServletContextHandler) {
       ServletContextHandler sch = (ServletContextHandler) handler;
       String servletPath = (String) sch.getAttribute(SERVLET_CONTEXT_PATH_ATTRIBUTE);
-      if (contextPath.equals(servletPath)) {
-        destroyQuietly(sch);
-        return true;
-      } else if (contextPath.equals(sch.getContextPath())) {
+      if (contextPath.equals(servletPath) || contextPath.equals(sch.getContextPath())) {
         destroyQuietly(sch);
         return true;
       }
@@ -549,10 +553,9 @@ public final class JettyServerManager implements ServerManager {
     try {
       parent.removeHandler(child);
     } catch (Exception e) {
-      ;
+
     }
   }
-
 
   private void manageHandler(String contextPath, boolean start, Handler handler) throws Exception {
     if (handler instanceof ContextHandler) {

--- a/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-failsafe.xml
+++ b/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-failsafe.xml
@@ -1,34 +1,31 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
 <!-- =============================================================== -->
-<!-- Configure the Jetty Server                                      -->
-<!--                                                                 -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!-- https://www.eclipse.org/jetty/documentation/current/            -->
 <!--                                                                 -->
 <!-- Additional configuration files are available in $JETTY_HOME/etc -->
-<!-- and can be mixed in.  For example:                              -->
-<!--   java -jar start.jar etc/jetty-ssl.xml                         -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
 <!--                                                                 -->
-<!-- See start.ini file for the default configuraton files           -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
 <!-- =============================================================== -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
-  <!-- Redirect from /adapter-web-gui -> /interlok -->
-  <New id="RewriteHandler" class="org.eclipse.jetty.rewrite.handler.RewriteHandler">
-    <Set name="rewriteRequestURI">true</Set>
-    <Set name="rewritePathInfo">false</Set>
-    <Set name="originalPathAttribute">requestedPath</Set>
-    <Call name="addRule">
-      <Arg>
-        <New class="org.eclipse.jetty.rewrite.handler.RedirectPatternRule">
-          <Set name="pattern">/adapter-web-gui/*</Set>
-          <Set name="location">/interlok</Set>
-          <Set name="terminating">true</Set>
-        </New>
-      </Arg>
-    </Call>
-  </New>
+  <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
 
   <!-- =========================================================== -->
   <!-- Get the platform mbean server                               -->
@@ -83,18 +80,19 @@
     <!-- =========================================================== -->
     <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
       <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
-      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
-      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
-      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
-      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
-      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
-      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="false" /></Set>
-      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" default="32768" /></Set>
+      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" default="8192" /></Set>
+      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" default="8192" /></Set>
+      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" default="8192" /></Set>
+      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" default="false" /></Set>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" default="false" /></Set>
       <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
-      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" default="true"/></Set>
       <Set name="maxErrorDispatches"><Property name="jetty.httpConfig.maxErrorDispatches" default="10"/></Set>
-      <Set name="blockingTimeout"><Property name="jetty.httpConfig.blockingTimeout" default="-1"/></Set>
+<!--       <Set name="blockingTimeout"><Property name="jetty.httpConfig.blockingTimeout" default="-1"/></Set> -->
       <Set name="persistentConnectionsEnabled"><Property name="jetty.httpConfig.persistentConnectionsEnabled" default="true"/></Set>
+      <Set name="httpCompliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230"/></Arg></Call></Set>
     </New>
 
   <!-- =========================================================== -->
@@ -111,23 +109,22 @@
     <Arg>
       <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
         <Arg name="server"><Ref refid="Server" /></Arg>
-        <Arg name="acceptors" type="int"><Property name="jetty.http.acceptors" deprecated="http.acceptors" default="-1"/></Arg>
-        <Arg name="selectors" type="int"><Property name="jetty.http.selectors" deprecated="http.selectors" default="-1"/></Arg>
+        <Arg name="acceptors" type="int"><Property name="jetty.http.acceptors" default="-1"/></Arg>
+        <Arg name="selectors" type="int"><Property name="jetty.http.selectors" default="-1"/></Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
                 <Arg name="config"><Ref refid="httpConfig" /></Arg>
-                <Arg name="compliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230"/></Arg></Call></Arg>
               </New>
             </Item>
           </Array>
         </Arg>
-        <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port" default="8080" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
-        <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
+        <Set name="host"><Property name="jetty.http.host" /></Set>
+        <Set name="port"><Property name="jetty.http.port" default="8080" /></Set>
+        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" default="0"/></Set>
+        <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" default="0"/></Set>
       </New>
     </Arg>
   </Call>
@@ -140,10 +137,7 @@
       <Set name="handlers">
         <Array type="org.eclipse.jetty.server.Handler">
           <Item>
-            <Ref id="RewriteHandler"></Ref>
-          </Item>
-          <Item>
-             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+             <Ref refid="Contexts"/>
            </Item>
            <Item>
              <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
@@ -154,12 +148,12 @@
   </Set>
 
   <!-- =========================================================== -->
-  <!-- extra options                                               -->
+  <!-- extra server options                                        -->
   <!-- =========================================================== -->
-  <Set name="stopAtShutdown">true</Set>
-  <Set name="stopTimeout">1000</Set>
-  <Set name="dumpAfterStart">false</Set>
-  <Set name="dumpBeforeStop">false</Set>
+  <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+  <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="1000"/></Set>
+  <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" default="false"/></Set>
+  <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" default="false"/></Set>
 
   <Array id="plusConfig" type="java.lang.String">
     <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
@@ -175,7 +169,7 @@
     <Arg>
       <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
         <Set name="contexts">
-          <Ref id="Contexts" />
+          <Ref refid="Contexts"/>
         </Set>
         <Call name="setContextAttribute">
           <Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
@@ -203,7 +197,7 @@
               <Set name="scanInterval"><Property name="jetty.deploy.scanInterval" default="120"/></Set>
               <Set name="extractWars"><Property name="jetty.deploy.extractWars" default="true"/></Set>
               <Set name="configurationClasses">
-                <Ref id="plusConfig" />
+                <Ref id="plusConfigRef" refid="plusConfig"/>
               </Set>
               <Set name="configurationManager">
                 <New class="org.eclipse.jetty.deploy.PropertiesConfigurationManager">
@@ -221,6 +215,5 @@
       </New>
     </Arg>
   </Call>
-
 
 </Configure>

--- a/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-webdefault-failsafe.xml
+++ b/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-webdefault-failsafe.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app
-   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app 
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
    metadata-complete="false"
-   version="3.1">
+   version="3.1"> 
 
   <!-- ===================================================================== -->
   <!-- This file contains the default descriptor for web applications.       -->
@@ -25,36 +25,36 @@
   <!-- ===================================================================== -->
 
   <description>
-    Default web.xml file.
-    This file is applied to a Web application before it's own WEB_INF/web.xml file
+    Default web.xml file.  
+    This file is applied to a Web application before its own WEB_INF/web.xml file
   </description>
-
+  
   <!-- ==================================================================== -->
   <!-- Removes static references to beans from javax.el.BeanELResolver to   -->
   <!-- ensure webapp classloader can be released on undeploy                -->
   <!-- ==================================================================== -->
-  <listener>
-   <listener-class>org.eclipse.jetty.servlet.listener.ELContextCleaner</listener-class>
-  </listener>
+<!--   <listener> -->
+<!--    <listener-class>org.eclipse.jetty.servlet.listener.ELContextCleaner</listener-class> -->
+<!--   </listener> -->
 
   <!-- ==================================================================== -->
   <!-- Removes static cache of Methods from java.beans.Introspector to      -->
   <!-- ensure webapp classloader can be released on undeploy                -->
-  <!-- ==================================================================== -->
-  <listener>
-   <listener-class>org.eclipse.jetty.servlet.listener.IntrospectorCleaner</listener-class>
-  </listener>
-
+  <!-- ==================================================================== -->  
+<!--   <listener> -->
+<!--    <listener-class>org.eclipse.jetty.servlet.listener.IntrospectorCleaner</listener-class> -->
+<!--   </listener> -->
+  
 
   <!-- ==================================================================== -->
   <!-- Context params to control Session Cookies                            -->
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
   <!--
-    UNCOMMENT TO ACTIVATE
-    <context-param>
-      <param-name>org.eclipse.jetty.servlet.SessionDomain</param-name>
-      <param-value>127.0.0.1</param-value>
-    </context-param>
+    UNCOMMENT TO ACTIVATE 
+    <context-param> 
+      <param-name>org.eclipse.jetty.servlet.SessionDomain</param-name> 
+      <param-value>127.0.0.1</param-value> 
+    </context-param> 
     <context-param>
       <param-name>org.eclipse.jetty.servlet.SessionPath</param-name>
       <param-value>/</param-value>
@@ -70,7 +70,7 @@
   <!-- This servlet, normally mapped to /, provides the handling for static -->
   <!-- content, OPTIONS and TRACE methods for the context.                  -->
   <!-- The following initParameters are supported:                          -->
-  <!--
+  <!--  
  *  acceptRanges      If true, range requests and responses are
  *                    supported
  *
@@ -82,7 +82,7 @@
  *                    resources could be found. If false, then a welcome
  *                    file must exist on disk. If "exact", then exact
  *                    servlet matches are supported without an existing file.
- *                    Default is true.
+ *                    Default is false.
  *
  *                    This must be false if you want directory listings,
  *                    but have index.jsp in your welcome file list.
@@ -92,12 +92,13 @@
  *
  *  gzip              If set to true, then static content will be served as
  *                    gzip content encoded if a matching resource is
- *                    found ending with ".gz" (default false)
+ *                    found ending with ".gz" (default false) 
  *                    (deprecated: use precompressed)
- *
- *  precompressed     If set to a comma separated list of file extensions, these
- *                    indicate compressed formats that are known to map to a mime-type
- *                    that may be listed in a requests Accept-Encoding header.
+ *                    
+ *  precompressed     If set to a comma separated list of encoding types (that may be
+ *                    listed in a requests Accept-Encoding header) to file
+ *                    extension mappings to look for and serve. For example:
+ *                    "br=.br,gzip=.gz,bzip2=.bz".
  *                    If set to a boolean True, then a default set of compressed formats
  *                    will be used, otherwise no precompressed formats.
  *
@@ -115,10 +116,7 @@
  *
  *  stylesheet        Set with the location of an optional stylesheet that will be used
  *                    to decorate the directory listing html.
- *
- *  aliases           If True, aliases of resources are allowed (eg. symbolic
- *                    links and caps variations). May bypass security constraints.
- *
+ *                    
  *  etags             If True, weak etags will be generated and handled.
  *
  *  maxCacheSize      The maximum total size of the cache or 0 for no cache.
@@ -134,15 +132,17 @@
  *  cacheControl      If set, all static content will have this value set as the cache-control
  *                    header.
  *
+ * encodingHeaderCacheSize
+ *                    Max entries in a cache of ACCEPT-ENCODING headers.
+ *
+ * otherGzipFileExtensions  
+ *                    defaults to .svgz but a comma separated list of gzip equivalent file extensions can be supplied
+ *
  -->
  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
   <servlet>
     <servlet-name>default</servlet-name>
     <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
-    <init-param>
-      <param-name>aliases</param-name>
-      <param-value>false</param-value>
-    </init-param>
     <init-param>
       <param-name>acceptRanges</param-name>
       <param-value>true</param-value>
@@ -174,7 +174,7 @@
     <!--
     <init-param>
       <param-name>precompressed</param-name>
-      <param-value>gzip,br</param-value>
+      <param-value>br=.br,gzip=.gz</param-value>
     </init-param>
     -->
     <init-param>
@@ -185,12 +185,6 @@
       <param-name>useFileMappedBuffer</param-name>
       <param-value>true</param-value>
     </init-param>
-    <!--
-    <init-param>
-      <param-name>resourceCache</param-name>
-      <param-value>resourceCache</param-value>
-    </init-param>
-    -->
     <!--
     <init-param>
       <param-name>cacheControl</param-name>
@@ -204,7 +198,6 @@
     <servlet-name>default</servlet-name>
     <url-pattern>/</url-pattern>
   </servlet-mapping>
-
 
   <!-- ==================================================================== -->
   <!-- Default session configuration                                        -->
@@ -417,4 +410,3 @@
   </security-constraint>
 
 </web-app>
-

--- a/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-webdefault-failsafe.xml
+++ b/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-webdefault-failsafe.xml
@@ -33,17 +33,17 @@
   <!-- Removes static references to beans from javax.el.BeanELResolver to   -->
   <!-- ensure webapp classloader can be released on undeploy                -->
   <!-- ==================================================================== -->
-<!--   <listener> -->
-<!--    <listener-class>org.eclipse.jetty.servlet.listener.ELContextCleaner</listener-class> -->
-<!--   </listener> -->
+  <listener>
+   <listener-class>org.eclipse.jetty.servlet.listener.ELContextCleaner</listener-class>
+  </listener>
 
   <!-- ==================================================================== -->
   <!-- Removes static cache of Methods from java.beans.Introspector to      -->
   <!-- ensure webapp classloader can be released on undeploy                -->
   <!-- ==================================================================== -->  
-<!--   <listener> -->
-<!--    <listener-class>org.eclipse.jetty.servlet.listener.IntrospectorCleaner</listener-class> -->
-<!--   </listener> -->
+  <listener>
+   <listener-class>org.eclipse.jetty.servlet.listener.IntrospectorCleaner</listener-class>
+  </listener>
   
 
   <!-- ==================================================================== -->

--- a/interlok-common/src/test/java/com/adaptris/core/management/webserver/JettyServerBuilder.java
+++ b/interlok-common/src/test/java/com/adaptris/core/management/webserver/JettyServerBuilder.java
@@ -1,4 +1,5 @@
 package com.adaptris.core.management.webserver;
+
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
@@ -15,7 +16,6 @@ import org.eclipse.jetty.server.handler.HandlerCollection;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JettyServerBuilder {
@@ -34,7 +34,7 @@ public class JettyServerBuilder {
     return server;
   }
 
-  public static void destroy(Server server)  {
+  public static void destroy(Server server) {
     if (server.isStarted()) {
       executeQuietly(() -> server.stop());
       executeQuietly(() -> server.join());
@@ -68,8 +68,9 @@ public class JettyServerBuilder {
   }
 
   private static ServerConnector createConnector(Server server) {
-    ServerConnector connector = new ServerConnector(server, -1, -1,
-        new HttpConnectionFactory(configure(new HttpConfiguration()), HttpCompliance.RFC2616));
+    HttpConfiguration httpConfig = configure(new HttpConfiguration());
+    httpConfig.setHttpCompliance(HttpCompliance.RFC2616);
+    ServerConnector connector = new ServerConnector(server, -1, -1, new HttpConnectionFactory(httpConfig));
     connector.setPort(PortManager.nextUnusedPort(8080));
     return connector;
   }
@@ -97,7 +98,6 @@ public class JettyServerBuilder {
     try {
       r.execute();
     } catch (Exception e) {
-
     }
   }
 
@@ -105,4 +105,5 @@ public class JettyServerBuilder {
   public interface Runner {
     void execute() throws Exception;
   }
+  
 }

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -12,6 +12,7 @@ ext {
   mssqlDriverVersion = '9.2.1.jre8'
   derbyDriverVersion = '10.15.2.0'
   junitVersion = '5.9.3'
+  jettyVersion= '10.0.15'
 
   verboseTests= project.hasProperty('verboseTests') ? project.getProperty('verboseTests') : "false"
   classesToTest = project.hasProperty("junit.test.classes") ? project.getProperty("junit.test.classes") : "**/*Test*"
@@ -86,7 +87,32 @@ dependencies {
   api ("org.glassfish.external:opendmk_jmxremote_optional_jar:1.0-b01-ea")
   api ("org.glassfish.external:opendmk_jdmkrt_jar:1.0-b01-ea")
   api ("com.github.mwiede:jsch:$jschVersion")
-  api ("org.eclipse.jetty.aggregate:jetty-all:9.4.51.v20230217")
+
+  api ("org.eclipse.jetty:jetty-alpn-client:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-annotations:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-client:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-deploy:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-http:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-io:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-jaspi:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-jmx:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-jndi:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-plus:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-quickstart:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-rewrite:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-security:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-server:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-servlet:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-servlets:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-util-ajax:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-util:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty:jetty-webapp:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-xml:$jettyVersion")
+  api ("org.eclipse.jetty.http2:http2-hpack:$jettyVersion") // implicit dependency
+  api ("org.eclipse.jetty.http2:http2-common:$jettyVersion")
+  api ("org.eclipse.jetty.http2:http2-server:$jettyVersion")
+  api ("org.eclipse.jetty.http2:http2-client:$jettyVersion")
+  
   api ("javax.servlet:javax.servlet-api:4.0.1")
   api ("net.sf.joost:joost:0.9.1")
   api ("org.quartz-scheduler:quartz:2.3.2") {

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -89,6 +89,9 @@ dependencies {
   api ("com.github.mwiede:jsch:$jschVersion")
 
   api ("org.eclipse.jetty:jetty-alpn-client:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-alpn-java-client:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-alpn-server:$jettyVersion")
+  api ("org.eclipse.jetty:jetty-alpn-java-server:$jettyVersion")
   api ("org.eclipse.jetty:jetty-annotations:$jettyVersion")
   api ("org.eclipse.jetty:jetty-client:$jettyVersion")
   api ("org.eclipse.jetty:jetty-deploy:$jettyVersion")
@@ -112,7 +115,9 @@ dependencies {
   api ("org.eclipse.jetty.http2:http2-common:$jettyVersion")
   api ("org.eclipse.jetty.http2:http2-server:$jettyVersion")
   api ("org.eclipse.jetty.http2:http2-client:$jettyVersion")
-  
+  api ("org.eclipse.jetty.websocket:websocket-javax-server:$jettyVersion")
+  api ("org.eclipse.jetty.websocket:websocket-javax-client:$jettyVersion")
+
   api ("javax.servlet:javax.servlet-api:4.0.1")
   api ("net.sf.joost:joost:0.9.1")
   api ("org.quartz-scheduler:quartz:2.3.2") {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/EmbeddedConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/EmbeddedConnection.java
@@ -17,12 +17,16 @@
 package com.adaptris.core.http.jetty;
 
 import static com.adaptris.core.management.jetty.JettyServerComponent.SERVER_ID;
+
 import java.util.HashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.Valid;
+
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -35,18 +39,20 @@ import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.util.TimeInterval;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * The EmbeddedConnection makes use of the existing Jetty Engine that has been enabled as part of the bootstrap process.
  * <p>
- * This is designed to be a replacement for {@link HttpConnection} and {@link HttpsConnection} and allows you to configure a single
- * jetty instance according to your requirements which can be re-used across many channels. Of course if you have not enabled a
- * global jetty instance, then exceptions will be thrown if you attempt to configure an instance of this class.
+ * This is designed to be a replacement for {@link HttpConnection} and {@link HttpsConnection} and allows you to configure a single jetty
+ * instance according to your requirements which can be re-used across many channels. Of course if you have not enabled a global jetty
+ * instance, then exceptions will be thrown if you attempt to configure an instance of this class.
  * </p>
  * <p>
  * If you use this connection; you may have to delete {@code ROOT.war} from the jetty webapps directory. The default servlet that is
- * registered with the default web application might interfere with the registering of servlets against arbitrary locations; if you
- * get HTTP 404 errors, then enable logging for the {@code org.eclipse.jetty} category and check how the request is routed by the
- * Jetty engine.
+ * registered with the default web application might interfere with the registering of servlets against arbitrary locations; if you get HTTP
+ * 404 errors, then enable logging for the {@code org.eclipse.jetty} category and check how the request is routed by the Jetty engine.
  * </p>
  *
  * @config jetty-embedded-connection
@@ -54,28 +60,50 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("jetty-embedded-connection")
 @AdapterComponent
-@ComponentProfile(summary = "Connection that uses the embedded Jetty engine management component for requests",
-    tag = "connections,http,https,jetty")
-@DisplayOrder(order =
-{
-    "roles", "securityHandler", "maxStartupWait"
-})
+@ComponentProfile(summary = "Connection that uses the embedded Jetty engine management component for requests", tag = "connections,http,https,jetty")
+@DisplayOrder(order = { "roles", "securityHandler", "maxStartupWait" })
 public class EmbeddedConnection extends AdaptrisConnectionImp implements JettyServletRegistrar {
   private static final int DEFAULT_WAIT_INTERVAL_MS = 250;
 
   private static final TimeInterval DEFAULT_MAX_WAIT = new TimeInterval(10l, TimeUnit.MINUTES);
 
+  /**
+   * Specify the maximum wait time for the underlying Jetty Server instance to startup.
+   * <p>
+   * The adapter cannot be fully initialised until the underlying {@link org.eclipse.jetty.server.Server} is ready to receive messages. We
+   * need to ensure that the {@link com.adaptris.core.AdaptrisConnection#init()} method blocks until the server is ready for registration of
+   * servlets and also ready for incoming HTTP requests. This value controls how long we wait for the server to start up before throwing an
+   * exception.
+   * </p>
+   *
+   * @param maxStartupWait
+   *          the maxStartupWait to set, default if not specified is 10 minutes.
+   */
+  @Getter
+  @Setter
   @AdvancedConfig(rare = true)
   private TimeInterval maxStartupWait;
+
+  /**
+   * Specify the SecurityHandler implementation.
+   * <p>
+   * By specifying a {@link SecurityHandlerWrapper} implementation you will overwrite whatever {@link SecurityHandler} implementation that
+   * is present in the {@link WebAppContext}. If you have multiple instances of {@link EmbeddedConnection} configured inside your adapter,
+   * then results may be undefined; you are advised to configure a single {@code EmbeddedConnection} as a {@code shared-component} to avoid
+   * any issues.
+   * </p>
+   *
+   * @param securityHandler
+   *          the securityHandler wrapper implementation.
+   */
+  @Getter
+  @Setter
   @Valid
   @AdvancedConfig
   private SecurityHandlerWrapper securityHandler;
 
-
   public EmbeddedConnection() {
-    super();
   }
-
 
   @Override
   protected void closeConnection() {
@@ -110,14 +138,13 @@ public class EmbeddedConnection extends AdaptrisConnectionImp implements JettySe
   public void addServlet(ServletWrapper wrapper) throws CoreException {
     try {
       JettyServerManager serverManager = JettyServerManager.getInstance();
-      HashMap<String, Object> additionalProperties = new HashMap<String, Object>();
+      HashMap<String, Object> additionalProperties = new HashMap<>();
       additionalProperties.put(JettyServerManager.CONTEXT_PATH, wrapper.getUrl());
       additionalProperties.put(JettyServerManager.SECURITY_CONSTRAINTS, getSecurityHandler());
       serverManager.addServlet(SERVER_ID, wrapper.getServletHolder(), additionalProperties);
       serverManager.startDeployment(SERVER_ID, wrapper.getUrl());
       log.trace("Added " + wrapper.getServletHolder() + " against " + wrapper.getUrl());
-    }
-    catch (Exception ex) {
+    } catch (Exception ex) {
       throw ExceptionHelper.wrapCoreException(ex);
     }
 
@@ -131,8 +158,7 @@ public class EmbeddedConnection extends AdaptrisConnectionImp implements JettySe
       serverManager.removeDeployment(SERVER_ID, wrapper.getUrl());
       serverManager.removeDeployment(SERVER_ID, wrapper.getServletHolder(), wrapper.getUrl());
       log.trace("Removed {} from {}", wrapper.getServletHolder(), wrapper.getUrl());
-    }
-    catch (Exception ex) {
+    } catch (Exception ex) {
       throw ExceptionHelper.wrapCoreException(ex);
     }
   }
@@ -148,58 +174,13 @@ public class EmbeddedConnection extends AdaptrisConnectionImp implements JettySe
       if (!sm.isStarted()) {
         throw new CoreException("Max Wait time exceeded : " + maxWaitTime + "ms");
       }
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }
 
-  /**
-   * @return the maxStartupWait
-   */
-  public TimeInterval getMaxStartupWait() {
-    return maxStartupWait;
-  }
-
-  /**
-   * Specify the maximum wait time for the underlying Jetty Server instance to startup.
-   * <p>
-   * The adapter cannot be fully initialised until the underlying {@link org.eclipse.jetty.server.Server} is ready to receive
-   * messages. We need to ensure that the {@link com.adaptris.core.AdaptrisConnection#init()} method blocks until the server is ready for registration
-   * of servlets and also ready for incoming HTTP requests. This value controls how long we wait for the server to start up before
-   * throwing an exception.
-   * </p>
-   *
-   * @param t the maxStartupWait to set, default if not specified is 10 minutes.
-   */
-  public void setMaxStartupWait(TimeInterval t) {
-    maxStartupWait = t;
-  }
-
   long maxStartupWaitTimeMs() {
     return TimeInterval.toMillisecondsDefaultIfNull(getMaxStartupWait(), DEFAULT_MAX_WAIT);
-  }
-
-  /**
-   * @return the securityHandler wrapper implementation
-   */
-  public SecurityHandlerWrapper getSecurityHandler() {
-    return securityHandler;
-  }
-
-  /**
-   * Specify the SecurityHandler implementation.
-   * <p>
-   * By specifying a {@link SecurityHandlerWrapper} implementation you will overwrite whatever {@link SecurityHandler}
-   * implementation that is present in the {@link WebAppContext}. If you have multiple instances of {@link EmbeddedConnection}
-   * configured inside your adapter, then results may be undefined; you are advised to configure a single {@code EmbeddedConnection}
-   * as a {@code shared-component} to avoid any issues.
-   * </p>
-   *
-   * @param s the securityHandler wrapper implementation.
-   */
-  public void setSecurityHandler(SecurityHandlerWrapper s) {
-    securityHandler = s;
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/HttpConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/HttpConnection.java
@@ -335,7 +335,7 @@ public class HttpConnection extends JettyConnection {
   /**
    * The Server Connector properties to set
    *
-   * @param httpConfiguration
+   * @param serverConnectorProperties
    *          KeyValuePairSet
    */
   @Getter

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/HttpConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/HttpConnection.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@ package com.adaptris.core.http.jetty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.AbstractConnector;
@@ -29,6 +30,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
@@ -42,6 +44,9 @@ import com.adaptris.util.KeyValuePairSet;
 import com.adaptris.util.SimpleBeanUtil;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Concrete implementation of JettyConnection that allows HTTP traffic.
  * <p>
@@ -49,11 +54,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * information on the behaviour and configuration required.
  * </p>
  * <p>
- * The key from the {@code server-connector-properties} element should match the name of the underlying {@link ServerConnector}
- * setter.
- * 
+ * The key from the {@code server-connector-properties} element should match the name of the underlying {@link ServerConnector} setter.
+ *
  * <pre>
- * {@code 
+ * {@code
  *   <server-connector-properties>
  *     <key-value-pair>
  *        <key>ReuseAddress</key>
@@ -61,35 +65,33 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *     </key-value-pair>
  *   </server-connector-properties>
  * }
- * </pre> will invoke {@code ServerConnector#setReuseAddress(boolean)}, setting the ReuseAddress property to true. Note that no
- * validation of the various properties is performed and will be passed as-is to the {@link AbstractConnector} with an attempt to
- * transform into the correct type. Invalid combinations may result in undefined behaviour. Similarly additional
- * {@code HttpConfiguration} properties can be configured via the {@code http-connection} element.
+ * </pre>
+ *
+ * will invoke {@code ServerConnector#setReuseAddress(boolean)}, setting the ReuseAddress property to true. Note that no validation of the
+ * various properties is performed and will be passed as-is to the {@link AbstractConnector} with an attempt to transform into the correct
+ * type. Invalid combinations may result in undefined behaviour. Similarly additional {@code HttpConfiguration} properties can be configured
+ * via the {@code http-connection} element.
  * </p>
- * 
+ *
  * @config jetty-http-connection
- * 
+ *
  * @author lchan
  */
 @XStreamAlias("jetty-http-connection")
 @AdapterComponent
-@ComponentProfile(summary = "Connection that creates its own jetty engine instance and listens on the specified port",
-    tag = "connections,http,jetty")
-@DisplayOrder(order =
-{
-    "port", "httpConfiguration", "serverConnectorProperties"
-})
+@ComponentProfile(summary = "Connection that creates its own jetty engine instance and listens on the specified port", tag = "connections,http,jetty")
+@DisplayOrder(order = { "port", "httpConfiguration", "serverConnectorProperties" })
 public class HttpConnection extends JettyConnection {
 
   /**
    * Standard {@link ServerConnector} properties for use with {@link HttpConnection#setServerConnectorProperties(KeyValuePairSet)}.
-   * 
+   *
    */
   public enum ServerConnectorProperty {
 
     /**
      * @see ServerConnector#setAcceptQueueSize(int)
-     * 
+     *
      */
     AcceptQueueSize {
       @Override
@@ -99,7 +101,7 @@ public class HttpConnection extends JettyConnection {
     },
     /**
      * @see ServerConnector#setAcceptorPriorityDelta(int)
-     * 
+     *
      */
     AcceptorPriorityDelta {
       @Override
@@ -109,7 +111,7 @@ public class HttpConnection extends JettyConnection {
     },
     /**
      * @see ServerConnector#setIdleTimeout(long)
-     * 
+     *
      */
     IdleTimeout {
       @Override
@@ -119,7 +121,7 @@ public class HttpConnection extends JettyConnection {
     },
     /**
      * @see ServerConnector#setInheritChannel(boolean)
-     * 
+     *
      */
     InheritChannel {
       @Override
@@ -136,29 +138,30 @@ public class HttpConnection extends JettyConnection {
         connector.setReuseAddress(Boolean.valueOf(value).booleanValue());
       }
     };
+
     abstract void applyProperty(ServerConnector connector, String value) throws Exception;
   }
 
   /**
    * Standard {@link HttpConfiguration} properties for use with {@link HttpConnection#setHttpConfiguration(KeyValuePairSet)}.
-   * 
+   *
    */
   public enum HttpConfigurationProperty {
     /**
      * @see HttpConfiguration#setSecureScheme(String).
-     * 
+     *
      */
     SecureScheme {
 
       @Override
       void applyProperty(HttpConfiguration config, String value) throws Exception {
-        config.setSecureScheme(value);        
+        config.setSecureScheme(value);
       }
-      
+
     },
     /**
      * @see HttpConfiguration#setSecurePort(int).
-     * 
+     *
      */
     SecurePort {
 
@@ -166,7 +169,7 @@ public class HttpConnection extends JettyConnection {
       void applyProperty(HttpConfiguration config, String value) throws Exception {
         config.setSecurePort(Integer.parseInt(value));
       }
-      
+
     },
     /**
      * @see HttpConfiguration#setOutputBufferSize(int)
@@ -291,7 +294,7 @@ public class HttpConnection extends JettyConnection {
       @Override
       void applyProperty(HttpConfiguration config, String value) throws Exception {
         config.setMinResponseDataRate(Long.parseLong(value));
-      }      
+      }
     },
     /**
      * @see HttpConfiguration#setPersistentConnectionsEnabled(boolean)
@@ -302,14 +305,41 @@ public class HttpConnection extends JettyConnection {
         config.setPersistentConnectionsEnabled(Boolean.valueOf(value).booleanValue());
       }
     };
+
     abstract void applyProperty(HttpConfiguration config, String value) throws Exception;
 
   }
 
+  /**
+   * Set the port to listen on for HTTP traffic.
+   *
+   * @param port
+   *          the port, by default it is 8080
+   */
+  @Getter
+  @Setter
   private int port;
+
+  /**
+   * Specify the SecurityHandler implementation.
+   *
+   * @param securityHandler
+   *          the securityHandler wrapper implementation.
+   */
+  @Getter
+  @Setter
   @Valid
   @AdvancedConfig
   private SecurityHandlerWrapper securityHandler;
+
+  /**
+   * The Server Connector properties to set
+   *
+   * @param httpConfiguration
+   *          KeyValuePairSet
+   */
+  @Getter
+  @Setter
   @NotNull
   @Valid
   @AutoPopulated
@@ -317,13 +347,20 @@ public class HttpConnection extends JettyConnection {
   @InputFieldHint(style = "com.adaptris.core.http.jetty.HttpConnection.ServerConnectorProperty")
   private KeyValuePairSet serverConnectorProperties;
 
+  /**
+   * The HTTP Configuration properties to set
+   *
+   * @param httpConfiguration
+   *          KeyValuePairSet
+   */
+  @Getter
+  @Setter
   @NotNull
   @Valid
   @AutoPopulated
   @AdvancedConfig
   @InputFieldHint(style = "com.adaptris.core.http.jetty.HttpConnection.HttpConfigurationProperty")
   private KeyValuePairSet httpConfiguration;
-
 
   public HttpConnection() {
     super();
@@ -333,10 +370,7 @@ public class HttpConnection extends JettyConnection {
   }
 
   protected ConnectionFactory[] createConnectionFactory() throws Exception {
-    return new ConnectionFactory[]
-    {
-        new HttpConnectionFactory(createConfig(), HttpCompliance.RFC2616)
-    };
+    return new ConnectionFactory[] { new HttpConnectionFactory(createConfig()) };
   }
 
   protected HttpConfiguration createConfig() throws Exception {
@@ -356,6 +390,7 @@ public class HttpConnection extends JettyConnection {
         }
       }
     }
+    cfg.setHttpCompliance(HttpCompliance.RFC2616);
     return cfg;
   }
 
@@ -398,64 +433,8 @@ public class HttpConnection extends JettyConnection {
     return connector;
   }
 
-  /**
-   * Set the port to listen on.
-   * 
-   * @param i the port, by default it is 8080
-   */
-  public void setPort(int i) {
-    port = i;
-  }
-
-  /**
-   * Get the port to listen on for HTTP traffic.
-   * 
-   * @return the port
-   */
-  public int getPort() {
-    return port;
-  }
-
-  public KeyValuePairSet getServerConnectorProperties() {
-    return serverConnectorProperties;
-  }
-
-  public void setServerConnectorProperties(KeyValuePairSet httpProperties) {
-    this.serverConnectorProperties = httpProperties;
-  }
-
-  /**
-   * @return the securityHandler wrapper implementation
-   */
-  public SecurityHandlerWrapper getSecurityHandler() {
-    return securityHandler;
-  }
-
-  /**
-   * Specify the SecurityHandler implementation.
-   * 
-   * @param s the securityHandler wrapper implementation.
-   */
-  public void setSecurityHandler(SecurityHandlerWrapper s) {
-    securityHandler = s;
-  }
-
   @Override
   protected void prepareConnection() throws CoreException {
-  }
-
-  /**
-   * @return the httpConfiguration
-   */
-  public KeyValuePairSet getHttpConfiguration() {
-    return httpConfiguration;
-  }
-
-  /**
-   * @param kvps the httpConfiguration to set
-   */
-  public void setHttpConfiguration(KeyValuePairSet kvps) {
-    this.httpConfiguration = kvps;
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/HttpsConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/HttpsConnection.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,6 +32,7 @@ import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.security.exc.PasswordException;
 import com.adaptris.security.password.Password;
 import com.adaptris.util.KeyValuePair;
@@ -39,18 +40,21 @@ import com.adaptris.util.KeyValuePairSet;
 import com.adaptris.util.SimpleBeanUtil;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Concrete implementation of JettyConnection that allows HTTPs traffic.
- * 
+ *
  * <p>
  * By default all fields are left as null. This will cause Jetty to use its internal defaults. Consult the Jetty Documentation for
  * information on the behaviour and configuration required.
  * </p>
  * <p>
- * The key from the <code>ssl-properties</code> element should match the name of the underlying {@link SslContextFactory} setter.
- * 
+ * The key from the <code>ssl-properties</code> element should match the name of the underlying {@link SslContextFactory.Server} setter.
+ *
  * <pre>
- * {@code 
+ * {@code
  *   <ssl-properties>
  *     <key-value-pair>
  *        <key>WantClientAuth</key>
@@ -59,344 +63,421 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *   </ssl-properties>
  * }
  * </pre>
- * will invoke {@link SslContextFactory#setWantClientAuth(boolean)}, setting the WantClientAuth property to true. Note that no
- * validation of the various properties is performed and will be passed as-is to the {@link SslContextFactory} with an attempt to
+ *
+ * will invoke {@link SslContextFactory.Server#setWantClientAuth(boolean)}, setting the WantClientAuth property to true. Note that no
+ * validation of the various properties is performed and will be passed as-is to the {@link SslContextFactory.Server} with an attempt to
  * transform into the correct type. Invalid combinations may result in undefined behaviour.
  * </p>
- * 
+ *
  * @config jetty-https-connection
- * 
+ *
  * @author lchan
  * @see JettyConnection
  */
 @XStreamAlias("jetty-https-connection")
 @AdapterComponent
-@ComponentProfile(summary = "Connection that creates its own jetty engine instance and listens on the specified port",
-    tag = "connections,https,jetty")
-@DisplayOrder(order =
-{
-    "port", "httpConfiguration", "serverConnectorProperties", "sslProperties"
-})
+@ComponentProfile(summary = "Connection that creates its own jetty engine instance and listens on the specified port", tag = "connections,https,jetty")
+@DisplayOrder(order = { "port", "httpConfiguration", "serverConnectorProperties", "sslProperties" })
 public class HttpsConnection extends HttpConnection {
   /**
    * Properties for {@link SslContextFactory}.
-   * 
-   * 
+   *
+   *
    */
   public enum SslProperty {
-    
+
     /**
-     * 
-     * @see SslContextFactory#setKeyStorePath(String)
+     *
+     * @see SslContextFactory.Server#setKeyStorePath(String)
      */
     KeyStorePath {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setKeyStorePath(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setKeyStorePath(value);
       }
     },
     /**
      * Set the keystore password (may be encoded using {@link com.adaptris.security.password.Password}.
      * <p>
-     * Note that the password may also be obfuscated using the internal jetty utility
-     * {@link org.eclipse.jetty.util.security.Password} using one of the reversible schemes.
+     * Note that the password may also be obfuscated using the internal jetty utility {@link org.eclipse.jetty.util.security.Password} using
+     * one of the reversible schemes.
      * </p>
-     * 
-     * @see SslContextFactory#setKeyStorePassword(String)
+     *
+     * @see SslContextFactory.Server#setKeyStorePassword(String)
      */
     KeyStorePassword {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value)
-          throws PasswordException {
-        sslContextFactory.setKeyStorePassword(Password.decode(value));
+      void applyProperty(SslContextFactory.Server server, String value) throws PasswordException {
+        server.setKeyStorePassword(Password.decode(value));
       }
     },
     /**
-     * 
-     * @see SslContextFactory#setKeyStoreType(String)
+     *
+     * @see SslContextFactory.Server#setKeyStoreType(String)
      */
     KeyStoreType {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setKeyStoreType(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setKeyStoreType(value);
       }
     },
     /**
-     * @see SslContextFactory#setKeyStoreProvider(String)
+     * @see SslContextFactory.Server#setKeyStoreProvider(String)
      */
     KeyStoreProvider {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setKeyStoreProvider(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setKeyStoreProvider(value);
       }
     },
     /**
-     * 
-     * @see SslContextFactory#setTrustStorePath(String)
+     *
+     * @see SslContextFactory.Server#setTrustStorePath(String)
      */
     TrustStorePath {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setTrustStorePath(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setTrustStorePath(value);
       }
     },
     /**
      * Set the truststore password (may be encoded using {@link com.adaptris.security.password.Password} .
      * <p>
-     * Note that the password may also be obfuscated using the internal jetty utility
-     * {@link org.eclipse.jetty.util.security.Password} using one of the reversible schemes.
+     * Note that the password may also be obfuscated using the internal jetty utility {@link org.eclipse.jetty.util.security.Password} using
+     * one of the reversible schemes.
      * </p>
-     * 
-     * @see SslContextFactory#setTrustStorePassword(String)
+     *
+     * @see SslContextFactory.Server#setTrustStorePassword(String)
      */
     TrustStorePassword {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value)
-          throws PasswordException {
-        sslContextFactory.setTrustStorePassword(Password.decode(value));
+      void applyProperty(SslContextFactory.Server server, String value) throws PasswordException {
+        server.setTrustStorePassword(Password.decode(value));
       }
     },
     /**
-     * 
-     * @see SslContextFactory#setTrustStoreType(String)
+     *
+     * @see SslContextFactory.Server#setTrustStoreType(String)
      */
     TrustStoreType {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setTrustStoreType(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setTrustStoreType(value);
       }
     },
     /**
-     * @see SslContextFactory#setTrustStoreProvider(String)
+     * @see SslContextFactory.Server#setTrustStoreProvider(String)
      */
     TrustStoreProvider {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setTrustStoreProvider(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setTrustStoreProvider(value);
       }
     },
     /**
      * Set the key manager password (may be encoded using {@link com.adaptris.security.password.Password} .
      * <p>
-     * Note that the password may also be obfuscated using the internal jetty utility
-     * {@link org.eclipse.jetty.util.security.Password} using one of the reversible schemes.
+     * Note that the password may also be obfuscated using the internal jetty utility {@link org.eclipse.jetty.util.security.Password} using
+     * one of the reversible schemes.
      * </p>
-     * 
-     * @see SslContextFactory#setKeyManagerPassword(String)
+     *
+     * @see SslContextFactory.Server#setKeyManagerPassword(String)
      */
     KeyManagerPassword {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value)
-          throws PasswordException {
-        sslContextFactory.setKeyManagerPassword(Password.decode(value));
+      void applyProperty(SslContextFactory.Server server, String value) throws PasswordException {
+        server.setKeyManagerPassword(Password.decode(value));
       }
     },
-    
+
     /**
      * A comma separated list of cipher suites to exclude.
-     * 
-     * @see SslContextFactory#setExcludeCipherSuites(String...)
+     *
+     * @see SslContextFactory.Server#setExcludeCipherSuites(String...)
      */
     ExcludeCipherSuites {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setExcludeCipherSuites(asArray(value));
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setExcludeCipherSuites(asArray(value));
       }
     },
     /**
      * A comma separated list of cipher suites to include.
-     * 
-     * @see SslContextFactory#setIncludeCipherSuites(String...)
+     *
+     * @see SslContextFactory.Server#setIncludeCipherSuites(String...)
      */
     IncludeCipherSuites {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setIncludeCipherSuites(asArray(value));
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setIncludeCipherSuites(asArray(value));
       }
     },
     /**
      * A comma separated list of protocols to exclude
-     * 
-     * @see SslContextFactory#setExcludeProtocols(String...)
+     *
+     * @see SslContextFactory.Server#setExcludeProtocols(String...)
      */
     ExcludeProtocols {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setExcludeProtocols(asArray(value));
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setExcludeProtocols(asArray(value));
       }
     },
     /**
      * A comma separated list of protocols to include
-     * 
-     * @see SslContextFactory#setIncludeProtocols(String...)
+     *
+     * @see SslContextFactory.Server#setIncludeProtocols(String...)
      */
     IncludeProtocols {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setIncludeProtocols(asArray(value));
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setIncludeProtocols(asArray(value));
       }
     },
     /**
-     * 
-     * @see SslContextFactory#setSecureRandomAlgorithm(String)
+     *
+     * @see SslContextFactory.Server#setSecureRandomAlgorithm(String)
      */
     SecureRandomAlgorithm {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setSecureRandomAlgorithm(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setSecureRandomAlgorithm(value);
       }
     },
     /**
-     * @see SslContextFactory#setSessionCachingEnabled(boolean)
+     * @see SslContextFactory.Server#setSessionCachingEnabled(boolean)
      */
     SessionCachingEnabled {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setSessionCachingEnabled(Boolean.valueOf(value).booleanValue());
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setSessionCachingEnabled(Boolean.valueOf(value).booleanValue());
       }
     },
     /**
-     * @see SslContextFactory#setMaxCertPathLength(int)
+     * @see SslContextFactory.Server#setMaxCertPathLength(int)
      */
     MaxCertPathLength {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setMaxCertPathLength(Integer.parseInt(value));
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setMaxCertPathLength(Integer.parseInt(value));
       }
     },
     /**
-     * @see SslContextFactory#setNeedClientAuth(boolean)
+     * @see SslContextFactory.Server#setNeedClientAuth(boolean)
      */
     NeedClientAuth {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setNeedClientAuth(Boolean.valueOf(value).booleanValue());
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setNeedClientAuth(Boolean.valueOf(value).booleanValue());
       }
     },
     /**
-     * @see SslContextFactory#setOcspResponderURL(String)
+     * @see SslContextFactory.Server#setOcspResponderURL(String)
      */
     OcspResponderURL {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setOcspResponderURL(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setOcspResponderURL(value);
       }
     },
     /**
-     * @see SslContextFactory#setSslSessionTimeout(int)
+     * @see SslContextFactory.Server#setSslSessionTimeout(int)
      */
     SslSessionTimeout {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setSslSessionTimeout(Integer.parseInt(value));
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setSslSessionTimeout(Integer.parseInt(value));
       }
     },
     /**
-     * @see SslContextFactory#setTrustAll(boolean)
+     * @see SslContextFactory.Server#setTrustAll(boolean)
      */
     TrustAll {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setTrustAll(Boolean.valueOf(value).booleanValue());
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setTrustAll(Boolean.valueOf(value).booleanValue());
       }
     },
     /**
-     * @see SslContextFactory#setTrustManagerFactoryAlgorithm(String)
+     * @see SslContextFactory.Server#setTrustManagerFactoryAlgorithm(String)
      */
     TrustManagerFactoryAlgorithm {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setTrustManagerFactoryAlgorithm(value);
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setTrustManagerFactoryAlgorithm(value);
       }
     },
     /**
-     * @see SslContextFactory#setValidateCerts(boolean)
+     * @see SslContextFactory.Server#setValidateCerts(boolean)
      */
     ValidateCerts {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setValidateCerts(Boolean.valueOf(value).booleanValue());
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setValidateCerts(Boolean.valueOf(value).booleanValue());
       }
     },
     /**
-     * @see SslContextFactory#setValidatePeerCerts(boolean)
+     * @see SslContextFactory.Server#setValidatePeerCerts(boolean)
      */
     ValidatePeerCerts {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setValidatePeerCerts(Boolean.valueOf(value).booleanValue());
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setValidatePeerCerts(Boolean.valueOf(value).booleanValue());
       }
     },
     /**
-     * 
-     * @see SslContextFactory#setWantClientAuth(boolean)
+     *
+     * @see SslContextFactory.Server#setWantClientAuth(boolean)
      */
     WantClientAuth {
       @Override
-      void applyProperty(SslContextFactory.Server sslContextFactory, String value) {
-        sslContextFactory.setWantClientAuth(Boolean.valueOf(value).booleanValue());
+      void applyProperty(SslContextFactory.Server server, String value) {
+        server.setWantClientAuth(Boolean.valueOf(value).booleanValue());
       }
     };
 
-    abstract void applyProperty(SslContextFactory.Server sslContextFactory, String value)
-        throws Exception;
-    
+    abstract void applyProperty(SslContextFactory.Server server, String value) throws Exception;
+
   }
 
+  /**
+   * Properties for {@link SecureRequestCustomizer}.
+   *
+   *
+   */
+  public enum SecureRequestCustomizerProperty {
+
+    /**
+     *
+     * @see SecureRequestCustomizer#setSniRequired(boolean)
+     */
+    SniRequired {
+      @Override
+      void applyProperty(SecureRequestCustomizer secureRequestCustomizer, String value) {
+        secureRequestCustomizer.setSniRequired(Boolean.valueOf(value).booleanValue());
+      }
+    },
+    /**
+     * @see SecureRequestCustomizer#setSniHostCheck(boolean)
+     */
+    SniHostCheck {
+      @Override
+      void applyProperty(SecureRequestCustomizer secureRequestCustomizer, String value) throws PasswordException {
+        secureRequestCustomizer.setSniHostCheck(Boolean.valueOf(value).booleanValue());
+      }
+    },
+    /**
+     *
+     * stsMaxAgeSeconds The max age in seconds for a Strict-Transport-Security response header. If set less than zero then no header is
+     * sent.
+     *
+     * @see SecureRequestCustomizer#setStsMaxAge(long)
+     */
+    StsMaxAge {
+      @Override
+      void applyProperty(SecureRequestCustomizer secureRequestCustomizer, String value) {
+        secureRequestCustomizer.setStsMaxAge(Long.parseLong(value));
+      }
+    },
+    /**
+     * @see SecureRequestCustomizer#setStsIncludeSubDomains(boolean)
+     */
+    StsIncludeSubDomains {
+      @Override
+      void applyProperty(SecureRequestCustomizer secureRequestCustomizer, String value) {
+        secureRequestCustomizer.setStsIncludeSubDomains(Boolean.valueOf(value).booleanValue());
+      }
+    };
+
+    abstract void applyProperty(SecureRequestCustomizer secureRequestCustomizer, String value) throws Exception;
+
+  }
+
+  /**
+   * Set the SSL properties.
+   *
+   * @param sslProperties
+   *          the SSL properties
+   * @see SslProperty
+   */
+  @Getter
+  @Setter
   @NotNull
   @Valid
   @AutoPopulated
   @AdvancedConfig
+  @InputFieldHint(style = "com.adaptris.core.http.jetty.HttpConnections.SslProperty")
   private KeyValuePairSet sslProperties;
+
+  /**
+   * Set the Secure Request Customizer properties.
+   *
+   * @param secureRequestCustomizerProperties
+   *          the Secure Request Customizer properties
+   * @see SecureRequestCustomizer
+   */
+  @Getter
+  @Setter
+  @NotNull
+  @Valid
+  @AutoPopulated
+  @AdvancedConfig
+  @InputFieldHint(style = "com.adaptris.core.http.jetty.HttpConnections.SecureRequestCustomizerProperty")
+  private KeyValuePairSet secureRequestCustomizerProperties;
 
   public HttpsConnection() {
     super();
     setPort(8443);
     setSslProperties(new KeyValuePairSet());
+    setSecureRequestCustomizerProperties(new KeyValuePairSet());
   }
 
-
-  @Override
-  protected ConnectionFactory[] createConnectionFactory() throws Exception {
-    HttpConfiguration httpsConfig = new HttpConfiguration(createConfig());
-    httpsConfig.addCustomizer(new SecureRequestCustomizer());
-    return new ConnectionFactory[] { 
-        new SslConnectionFactory(createSslContext(), HttpVersion.HTTP_1_1.asString()),
-        new HttpConnectionFactory(httpsConfig)
-    };
-  }
-
-  SslContextFactory createSslContext() throws Exception {
-    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
-    for (KeyValuePair kvp : getSslProperties().getKeyValuePairs()) {
+  SecureRequestCustomizer createSecureRequestCustomizer() throws Exception {
+    SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+    for (KeyValuePair kvp : getSecureRequestCustomizerProperties().getKeyValuePairs()) {
       boolean matched = false;
-      for (SslProperty sp : SslProperty.values()) {
-        if (kvp.getKey().equalsIgnoreCase(sp.toString())) {
-          sp.applyProperty(sslContextFactory, kvp.getValue());
+      for (SecureRequestCustomizerProperty secp : SecureRequestCustomizerProperty.values()) {
+        if (kvp.getKey().equalsIgnoreCase(secp.toString())) {
+          secp.applyProperty(secureRequestCustomizer, kvp.getValue());
           matched = true;
           break;
         }
       }
       if (!matched) {
-        if (!SimpleBeanUtil.callSetter(sslContextFactory, "set" + kvp.getKey(), kvp.getValue())) {
+        if (!SimpleBeanUtil.callSetter(server, "set" + kvp.getKey(), kvp.getValue())) {
           log.trace("Ignoring unsupported Property {}", kvp.getKey());
         }
       }
     }
-    return sslContextFactory;
+    return secureRequestCustomizer;
   }
 
-  public KeyValuePairSet getSslProperties() {
-    return sslProperties;
+  @Override
+  protected ConnectionFactory[] createConnectionFactory() throws Exception {
+    HttpConfiguration httpsConfig = new HttpConfiguration(createConfig());
+    httpsConfig.addCustomizer(createSecureRequestCustomizer());
+    SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(createSslContext(), HttpVersion.HTTP_1_1.asString());
+    return new ConnectionFactory[] { sslConnectionFactory, new HttpConnectionFactory(httpsConfig) };
   }
 
-  /**
-   * Set the SSL properties.
-   * 
-   * @param kvps the SSL properties
-   * @see SslProperty
-   */
-  public void setSslProperties(KeyValuePairSet kvps) {
-    this.sslProperties = kvps;
+  SslContextFactory.Server createSslContext() throws Exception {
+    SslContextFactory.Server sslServer = new SslContextFactory.Server();
+    for (KeyValuePair kvp : getSslProperties().getKeyValuePairs()) {
+      boolean matched = false;
+      for (SslProperty sp : SslProperty.values()) {
+        if (kvp.getKey().equalsIgnoreCase(sp.toString())) {
+          sp.applyProperty(sslServer, kvp.getValue());
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        if (!SimpleBeanUtil.callSetter(sslServer, "set" + kvp.getKey(), kvp.getValue())) {
+          log.trace("Ignoring unsupported Property {}", kvp.getKey());
+        }
+      }
+    }
+    return sslServer;
   }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/LoginServiceProxy.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/LoginServiceProxy.java
@@ -4,7 +4,7 @@ import java.util.stream.Collectors;
 
 import javax.servlet.ServletRequest;
 
-import org.eclipse.jetty.security.AbstractLoginService.RolePrincipal;
+import org.eclipse.jetty.security.RolePrincipal;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;

--- a/interlok-core/src/main/java/com/adaptris/core/management/jetty/FromProperties.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/jetty/FromProperties.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,9 @@
 package com.adaptris.core.management.jetty;
 
 import static com.adaptris.core.management.jetty.JettyServerComponent.DEFAULT_JETTY_PORT;
+
 import java.util.Properties;
+
 import org.eclipse.jetty.deploy.DeploymentManager;
 import org.eclipse.jetty.deploy.providers.WebAppProvider;
 import org.eclipse.jetty.http.HttpCompliance;
@@ -95,8 +97,9 @@ final class FromProperties extends ServerBuilder {
   }
 
   private ServerConnector createConnector(Server server) {
-    ServerConnector connector = new ServerConnector(server, -1, -1,
-        new HttpConnectionFactory(configure(new HttpConfiguration()), HttpCompliance.RFC2616));
+    HttpConfiguration httpConfig = new HttpConfiguration();
+    httpConfig.setHttpCompliance(HttpCompliance.RFC2616);
+    ServerConnector connector = new ServerConnector(server, -1, -1, new HttpConnectionFactory(configure(httpConfig)));
     connector.setPort(Integer.parseInt(getConfigItem(WEB_SERVER_PORT_CFG_KEY, DEFAULT_JETTY_PORT)));
     return connector;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/management/jetty/FromXmlConfig.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/jetty/FromXmlConfig.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,26 +17,25 @@ package com.adaptris.core.management.jetty;
 
 import static com.adaptris.core.util.PropertyHelper.asMap;
 import static com.adaptris.core.util.PropertyHelper.getPropertySubset;
-import java.net.URI;
-import java.net.URISyntaxException;
+
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.Map;
 import java.util.Properties;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.xml.XmlConfiguration;
+
 import com.adaptris.interlok.util.Args;
 import com.adaptris.interlok.util.ResourceLocator;
 
 /**
  * Build a jetty server from xml.
  * <p>
- * The {@link XmlConfiguration} will be configured with a property set that contains all the system properties and local properties
- * (from bootstrap.properties) that are prefixed {@code jetty.}. Properties defined in bootstrap.properties override system
- * properties.
+ * The {@link XmlConfiguration} will be configured with a property set that contains all the system properties and local properties (from
+ * bootstrap.properties) that are prefixed {@code jetty.}. Properties defined in bootstrap.properties override system properties.
  * </p>
- * 
+ *
  */
 class FromXmlConfig extends ServerBuilder {
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/jetty/ServerBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/jetty/ServerBuilder.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
@@ -14,13 +14,16 @@ package com.adaptris.core.management.jetty;
 
 import static com.adaptris.core.management.jetty.JettyServerComponent.ATTR_BOOTSTRAP_KEYS;
 import static com.adaptris.core.management.jetty.JettyServerComponent.ATTR_JMX_ADAPTER_UID;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.management.Constants;
 
 public abstract class ServerBuilder {
@@ -57,20 +60,20 @@ public abstract class ServerBuilder {
       public boolean canBuild(Properties p) {
         return true;
       }
+
       @Override
       public ServerBuilder builder(Properties cfg) {
         return new FromClasspath(cfg);
       }
     };
-    
+
     public abstract boolean canBuild(Properties p);
 
     public abstract ServerBuilder builder(Properties p);
 
   }
 
-  private static List<Builder> FACTORIES = Collections
-      .unmodifiableList(Arrays.asList(Builder.XML, Builder.PROPERTIES, Builder.FAILSAFE));
+  private static List<Builder> FACTORIES = Collections.unmodifiableList(Arrays.asList(Builder.XML, Builder.PROPERTIES, Builder.FAILSAFE));
 
   protected static final Logger log = LoggerFactory.getLogger(JettyServerComponent.class);
   private Properties initialProperties;
@@ -88,7 +91,7 @@ public abstract class ServerBuilder {
   private static Server configure(final Server server, final Properties config) throws Exception {
     // TODO This is all wrong. Can't get server attributes from the ServletContext
     // OLD-SKOOL Do it via SystemProperties!!!!!
-    // Add Null Prodction in to avoid System.setProperty issues during tests.
+    // Add Null Production in to avoid System.setProperty issues during tests.
     // Or in fact if people decide to not enable JMXServiceUrl in bootstrap.properties
     if (config.containsKey(Constants.CFG_JMX_LOCAL_ADAPTER_UID)) {
       // server.setAttribute(ATTR_JMX_ADAPTER_UID, config.getProperty(Constants.CFG_JMX_LOCAL_ADAPTER_UID));

--- a/interlok-core/src/main/java/com/adaptris/core/management/jmx/SimpleCallbackHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/jmx/SimpleCallbackHandler.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,14 +26,13 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.AuthorizeCallback;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.adaptris.security.exc.PasswordException;
 import com.sun.jdmk.security.sasl.AuthenticateCallback;
 
 /**
  * Simple {@link CallbackHandler} implementation.
+ *
  * @author lchan
  *
  */
@@ -41,25 +40,24 @@ class SimpleCallbackHandler implements CallbackHandler {
 
   private String password;
   private String username;
-  private transient Logger logger = LoggerFactory.getLogger(JmxRemoteComponent.class);
 
   SimpleCallbackHandler(String user, String password) {
-    this.username = user;
+    username = user;
     this.password = password;
   }
 
   @Override
   public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-    for (int i = 0; i < callbacks.length; ++i) {
-      if (callbacks[i] instanceof AuthenticateCallback) {
-        AuthenticateCallback cb = (AuthenticateCallback) callbacks[i];
+    for (Callback callback : callbacks) {
+      if (callback instanceof AuthenticateCallback) {
+        AuthenticateCallback cb = (AuthenticateCallback) callback;
         cb.setAuthenticated(authenticate(cb.getAuthenticationID(), cb.getPassword()));
-      } else if (callbacks[i] instanceof AuthorizeCallback) {
-        AuthorizeCallback cb = (AuthorizeCallback) callbacks[i];
+      } else if (callback instanceof AuthorizeCallback) {
+        AuthorizeCallback cb = (AuthorizeCallback) callback;
         // If you can login; then you're authorized.
         cb.setAuthorized(authorize(cb.getAuthenticationID()));
       } else {
-        throw new UnsupportedCallbackException(callbacks[i]);
+        throw new UnsupportedCallbackException(callback);
       }
     }
   }
@@ -77,4 +75,5 @@ class SimpleCallbackHandler implements CallbackHandler {
   private boolean authorize(String user) {
     return new EqualsBuilder().append(username, user).isEquals();
   }
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/HttpConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/HttpConsumerTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,6 @@ import com.adaptris.core.Channel;
 import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.PoolingWorkflow;
-import com.adaptris.core.PortManager;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.StandaloneProducer;
@@ -64,6 +63,7 @@ import com.adaptris.core.stubs.StaticMockMessageProducer;
 import com.adaptris.core.stubs.StubMessageFactory;
 import com.adaptris.http.legacy.HttpProduceConnection;
 import com.adaptris.http.legacy.SimpleHttpProducer;
+import com.adaptris.interlok.junit.scaffolding.util.PortManager;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.TimeInterval;
 
@@ -83,7 +83,6 @@ public class HttpConsumerTest extends HttpConsumerExample {
   public static final String XML_PAYLOAD = "<root><document>value</document></root>";
 
   protected SimpleHttpProducer httpProducer;
-
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -142,8 +141,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
     Channel channel = JettyHelper.createChannel(connection, JettyHelper.createConsumer(URL_TO_POST_TO), new MockMessageProducer());
     try {
       channel.requestStart();
-    }
-    finally {
+    } finally {
       channel.requestClose();
     }
 
@@ -155,8 +153,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
     JettyMessageConsumer consumer1 = JettyHelper.createConsumer(URL_TO_POST_TO);
     StandardWorkflow workflow1 = new StandardWorkflow();
     workflow1.setConsumer(consumer1);
-    workflow1.getServiceCollection()
-        .add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
+    workflow1.getServiceCollection().add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
     Channel channel = JettyHelper.createChannel(connection, workflow1);
     try {
       channel.requestStart();
@@ -173,8 +170,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply2 = httpProducer.request(msg2);
       assertEquals("404", reply2.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
 
-    }
-    finally {
+    } finally {
       channel.requestClose();
     }
   }
@@ -186,15 +182,13 @@ public class HttpConsumerTest extends HttpConsumerExample {
     JettyMessageConsumer consumer1 = JettyHelper.createConsumer(URL_TO_POST_TO);
     StandardWorkflow workflow1 = new StandardWorkflow();
     workflow1.setConsumer(consumer1);
-    workflow1.getServiceCollection()
-        .add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
+    workflow1.getServiceCollection().add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
     Channel channel = JettyHelper.createChannel(connection, workflow1);
 
     JettyMessageConsumer consumer2 = JettyHelper.createConsumer("/some/other/urlmapping/");
     StandardWorkflow workflow2 = new StandardWorkflow();
     workflow2.setConsumer(consumer2);
-    workflow2.getServiceCollection()
-        .add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
+    workflow2.getServiceCollection().add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
     channel.getWorkflowList().add(workflow2);
 
     try {
@@ -213,8 +207,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply2 = httpProducer.request(msg2);
       assertEquals("200", reply2.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
 
-    }
-    finally {
+    } finally {
       channel.requestClose();
     }
   }
@@ -244,8 +237,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply = httpProducer.request(msg);
       assertEquals(XML_PAYLOAD, reply.getContent());
       doAssertions(mockProducer);
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
     }
@@ -275,8 +267,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply = httpProducer.request(msg);
       // Because of redmineID #4715 it should just "return immediatel" which flushes the stream so there's no content.
       assertEquals("", reply.getContent());
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
     }
@@ -308,8 +299,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply = httpProducer.request(msg);
       assertEquals(Integer.valueOf(HttpStatus.ACCEPTED_202.getStatusCode()),
           Integer.valueOf(reply.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE)));
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
     }
@@ -331,8 +321,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals(XML_PAYLOAD, reply.getContent());
       AdaptrisMessage receivedMsg = doAssertions(mockProducer);
       assertFalse(receivedMsg.containsKey("Content-Type"));
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -356,8 +345,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       start(httpProducer);
       AdaptrisMessage reply = httpProducer.request(msg);
       assertEquals("405", reply.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -404,8 +392,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals(XML_PAYLOAD, reply.getContent());
       AdaptrisMessage receivedMsg = doAssertions(mockProducer);
       assertEquals("text/xml", receivedMsg.getMetadataValue("Http_Header_Content-Type"));
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -437,8 +424,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals("1", receivedMsg.getMetadataValue("queryParam1"));
       assertEquals("2", receivedMsg.getMetadataValue("queryParam2"));
       assertEquals("3", receivedMsg.getMetadataValue("queryParam3"));
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -470,8 +456,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals("1", receivedMsg.getObjectHeaders().get("queryParam1"));
       assertEquals("2", receivedMsg.getObjectHeaders().get("queryParam2"));
       assertEquals("3", receivedMsg.getObjectHeaders().get("queryParam3"));
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -505,8 +490,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals("1", receivedMsg.getMetadataValue("Http_Param_queryParam1"));
       assertEquals("2", receivedMsg.getMetadataValue("Http_Param_queryParam2"));
       assertEquals("3", receivedMsg.getMetadataValue("Http_Param_queryParam3"));
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -540,8 +524,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals("1", receivedMsg.getObjectHeaders().get("Http_Param_queryParam1"));
       assertEquals("2", receivedMsg.getObjectHeaders().get("Http_Param_queryParam2"));
       assertEquals("3", receivedMsg.getObjectHeaders().get("Http_Param_queryParam3"));
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -552,17 +535,14 @@ public class HttpConsumerTest extends HttpConsumerExample {
   public void testBasicConsumeWorkflow_ConsumeDestinationContainsInvalidURL() throws Exception {
     // {} won't be valid for a URL, so this should immediately fail.
     HttpConnection con = createConnection(null);
-    Channel c = JettyHelper.createChannel(con, JettyHelper.createConsumer(URL_TO_POST_TO + "?token={}"),
-        new MockMessageProducer());
+    Channel c = JettyHelper.createChannel(con, JettyHelper.createConsumer(URL_TO_POST_TO + "?token={}"), new MockMessageProducer());
     c.requestInit();
     try {
       c.requestStart();
       fail();
-    }
-    catch (CoreException expected) {
+    } catch (CoreException expected) {
       expected.printStackTrace();
-    }
-    finally {
+    } finally {
       stop(c);
       PortManager.release(con.getPort());
     }
@@ -585,8 +565,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply = httpProducer.request(msg);
       assertEquals(XML_PAYLOAD, reply.getContent());
       doAssertions(mockProducer);
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -606,13 +585,11 @@ public class HttpConsumerTest extends HttpConsumerExample {
       msg.addMetadata(CONTENT_TYPE_METADATA_KEY, "text/xml");
       httpProducer.setUrl(createProduceDestinationUrl(connection.getPort()));
       start(httpProducer);
-      AdaptrisMessage reply = httpProducer.request(msg);
+      httpProducer.request(msg);
       AdaptrisMessage consumedMessage = doAssertions(mockProducer);
       assertFalse(consumedMessage.headersContainsKey(JettyConstants.JETTY_USER_ROLES));
       assertFalse(consumedMessage.headersContainsKey(JettyConstants.JETTY_QUERY_STRING));
-
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -636,8 +613,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply = httpProducer.request(msg);
       assertEquals(XML_PAYLOAD, reply.getContent());
       doAssertions(mockProducer);
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -666,8 +642,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply = httpProducer.request(msg);
       assertEquals(XML_PAYLOAD, reply.getContent());
       doAssertions(mock2);
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -682,7 +657,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
     assertTrue(msg.containsKey(JettyConstants.JETTY_URI));
     assertEquals(URL_TO_POST_TO, msg.getMetadataValue(JettyConstants.JETTY_URI));
     assertTrue(msg.containsKey(JettyConstants.JETTY_URL));
-    Map objMetadata = msg.getObjectHeaders();
+    Map<Object, Object> objMetadata = msg.getObjectHeaders();
     assertNotNull(objMetadata.get(JettyConstants.JETTY_WRAPPER));
     return msg;
   }
@@ -723,8 +698,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
 
       assertFalse(consumedMsg.containsKey(IGNORED_METADATA));
 
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       adapter.requestClose();
       PortManager.release(connection.getPort());
@@ -750,8 +724,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals(XML_PAYLOAD, reply.getContent());
       doAssertions(mockProducer);
       assertEquals(AdaptrisMessageStub.class, mockProducer.getMessages().get(0).getClass());
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       adapter.requestClose();
       PortManager.release(connection.getPort());
@@ -778,13 +751,11 @@ public class HttpConsumerTest extends HttpConsumerExample {
       int rc = Integer.valueOf(reply.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE)).intValue();
       assertEquals(HttpURLConnection.HTTP_NOT_FOUND, rc);
 
-    }
-    catch (ProduceException e) {
+    } catch (ProduceException e) {
       if (!(e.getCause() instanceof FileNotFoundException)) {
         throw e;
       }
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       adapter.requestClose();
       PortManager.release(connection.getPort());
@@ -861,8 +832,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply = httpProducer.request(msg);
       assertEquals(XML_PAYLOAD, reply.getContent());
       doAssertions(mockProducer);
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       adapter.requestClose();
       Thread.currentThread().setName(threadName);
@@ -902,10 +872,8 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals(0, mockProducer.getMessages().size());
       assertTrue(reply.containsKey(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
       int rc = Integer.valueOf(reply.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE)).intValue();
-      assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED
-          || rc == HttpURLConnection.HTTP_FORBIDDEN);
-    }
-    catch (Exception e) {
+      assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED || rc == HttpURLConnection.HTTP_FORBIDDEN);
+    } catch (Exception e) {
       // This is expected actually,.
       if (e.getCause() instanceof IOException) {
         String s = ((IOException) e.getCause()).getMessage();
@@ -913,16 +881,13 @@ public class HttpConsumerTest extends HttpConsumerExample {
         if (s.startsWith(httpString)) {
           int rc = Integer.parseInt(s.substring(httpString.length(), httpString.length() + 3));
           assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED || rc == HttpURLConnection.HTTP_FORBIDDEN);
-        }
-        else {
+        } else {
           throw e;
         }
-      }
-      else {
+      } else {
         throw e;
       }
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       adapter.requestClose();
       Thread.currentThread().setName(threadName);
@@ -961,10 +926,8 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals(0, mockProducer.getMessages().size());
       assertTrue(reply.containsKey(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
       int rc = Integer.valueOf(reply.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE)).intValue();
-      assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED
-          || rc == HttpURLConnection.HTTP_FORBIDDEN);
-    }
-    catch (Exception e) {
+      assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED || rc == HttpURLConnection.HTTP_FORBIDDEN);
+    } catch (Exception e) {
       e.printStackTrace();
       // This is expected actually,.
       if (e.getCause() instanceof IOException) {
@@ -973,16 +936,13 @@ public class HttpConsumerTest extends HttpConsumerExample {
         if (s.startsWith(httpString)) {
           int rc = Integer.parseInt(s.substring(httpString.length(), httpString.length() + 3));
           assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED || rc == HttpURLConnection.HTTP_FORBIDDEN);
-        }
-        else {
+        } else {
           throw e;
         }
-      }
-      else {
+      } else {
         throw e;
       }
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       adapter.requestClose();
       Thread.currentThread().setName(threadName);
@@ -1023,10 +983,8 @@ public class HttpConsumerTest extends HttpConsumerExample {
       assertEquals(0, mockProducer.getMessages().size());
       assertTrue(reply.containsKey(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
       int rc = Integer.valueOf(reply.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE)).intValue();
-      assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED
-          || rc == HttpURLConnection.HTTP_FORBIDDEN);
-    }
-    catch (ProduceException e) {
+      assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED || rc == HttpURLConnection.HTTP_FORBIDDEN);
+    } catch (ProduceException e) {
       // This is expected actually,.
       if (e.getCause() instanceof IOException) {
         String s = ((IOException) e.getCause()).getMessage();
@@ -1034,16 +992,13 @@ public class HttpConsumerTest extends HttpConsumerExample {
         if (s.startsWith(httpString)) {
           int rc = Integer.parseInt(s.substring(httpString.length(), httpString.length() + 3));
           assertTrue(rc == HttpURLConnection.HTTP_UNAUTHORIZED || rc == HttpURLConnection.HTTP_FORBIDDEN);
-        }
-        else {
+        } else {
           throw e;
         }
-      }
-      else {
+      } else {
         throw e;
       }
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       adapter.requestClose();
       PortManager.release(connection.getPort());
@@ -1072,8 +1027,7 @@ public class HttpConsumerTest extends HttpConsumerExample {
       AdaptrisMessage reply = httpProducer.request(msg);
       assertEquals(XML_PAYLOAD, reply.getContent());
       doAssertions(mockProducer);
-    }
-    finally {
+    } finally {
       stop(httpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -1124,25 +1078,24 @@ public class HttpConsumerTest extends HttpConsumerExample {
 
   SecurityHandlerWrapper createSecurityHandlerExample() {
     ConfigurableSecurityHandler csh = new ConfigurableSecurityHandler();
-    HashLoginServiceFactory hsl =
-        new HashLoginServiceFactory().withUserRealm("InterlokJetty").withFilename("/path/to/realm.properties");
+    HashLoginServiceFactory hsl = new HashLoginServiceFactory().withUserRealm("InterlokJetty").withFilename("/path/to/realm.properties");
     csh.setLoginService(hsl);
 
     SecurityConstraint securityConstraint = new SecurityConstraint();
     securityConstraint.setMustAuthenticate(false);
-    securityConstraint.setPaths(new ArrayList(Arrays.asList("/public")));
+    securityConstraint.setPaths(new ArrayList<>(Arrays.asList("/public")));
 
     SecurityConstraint securityConstraint2 = new SecurityConstraint();
     securityConstraint2.setMustAuthenticate(true);
     securityConstraint2.setRoles("adminUserRole");
-    securityConstraint2.setPaths(new ArrayList(Arrays.asList("/private", "/admin")));
+    securityConstraint2.setPaths(new ArrayList<>(Arrays.asList("/private", "/admin")));
 
     SecurityConstraint securityConstraint3 = new SecurityConstraint();
     securityConstraint3.setMustAuthenticate(true);
     securityConstraint3.setRoles("serviceUserRole,optionsUserRole,anotherUserRole");
-    securityConstraint3.setPaths(new ArrayList(Arrays.asList("/myServices", "/myOptions", "/myOtherURL")));
+    securityConstraint3.setPaths(new ArrayList<>(Arrays.asList("/myServices", "/myOptions", "/myOtherURL")));
 
-    csh.setSecurityConstraints(new ArrayList(Arrays.asList(securityConstraint, securityConstraint2, securityConstraint3)));
+    csh.setSecurityConstraints(new ArrayList<>(Arrays.asList(securityConstraint, securityConstraint2, securityConstraint3)));
     return csh;
   }
 
@@ -1150,4 +1103,5 @@ public class HttpConsumerTest extends HttpConsumerExample {
   protected String createBaseFileName(Object object) {
     return super.createBaseFileName(object) + "-HTTP";
   }
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/HttpsConsumerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/HttpsConsumerTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,10 +31,10 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.Channel;
 import com.adaptris.core.CoreException;
-import com.adaptris.core.PortManager;
 import com.adaptris.core.StandaloneConsumer;
 import com.adaptris.core.http.jetty.HttpConnection.HttpConfigurationProperty;
 import com.adaptris.core.http.jetty.HttpConnection.ServerConnectorProperty;
+import com.adaptris.core.http.jetty.HttpsConnection.SecureRequestCustomizerProperty;
 import com.adaptris.core.http.jetty.HttpsConnection.SslProperty;
 import com.adaptris.core.management.webserver.SecurityHandlerWrapper;
 import com.adaptris.core.security.ConfiguredPrivateKeyPasswordProvider;
@@ -43,14 +43,13 @@ import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.http.legacy.HttpsProduceConnection;
 import com.adaptris.http.legacy.SimpleHttpProducer;
 import com.adaptris.http.legacy.VersionedHttpsProduceConnection;
+import com.adaptris.interlok.junit.scaffolding.util.PortManager;
 import com.adaptris.util.KeyValuePair;
 
 @SuppressWarnings("deprecation")
 public class HttpsConsumerTest extends HttpConsumerTest {
 
   private static final String JETTY_HTTPS_PORT = "jetty.https.port";
-  private static final String URL_TO_POST_TO = "/url/to/post/to";
-  private static final String XML_PAYLOAD = "<root><document>value</document></root>";
 
   @BeforeEach
   public void doKeyStore() throws Exception {
@@ -75,8 +74,7 @@ public class HttpsConsumerTest extends HttpConsumerTest {
       AdaptrisMessage reply = myHttpProducer.request(msg);
       assertEquals(XML_PAYLOAD, reply.getContent());
       doAssertions(mockProducer);
-    }
-    finally {
+    } finally {
       stop(myHttpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -99,14 +97,12 @@ public class HttpsConsumerTest extends HttpConsumerTest {
       msg.addMetadata(CONTENT_TYPE_METADATA_KEY, "text/xml");
       myHttpProducer.setUrl(createProduceDestinationUrl(connection.getPort()));
       start(myHttpProducer);
-      AdaptrisMessage reply = myHttpProducer.request(msg);
+      myHttpProducer.request(msg);
       // SSLv3 context shouldn't be allowed to connect to TLSv1.2 only
       fail();
-    }
-    catch (CoreException expected) {
+    } catch (CoreException expected) {
 
-    }
-    finally {
+    } finally {
       stop(myHttpProducer);
       channel.requestClose();
       PortManager.release(connection.getPort());
@@ -124,8 +120,7 @@ public class HttpsConsumerTest extends HttpConsumerTest {
     connection.getSslProperties().add(new KeyValuePair(HttpsConnection.SslProperty.KeyStoreType.name(), "JCEKS"));
     connection.getSslProperties().add(new KeyValuePair(HttpsConnection.SslProperty.TrustStorePassword.name(), "password"));
     connection.getSslProperties().add(new KeyValuePair(HttpsConnection.SslProperty.TrustStoreType.name(), "JKS"));
-    connection.getSslProperties()
-        .add(new KeyValuePair(HttpsConnection.SslProperty.TrustStorePath.name(), "/path/to/trust/keystore"));
+    connection.getSslProperties().add(new KeyValuePair(HttpsConnection.SslProperty.TrustStorePath.name(), "/path/to/trust/keystore"));
     StandaloneConsumer result = new StandaloneConsumer(connection, JettyHelper.createConsumer(URL_TO_POST_TO));
     return result;
   }
@@ -139,8 +134,8 @@ public class HttpsConsumerTest extends HttpConsumerTest {
     SimpleHttpProducer p = new SimpleHttpProducer();
     https.setKeystore(PROPERTIES.getProperty(JunitSecurityHelper.KEYSTORE_URL));
     https.setAlwaysTrust(true);
-    https.setPrivateKeyPasswordProvider(new ConfiguredPrivateKeyPasswordProvider(PROPERTIES
-        .getProperty(JunitSecurityHelper.SECURITY_PASSWORD)));
+    https.setPrivateKeyPasswordProvider(
+        new ConfiguredPrivateKeyPasswordProvider(PROPERTIES.getProperty(JunitSecurityHelper.SECURITY_PASSWORD)));
     https.setKeystorePassword(PROPERTIES.getProperty(JunitSecurityHelper.SECURITY_PASSWORD));
     p.registerConnection(https);
     p.setContentTypeKey("content.type");
@@ -166,11 +161,9 @@ public class HttpsConsumerTest extends HttpConsumerTest {
     https.getSslProperties().add(new KeyValuePair(SslProperty.KeyStorePassword.name(), PROPERTIES.getProperty(SECURITY_PASSWORD)));
     https.getSslProperties().add(new KeyValuePair(SslProperty.KeyStorePath.name(), PROPERTIES.getProperty(KEYSTORE_PATH)));
     https.getSslProperties().add(new KeyValuePair(SslProperty.KeyStoreType.name(), PROPERTIES.getProperty(KEYSTORE_TYPE)));
-    https.getSslProperties()
-        .add(new KeyValuePair(SslProperty.KeyManagerPassword.name(), PROPERTIES.getProperty(SECURITY_PASSWORD)));
+    https.getSslProperties().add(new KeyValuePair(SslProperty.KeyManagerPassword.name(), PROPERTIES.getProperty(SECURITY_PASSWORD)));
 
-    https.getSslProperties()
-        .add(new KeyValuePair(SslProperty.TrustStorePassword.name(), PROPERTIES.getProperty(SECURITY_PASSWORD)));
+    https.getSslProperties().add(new KeyValuePair(SslProperty.TrustStorePassword.name(), PROPERTIES.getProperty(SECURITY_PASSWORD)));
     https.getSslProperties().add(new KeyValuePair(SslProperty.TrustStoreType.name(), PROPERTIES.getProperty(KEYSTORE_TYPE)));
     https.getSslProperties().add(new KeyValuePair(SslProperty.TrustStorePath.name(), PROPERTIES.getProperty(KEYSTORE_PATH)));
 
@@ -178,6 +171,8 @@ public class HttpsConsumerTest extends HttpConsumerTest {
     https.getHttpConfiguration().add(new KeyValuePair(HttpConfigurationProperty.OutputBufferSize.name(), "8192"));
     https.getHttpConfiguration().add(new KeyValuePair(HttpConfigurationProperty.SendServerVersion.name(), "false"));
     https.getHttpConfiguration().add(new KeyValuePair(HttpConfigurationProperty.SendDateHeader.name(), "false"));
+    https.getSecureRequestCustomizerProperties().add(new KeyValuePair(SecureRequestCustomizerProperty.SniRequired.name(), "false"));
+    https.getSecureRequestCustomizerProperties().add(new KeyValuePair(SecureRequestCustomizerProperty.SniHostCheck.name(), "false"));
 
     if (sh != null) {
       https.setSecurityHandler(sh);

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/JettyLoginProxyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/JettyLoginProxyTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
 
 import javax.security.auth.Subject;
 import javax.servlet.ServletRequest;
@@ -30,6 +32,8 @@ import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.DefaultUserIdentity;
 import org.eclipse.jetty.security.IdentityService;
+import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.UserPrincipal;
 import org.eclipse.jetty.server.UserIdentity;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -142,9 +146,9 @@ public class JettyLoginProxyTest {
     }
 
     @Override
-    protected String[] loadRoleInfo(UserPrincipal user) {
+    protected List<RolePrincipal> loadRoleInfo(UserPrincipal user) {
       // Never called since we override all the LoginService imps
-      return new String[0];
+      return Collections.emptyList();
     }
 
     @Override
@@ -166,14 +170,6 @@ public class JettyLoginProxyTest {
     @Override
     public String getName() {
       return username;
-    }
-
-    public boolean authenticate(KnownUser user) {
-      return true;
-    }
-
-    public boolean checkCredentials(Object credentials) {
-        return true;
     }
 
   }

--- a/interlok-core/src/test/java/com/adaptris/core/management/jetty/JettyMgmtComponentTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/management/jetty/JettyMgmtComponentTest.java
@@ -18,6 +18,7 @@ public class JettyMgmtComponentTest {
 
   private static final Duration MAX_STARTUP_WAIT = Duration.ofSeconds(5);
   private static final Duration STARTUP_POLL = Duration.ofMillis(100);
+
   @Test
   public void testFromProperties() throws Exception {
     JettyServerComponent jetty = new JettyServerComponent();
@@ -98,7 +99,6 @@ public class JettyMgmtComponentTest {
   @Test
   public void testFailsafe() throws Exception {
     JettyServerComponent jetty = new JettyServerComponent();
-    String xmlFile = BaseCase.PROPERTIES.getProperty(JETTY_MGMT_XML);
     int portForServer = PortManager.nextUnusedPort(18080);
     try {
       Properties jettyConfig = new Properties();
@@ -119,7 +119,6 @@ public class JettyMgmtComponentTest {
   @Test
   public void testFailsafe_WithOverrideDescriptor() throws Exception {
     JettyServerComponent jetty = new JettyServerComponent();
-    String xmlFile = BaseCase.PROPERTIES.getProperty(JETTY_MGMT_XML);
     int portForServer = PortManager.nextUnusedPort(18080);
     try {
       Properties jettyConfig = new Properties();
@@ -144,7 +143,7 @@ public class JettyMgmtComponentTest {
         c.destroy();
       }
     } catch (Exception e) {
-
     }
   }
+
 }

--- a/interlok-core/src/test/resources/jetty-configure.dtd
+++ b/interlok-core/src/test/resources/jetty-configure.dtd
@@ -15,22 +15,22 @@ Values themselves may be configured objects that are created with the
 
 Values are matched to arguments on a best effort approach, but types
 my be specified if a match is not achieved.
-
 -->
 
 <!ENTITY % CONFIG "Set|Get|Put|Call|New|Ref|Array|Map|Property">
 <!ENTITY % VALUE "#PCDATA|Get|Call|New|Ref|Array|Map|SystemProperty|Env|Property">
-
-<!ENTITY % TYPEATTR "type CDATA #IMPLIED " > <!-- String|Character|Short|Byte|Integer|Long|Boolean|Float|Double|char|short|byte|int|long|boolean|float|double|URL|InetAddress|InetAddrPort| #classname -->
-<!ENTITY % IMPLIEDCLASSATTR "class CDATA #IMPLIED" >
-<!ENTITY % CLASSATTR "class CDATA #REQUIRED" >
-<!ENTITY % NAMEATTR "name CDATA #REQUIRED" >
-<!ENTITY % IMPLIEDNAMEATTR "name CDATA #IMPLIED" >
-<!ENTITY % DEFAULTATTR "default CDATA #IMPLIED" >
-<!ENTITY % IDATTR "id ID #IMPLIED" >
-<!ENTITY % REFATTR "refid CDATA #IMPLIED" >
-<!ENTITY % REQUIREDIDATTR "id ID #REQUIRED" >
-
+<!ENTITY % TYPE_ATTR "type CDATA #IMPLIED " >
+<!ENTITY % CLASS_ATTR "class CDATA #IMPLIED" >
+<!ENTITY % NAME_ATTR_REQUIRED "name CDATA #REQUIRED" >
+<!ENTITY % NAME_ATTR "name CDATA #IMPLIED" >
+<!ENTITY % PROPERTY_ATTR "property CDATA #IMPLIED" >
+<!ENTITY % DEPRECATED_ATTR "deprecated CDATA #IMPLIED" >
+<!ENTITY % DEFAULT_ATTR "default CDATA #IMPLIED" >
+<!ENTITY % ID_ATTR "id ID #IMPLIED" >
+<!ENTITY % ARG_ATTR "arg CDATA #IMPLIED" >
+<!ENTITY % ITEM_ATTR "item CDATA #IMPLIED" >
+<!ENTITY % REF_ATTR "refid CDATA #IMPLIED" >
+<!ENTITY % ID_ATTR_REQUIRED "id ID #REQUIRED" >
 
 <!--
 Configure Element.
@@ -39,8 +39,8 @@ can be configured:
 
     <Configure class="com.acme.MyClass"> ... </Configure>
 -->
-<!ELEMENT Configure (Arg*,(%CONFIG;)*) >
-<!ATTLIST Configure %IMPLIEDCLASSATTR; %IDATTR; >
+<!ELEMENT Configure (Id?,Class?,Arg*,(%CONFIG;)*) >
+<!ATTLIST Configure %ID_ATTR; %CLASS_ATTR; >
 
 
 <!--
@@ -49,6 +49,7 @@ This element maps to a call to a setter method or field on the current object.
 The name and optional type attributes are used to select the setter
 method. If the name given is xxx, then a setXxx method is used, or
 the xxx field is used of setXxx cannot be found.
+
 A Set element can contain value text and/or the value objects returned
 by other elements such as Call, New, SystemProperty, etc.
 If no value type is specified, then white
@@ -56,10 +57,15 @@ space is trimmed out of the value. If it contains multiple value
 elements they are added as strings before being converted to any
 specified type.
 
+If the property attribute is set to a property name, then the set is
+performed only if the property has a non null value. If the Set element
+contains no value then the the property attribute value is used as the set
+value.
+
 A Set with a class attribute is treated as a static set method invocation.
 -->
 <!ELEMENT Set (%VALUE;)* >
-<!ATTLIST Set %NAMEATTR; %TYPEATTR; %IMPLIEDCLASSATTR; >
+<!ATTLIST Set %ID_ATTR; %CLASS_ATTR; %NAME_ATTR_REQUIRED; %TYPE_ATTR; %PROPERTY_ATTR;>
 
 
 <!--
@@ -73,8 +79,8 @@ which act on the object returned by the get call.
 
 A Get with a class attribute is treated as a static get method or field.
 -->
-<!ELEMENT Get (%CONFIG;)* >
-<!ATTLIST Get %NAMEATTR; %IMPLIEDCLASSATTR; %IDATTR; >
+<!ELEMENT Get (Id?,Name?,Class?,(%CONFIG;)*) >
+<!ATTLIST Get %ID_ATTR; %NAME_ATTR; %CLASS_ATTR; >
 
 
 <!--
@@ -91,7 +97,49 @@ elements they are added as strings before being converted to any
 specified type.
 -->
 <!ELEMENT Put (%VALUE;)* >
-<!ATTLIST Put %NAMEATTR; %TYPEATTR; >
+<!ATTLIST Put %NAME_ATTR_REQUIRED; %TYPE_ATTR; >
+
+
+<!--
+Id Element.
+This element is the equivalent of the id attribute.
+-->
+<!ELEMENT Id (%VALUE;)* >
+
+
+<!--
+Name element.
+This element is the equivalent of the name attribute.
+-->
+<!ELEMENT Name (%VALUE;)* >
+
+
+<!--
+Deprecated element.
+This element is the equivalent of the deprecated attribute.
+-->
+<!ELEMENT Deprecated (%VALUE;)* >
+
+
+<!--
+Default element.
+This element is the equivalent of the default attribute.
+-->
+<!ELEMENT Default (%VALUE;)* >
+
+
+<!--
+Class element.
+This element is the equivalent of the class attribute.
+-->
+<!ELEMENT Class (%VALUE;)* >
+
+
+<!--
+Type element.
+This element is the equivalent of the type attribute.
+-->
+<!ELEMENT Type (%VALUE;)* >
 
 
 <!--
@@ -115,14 +163,14 @@ This is equivalent to:
 
 A Call with a class attribute is treated as a static call.
 -->
-<!ELEMENT Call (Arg*,(%CONFIG;)*) >
-<!ATTLIST Call %NAMEATTR; %IMPLIEDCLASSATTR; %IDATTR; >
+<!ELEMENT Call (Id?,Name?,Class?,Arg*,(%CONFIG;)*) >
+<!ATTLIST Call %ID_ATTR; %NAME_ATTR; %CLASS_ATTR; %ARG_ATTR; >
 
 
 <!--
 Arg Element.
-This element defines a positional or optional named argument for the 
-Call and New elements. The optional type attribute can force the type 
+This element defines a positional or optional named argument for the
+Call and New elements. The optional type attribute can force the type
 of the value.
 
 An Arg element can contain value text and/or value elements such as Call,
@@ -132,13 +180,13 @@ elements they are added as strings before being converted to any
 specified type.
 -->
 <!ELEMENT Arg (%VALUE;)* >
-<!ATTLIST Arg %TYPEATTR; %IMPLIEDNAMEATTR; >
+<!ATTLIST Arg %NAME_ATTR; %TYPE_ATTR; >
 
 
 <!--
 New Element.
 This element allows the creation of a new object as part of a
-value for elements such as Set, Put, Arg, etc. The class attribute 
+value for elements such as Set, Put, Arg, etc. The class attribute
 determines the type of the new object and the contained Arg elements
 are used to select the constructor for the new object.
 
@@ -156,13 +204,13 @@ This is equivalent to:
  Object o = new com.acme.MyClass("value1");
  o.setTest("Value2");
 -->
-<!ELEMENT New (Arg*,(%CONFIG;)*) >
-<!ATTLIST New %CLASSATTR; %IDATTR;>
+<!ELEMENT New (Id?,Class?,Arg*,(%CONFIG;)*) >
+<!ATTLIST New %ID_ATTR; %CLASS_ATTR; %ARG_ATTR; >
 
 
 <!--
 Ref Element.
-This element allows a previously created object to be referenced by id.  The 
+This element allows a previously created object to be referenced by id.  The
 attribute refid is used to specify the id of another object (the attribute id can
 also be used, but it's use is deprecated).
 A Ref element can contain a sequence of elements such as Set, Put, Call, etc.
@@ -172,8 +220,8 @@ which act on the referenced object.
    <Set name="Test">Value2</Set>
  </New>
 -->
-<!ELEMENT Ref (%CONFIG;)* >
-<!ATTLIST Ref %IDATTR; %REFATTR;>
+<!ELEMENT Ref (Id?,(%CONFIG;)*) >
+<!ATTLIST Ref %ID_ATTR; %REF_ATTR;>
 
 
 <!--
@@ -191,8 +239,8 @@ are used for each element of the array:
 This is equivalent to:
  String[] a = new String[] { "value0", new String("value1") };
 -->
-<!ELEMENT Array (Item*) >
-<!ATTLIST Array %TYPEATTR; %IDATTR; >
+<!ELEMENT Array (Id?,Type?,Item*) >
+<!ATTLIST Array %ID_ATTR; %TYPE_ATTR; %ITEM_ATTR; >
 
 
 <!--
@@ -213,8 +261,8 @@ This is equivalent to:
  Map m = new HashMap();
  m.put("keyName", new String("value1"));
 -->
-<!ELEMENT Map (Entry*) >
-<!ATTLIST Map %IDATTR; >
+<!ELEMENT Map (Id?,Class?,Entry*) >
+<!ATTLIST Map %ID_ATTR; %CLASS_ATTR; >
 <!ELEMENT Entry (Item,Item) >
 
 
@@ -230,7 +278,7 @@ If it contains multiple value elements they are added as strings
 before being converted to any specified type.
 -->
 <!ELEMENT Item (%VALUE;)* >
-<!ATTLIST Item %TYPEATTR; %IDATTR; >
+<!ATTLIST Item %ID_ATTR; %TYPE_ATTR; >
 
 
 <!--
@@ -238,7 +286,7 @@ System Property Element.
 This element allows JVM System properties to be retrieved as
 part of the value of elements such as Set, Put, Arg, etc.
 The name attribute specifies the property name and the optional
-default argument provides a default value.
+default attribute provides a default value.
 
  <SystemProperty name="Test" default="value" />
 
@@ -246,8 +294,8 @@ This is equivalent to:
 
  System.getProperty("Test","value");
 -->
-<!ELEMENT SystemProperty EMPTY >
-<!ATTLIST SystemProperty %NAMEATTR; %DEFAULTATTR; %IDATTR; >
+<!ELEMENT SystemProperty (Id?,Name?,Deprecated*,Default?) >
+<!ATTLIST SystemProperty %ID_ATTR; %NAME_ATTR; %DEPRECATED_ATTR; %DEFAULT_ATTR; >
 
 
 <!--
@@ -255,7 +303,7 @@ Environment variable Element.
 This element allows OS Environment variables to be retrieved as
 part of the value of elements such as Set, Put, Arg, etc.
 The name attribute specifies the env variable name and the optional
-default argument provides a default value.
+default attribute provides a default value.
 
  <Env name="Test" default="value" />
 
@@ -263,26 +311,16 @@ This is equivalent to:
 
  String v=System.getEnv("Test");
  if (v==null) v="value";
-
 -->
-<!ELEMENT Env EMPTY >
-<!ATTLIST Env %NAMEATTR; %DEFAULTATTR; %IDATTR; >
+<!ELEMENT Env (Id?,Name?,Deprecated*,Default?) >
+<!ATTLIST Env %ID_ATTR; %NAME_ATTR; %DEPRECATED_ATTR; %DEFAULT_ATTR; >
 
 
 <!--
 Property Element.
 This element allows arbitrary properties to be retrieved by name.
 The name attribute specifies the property name and the optional
-default argument provides a default value.
-
-A Property element can contain a sequence of elements such as Set, Put, Call, etc.
-which act on the retrieved object:
-
- <Property name="Server">
-   <Call id="jdbcIdMgr" name="getAttribute">
-     <Arg>jdbcIdMgr</Arg>
-   </Call>
- </Property>
+default attribute provides a default value.
 -->
-<!ELEMENT Property (%CONFIG;)* >
-<!ATTLIST Property %NAMEATTR; %DEFAULTATTR; %IDATTR; >
+<!ELEMENT Property (Id?,Name?,Deprecated*,Default?) >
+<!ATTLIST Property %ID_ATTR; %NAME_ATTR; %DEPRECATED_ATTR; %DEFAULT_ATTR; >

--- a/interlok-core/src/test/resources/jetty/jetty.xml
+++ b/interlok-core/src/test/resources/jetty/jetty.xml
@@ -1,10 +1,39 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_10_0.dtd">
+
+<!-- =============================================================== -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- https://www.eclipse.org/jetty/documentation/current/            -->
+<!--                                                                 -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
+<!--                                                                 -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
+<!-- =============================================================== -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
+  <!-- =========================================================== -->
+  <!-- Get the platform mbean server                               -->
+  <!-- =========================================================== -->
   <Call id="MBeanServer" class="java.lang.management.ManagementFactory"
     name="getPlatformMBeanServer" />
 
+  <!-- =========================================================== -->
+  <!-- Initialize the Jetty MBean container -->
+  <!-- =========================================================== -->
   <Call name="addBean">
     <Arg>
       <New id="MBeanContainer" class="org.eclipse.jetty.jmx.MBeanContainer">
@@ -15,12 +44,16 @@
     </Arg>
   </Call>
 
+  <!-- Add the static log -->
   <Call name="addBean">
     <Arg>
       <New class="org.eclipse.jetty.util.log.Log" />
     </Arg>
   </Call>
 
+  <!-- =========================================================== -->
+  <!-- Server Thread Pool                                          -->
+  <!-- =========================================================== -->
   <Get name="ThreadPool">
      <Set name="minThreads" type="int">20</Set>
      <Set name="maxThreads" type="int">200</Set>
@@ -28,50 +61,68 @@
      <Set name="detailedDump">false</Set>
   </Get>
 
+    <!-- =========================================================== -->
+    <!-- Http Configuration.                                         -->
+    <!-- This is a common configuration instance used by all         -->
+    <!-- connectors that can carry HTTP semantics (HTTP, HTTPS, etc.)-->
+    <!-- It configures the non wire protocol aspects of the HTTP     -->
+    <!-- semantic.                                                   -->
+    <!--                                                             -->
+    <!-- This configuration is only defined here and is used by      -->
+    <!-- reference from other XML files such as jetty-http.xml,      -->
+    <!-- jetty-https.xml and other configuration files which         -->
+    <!-- instantiate the connectors.                                 -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.server.HttpConfiguration       -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
     <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
-      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
-      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
-      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
-      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
-      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
-      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
-      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="false" /></Set>
-      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="secureScheme" property="jetty.httpConfig.secureScheme"/>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" default="32768" /></Set>
+      <Set name="outputAggregationSize" property="jetty.httpConfig.outputAggregationSize" />
+      <Set name="requestHeaderSize" property="jetty.httpConfig.requestHeaderSize"/>
+      <Set name="responseHeaderSize" property="jetty.httpConfig.responseHeaderSize"/>
+      <Set name="sendServerVersion" property="jetty.httpConfig.sendServerVersion"/>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" default="false"/></Set>
       <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
-      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <Set name="delayDispatchUntilContent" property="jetty.httpConfig.delayDispatchUntilContent"/>
       <Set name="maxErrorDispatches"><Property name="jetty.httpConfig.maxErrorDispatches" default="10"/></Set>
-      <Set name="blockingTimeout"><Property name="jetty.httpConfig.blockingTimeout" default="-1"/></Set>
+<!--       <Set name="blockingTimeout"><Property name="jetty.httpConfig.blockingTimeout" default="-1"/></Set> -->
       <Set name="persistentConnectionsEnabled"><Property name="jetty.httpConfig.persistentConnectionsEnabled" default="true"/></Set>
+      <Set name="httpCompliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230"/></Arg></Call></Set>
     </New>
 
   <Call name="addConnector">
     <Arg>
       <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
         <Arg name="server"><Ref refid="Server" /></Arg>
-        <Arg name="acceptors" type="int"><Property name="jetty.http.acceptors" deprecated="http.acceptors" default="-1"/></Arg>
-        <Arg name="selectors" type="int"><Property name="jetty.http.selectors" deprecated="http.selectors" default="-1"/></Arg>
+        <Arg name="acceptors" type="int"><Property name="jetty.http.acceptors" default="-1"/></Arg>
+        <Arg name="selectors" type="int"><Property name="jetty.http.selectors" default="-1"/></Arg>
         <Arg name="factories">
           <Array type="org.eclipse.jetty.server.ConnectionFactory">
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
                 <Arg name="config"><Ref refid="httpConfig" /></Arg>
-                <Arg name="compliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230"/></Arg></Call></Arg>
               </New>
             </Item>
           </Array>
         </Arg>
-        <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port" default="8080" /></Set>
-        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
-        <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
+        <Set name="host"><Property name="jetty.http.host" /></Set>
+        <Set name="port"><Property name="jetty.http.port" default="8080" /></Set>
+        <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" default="30000"/></Set>
+        <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" default="0"/></Set>
+        <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" default="0"/></Set>
       </New>
     </Arg>
   </Call>
 
-  <Set name="stopAtShutdown">true</Set>
-  <Set name="stopTimeout">1000</Set>
-  <Set name="dumpAfterStart">false</Set>
-  <Set name="dumpBeforeStop">false</Set>
+  <!-- =========================================================== -->
+  <!-- extra server options                                        -->
+  <!-- =========================================================== -->
+  <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+  <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
+  <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" default="false"/></Set>
+  <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" default="false"/></Set>
 
 </Configure>


### PR DESCRIPTION
## Motivation

Upgrade Interlok to Jetty 10

## Modification

- Mostly upgraded dependencies and the jetty xml files
- Remove the RewriteHandler to forward the old UI context /adapter-web-ui to /interlok
- JettyServerManager reconfigureWar now set the rootwar classloader with the current classloader to be able to load jetty's classes.
- Upgrade all the jetty related classes to fix compile issues.
- Use lombok in some of the jetty classes
- Fix tests.
- Update javadocs.
- Remove some warnings.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

Interlok is using jetty 10.
No visible impact on the end user.

## Testing

This PR build should pass.
Use the jars from this branch and the right jetty 10 dependencies.

```
  interlokRuntime ("org.eclipse.jetty:jetty-alpn-client:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-alpn-java-client:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-alpn-server:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-alpn-java-server:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-annotations:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-client:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-deploy:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-http:$jettyVersion") // implicit dependency
  interlokRuntime ("org.eclipse.jetty:jetty-io:$jettyVersion") // implicit dependency
  interlokRuntime ("org.eclipse.jetty:jetty-jaspi:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-jmx:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-jndi:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-plus:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-quickstart:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-rewrite:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-security:$jettyVersion") // implicit dependency
  interlokRuntime ("org.eclipse.jetty:jetty-server:$jettyVersion") // implicit dependency
  interlokRuntime ("org.eclipse.jetty:jetty-servlet:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-servlets:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-util-ajax:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-util:$jettyVersion") // implicit dependency
  interlokRuntime ("org.eclipse.jetty:jetty-webapp:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty:jetty-xml:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty.http2:http2-hpack:$jettyVersion") // implicit dependency
  interlokRuntime ("org.eclipse.jetty.http2:http2-common:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty.http2:http2-server:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty.http2:http2-client:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty.websocket:websocket-javax-server:$jettyVersion")
  interlokRuntime ("org.eclipse.jetty.websocket:websocket-javax-client:$jettyVersion")
```

Create some jetty consumer/producer workflows and test that it works fine.

You can use this:

```xml
<adapter>
  <unique-id>MyInterlokInstance</unique-id>
  <start-up-event-imp>com.adaptris.core.event.StandardAdapterStartUpEvent</start-up-event-imp>
  <heartbeat-event-imp>com.adaptris.core.HeartbeatEvent</heartbeat-event-imp>
  <shared-components>
    <connections/>
    <services/>
  </shared-components>
  <event-handler class="default-event-handler">
    <unique-id>DefaultEventHandler</unique-id>
    <connection class="null-connection">
      <unique-id>tender-mayer</unique-id>
    </connection>
    <producer class="null-message-producer">
      <unique-id>suspicious-curran</unique-id>
    </producer>
  </event-handler>
  <heartbeat-event-interval>
    <unit>MINUTES</unit>
    <interval>60</interval>
  </heartbeat-event-interval>
  <message-error-handler class="null-processing-exception-handler">
    <unique-id>grave-panini</unique-id>
  </message-error-handler>
  <failed-message-retrier class="no-retries">
    <unique-id>serene-golick</unique-id>
  </failed-message-retrier>
  <channel-list>
    <channel>
      <consume-connection class="jetty-embedded-connection">
        <unique-id>Embedded Jetty Connection</unique-id>
      </consume-connection>
      <produce-connection class="null-connection">
        <unique-id>clever-mclean</unique-id>
      </produce-connection>
      <workflow-list>
        <standard-workflow>
          <consumer class="jetty-message-consumer">
            <unique-id>/subPath/*</unique-id>
            <path>/subPath/*</path>
            <parameter-handler class="jetty-http-parameters-as-metadata"/>
            <header-handler class="jetty-http-ignore-headers"/>
          </consumer>
          <service-collection class="service-list">
            <unique-id>mad-noether</unique-id>
            <services>
              <branching-service-collection>
                <unique-id>HTTP Router</unique-id>
                <services>
                  <jetty-routing-service>
                    <unique-id>Route</unique-id>
                    <route>
                      <service-id>Get All the contacts</service-id>
                      <condition>
                        <url-pattern>^/subPath/contacts$</url-pattern>
                        <method>GET</method>
                      </condition>
                    </route>
                    <default-service-id>NotHandled</default-service-id>
                  </jetty-routing-service>
                  <service-list>
                    <unique-id>Get All the contacts</unique-id>
                    <services>
                      <payload-from-template>
                        <unique-id>agitated-poincare</unique-id>
                        <metadata-tokens/>
                        <template><![CDATA[[{"name":"Smith"}]]]></template>
                      </payload-from-template>
                    </services>
                  </service-list>
                  <service-list>
                    <unique-id>NotHandled</unique-id>
                    <services>
                      <add-metadata-service>
                        <unique-id>Add 400 Response Code</unique-id>
                        <metadata-element>
                          <key>ResponseCode</key>
                          <value>400</value>
                        </metadata-element>
                      </add-metadata-service>
                      <payload-from-template>
                        <unique-id>Add Not Handled Status Message</unique-id>
                        <metadata-tokens/>
                        <template><![CDATA[{"Status" : "Not Handled; please check"}]]></template>
                      </payload-from-template>
                    </services>
                  </service-list>
                </services>
                <first-service-id>Route</first-service-id>
              </branching-service-collection>
              <standalone-producer>
                <unique-id>SendResponse</unique-id>
                <connection class="null-connection">
                  <unique-id>compassionate-feynman</unique-id>
                </connection>
                <producer class="jetty-standard-response-producer">
                  <unique-id>ResponseProducer</unique-id>
                  <status-provider class="http-metadata-status">
                    <code-key>ResponseCode</code-key>
                    <default-status>OK_200</default-status>
                  </status-provider>
                  <response-header-provider class="jetty-no-response-headers"/>
                  <content-type-provider class="http-metadata-content-type-provider">
                    <metadata-key>ResponseContenType</metadata-key>
                    <default-mime-type>application/json</default-mime-type>
                  </content-type-provider>
                  <send-payload>true</send-payload>
                </producer>
              </standalone-producer>
            </services>
          </service-collection>
          <producer class="null-message-producer">
            <unique-id>sharp-clarke</unique-id>
          </producer>
          <unique-id>subPath API</unique-id>
          <message-metrics-interceptor>
            <unique-id>subPath API-MessageMetrics</unique-id>
            <timeslice-duration>
              <unit>MINUTES</unit>
              <interval>5</interval>
            </timeslice-duration>
            <timeslice-history-count>12</timeslice-history-count>
          </message-metrics-interceptor>
          <in-flight-workflow-interceptor>
            <unique-id>subPath API-InFlight</unique-id>
          </in-flight-workflow-interceptor>
        </standard-workflow>
      </workflow-list>
      <unique-id>Simple Contact Manager</unique-id>
      <auto-start>true</auto-start>
    </channel>
    <channel>
      <consume-connection class="jetty-http-connection">
        <unique-id>Embedded Jetty Connection</unique-id>
        <port>8084</port>
        <server-connector-properties/>
        <http-configuration/>
      </consume-connection>
      <produce-connection class="null-connection">
        <unique-id>clever-mclean</unique-id>
      </produce-connection>
      <workflow-list>
        <standard-workflow>
          <consumer class="jetty-message-consumer">
            <unique-id>/subPath/*</unique-id>
            <path>/subPath/*</path>
            <parameter-handler class="jetty-http-parameters-as-metadata"/>
            <header-handler class="jetty-http-ignore-headers"/>
          </consumer>
          <service-collection class="service-list">
            <unique-id>mad-noether</unique-id>
            <services>
              <branching-service-collection>
                <unique-id>HTTP Router</unique-id>
                <services>
                  <jetty-routing-service>
                    <unique-id>Route</unique-id>
                    <route>
                      <service-id>Get All the contacts</service-id>
                      <condition>
                        <url-pattern>^/subPath/contacts$</url-pattern>
                        <method>GET</method>
                      </condition>
                    </route>
                    <default-service-id>NotHandled</default-service-id>
                  </jetty-routing-service>
                  <service-list>
                    <unique-id>Get All the contacts</unique-id>
                    <services>
                      <payload-from-template>
                        <unique-id>agitated-poincare</unique-id>
                        <metadata-tokens/>
                        <template><![CDATA[[{"name":"Smith2"}]]]></template>
                      </payload-from-template>
                    </services>
                  </service-list>
                  <service-list>
                    <unique-id>NotHandled</unique-id>
                    <services>
                      <add-metadata-service>
                        <unique-id>Add 400 Response Code</unique-id>
                        <metadata-element>
                          <key>ResponseCode</key>
                          <value>400</value>
                        </metadata-element>
                      </add-metadata-service>
                      <payload-from-template>
                        <unique-id>Add Not Handled Status Message</unique-id>
                        <metadata-tokens/>
                        <template><![CDATA[{"Status" : "Not Handled; please check"}]]></template>
                      </payload-from-template>
                    </services>
                  </service-list>
                </services>
                <first-service-id>Route</first-service-id>
              </branching-service-collection>
              <standalone-producer>
                <unique-id>SendResponse</unique-id>
                <connection class="null-connection">
                  <unique-id>compassionate-feynman</unique-id>
                </connection>
                <producer class="jetty-standard-response-producer">
                  <unique-id>ResponseProducer</unique-id>
                  <status-provider class="http-metadata-status">
                    <code-key>ResponseCode</code-key>
                    <default-status>OK_200</default-status>
                  </status-provider>
                  <response-header-provider class="jetty-no-response-headers"/>
                  <content-type-provider class="http-metadata-content-type-provider">
                    <metadata-key>ResponseContenType</metadata-key>
                    <default-mime-type>application/json</default-mime-type>
                  </content-type-provider>
                  <send-payload>true</send-payload>
                </producer>
              </standalone-producer>
            </services>
          </service-collection>
          <producer class="null-message-producer">
            <unique-id>sharp-clarke</unique-id>
          </producer>
          <unique-id>subPath API</unique-id>
          <message-metrics-interceptor>
            <unique-id>subPath API-MessageMetrics</unique-id>
            <timeslice-duration>
              <unit>MINUTES</unit>
              <interval>5</interval>
            </timeslice-duration>
            <timeslice-history-count>12</timeslice-history-count>
          </message-metrics-interceptor>
          <in-flight-workflow-interceptor>
            <unique-id>subPath API-InFlight</unique-id>
          </in-flight-workflow-interceptor>
        </standard-workflow>
      </workflow-list>
      <unique-id>Simple Contact Manager 2</unique-id>
      <auto-start>true</auto-start>
    </channel>
  </channel-list>
  <message-error-digester class="standard-message-error-digester">
    <unique-id>ErrorDigest</unique-id>
    <digest-max-size>100</digest-max-size>
  </message-error-digester>
</adapter>
```
And test it with `http://localhost:8080/subPath/contacts` and `http://localhost:8084/subPath/contacts`