### PR TITLE
Adding a condition to check which JDBC vendor is set and only run the…

### DIFF
--- a/interlok-core/src/test/java/com/adaptris/jdbc/JdbcStoredProcedureTest.java
+++ b/interlok-core/src/test/java/com/adaptris/jdbc/JdbcStoredProcedureTest.java
@@ -37,6 +37,9 @@ import com.adaptris.core.util.JdbcUtil;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.junit.scaffolding.BaseCase;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class JdbcStoredProcedureTest extends BaseCase {
 
   private static final String JDBC_STOREDPROC_TESTS_ENABLED = "jdbc.storedproc.tests.enabled";
@@ -50,6 +53,10 @@ public class JdbcStoredProcedureTest extends BaseCase {
   private Connection connection;
 
   private CallableStatementCreator statementCreator;
+  
+  @Getter
+  @Setter
+  private boolean runMultiResultSetTest;
 
   private StoredProcedure storedProcedure;
 
@@ -66,10 +73,14 @@ public class JdbcStoredProcedureTest extends BaseCase {
 
     LifecycleHelper.initAndStart(jdbcConnection);
 
-    if (PROPERTIES.getProperty(JDBC_VENDOR).equals("mysql"))
+    if (PROPERTIES.getProperty(JDBC_VENDOR).equals("mysql")) {
       statementCreator = new MysqlStatementCreator();
-    else if (PROPERTIES.getProperty(JDBC_VENDOR).equals("sqlserver"))
+      setRunMultiResultSetTest(true);
+    }
+    else if (PROPERTIES.getProperty(JDBC_VENDOR).equals("sqlserver")) {
       statementCreator = new SqlServerStatementCreator();
+      setRunMultiResultSetTest(false);
+    }
     else
       fail("Vendor for JDBC tests unknown: " + PROPERTIES.getProperty(JDBC_VENDOR));
 
@@ -380,11 +391,13 @@ public class JdbcStoredProcedureTest extends BaseCase {
 
     JdbcResult procedureResult = storedProcedure.execute();
     assertEquals(true, procedureResult.isHasResultSet());
-
-    assertEquals(2, procedureResult.countResultSets());
-
     assertEquals(5, countRows(procedureResult.getResultSet(0).getRows()));
-    assertEquals(5, countRows(procedureResult.getResultSet(1).getRows()));
+    
+    if(getRunMultiResultSetTest()) {
+      assertEquals(2, procedureResult.countResultSets());
+      System.out.println("hi");
+      assertEquals(5, countRows(procedureResult.getResultSet(1).getRows()));
+    }
   }
 
   @Test
@@ -396,11 +409,12 @@ public class JdbcStoredProcedureTest extends BaseCase {
 
     JdbcResult procedureResult = storedProcedure.execute();
     assertEquals(true, procedureResult.isHasResultSet());
-
-    assertEquals(2, procedureResult.countResultSets());
-
     assertEquals(5, countRows(procedureResult.getResultSet(0).getRows()));
-    assertEquals(5, countRows(procedureResult.getResultSet(1).getRows()));
+    
+    if(getRunMultiResultSetTest()) {
+      assertEquals(2, procedureResult.countResultSets());
+      assertEquals(5, countRows(procedureResult.getResultSet(1).getRows()));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Motivation

fixes https://github.com/adaptris/interlok/issues/866

This is due to the fact that the 'sqlserver' vendor does not support multiple open result sets. Page can be found here: https://learn.microsoft.com/en-us/sql/connect/jdbc/reference/supportsmultipleopenresults-method-sqlserverdatabasemetadata?view=sql-server-ver16

## Modification

Added conditions to the two unit tests so they will check which vendor is being used and run the tests accordingly.

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [n/a] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [n/a] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

No end result for the user, the change is only to how the unit tests are run.

## Testing

Run the two modified unit tests:
JdbcStoredProcedureTest.java
StoredProcedureProducerTest.java

try with both the 'mysql' and then the 'sqlserver' vendors and confirm all the unit tests still run. How to configure the vendors for running these tests is defined in this repo's readme and also some information in the issue: https://github.com/adaptris/interlok/issues/866
