### PR TITLE
INTERLOK-4156 CVE-2023-39017

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -225,4 +225,11 @@
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
     <cve>CVE-2023-35116</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: quartz-2.3.2.jar. The CVE is only for quartz-jobs-2.3.2.jar and org.quartz.jobs.ee.jms.SendQueueMessageJob.execute which we are not using. 
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.quartz\-scheduler/quartz@.*$</packageUrl>
+    <cve>CVE-2023-39017</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION

## Motivation

OWASP dependency check is failing.

## Modification

Suppress CVE-2023-39017 as it is only for quartz-jobs-2.3.2.jar and org.quartz.jobs.ee.jms.SendQueueMessageJob.execute which we are not using.

## PR Checklist

- [x] been self-reviewed.

## Result

No change for the end user

## Testing

OWASP dependency check should pass.
