### PR TITLE
updated removal warnings from <=5.0 to 5.1

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/interlok/types/InterlokMessage.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/types/InterlokMessage.java
@@ -87,7 +87,7 @@ public interface InterlokMessage {
    * {@link #replaceAllMessageHeaders(Map)} instead. instead.
    */
   @Deprecated
-  @Removal(version = "5.0.0")
+  @Removal(version = "5.1.0")
   void setMessageHeaders(Map<String, String> metadata);
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessage.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessage.java
@@ -69,7 +69,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    *             string; since 2.9.3
    */
   @Deprecated
-  @Removal(version="5.0.0")
+  @Removal(version="5.1.0")
   default void setStringPayload(String payload) {
     setContent(payload, null);
   }
@@ -86,7 +86,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 Use {@link #setContent(String, String)}
    */
   @Deprecated
-  @Removal(version="5.0.0")
+  @Removal(version="5.1.0")
   default void setStringPayload(String payload, String charEncoding) {
     setContent(payload, charEncoding);
   }
@@ -104,7 +104,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {{@link #getContent()} instead.
    */
   @Deprecated
-  @Removal(version="5.0.0")
+  @Removal(version="5.1.0")
   default String getStringPayload() {
     return getContent();
   }
@@ -121,7 +121,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {{@link #setContentEncoding(String)} instead.
    */
   @Deprecated
-  @Removal(version="5.0.0")
+  @Removal(version="5.1.0")
   default void setCharEncoding(String charEncoding) {
     setContentEncoding(charEncoding);
   }
@@ -137,7 +137,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {{@link #getContentEncoding()} instead.
    */
   @Deprecated
-  @Removal(version="5.0.0")
+  @Removal(version="5.1.0")
   default String getCharEncoding() {
     return getContentEncoding();
   }
@@ -180,7 +180,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {@link #headersContainsKey(String)} instead.
    */
   @Deprecated
-  @Removal(version="5.0.0")
+  @Removal(version="5.1.0")
   default boolean containsKey(String key) {
     return headersContainsKey(key);
   }
@@ -238,7 +238,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    * instead.
    */
   @Deprecated
-  @Removal(version="5.0")
+  @Removal(version="5.1.0")
   default void setMetadata(Set<MetadataElement> metadata) {
     addMetadata(metadata);
   }
@@ -350,7 +350,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {@link #addObjectHeader(Object, Object)} instead.
    */
   @Deprecated
-  @Removal(version="5.0.0")
+  @Removal(version="5.1.0")
   default void addObjectMetadata(String key, Object object) {
     addObjectHeader(key, object);
   }
@@ -364,7 +364,7 @@ public interface AdaptrisMessage extends InterlokMessage {
    * @deprecated since 3.0.6 use {@link #getObjectHeaders()} instead.
    */
   @Deprecated
-  @Removal(version="5.0.0")
+  @Removal(version="5.1.0")
   default Map getObjectMetadata() {
     return getObjectHeaders();
   }

--- a/interlok-core/src/main/java/com/adaptris/core/ChannelRestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelRestartProduceExceptionHandler.java
@@ -29,8 +29,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @deprecated since 4.2.0
  */
 @Deprecated(since = "4.2.0")
-@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
-@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.1.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.1.0")
 @XStreamAlias("channel-restart-produce-exception-handler")
 public class ChannelRestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/NullProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/NullProduceExceptionHandler.java
@@ -30,8 +30,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @deprecated since 4.2.0
  */
 @Deprecated(since = "4.2.0")
-@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
-@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.1.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.1.0")
 @XStreamAlias("null-produce-exception-handler")
 public class NullProduceExceptionHandler extends ProduceExceptionHandlerImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/ProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ProduceExceptionHandler.java
@@ -29,8 +29,8 @@ import com.adaptris.validation.constraints.ConfigDeprecated;
  * @deprecated since 4.2.0
  */
 @Deprecated(since = "4.2.0")
-@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
-@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.1.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.1.0")
 public interface ProduceExceptionHandler {
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/ProduceExceptionHandlerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ProduceExceptionHandlerImp.java
@@ -33,8 +33,8 @@ import com.adaptris.core.util.ManagedThreadFactory;
  * @deprecated since 4.2.0
  */
 @Deprecated(since = "4.2.0")
-@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
-@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.1.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.1.0")
 public abstract class ProduceExceptionHandlerImp implements ProduceExceptionHandler {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());

--- a/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RestartProduceExceptionHandler.java
@@ -28,8 +28,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @deprecated since 3.10.2
  */
 @Deprecated(since = "3.10.2")
-@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.0.0", groups = Deprecated.class)
-@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.0.0")
+@ConfigDeprecated(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", removalVersion = "5.1.0", groups = Deprecated.class)
+@Removal(message = "If you need restarting capability wrap your producer into a standalone-producer and set restart services on failure.", version = "5.1.0")
 @XStreamAlias("restart-produce-exception-handler")
 public class RestartProduceExceptionHandler extends ProduceExceptionHandlerImp {
 

--- a/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponent.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/ManagementComponent.java
@@ -27,7 +27,7 @@ import com.adaptris.annotation.Removal;
 public interface ManagementComponent {
 
   @Deprecated
-  @Removal(version = "5.0.0", message = "Is ignored, and has no purpose.")
+  @Removal(version = "5.1.0", message = "Is ignored, and has no purpose.")
   default void setClassLoader(ClassLoader classLoader) {
 
   }

--- a/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
+++ b/interlok-core/src/main/java/com/adaptris/core/management/config/ConfigurationCheckRunner.java
@@ -33,7 +33,7 @@ public class ConfigurationCheckRunner {
    *             UnifiedBootstrap is ignored.
    */
   @Deprecated
-  @Removal(version = "4.0.0")
+  @Removal(version = "5.1.0")
   public List<ConfigurationCheckReport> runChecks(BootstrapProperties bootProperties,
       UnifiedBootstrap bootstrap) {
     return runChecks(bootProperties);

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterComponentMBean.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterComponentMBean.java
@@ -104,7 +104,7 @@ public interface AdapterComponentMBean extends BaseComponentMBean {
   String JMX_MSG_ERR_DIGESTER_TYPE = JMX_DOMAIN_NAME + ":type=MessageErrorDigest";
 
   @Deprecated
-  @Removal(version = "5.0")
+  @Removal(version = "5.1.0")
   String JMX_LOG_HANDLER_TYPE = JMX_DOMAIN_NAME + ":type=LogHandler";
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MetadataXpathQuery.java
@@ -34,7 +34,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *
  */
 @Deprecated(since = "4.1.0")
-@Removal(version = "5.0.0",
+@Removal(version = "5.1.0",
     message = "Use ConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.")
 @XStreamAlias("metadata-xpath-query")
 @DisplayOrder(order = {"metadataKey", "xpathMetadataKey"})

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/xpath/MultiItemMetadataXpathQuery.java
@@ -42,7 +42,7 @@ import lombok.Getter;
  *
  */
 @Deprecated(since = "4.1.0")
-@Removal(version = "5.0.0",
+@Removal(version = "5.1.0",
     message = "Use MultiItemConfiguredXpathQuery with %message{metadata} syntax to extract XPath from metadata.")
 @XStreamAlias("multi-item-metadata-xpath-query")
 @DisplayOrder(order = {"metadataKey", "xpathMetadataKey"})

--- a/interlok-core/src/main/java/com/adaptris/util/XmlUtils.java
+++ b/interlok-core/src/main/java/com/adaptris/util/XmlUtils.java
@@ -88,7 +88,7 @@ public class XmlUtils {
    * @deprecated URIResolver does nothing so use {@link #XmlUtils(EntityResolver)} instead.
    */
   @Deprecated
-  @Removal(version = "4.0.0")
+  @Removal(version = "5.1.0")
   public XmlUtils(EntityResolver er, URIResolver ur) {
     this(er);
   }
@@ -98,7 +98,7 @@ public class XmlUtils {
    *             instead.
    */
   @Deprecated
-  @Removal(version = "4.0.0")
+  @Removal(version = "5.1.0")
   public XmlUtils(EntityResolver er, URIResolver ur, NamespaceContext ctx) {
     this(er, ctx, DocumentBuilderFactory.newInstance());
   }
@@ -108,7 +108,7 @@ public class XmlUtils {
    *             instead.
    */
   @Deprecated
-  @Removal(version = "4.0.0")
+  @Removal(version = "5.1.0")
   public XmlUtils(EntityResolver er, URIResolver ur, NamespaceContext ctx, DocumentBuilderFactory dbf) {
     this(er, ctx, dbf);
   }

--- a/interlok-core/src/test/java/com/adaptris/core/BaseCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/BaseCase.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0")
+@Removal(version = "5.1.0")
 public abstract class BaseCase extends com.adaptris.interlok.junit.scaffolding.BaseCase
     implements UpgradedToJunit4 {
 

--- a/interlok-core/src/test/java/com/adaptris/core/ConsumerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConsumerCase.java
@@ -21,7 +21,7 @@ import com.adaptris.core.stubs.UpgradedToJunit4;
 import com.adaptris.interlok.junit.scaffolding.ExampleConsumerCase;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ConsumerCase extends ExampleConsumerCase implements UpgradedToJunit4 {
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleChannelCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleChannelCase.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ExampleChannelCase
     extends com.adaptris.interlok.junit.scaffolding.ExampleChannelCase implements UpgradedToJunit4 {
 

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleConfigCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleConfigCase.java
@@ -21,7 +21,7 @@ import com.adaptris.core.stubs.UpgradedToJunit4;
 import com.adaptris.interlok.junit.scaffolding.ExampleConfigGenerator;
 
 @Deprecated
-@Removal(version = "4.0.0",
+@Removal(version = "5.1.0",
     message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ExampleConfigCase extends ExampleConfigGenerator implements UpgradedToJunit4 {
 

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleErrorHandlerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleErrorHandlerCase.java
@@ -27,7 +27,7 @@ import com.adaptris.core.stubs.UpgradedToJunit4;
  */
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ExampleErrorHandlerCase
     extends com.adaptris.interlok.junit.scaffolding.ExampleErrorHandlerCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleEventHandlerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleEventHandlerCase.java
@@ -21,7 +21,7 @@ import com.adaptris.core.stubs.UpgradedToJunit4;
 
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ExampleEventHandlerCase<T extends EventHandlerBase>
     extends com.adaptris.interlok.junit.scaffolding.ExampleEventHandlerCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleFailedMessageRetrierCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleFailedMessageRetrierCase.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ExampleFailedMessageRetrierCase
     extends com.adaptris.interlok.junit.scaffolding.ExampleFailedMessageRetrierCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleProduceDestinationCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleProduceDestinationCase.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ExampleProduceDestinationCase
     extends com.adaptris.interlok.junit.scaffolding.ExampleProduceDestinationCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleServiceConfig.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleServiceConfig.java
@@ -26,7 +26,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("dummy-placeholder-service-element")
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public class ExampleServiceConfig
     extends com.adaptris.interlok.junit.scaffolding.ExampleServiceConfig {
 

--- a/interlok-core/src/test/java/com/adaptris/core/ExampleWorkflowCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExampleWorkflowCase.java
@@ -19,7 +19,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ExampleWorkflowCase
     extends com.adaptris.interlok.junit.scaffolding.ExampleWorkflowCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/FailedMessageRetrierCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/FailedMessageRetrierCase.java
@@ -19,7 +19,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class FailedMessageRetrierCase
     extends com.adaptris.interlok.junit.scaffolding.FailedMessageRetrierCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/MarshallingBaseCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MarshallingBaseCase.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0")
+@Removal(version = "5.1.0")
 public abstract class MarshallingBaseCase extends
     com.adaptris.interlok.junit.scaffolding.MarshallingBaseCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/PortManager.java
+++ b/interlok-core/src/test/java/com/adaptris/core/PortManager.java
@@ -19,7 +19,7 @@ package com.adaptris.core;
 import com.adaptris.annotation.Removal;
 
 @Deprecated
-@Removal(version = "4.0.0", message="moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message="moved to com.adaptris.interlok.junit.scaffolding")
 public class PortManager extends com.adaptris.interlok.junit.scaffolding.util.PortManager {
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/ProducerCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ProducerCase.java
@@ -21,7 +21,7 @@ import com.adaptris.core.stubs.UpgradedToJunit4;
 import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ProducerCase extends ExampleProducerCase implements UpgradedToJunit4 {
 
 

--- a/interlok-core/src/test/java/com/adaptris/core/ServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ServiceCase.java
@@ -25,7 +25,7 @@ import com.adaptris.core.stubs.UpgradedToJunit4;
  * </p>
  */
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ServiceCase
     extends com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/ServiceCollectionCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ServiceCollectionCase.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ServiceCollectionCase
     extends com.adaptris.interlok.junit.scaffolding.services.ServiceCollectionCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/ServiceCollectionExample.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ServiceCollectionExample.java
@@ -21,7 +21,7 @@ import com.adaptris.core.stubs.UpgradedToJunit4;
 import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCollection;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class ServiceCollectionExample extends ExampleServiceCollection
     implements UpgradedToJunit4 {
 

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/DatabaseConnectionCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/DatabaseConnectionCase.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class DatabaseConnectionCase<T extends DatabaseConnection>
     extends com.adaptris.interlok.junit.scaffolding.DatabaseConnectionCase<T>
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/JdbcServiceCase.java
@@ -19,7 +19,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class JdbcServiceCase
     extends com.adaptris.interlok.junit.scaffolding.services.JdbcServiceCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/jms/jndi/JndiImplementationCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/jndi/JndiImplementationCase.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class JndiImplementationCase
     extends com.adaptris.interlok.junit.scaffolding.jms.JndiImplementationCase
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/BasicCacheExampleGenerator.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/BasicCacheExampleGenerator.java
@@ -18,7 +18,7 @@ package com.adaptris.core.services.cache;
 import com.adaptris.annotation.Removal;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class BasicCacheExampleGenerator
     extends com.adaptris.interlok.junit.scaffolding.services.BasicCacheExampleGenerator {
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/cache/CacheServiceExample.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/cache/CacheServiceExample.java
@@ -4,7 +4,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class CacheServiceExample
     extends com.adaptris.interlok.junit.scaffolding.services.CacheServiceExample
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/core/services/mime/MimeJunitHelper.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/mime/MimeJunitHelper.java
@@ -19,7 +19,7 @@ package com.adaptris.core.services.mime;
 import com.adaptris.annotation.Removal;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public class MimeJunitHelper extends com.adaptris.interlok.junit.scaffolding.util.MimeJunitHelper {
 
 

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/UpgradedToJunit4.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/UpgradedToJunit4.java
@@ -3,7 +3,7 @@ package com.adaptris.core.stubs;
 import com.adaptris.annotation.Removal;
 
 @Deprecated
-@Removal(version = "4.0.0")
+@Removal(version = "5.1.0")
 public interface UpgradedToJunit4 {
 
   boolean isAnnotatedForJunit4();

--- a/interlok-core/src/test/java/com/adaptris/core/transform/TransformServiceExample.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/TransformServiceExample.java
@@ -20,7 +20,7 @@ import com.adaptris.annotation.Removal;
 import com.adaptris.core.stubs.UpgradedToJunit4;
 
 @Deprecated
-@Removal(version = "4.0.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
+@Removal(version = "5.1.0", message = "moved to com.adaptris.interlok.junit.scaffolding")
 public abstract class TransformServiceExample
     extends com.adaptris.interlok.junit.scaffolding.services.TransformServiceExample
     implements UpgradedToJunit4 {

--- a/interlok-core/src/test/java/com/adaptris/util/system/Environment.java
+++ b/interlok-core/src/test/java/com/adaptris/util/system/Environment.java
@@ -24,7 +24,7 @@ import com.adaptris.annotation.Removal;
  * @author lchan
  */
 @Deprecated
-@Removal(version = "4.0.0")
+@Removal(version = "5.1.0")
 public class Environment extends com.adaptris.interlok.junit.scaffolding.util.Environment {
 
 

--- a/interlok-core/src/test/java/com/adaptris/util/system/Os.java
+++ b/interlok-core/src/test/java/com/adaptris/util/system/Os.java
@@ -25,7 +25,7 @@ import com.adaptris.annotation.Removal;
  * @author lchan
  */
 @Deprecated
-@Removal(version = "4.0.0")
+@Removal(version = "5.1.0")
 public class Os extends com.adaptris.interlok.junit.scaffolding.util.Os {
 
 


### PR DESCRIPTION
## Motivation

to update deprecation warnings where the removal target is 5.0 or lower

## Modification

changed those warnings to 5.1.0

## PR Checklist

- [x] been self-reviewed.
