### PR TITLE
Interlok 4121 fs helper improvements

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
@@ -43,17 +43,30 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * File system implementation of <code>AdaptrisMessageConsumer</code> based on the <code>com.adaptris.fs</code> package.
  * </p>
  * <p>
- * The configured <code>Destination</code> may return a string in one of two formats
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
  * </p>
  * <ul>
- * <li>If a <code>file</code> based url is used. e.g. file:///c:/path/to/my/directory or file:////path/to/my/directory then the
- * patch is considered to be fully qualified</li>
- * <li>If just a path is returned, then it is considered to be relative to the current working directory. e.g. if /opt/fred is used,
- * and the adapter is installed to /opt/adapter, then the fully qualified name is /opt/adapter/opt/fred.</li>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or 
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
  * </ul>
- * <p>
- * On windows based platforms, you should always use a file based url.
- * </p>
  * <p>
  * Once A file has been consumed from the file-system a standard set of metadata is added to the resulting message;
  * <table>

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -42,6 +42,7 @@ import com.adaptris.interlok.util.FileFilterBuilder;
 public abstract class FsHelper {
 
   private static transient Logger log = LoggerFactory.getLogger(FsHelper.class);
+  private static final String WIN_DRIVE_REGEX = "^[a-zA-Z]{1}$"; //matches an alphabetic character exactly 1 time in the string.
 
   /**
    * Go straight to a {@link File} from a url style string.
@@ -143,9 +144,11 @@ public abstract class FsHelper {
       // nb for some reason, configuredUri.toUrl() doesn't work...
       // return configuredUri.toURL();
       return new URL(configuredUri.toString());
-    }
+    } 
     else {
       if (scheme == null) {
+        return new URL("file:///" + configuredUri.toString());
+      } else if (scheme.matches(WIN_DRIVE_REGEX)) {
         return new URL("file:///" + configuredUri.toString());
       }
       else {

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -89,32 +89,16 @@ public abstract class FsHelper {
   /**
    * Creates a {@link URL} based on the passed destination.
    * <p>
-   * If a {@code scheme} is present and is equal to {@code file} then the URL is deemed to be <strong>absolute</strong> and is used
-   * as is. If the {@code scheme} is null then the URL is considered a {@code "file"} URL, and <strong>relative</strong> to the
-   * current working directory.
+   * Supports URLs with both the {@code file scheme} and without. If you define a directory without any leading slash or 
+   * if it starts with a slash is deemed to be an <strong>absolute</strong> path. If "./" or "../" is used at the start of your definition then
+   * the path is deemed to be <strong>relative</strong> . This is true when using the {@code file scheme} or not.
    * </p>
    * <p>
-   * Note that this method will not convert backslashes into forward slashes, so passing in a string like {@code ..\dir\} will fail
-   * with a URISyntaxException; use {@link #createUrlFromString(String, boolean)} to convert backslashes into forward slashes prior
-   * to processing.
+   * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+   * e.g. 'c://my/path' this is also valid.
    * </p>
-   *
-   * @param s the String to convert to a URL.
-   * @return a new URL
-   * @see #createUrlFromString(String, boolean)
-   * @deprecated use {@link #createUrlFromString(String, boolean)} since 3.0.3
-   */
-  @Deprecated
-  public static URL createUrlFromString(String s) throws IOException, URISyntaxException {
-    return createUrlFromString(s, false);
-  }
-
-  /**
-   * Creates a {@link URL} based on the passed destination.
    * <p>
-   * If a {@code scheme} is present and is equal to {@code file} then the URL is deemed to be <strong>absolute</strong> and is used
-   * as is. If the {@code scheme} is null then the URL is considered a {@code "file"} URL, and <strong>relative</strong> to the
-   * current working directory.
+   * Both / and \ slashes are supported.
    * </p>
    *
    * @param s the string to convert to a URL.
@@ -186,23 +170,6 @@ public abstract class FsHelper {
     }
     return newFile;
   }
-
-  // /**
-  // *
-  // * @param uri the relative <code>URI</code> to process
-  // * @return a <code>file:/// URL</code> based on the current working directory (obtained by
-  // calling
-  // * <code>System.getProperty("user.dir")</code>) plus the passed relative <code>uri</code>
-  // * @throws Exception wrapping any underlying <code>Exception</code>
-  // */
-  // private static URL relativeConfig(URI uri) throws IOException {
-  // String pwd = System.getProperty("user.dir");
-  //
-  // String path = pwd + "/" + uri; // ok even if uri starts with a /
-  // URL result = new URL("file:///" + path);
-  //
-  // return result;
-  // }
 
   private static String backslashToSlash(String url) {
     if (!isEmpty(url)) {

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsProducer.java
@@ -47,7 +47,34 @@ import lombok.NonNull;
 import lombok.Setter;
 
 /**
+ * <p>
  * {@link com.adaptris.core.AdaptrisMessageProducer} implementation that writes to the file system.
+ * </p>
+ * <p>
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
+ * </p>
+ * <ul>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or 
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems The above is above is true plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
+ * </ul>
  *
  * @config fs-producer
  *

--- a/interlok-core/src/main/java/com/adaptris/core/fs/NonDeletingFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/NonDeletingFsConsumer.java
@@ -41,17 +41,30 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * changes.
  * </p>
  * <p>
- * The configured <code>Destination</code> may return a string in one of two formats
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
  * </p>
  * <ul>
- * <li>If a <code>file</code> based url is used. e.g. file:///c:/path/to/my/directory or file:////path/to/my/directory then the
- * patch is considered to be fully qualified</li>
- * <li>If just a path is returned, then it is considered to be relative to the current working directory. e.g. if /opt/fred is used,
- * and the adapter is installed to /opt/adapter, then the fully qualified name is /opt/adapter/opt/fred.</li>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or 
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
  * </ul>
- * <p>
- * On windows based platforms, you should always use a file based url.
- * </p>
  *
  * @config non-deleting-fs-consumer
  *

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsConsumer.java
@@ -38,15 +38,31 @@ import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
  * <p>
  * File system implementation of <code>AdaptrisMessageConsumer</code> with large message support.
  * </p>
- * <ul>
- * <li>If a <code>file</code> based url is used. e.g. file:///c:/path/to/my/directory or file:////path/to/my/directory then the
- * patch is considered to be fully qualified</li>
- * <li>If just a path is returned, then it is considered to be relative to the current working directory. e.g. if /opt/fred is used,
- * and the adapter is installed to /opt/adapter, then the fully qualified name is /opt/adapter/opt/fred.</li>
- * </ul>
  * <p>
- * On windows based platforms, you should always use a file based url.
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
  * </p>
+ * <ul>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or 
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
+ * </ul>
  * <p>
  * Additionally the behaviour of this consumer is subtly different from the standard {@link FsConsumer} :
  * </p>

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsProducer.java
@@ -34,19 +34,31 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * File system implementation of <code>AdaptrisMessageProducer</code> with large message support.
  * </p>
- * *
  * <p>
- * The configured <code>Destination</code> may return a string in one of two formats
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
  * </p>
  * <ul>
- * <li>If a <code>file</code> based url is used. e.g. file:///c:/path/to/my/directory or file:////path/to/my/directory then the
- * patch is considered to be fully qualified</li>
- * <li>If just a path is returned, then it is considered to be relative to the current working directory. e.g. if /opt/fred is used,
- * and the adapter is installed to /opt/adapter, then the fully qualified name is /opt/adapter/opt/fred.</li>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or 
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
  * </ul>
- * <p>
- * On windows based platforms, you should always use a file based url.
- * </p>
  * <p>
  * Additionally the behaviour of this consumer is subtly different from the standard {@link FsProducer} :
  * </p>


### PR DESCRIPTION
Interlok https://adaptris.atlassian.net/browse/INTERLOK-4121

## Motivation
Making sure the util class that handles file io can handle all the required path formats we will throw at it.

## Modification

Adding new logic to createUrlFromString method to also handle absolute paths including a Windows drive letter where no "file" scheme has been defined.
Removing deprecated code and old commented out code.
Updating javadoc comments.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Any classes that call the FsHelper class when creating a url from a string should now support different file path formats such as:
./dir
../dir
dir
/dir
file:///dir
file:///./dir
file:///c:/dir
c:/dir
c:\dir

and so on..

## Testing

Load up a copy of v5 with the latest interlok-core.jar and setup a simple workflow with an FSProducer, or FsConsumer(or a variation of one of these i.e. LargeFsProducer) and test the different combiantion of file paths and have create directories set to true. Then make sure it creates the directories you test and they are created in the expected location.