### PR TITLE
Interlok 4134 jdbc retrystore v4

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+
 import javax.validation.constraints.NotBlank;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -20,6 +21,7 @@ import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
@@ -227,5 +229,35 @@ public class FilesystemRetryStore implements RetryStore {
   public FilesystemRetryStore withBaseUrl(String s) {
     setBaseUrl(s);
     return this;
+  }
+
+  @Override
+  public void acknowledge(String acknowledgeId) throws InterlokException {
+ // null implementation
+  }
+
+  @Override
+  public void deleteAcknowledged() throws InterlokException {
+ // null implementation
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
+    return null; // null implementation
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
+    return null; // null implementation
+  }
+
+  @Override
+  public void updateRetryCount(String messageId) throws InterlokException {
+   // null implementation
+  }
+
+  @Override
+  public void makeConnection(AdaptrisConnection connection) {
+   // null implementation 
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
@@ -1,7 +1,10 @@
 package com.adaptris.core.http.jetty.retry;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+
+import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ComponentLifecycle;
@@ -86,6 +89,71 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
 
   @Override
   default void prepare() throws CoreException {
-
   }
+  
+  /**
+   * <p>
+   * Acknowledge that the message with the passed ID has now been successfully
+   * processed and should not be retried again. NB this method does not throw an
+   * Exception if the acknowledge ID does not exist in the store.
+   * </p>
+   * 
+   * @param acknowledgeId the acknowledge ID of the message to acknowledge
+   * @throws InterlokException wrapping any <code>Exception</code> which occurs
+   */
+  void acknowledge(String acknowledgeId) throws InterlokException;
+  
+  /**
+   * Delete any messages that have been successfully Acknowledged.
+   *
+   * @throws InterlokException wrapping any <code>Exception</code> which occurs
+   */
+  void deleteAcknowledged() throws InterlokException;
+  
+  /**
+   * <p>
+   * Obtain a list of <code>AdaptrisMessage</code>s which meet the expiration
+   * criteria.
+   * In the most abstract sense, expired messages are those that have exceeded
+   * their max retry count but not yet been acknowledged.
+   * </p>
+   * 
+   * @return a list of <code>AdaptrisMessage</code>s which meet the expiration
+   * criteria.
+   * @throws InterlokException wrapping any <code>Exception</code> which occurs
+   */
+  List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException;
+  
+  /**
+   * <p>
+   * Obtain a list of <code>AdaptrisMessage</code>s which meet the criteria
+   * for retrying.
+   * </p>
+   *
+   * @return a list of <code>AdaptrisMessage</code>s which meet the criteria
+   * for retrying
+   * @throws InterlokException wrapping any <code>Exception</code> which occurs
+   */
+  List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException;
+  
+  /**
+   * <p>
+   * Update the number of retries which have taken place for the message with
+   * the passed ID. NB this method does not throw an Exception if an attempt is
+   * made to update the retry count for a message ID which does not exist in the
+   * store.
+   * </p>
+   *
+   * @param messageId the ID of the message to update
+   * @throws InterlokException wrapping any <code>Exception</code> which occurs
+   */
+  void updateRetryCount(String messageId) throws InterlokException;
+  
+  /**
+   * <p>
+   * Used for any implementations that have a connected RetryStore
+   * </p>
+   */
+  void makeConnection(AdaptrisConnection connection);
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/AcknowledgeService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/AcknowledgeService.java
@@ -1,0 +1,55 @@
+package com.adaptris.core.jdbc.retry;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.InterlokException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * <p>
+ * Service which processes asynchronous acknowledgements for messages stored
+ * using {@link StoreMessageForRetryServiceTest}.
+ * </p>
+ * <p>
+ * The following metadata keys are required.
+ * <ul>
+ * <li>{@value com.adaptris.core.services.retry.Constants#ACKNOWLEDGE_ID_KEY}
+ * contains the ID that was previously used by
+ * {@link StoreMessageForRetryServiceTest} as the correlation id.</li>
+ * </ul>
+ * </p>
+ */
+@XStreamAlias("acknowledge-message-service")
+@AdapterComponent
+@ComponentProfile(summary = "processes asynchronous acknowledgements.", since = "4.9.0", tag = "retry")
+@DisplayOrder(order = { "pruneExpired", "retryStore" })
+public class AcknowledgeService extends RetryServiceImp {
+
+  /**
+   *
+   * @see RetryServiceImpTest#performService(com.adaptris.core.AdaptrisMessage)
+   */
+  @Override
+  protected void performService(AdaptrisMessage msg) throws ServiceException {
+
+    String acknowledgeId = msg.getMetadataValue(Constants.ACKNOWLEDGE_ID_KEY);
+    if (acknowledgeId == null) {
+      log.debug(Constants.ACKNOWLEDGE_ID_KEY + " not available as metadata key or returned null");
+      return;
+    }
+    try {
+      log.debug("Acknowledging [" + acknowledgeId + "] as successfully sent");
+      getRetryStore().acknowledge(acknowledgeId);
+    } catch (InterlokException e) {
+      throw new ServiceException(e);
+    }
+  }
+
+  @Override
+  protected void stopService() {
+    // TODO Auto-generated method stub
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/Constants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/Constants.java
@@ -1,0 +1,68 @@
+package com.adaptris.core.jdbc.retry;
+
+/**
+ * <p>
+ * Constants relating to retrying messages.
+ * </p>
+ */
+
+public final class Constants {
+
+  /**
+   * <p>
+   * Metadata key for message acknowledgement ID.
+   * </p>
+   */
+  public static final String ACKNOWLEDGE_ID_KEY = "retryAckId";
+
+  /**
+   * <p>
+   * Metadata key for message retry interval.
+   * </p>
+   */
+  public static final String RETRY_INTERVAL_KEY = "retryAckInterval";
+
+  /**
+   * <p>
+   * Metadata key for the number of message retries.
+   * </p>
+   */
+  public static final String RETRIES_KEY = "retryRetries";
+
+  /**
+   * <p>
+   * Metadata key for marshalled <code>Service</code>.
+   * </p>
+   */
+  public static final String MARSHALLED_SERVICE_KEY = "retryService";
+
+  /**
+   * <p>
+   * Metadata key for marshalled <code>Service</code> class name.
+   * </p>
+   */
+  public static final String MARSHALLED_CLASS_NAME_KEY = "retryServiceClass";
+
+  /**
+   * <p>
+   * Metadata key indicating whether asynchronous acknowledgment is required.
+   * </p>
+   */
+  public static final String ASYNCHRONOUS_KEY = "retryAsynch";
+
+  /**
+   * <p>
+   * Metadata key indicating whether we should treat exceptions from the service
+   * as normal behaviour.
+   * </p>
+   */
+  public static final String ASYNC_AUTO_RETRY = "retryAsyncRetry";
+
+  protected static final String ACKNOWLEDGED = "T";
+  protected static final String NOT_ACKNOWLEDGED = "F";
+
+  private Constants() {
+    // no instances
+  }
+}
+

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
@@ -1,0 +1,442 @@
+package com.adaptris.core.jdbc.retry;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.validation.constraints.NotBlank;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.MimeEncoder;
+import com.adaptris.core.http.jetty.retry.RetryStore;
+import com.adaptris.core.jdbc.DatabaseConnection;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.JdbcUtil;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.util.Args;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * <p>
+ * JDBC-based implementation of <code>RetryStore</code>.
+ * </p>
+ * <p>
+ * This uses <code>JdbcTemplate</code> from Spring for database operations. If
+ * there is no explicit configuration of the sqlProperties then the SQL
+ * statements are found in the file <code>retry-store-derby.properties</code> which
+ * is suitable for Apache Derby and MySQL. If explicitly configured, the
+ * property file is expected to be present on the classpath.
+ * </p>
+ * <p>
+ * The default property file is listed below.
+ *
+ * <pre><code>
+ create.sql = CREATE TABLE retry_store \
+ (message_id VARCHAR(256) NOT NULL, \
+ acknowledge_id VARCHAR(256) NOT NULL, \
+ message BLOB NOT NULL, \
+ retry_interval INTEGER NOT NULL, \
+ total_retries INTEGER NOT NULL, \
+ retries_to_date INTEGER NOT NULL, \
+ marshalled_service BLOB NOT NULL, \
+ acknowledged CHAR NOT NULL, \
+ updated_on TIMESTAMP, \
+ inserted_on TIMESTAMP, \
+ \
+ CONSTRAINT pk_message_id PRIMARY KEY (message_id), \
+ CONSTRAINT idx_acknowledge_id UNIQUE (acknowledge_id))
+
+ insert.sql = INSERT INTO retry_store \
+ (message_id, acknowledge_id, message, retry_interval, total_retries, \
+ retries_to_date, marshalled_service, acknowledged, inserted_on, updated_on) \
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+
+ select.sql = SELECT * FROM retry_store WHERE message_id=?
+
+ acknowledge.sql = UPDATE retry_store SET acknowledged=?, \
+ updated_on=? WHERE acknowledge_id=?
+
+ update-retry.sql = UPDATE retry_store SET retries_to_date=(retries_to_date + 1), \
+ updated_on=? WHERE message_id=?
+
+ retry.sql = SELECT * FROM retry_store WHERE \
+ (acknowledged='F' AND (retries_to_date < total_retries OR total_retries = -1))
+
+ delete.acknowleged.sql = DELETE FROM retry_store WHERE acknowledged='T'
+
+ delete.sql = DELETE FROM retry_store WHERE message_id=?
+
+ select.expired.sql = SELECT * FROM retry_store \
+ WHERE (acknowledged='F' AND \
+ (retries_to_date >= total_retries AND total_retries != -1))
+ </code></pre>
+ *
+ * </p>
+ * <p>
+ * The create.sql script is <b>always</b> executed upon initialisation, 
+ * any errors are discarded
+ * </p>
+ */
+
+@XStreamAlias("retry-store-jdbc")
+@ComponentProfile(summary = "Store message for retry in a database using jdbc", since = "4.9.0")
+@DisplayOrder(order = { "sqlPropertiesFile" })
+@Slf4j
+public class JdbcRetryStore implements RetryStore {
+
+  private static final String RETRY_STORE_PROPERTIES = "retry-store-derby.properties";
+  private static final String CREATE_SQL = "create.sql";
+  private static final String INSERT_SQL = "insert.sql";
+  private static final String DELETE_SQL = "delete.sql";
+  private static final String SELECT_EXPIRED_SQL = "select.expired.sql";
+  private static final String RETRY_SQL = "retry.sql";
+  private static final String UPDATE_RETRY_SQL = "update-retry.sql";
+  private static final String DELETE_ACKNOWLEGED_SQL = "delete.acknowleged.sql";
+  private static final String ACKNOWLEDGE_SQL = "acknowledge.sql";
+
+  private transient Properties sqlStatements;
+  private transient MimeEncoder encoder;
+  private AdaptrisConnection connection;
+  private Connection sqlConnection;
+
+  /**
+   * Set the sql properties file to use, by default it will look for the value
+   * "retry-store-derby.properties"
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  @InputFieldDefault(value = RETRY_STORE_PROPERTIES)
+  private String sqlPropertiesFile;
+
+  /**
+   * <p>
+   * Creates a new instance. Default properties file is
+   * <code>retry-store-derby.properties</code>.
+   * </p>
+   */
+  public JdbcRetryStore() {
+    encoder = new MimeEncoder();
+    encoder.setRetainUniqueId(true);
+    setSqlPropertiesFile(RETRY_STORE_PROPERTIES);
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notBlank(getSqlPropertiesFile(), "sqlPropertiesFile");
+  }
+
+  @Override
+  public void init() throws CoreException {
+    if (sqlStatements == null) {
+      sqlStatements = new Properties();
+
+      InputStream in = null;
+
+      try {
+        in = this.getClass().getClassLoader().getResourceAsStream(getSqlPropertiesFile());
+        if (in == null) {
+          in = new FileInputStream(getSqlPropertiesFile());
+        }
+        sqlStatements.load(in);
+        in.close();
+      } catch (Exception e) {
+        throw new CoreException("problem loading file [" + getSqlPropertiesFile() + "]");
+      }
+    }
+
+    if (sqlConnection == null) {
+      try {
+        sqlConnection = getConnection();
+      } catch (Exception e) {
+        throw new CoreException("error connecting to the Database");
+      }
+    }
+    try {
+      createStoreTable();
+      log.debug("store table created");
+    } catch (Exception e) {
+    }
+  }
+
+  @Override
+  public void write(AdaptrisMessage msg) throws InterlokException {
+    PreparedStatement ps = null;
+    validateMessage(msg);
+    Object[] params = new Object[] { msg.getUniqueId(), msg.getMetadataValue(Constants.ACKNOWLEDGE_ID_KEY),
+        encoder.encode(msg), Integer.parseInt(msg.getMetadataValue(Constants.RETRY_INTERVAL_KEY)),
+        Integer.parseInt(msg.getMetadataValue(Constants.RETRIES_KEY)), Integer.valueOf(0),
+        msg.getMetadataValue(Constants.MARSHALLED_SERVICE_KEY).getBytes(), "F" };
+    try {
+      ps = prepareStatementWithParameters(sqlConnection, sqlStatements.getProperty(INSERT_SQL), params);
+      log.trace("executing insert statement");
+      ps.executeUpdate();
+    } catch (SQLException e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    } finally {
+      JdbcUtil.closeQuietly(ps);
+    }
+  }
+
+  @Override
+  public boolean delete(String msgId) throws InterlokException {
+    PreparedStatement ps = null;
+    Object[] params = new Object[] { msgId };
+    try {
+      ps = prepareStatementWithParameters(sqlConnection, sqlStatements.getProperty(DELETE_SQL), params);
+      log.trace("executing delete statement");
+      ps.executeUpdate();
+      return true;
+    } catch (SQLException e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    } finally {
+      JdbcUtil.closeQuietly(ps);
+    }
+  }
+
+  @Override
+  public Iterable<RemoteBlob> report() throws InterlokException {
+    return Collections.EMPTY_LIST;
+  }
+
+  @Override
+  public AdaptrisMessage buildForRetry(String msgId, Map<String, String> metadata, AdaptrisMessageFactory factory)
+      throws InterlokException {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getMetadata(String msgId) throws InterlokException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public void acknowledge(String acknowledgeId) throws InterlokException {
+    PreparedStatement ps = null;
+    Object[] params = { Constants.ACKNOWLEDGED, new Date(), acknowledgeId };
+    try {
+      ps = prepareStatementWithParameters(sqlConnection, sqlStatements.getProperty(ACKNOWLEDGE_SQL), params);
+      log.trace("executing update statement");
+      ps.executeUpdate();
+    } catch (SQLException e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    } finally {
+      JdbcUtil.closeQuietly(ps);
+    }
+  }
+
+  @Override
+  public void deleteAcknowledged() throws InterlokException {
+    PreparedStatement ps = null;
+    try {
+      ps = prepareStatementWithoutParameters(sqlConnection, sqlStatements.getProperty(DELETE_ACKNOWLEGED_SQL));
+      log.trace("executing delete statement");
+      ps.executeUpdate();
+    } catch (SQLException e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    } finally {
+      JdbcUtil.closeQuietly(ps);
+    }
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
+    List<AdaptrisMessage> result = new ArrayList<AdaptrisMessage>();
+    PreparedStatement ps = null;
+    ResultSet rs = null;
+    try {
+      ps = prepareStatementWithoutParameters(sqlConnection, sqlStatements.getProperty(SELECT_EXPIRED_SQL));
+      log.trace("executing select statement");
+      rs = ps.executeQuery();
+      if (rs == null) {
+        return result;
+      }
+      while (rs.next()) {
+        JdbcRetryStoreEntry resultRow = mapRow(rs);
+        result.add(convert(resultRow));
+      }
+    } catch (SQLException e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    } finally {
+      JdbcUtil.closeQuietly(rs);
+      JdbcUtil.closeQuietly(ps);
+    }
+
+    return result;
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
+    PreparedStatement ps = null;
+    ResultSet rs = null;
+    List<AdaptrisMessage> result = new ArrayList<AdaptrisMessage>();
+    try {
+      ps = prepareStatementWithoutParameters(sqlConnection, sqlStatements.getProperty(RETRY_SQL));
+      log.trace("executing select statement");
+      rs = ps.executeQuery();
+      if (rs == null) {
+        return result;
+      }
+      while (rs.next()) {
+        JdbcRetryStoreEntry resultRow = mapRow(rs);
+        long now = System.currentTimeMillis();
+        long lastRetry = resultRow.getUpdatedOn().getTime();
+        int interval = resultRow.getRetryInterval();
+        if (lastRetry + interval < now) { // retry required
+          result.add(convert(resultRow));
+        }
+      }
+    } catch (InterlokException | SQLException e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    } finally {
+      JdbcUtil.closeQuietly(rs);
+      JdbcUtil.closeQuietly(ps);
+    }
+
+    return result;
+  }
+
+  @Override
+  public void updateRetryCount(String messageId) throws InterlokException {
+    PreparedStatement ps = null;
+    Object[] params = { new Date(), messageId };
+    try {
+      ps = prepareStatementWithParameters(sqlConnection, sqlStatements.getProperty(UPDATE_RETRY_SQL), params);
+      log.trace("executing update statement");
+      ps.executeUpdate();
+    } catch (SQLException e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    } finally {
+      JdbcUtil.closeQuietly(ps);
+    }
+  }
+
+  private void validateMessage(AdaptrisMessage msg) throws InterlokException {
+    if (msg == null) {
+      throw new InterlokException("null param");
+    }
+    if (msg.getMetadataValue(Constants.ACKNOWLEDGE_ID_KEY) == null
+        || msg.getMetadataValue(Constants.ACKNOWLEDGE_ID_KEY).isEmpty()) {
+      throw new InterlokException("null or empty acknowledge ID");
+    }
+    if (msg.getMetadataValue(Constants.RETRY_INTERVAL_KEY) == null
+        || msg.getMetadataValue(Constants.RETRY_INTERVAL_KEY).isEmpty()) {
+      throw new InterlokException("null or empty retry interval");
+    }
+    if (msg.getMetadataValue(Constants.RETRIES_KEY) == null || msg.getMetadataValue(Constants.RETRIES_KEY).isEmpty()) {
+      throw new InterlokException("null or empty retries");
+    }
+    if (msg.getMetadataValue(Constants.MARSHALLED_SERVICE_KEY) == null
+        || msg.getMetadataValue(Constants.MARSHALLED_SERVICE_KEY).isEmpty()) {
+      throw new InterlokException("null or empty marshalled service");
+    }
+    if (msg.getMetadataValue(Constants.MARSHALLED_CLASS_NAME_KEY) == null
+        || msg.getMetadataValue(Constants.MARSHALLED_CLASS_NAME_KEY).isEmpty()) {
+      throw new InterlokException("null or empty marshalled class name");
+    }
+    if (msg.getMetadataValue(Constants.ASYNCHRONOUS_KEY) == null
+        || msg.getMetadataValue(Constants.ASYNCHRONOUS_KEY).isEmpty()) {
+      throw new InterlokException("null or empty asynchronous ack");
+    }
+  }
+
+  private AdaptrisMessage convert(JdbcRetryStoreEntry retryStoreEntry) throws InterlokException {
+
+    AdaptrisMessage result = encoder.decode(retryStoreEntry.getEncodedMessage());
+
+    // MimeEncoder 'workaround'...
+    result.setUniqueId(retryStoreEntry.getMessageId()); // bodge
+
+    // for size reasons
+    retryStoreEntry.setEncodedMessage(null);
+    retryStoreEntry.setMarshalledService(null);
+
+    return result;
+  }
+
+  private void createStoreTable() throws Exception {
+    PreparedStatement ps = null;
+    try {
+      ps = prepareStatementWithoutParameters(sqlConnection, sqlStatements.getProperty(CREATE_SQL));
+      log.trace("Executing create statement");
+      ps.executeUpdate();
+    } catch (SQLException e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    } finally {
+      JdbcUtil.closeQuietly(ps);
+    }
+  }
+
+  private static PreparedStatement prepareStatementWithParameters(Connection c, String query, Object[] parameters)
+      throws SQLException {
+    PreparedStatement preparedStatement = c.prepareStatement(query);
+    int count = 1;
+    for (Object o : parameters) {
+      preparedStatement.setObject(count, o);
+      count++;
+    }
+    return preparedStatement;
+  }
+
+  private static PreparedStatement prepareStatementWithoutParameters(Connection c, String query) throws SQLException {
+    return c.prepareStatement(query);
+  }
+
+  private JdbcRetryStoreEntry mapRow(ResultSet rs) throws SQLException {
+    JdbcRetryStoreEntry result = new JdbcRetryStoreEntry();
+
+    result.setMessageId(rs.getString("message_id"));
+    result.setAcknowledgeId(rs.getString("acknowledge_id"));
+    result.setEncodedMessage(rs.getBytes("message"));
+    result.setRetryInterval(rs.getInt("retry_interval"));
+    result.setTotalRetries(rs.getInt("total_retries"));
+    result.setRetriesToDate(rs.getInt("retries_to_date"));
+    result.setMarshalledService(new String(rs.getBytes("marshalled_service")));
+    result.setInsertedOn(rs.getTimestamp("inserted_on"));
+    result.setUpdatedOn(rs.getTimestamp("updated_on"));
+
+    if (Constants.NOT_ACKNOWLEDGED.equals(rs.getString("acknowledged"))) {
+      result.setAcknowledged(false);
+    }
+    if (Constants.ACKNOWLEDGED.equals(rs.getString("acknowledged"))) {
+      result.setAcknowledged(true);
+    }
+
+    return result;
+  }
+
+  public void setConnection(AdaptrisConnection connection) {
+    this.connection = connection;
+  }
+
+  public Connection getConnection() throws SQLException {
+    return this.connection.retrieveConnection(DatabaseConnection.class).connect();
+  }
+
+  @Override
+  public void makeConnection(AdaptrisConnection connection) {
+    setConnection(connection);
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStoreEntry.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStoreEntry.java
@@ -1,0 +1,103 @@
+package com.adaptris.core.jdbc.retry;
+
+import java.util.Date;
+
+/**
+ * <p>
+ * Represents an entry in <code>retry_store</code>, the sole table in the 
+ * 'retry store database'.
+ * </p>
+ */
+class JdbcRetryStoreEntry {
+
+  private String messageId;
+  private String acknowledgeId;
+  private byte[] encodedMessage;
+  private int retryInterval;
+  private int totalRetries;
+  private int retriesToDate;
+  private String marshalledService;
+  private boolean acknowledged;
+  private Date insertedOn;
+  private Date updatedOn;
+
+  Date getInsertedOn() {
+    return insertedOn;
+  }
+  
+  void setInsertedOn(Date d) {
+    this.insertedOn = d;
+  }
+  
+  Date getUpdatedOn() {
+    return updatedOn;
+  }
+  
+  void setUpdatedOn(Date d) {
+    this.updatedOn = d;
+  }
+  
+  String getAcknowledgeId() {
+    return acknowledgeId;
+  }
+  
+  void setAcknowledgeId(String s) {
+    this.acknowledgeId = s;
+  }
+  
+  byte[] getEncodedMessage() {
+    return encodedMessage;
+  }
+  
+  void setEncodedMessage(byte[] b) {
+    this.encodedMessage = b;
+  }
+  
+  String getMessageId() {
+    return messageId;
+  }
+  
+  void setMessageId(String s) {
+    this.messageId = s;
+  }
+  
+  int getTotalRetries() {
+    return totalRetries;
+  }
+  
+  void setTotalRetries(int i) {
+    this.totalRetries = i;
+  }
+  
+  int getRetriesToDate() {
+    return retriesToDate;
+  }
+  
+  void setRetriesToDate(int i) {
+    this.retriesToDate = i;
+  }
+  
+  int getRetryInterval() {
+    return retryInterval;
+  }
+  
+  void setRetryInterval(int i) {
+    this.retryInterval = i;
+  }
+  
+  String getMarshalledService() {
+    return marshalledService;
+  }
+  
+  void setMarshalledService(String s) {
+    this.marshalledService = s;
+  }
+  
+  boolean getAcknowledged() {
+    return acknowledged;
+  }
+  
+  void setAcknowledged(boolean b) {
+    this.acknowledged = b;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/RetryMessagesService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/RetryMessagesService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -160,7 +162,7 @@ public class RetryMessagesService extends RetryServiceImp {
 
   private void pruneExpired() {
     try {
-      if (pruneExpired) {
+      if (isPruneExpired()) {
         log.debug("Pruning Expired Messages");
         List<AdaptrisMessage> expiredMsgs = getRetryStore().obtainExpiredMessages();
         for (AdaptrisMessage expired : expiredMsgs) {
@@ -211,5 +213,9 @@ public class RetryMessagesService extends RetryServiceImp {
    */
   public void setPruneExpired(boolean b) {
     pruneExpired = b;
+  }
+  
+  private boolean isPruneExpired() {
+    return BooleanUtils.toBooleanDefaultIfNull(getPruneExpired(), false);
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/RetryMessagesService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/RetryMessagesService.java
@@ -1,0 +1,215 @@
+package com.adaptris.core.jdbc.retry;
+
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.interlok.InterlokException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * <p>
+ * Service which obtains messages from the retry store that meet the appropriate
+ * criteria and retries them. This service is intended to be used in conjunction
+ * with <code>PollingTrigger</code>.
+ * </p>
+ * <p>
+ * The 'appropriate criteria' are as follows:
+ * <ul>
+ * <li>the message has not been acknowledged</li>
+ * <li>the total number of retries has not been exceeded</li>
+ * <li>the retry interval has elapsed since the last retry.</li>
+ * </ul>
+ * </p>
+ */
+
+@XStreamAlias("retry-message-service")
+@AdapterComponent
+@ComponentProfile(summary = "retries a message from the retry store.",
+    since = "4.9.0", tag = "retry")
+@DisplayOrder(order = {"pruneExpired", "retryStore"})
+public class RetryMessagesService extends RetryServiceImp {
+  
+  @InputFieldDefault(value = "false")
+  private boolean pruneExpired;
+  
+  @NotNull
+  @Valid
+  private StandaloneProducer expiredMessagesProducer;
+
+  public RetryMessagesService() {
+    setExpiredMessagesProducer(new StandaloneProducer());
+    setPruneExpired(false);
+  }
+
+  /** @see com.adaptris.core.ServiceImp#start() */
+  @Override
+  public void start() throws CoreException {
+    super.start();
+    getExpiredMessagesProducer().start();
+  }
+
+  /** @see com.adaptris.core.ServiceImp#stop() */
+  @Override
+  public void stop() {
+    super.stop();
+    getExpiredMessagesProducer().stop();
+  }
+
+  @Override
+  protected void stopService() {
+    super.close();
+    getExpiredMessagesProducer().close();
+    getConnection().stop();
+  }
+
+  /**
+   *
+   * @see RetryServiceImpTest#performService(com.adaptris.core.AdaptrisMessage)
+   */
+  @Override
+  protected void performService(AdaptrisMessage msg) throws ServiceException {
+    try {
+      pruneExpired();
+      List<AdaptrisMessage> retryMsgs = getRetryStore().obtainMessagesToRetry();
+      for (AdaptrisMessage retry : retryMsgs) {
+        doRetry(retry);
+      }
+    }
+    catch (InterlokException e) {
+      throw new ServiceException(e);
+    }
+  }
+
+  private void doRetry(AdaptrisMessage retry) throws InterlokException {
+    String marshalledService = retry
+        .getMetadataValue(Constants.MARSHALLED_SERVICE_KEY);
+
+    Class c = null;
+
+    try {
+      c = Class.forName(retry
+          .getMetadataValue(Constants.MARSHALLED_CLASS_NAME_KEY));
+    }
+    catch (ClassNotFoundException e) {
+      throw new CoreException(e);
+    }
+
+    Service service = (Service) marshaller.unmarshal(marshalledService);
+
+    service.init();
+    service.start();
+
+    try {
+      log.debug("Retrying message [" + retry.getUniqueId()
+          + "] with acknowledge id ["
+          + retry.getMetadataValue(Constants.ACKNOWLEDGE_ID_KEY) + "]");
+      if ("true".equalsIgnoreCase(retry
+          .getMetadataValue(Constants.ASYNCHRONOUS_KEY))) {
+        handleAsynchronous(retry, service);
+      }
+      else {
+        handleSynchronous(retry, service);
+      }
+    }
+    finally {
+      service.stop();
+      service.close();
+    }
+  }
+
+  private void handleSynchronous(AdaptrisMessage retry, Service service)
+      throws InterlokException {
+
+    try {
+      service.doService(retry);
+      getRetryStore().acknowledge(
+          retry.getMetadataValue(Constants.ACKNOWLEDGE_ID_KEY));
+    }
+    catch (InterlokException e) {
+      getRetryStore().updateRetryCount(retry.getUniqueId());
+    }
+  }
+
+  private void handleAsynchronous(AdaptrisMessage retry, Service service)
+      throws InterlokException {
+    try {
+      service.doService(retry);
+      getRetryStore().updateRetryCount(retry.getUniqueId());
+    }
+    catch (ServiceException e) {
+      if ("true".equalsIgnoreCase(retry
+          .getMetadataValue(Constants.ASYNC_AUTO_RETRY))) {
+        getRetryStore().updateRetryCount(retry.getUniqueId());
+      }
+      else {
+        throw e;
+      }
+    }
+  }
+
+  private void pruneExpired() {
+    try {
+      if (pruneExpired) {
+        log.debug("Pruning Expired Messages");
+        List<AdaptrisMessage> expiredMsgs = getRetryStore().obtainExpiredMessages();
+        for (AdaptrisMessage expired : expiredMsgs) {
+          log.debug("Producing Expired Message " + expired.getUniqueId());
+          log.debug("EXPIRED MESSAGE" + expired.toString());
+          getExpiredMessagesProducer().produce(expired);
+          getRetryStore().delete(expired.getUniqueId());
+        }
+      }
+    }
+    catch (Exception e) {
+      log.warn("Ignoring exception while pruning expired messages ["
+          + e.getMessage() + "]");
+    }
+  }
+
+  /**
+   * @return the expiredMessagesProducer
+   */
+  public StandaloneProducer getExpiredMessagesProducer() {
+    return expiredMessagesProducer;
+  }
+
+  /**
+   * @param sp the expiredMessagesProducer to set
+   */
+  public void setExpiredMessagesProducer(StandaloneProducer sp) {
+    if (sp == null) {
+      throw new IllegalArgumentException(
+          "Null StandaloneProducer is not allowed");
+    }
+    expiredMessagesProducer = sp;
+  }
+
+  /**
+   * @return the pruneExpired
+   */
+  public boolean getPruneExpired() {
+    return pruneExpired;
+  }
+
+  /**
+   * Specify whether to produce messages using the configured
+   * <code>expiredMessagesProducer</code> and subsequently deleting them.
+   *
+   * @param b the pruneExpired to set
+   * @see #setExpiredMessagesProducer(StandaloneProducer)
+   */
+  public void setPruneExpired(boolean b) {
+    pruneExpired = b;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/RetryServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/RetryServiceImp.java
@@ -4,6 +4,8 @@ import java.sql.SQLException;
 
 import javax.validation.constraints.NotNull;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMarshaller;
@@ -44,7 +46,7 @@ public abstract class RetryServiceImp extends JdbcService {
   @NonNull
   private RetryStore retryStore;
 
-  @InputFieldDefault(value = "false")
+  @InputFieldDefault(value = "true")
   private boolean pruneAcknowledged;
 
   /**
@@ -88,7 +90,7 @@ public abstract class RetryServiceImp extends JdbcService {
 
   private void pruneAcknowledged() {
     try {
-      if (pruneAcknowledged) {
+      if (isPruneAcknowledged()) {
         log.debug("Pruning Previously Acknowledged Messages");
         getRetryStore().deleteAcknowledged();
       }
@@ -142,6 +144,10 @@ public abstract class RetryServiceImp extends JdbcService {
    */
   public void setPruneAcknowledged(boolean b) {
     this.pruneAcknowledged = b;
+  }
+  
+  private boolean isPruneAcknowledged() {
+    return BooleanUtils.toBooleanDefaultIfNull(getPruneAcknowledged(), false);
   }
   
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/RetryServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/RetryServiceImp.java
@@ -1,0 +1,159 @@
+package com.adaptris.core.jdbc.retry;
+
+import java.sql.SQLException;
+
+import javax.validation.constraints.NotNull;
+
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.AdaptrisMarshaller;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.DefaultMarshaller;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.http.jetty.retry.RetryStore;
+import com.adaptris.core.jdbc.DatabaseConnection;
+import com.adaptris.core.jdbc.JdbcService;
+import com.adaptris.core.util.ExceptionHelper;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+
+
+/**
+ * <p>
+ * Partial implementation of behaviour common to retry services.
+ * </p>
+ */
+@NoArgsConstructor
+public abstract class RetryServiceImp extends JdbcService {
+  
+  protected static AdaptrisMarshaller marshaller;
+
+  static { // only create marshaller once
+    marshaller = DefaultMarshaller.getDefaultMarshaller();
+  }
+  
+  @Getter
+  @Setter
+  private AdaptrisConnection connection;
+  
+  @NotNull
+  @NonNull
+  private RetryStore retryStore;
+
+  @InputFieldDefault(value = "false")
+  private boolean pruneAcknowledged;
+
+  /**
+   * <p>
+   * Creates a new instance. Defaults to <code>JdbcRetryStore</code>.
+   * </p>
+   */
+
+
+  /** @see com.adaptris.core.AdaptrisComponent#init() */
+  @Override
+  protected void initJdbcService() throws CoreException {
+    if (getConnection() == null) {
+      throw new CoreException("DatabaseConnection is null in service");
+    }
+    
+    getConnection().init();
+    getRetryStore().makeConnection(connection);
+    getRetryStore().init();
+  }
+
+  /** @see com.adaptris.core.ServiceImp#start() */
+  @Override
+  public void start() throws CoreException {
+    getConnection().start();
+  }
+
+  /** @see com.adaptris.core.AdaptrisComponent#close() */
+  @Override
+  protected void closeJdbcService() {
+    getConnection().close();
+  }
+
+  public final void doService(AdaptrisMessage msg) throws ServiceException {
+    pruneAcknowledged();
+    performService(msg);
+  }
+
+  protected abstract void performService(AdaptrisMessage msg)
+      throws ServiceException;
+
+  private void pruneAcknowledged() {
+    try {
+      if (pruneAcknowledged) {
+        log.debug("Pruning Previously Acknowledged Messages");
+        getRetryStore().deleteAcknowledged();
+      }
+    }
+    catch (Exception e) {
+      log.warn("Ignoring exception while pruning acknowledged messages["
+          + e.getMessage() + "]");
+    }
+  }
+
+  // properties
+
+  /**
+   * <p>
+   * Returns the <code>RetryStore</code> to use.
+   * </p>
+   *
+   * @return the <code>RetryStore</code> to use
+   */
+  public final RetryStore getRetryStore() {
+    return retryStore;
+  }
+
+  /**
+   * <p>
+   * Sets the <code>RetryStore</code> to use. May not be null.
+   * </p>
+   *
+   * @param r the <code>RetryStore</code> to use
+   */
+  public final void setRetryStore(RetryStore r) {
+    if (r == null) {
+      throw new IllegalArgumentException("null param");
+    }
+    this.retryStore = r;
+  }
+
+
+  /**
+   * @return the pruneAcknowledged
+   */
+  public boolean getPruneAcknowledged() {
+    return pruneAcknowledged;
+  }
+
+  /**
+   * Specify whether to delete messages from the underlying store if they have
+   * already been acknowledged.
+   *
+   * @param b the pruneAcknowledged to set
+   */
+  public void setPruneAcknowledged(boolean b) {
+    this.pruneAcknowledged = b;
+  }
+  
+  @Override
+  protected void prepareService() throws CoreException {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  protected void startService() throws CoreException {
+    // TODO Auto-generated method stub
+    
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/StoreMessageForRetryService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/StoreMessageForRetryService.java
@@ -1,0 +1,244 @@
+package com.adaptris.core.jdbc.retry;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.NullService;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.InterlokException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * <p>
+ * Service which stores unacknowledged messages for future retry.
+ * </p>
+ * <p>
+ * This class supports both synchronous and asynchronous acknowledgement. This is controlled by the field
+ * {@linkplain StoreMessageForRetryServiceTest#setAsynchronousAcknowledgment(boolean)}.
+ * </p>
+ * <p>
+ * A message is deemed to be synchronously acknowledged if the wrapped service completes normally. In such cases it is not added to
+ * the retry store. If an exception occurs the message is added to the retry store and normal error handling is not invoked.
+ * </p>
+ * <p>
+ * Where asynchronous acknowledgment is required and a message causes an exception, then the behaviour is determined by the
+ * async-auto-retry-on-fail setting. If set to true, then the message is added to the retry store for future retrying and message
+ * error handling is not invoked. If set to false, then normal message error handling is invoked. Where no exception occurs the
+ * message is added to the retry store to wait for asynchronous acknowledgment.
+ * </p>
+ * <p>
+ * The following metadata keys control the behaviour of the underlying datastore:
+ * <ul>
+ * <li>{@value com.adaptris.core.jdbc.retry.Constants#ACKNOWLEDGE_ID_KEY} contains the ID that will be used to correlate this
+ * message against any asynchronous confirmations; if not specified will default to the messages unique-id</li>
+ * <li>{@value com.adaptris.core.jdbc.retry.Constants#RETRY_INTERVAL_KEY} contains the number of milliseconds between each retry
+ * attempt; if not specified then this service will fail.</li>
+ * <li>{@value com.adaptris.core.jdbc.retry.Constants#RETRIES_KEY} contains the maximum number of retries (-1 for forever); if
+ * not specified then this service will fail.</li>
+ * </ul>
+ * </p>
+ */
+
+@XStreamAlias("store-message-for-retry-service")
+@AdapterComponent
+@ComponentProfile(summary = "Wraps an interlok service and gives the option to store the message in a retry store in the event of an exception.",
+    since = "4.9.0", tag = "retry")
+@DisplayOrder(order = {"asynchronousAcknowledgment", "asyncAutoRetryOnFail", "retryStore"})
+public class StoreMessageForRetryService extends RetryServiceImp {
+
+  // persistent
+  @NotNull
+  @Valid
+  private Service service;
+  
+  @InputFieldDefault(value = "false")
+  private boolean asynchronousAcknowledgment;
+  @InputFieldDefault(value = "false")
+  private boolean asyncAutoRetryOnFail;
+
+  /**
+   * <p>
+   * Creates a new instance.
+   * </p>
+   * <ul>
+   * <li>Default service is <code>NullService</code></li>
+   * <li>asynchronousAcknowledgment is false</li>
+   * <li>asyncAutoRetryOnFail is true</li> </p>
+   */
+  public StoreMessageForRetryService() {
+    super();
+    setService(new NullService());
+    setAsyncAutoRetryOnFail(true);
+  }
+
+  /** @see com.adaptris.core.ServiceImp#start() */
+  @Override
+  public void start() throws CoreException {
+    super.start();
+    getService().start();
+  }
+
+  /** @see com.adaptris.core.ServiceImp#stop() */
+  @Override
+  public void stop() {
+    getService().stop();
+    super.stop();
+  }
+
+
+  /**
+   *
+   * @see RetryServiceImpTest#performService(com.adaptris.core.AdaptrisMessage)
+   */
+  @Override
+  protected void performService(AdaptrisMessage msg) throws ServiceException {
+    if (getAsynchronousAcknowledgment()) {
+      handleAsynchronous(msg);
+    }
+    else {
+      handleSynchronous(msg);
+    }
+  }
+
+  private void handleAsynchronous(AdaptrisMessage msg) throws ServiceException {
+    try {
+      if (asyncAutoRetryOnFail) {
+        insertMessageForRetry(msg);
+      }
+
+      getService().doService(msg);
+
+      if (!asyncAutoRetryOnFail) {
+        insertMessageForRetry(msg);
+      }
+    }
+    catch (ServiceException e) {
+      if (asyncAutoRetryOnFail) {
+        log.warn("Inserted " + msg.getUniqueId() + " for retrying and ignoring ServiceException: " + e.getMessage());
+      }
+      else {
+        throw e;
+      }
+    }
+  }
+
+  private void handleSynchronous(AdaptrisMessage msg) throws ServiceException {
+    try {
+      getService().doService(msg);
+    }
+    catch (Exception e) { // inc. runtime
+      insertMessageForRetry(msg); // store only if msg fails
+    }
+  }
+
+  private String applyMetadata(AdaptrisMessage msg) throws ServiceException {
+    String ackId;
+    try {
+      msg.addMetadata(Constants.MARSHALLED_SERVICE_KEY, marshaller.marshal(getService()));
+      msg.addMetadata(Constants.MARSHALLED_CLASS_NAME_KEY, getService().getClass().getName());
+      msg.addMetadata(Constants.ASYNCHRONOUS_KEY, Boolean.valueOf(getAsynchronousAcknowledgment()).toString());
+      msg.addMetadata(Constants.ASYNC_AUTO_RETRY, Boolean.valueOf(getAsyncAutoRetryOnFail()).toString());
+
+      ackId = msg.getMetadataValue(Constants.ACKNOWLEDGE_ID_KEY);
+      if (ackId == null || ackId.isEmpty()) {
+        msg.addMetadata(Constants.ACKNOWLEDGE_ID_KEY, msg.getUniqueId());
+        ackId = msg.getUniqueId();
+      }
+    }
+    catch (CoreException e) {
+      throw new ServiceException(e);
+    }
+    return ackId;
+  }
+
+  private void insertMessageForRetry(AdaptrisMessage msg) throws ServiceException {
+    try {
+      String ackId = applyMetadata(msg);
+      getRetryStore().write(msg);
+      log.debug("Storing [" + ackId + "] for future acknowledgement");
+
+    }
+    catch (InterlokException e) {
+      log.warn("exception storing message for retry", e);
+      throw new ServiceException(e);
+    }
+  }
+
+  // properties
+
+  /**
+   * <p>
+   * Returns the <code>Service</code> to use.
+   * </p>
+   *
+   * @return the <code>Service</code> to use
+   */
+  public Service getService() {
+    return service;
+  }
+
+  /**
+   * Set the service which will initially produce the message to the remote system.
+   *
+   * @param s the <code>Service</code> to use
+   */
+  public void setService(Service s) {
+    if (s == null) {
+      throw new IllegalArgumentException("null param");
+    }
+    service = s;
+  }
+
+  /**
+   * <p>
+   * Returns true if asynchronous acknowledgment is required, otherwise false.
+   * </p>
+   *
+   * @return true if asynchronous acknowledgment is required, otherwise false
+   */
+  public boolean getAsynchronousAcknowledgment() {
+    return asynchronousAcknowledgment;
+  }
+
+  /**
+   * <p>
+   * Sets whether asynchronous acknowledgment is required.
+   * </p>
+   *
+   * @param b true if asynchronous acknowledgment is required, otherwise false
+   */
+  public void setAsynchronousAcknowledgment(boolean b) {
+    asynchronousAcknowledgment = b;
+  }
+
+  /**
+   * @return the retryOnFail
+   */
+  public boolean getAsyncAutoRetryOnFail() {
+    return asyncAutoRetryOnFail;
+  }
+
+  /**
+   * Flag for setting whether to store asynchronous acknolwedgement messages for retrying rather than invoking normal message error
+   * handling.
+   *
+   * @param b the retryOnFail to set
+   */
+  public void setAsyncAutoRetryOnFail(boolean b) {
+    asyncAutoRetryOnFail = b;
+  }
+
+  @Override
+  protected void stopService() {
+    // TODO Auto-generated method stub
+    
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
@@ -2,8 +2,11 @@ package com.adaptris.core.http.jetty.retry;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.interlok.InterlokException;
@@ -56,4 +59,33 @@ public class InMemoryRetryStore implements RetryStore {
     STORE.clear();
   }
 
+  @Override
+  public void acknowledge(String acknowledgeId) throws InterlokException {
+   // null implementation
+  }
+
+  @Override
+  public void deleteAcknowledged() throws InterlokException {
+   // null implementation   
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
+    return null; // null implementation
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
+    return null; // null implementation
+  }
+
+  @Override
+  public void updateRetryCount(String messageId) throws InterlokException {
+   // null implementation   
+  }
+
+  @Override
+  public void makeConnection(AdaptrisConnection connection) {
+   // null implementation 
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -16,6 +16,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import com.adaptris.core.Adapter;
+import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ChannelList;
@@ -406,6 +407,36 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
     @Override
     public Iterable<RemoteBlob> report() throws InterlokException {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void acknowledge(String acknowledgeId) throws InterlokException {
+     // null implementation
+    }
+
+    @Override
+    public void deleteAcknowledged() throws InterlokException {
+     // null implementation 
+    }
+
+    @Override
+    public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
+      return null; // null implementation 
+    }
+
+    @Override
+    public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
+      return null; // null implementation 
+    }
+
+    @Override
+    public void updateRetryCount(String messageId) throws InterlokException {
+     // null implementation 
+    }
+
+    @Override
+    public void makeConnection(AdaptrisConnection connection) {
+      // null implementation 
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
@@ -3,10 +3,13 @@ package com.adaptris.core.http.jetty.retry;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.util.LifecycleHelper;
@@ -56,5 +59,34 @@ public class RetryStoreTest implements RetryStore {
   public Map<String, String> getMetadata(String msgId) throws InterlokException {
     return Collections.EMPTY_MAP;
   }
+  
+  @Override
+  public void acknowledge(String acknowledgeId) throws InterlokException {
+   // null implementation
+  }
 
+  @Override
+  public void deleteAcknowledged() throws InterlokException {
+   // null implementation 
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
+    return null; // null implementation 
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
+    return null; // null implementation 
+  }
+
+  @Override
+  public void updateRetryCount(String messageId) throws InterlokException {
+   // null implementation 
+  }
+
+  @Override
+  public void makeConnection(AdaptrisConnection connection) {
+    // null implementation 
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/AcknowledgeServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/AcknowledgeServiceTest.java
@@ -1,0 +1,14 @@
+package com.adaptris.core.jdbc.retry;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+
+public class AcknowledgeServiceTest {
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/AcknowledgeServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/AcknowledgeServiceTest.java
@@ -1,12 +1,13 @@
 package com.adaptris.core.jdbc.retry;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
 
 
 public class AcknowledgeServiceTest {

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/JdbcRetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/JdbcRetryStoreTest.java
@@ -1,12 +1,13 @@
 package com.adaptris.core.jdbc.retry;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
 
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.interlok.junit.scaffolding.BaseCase;
@@ -24,34 +25,6 @@ public class JdbcRetryStoreTest extends BaseCase {
   private Connection sqlConnection;
 
   public JdbcRetryStoreTest() throws Exception {
-    jdbcRetryStore = new JdbcRetryStore();
-    jdbcRetryStore.makeConnection(null);
-    createConnection();
-  }
-
-  @BeforeAll
-  public void setUp() throws Exception {
-    sqlConnection = createConnection();
-    jdbcRetryStore.setConnection((AdaptrisConnection) sqlConnection);
-    jdbcRetryStore.init();
-  }
-
-  @AfterAll
-  public void tearDown() throws Exception {
-    sqlConnection.close();
-  }
-
-  @Test
-  public void testLoadingSqlPropertiesFile() {
-    jdbcRetryStore.getSqlPropertiesFile();
-  }
-  
-  protected Connection createConnection() throws Exception {
-    Connection c = null;
-    Class.forName(PROPERTIES.getProperty(JDBC_RETRY_STORE_DRIVER));
-    c = DriverManager.getConnection(PROPERTIES.getProperty(JDBC_RETRY_STORE_URL));
-    c.setAutoCommit(true);
-    return c;
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/JdbcRetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/JdbcRetryStoreTest.java
@@ -1,0 +1,57 @@
+package com.adaptris.core.jdbc.retry;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+public class JdbcRetryStoreTest extends BaseCase {
+
+  protected static final String JDBC_RETRY_STORE_DRIVER = "jdbc.retrystore.driver";
+  protected static final String JDBC_RETRY_STORE_URL = "jdbc.retrystore.url";
+
+  private JdbcRetryStore jdbcRetryStore;
+  private Connection sqlConnection;
+
+  public JdbcRetryStoreTest() throws Exception {
+    jdbcRetryStore = new JdbcRetryStore();
+    jdbcRetryStore.makeConnection(null);
+    createConnection();
+  }
+
+  @BeforeAll
+  public void setUp() throws Exception {
+    sqlConnection = createConnection();
+    jdbcRetryStore.setConnection((AdaptrisConnection) sqlConnection);
+    jdbcRetryStore.init();
+  }
+
+  @AfterAll
+  public void tearDown() throws Exception {
+    sqlConnection.close();
+  }
+
+  @Test
+  public void testLoadingSqlPropertiesFile() {
+    jdbcRetryStore.getSqlPropertiesFile();
+  }
+  
+  protected Connection createConnection() throws Exception {
+    Connection c = null;
+    Class.forName(PROPERTIES.getProperty(JDBC_RETRY_STORE_DRIVER));
+    c = DriverManager.getConnection(PROPERTIES.getProperty(JDBC_RETRY_STORE_URL));
+    c.setAutoCommit(true);
+    return c;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/JdbcRetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/JdbcRetryStoreTest.java
@@ -1,14 +1,5 @@
 package com.adaptris.core.jdbc.retry;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import org.junit.Test;
-
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.interlok.junit.scaffolding.BaseCase;
 
@@ -17,14 +8,5 @@ import java.sql.DriverManager;
 import java.sql.Statement;
 
 public class JdbcRetryStoreTest extends BaseCase {
-
-  protected static final String JDBC_RETRY_STORE_DRIVER = "jdbc.retrystore.driver";
-  protected static final String JDBC_RETRY_STORE_URL = "jdbc.retrystore.url";
-
-  private JdbcRetryStore jdbcRetryStore;
-  private Connection sqlConnection;
-
-  public JdbcRetryStoreTest() throws Exception {
-  }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/RetryMessagesServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/RetryMessagesServiceTest.java
@@ -1,12 +1,13 @@
 package com.adaptris.core.jdbc.retry;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
 
 
 public class RetryMessagesServiceTest {

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/RetryMessagesServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/RetryMessagesServiceTest.java
@@ -1,0 +1,14 @@
+package com.adaptris.core.jdbc.retry;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+
+public class RetryMessagesServiceTest {
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/RetryServiceImpTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/RetryServiceImpTest.java
@@ -1,0 +1,14 @@
+package com.adaptris.core.jdbc.retry;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+
+public class RetryServiceImpTest {
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/RetryServiceImpTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/RetryServiceImpTest.java
@@ -1,12 +1,13 @@
 package com.adaptris.core.jdbc.retry;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
 
 
 public class RetryServiceImpTest {

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/StoreMessageForRetryServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/StoreMessageForRetryServiceTest.java
@@ -1,0 +1,14 @@
+package com.adaptris.core.jdbc.retry;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+
+public class StoreMessageForRetryServiceTest {
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/StoreMessageForRetryServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jdbc/retry/StoreMessageForRetryServiceTest.java
@@ -1,12 +1,13 @@
 package com.adaptris.core.jdbc.retry;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
 
 
 public class StoreMessageForRetryServiceTest {

--- a/interlok-core/src/test/resources/unit-tests.properties.template
+++ b/interlok-core/src/test/resources/unit-tests.properties.template
@@ -161,6 +161,8 @@ junit.jdbc.queryservice.driver=org.apache.derby.jdbc.EmbeddedDriver
 junit.jdbc.captureservice.url=jdbc:derby:memory:JdbcDataQueryService;create=true
 junit.jdbc.captureservice.driver=org.apache.derby.jdbc.EmbeddedDriver
 
+junit.jdbc.retrystore.url=jdbc:derby:memory:retryStore;create=true
+junit.jdbc.retrystore.driver=org.apache.derby.jdbc.EmbeddedDriver
 
 
 junit.fs.SizeBasedFilter=@BASE_DIR@/src/test/resources/readme.txt


### PR DESCRIPTION
## Motivation

To replicate the JDBC retry store and it's related set of services from v2 in v4

## Modification

Updated the underlying RetryStore interface with some new required methods.
Updated existing classes that implemented that interface with the new methods but all have empty imps for now.
Added the new JdbcRetryStore class and it's related services.
Adding unit test classes too.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

A new set of services and a JDBC retry store which can now be used.

## Testing