### PR TITLE
Interlok 4134 correct null implementations v4

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -242,16 +242,6 @@ public class FilesystemRetryStore implements RetryStore {
   }
 
   @Override
-  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
-  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
   public void updateRetryCount(String messageId) throws InterlokException {
    // null implementation
   }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
@@ -120,21 +120,28 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
    * 
    * @return a list of <code>AdaptrisMessage</code>s which meet the expiration
    * criteria.
+      * @implNote The default implementation throws an instance of
+   * {@link UnsupportedOperationException} and performs no other action.
    * @throws InterlokException wrapping any <code>Exception</code> which occurs
    */
-  List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException;
+  default List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
+    throw new UnsupportedOperationException("Not supported by implementation");
+  }
   
   /**
    * <p>
    * Obtain a list of <code>AdaptrisMessage</code>s which meet the criteria
    * for retrying.
    * </p>
-   *
+   * @implNote The default implementation throws an instance of
+   * {@link UnsupportedOperationException} and performs no other action.
    * @return a list of <code>AdaptrisMessage</code>s which meet the criteria
    * for retrying
    * @throws InterlokException wrapping any <code>Exception</code> which occurs
    */
-  List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException;
+  default List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
+    throw new UnsupportedOperationException("Not supported by implementation");
+  }
   
   /**
    * <p>

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
@@ -70,16 +70,6 @@ public class InMemoryRetryStore implements RetryStore {
   }
 
   @Override
-  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
-  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
   public void updateRetryCount(String messageId) throws InterlokException {
    // null implementation   
   }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -420,16 +420,6 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
     }
 
     @Override
-    public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
-      return null; // null implementation 
-    }
-
-    @Override
-    public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
-      return null; // null implementation 
-    }
-
-    @Override
     public void updateRetryCount(String messageId) throws InterlokException {
      // null implementation 
     }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
@@ -71,16 +71,6 @@ public class RetryStoreTest implements RetryStore {
   }
 
   @Override
-  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
-    return null; // null implementation 
-  }
-
-  @Override
-  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
-    return null; // null implementation 
-  }
-
-  @Override
   public void updateRetryCount(String messageId) throws InterlokException {
    // null implementation 
   }


### PR DESCRIPTION
## Motivation

Updating the interface so the two List methods have default implementations that will throw a UnsupportedOperationException exception if called.

This is to replace having null implementions defined within the classes that don't need them.

## Modification

RetryStore interface and the classes that implement it.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [n/a] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [n/a] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [n/a] Checked that javadoc generation doesn't report errors
- [n/a] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user

## Testing

How can I test this if I'm reviewing this.
