### PR TITLE
Removing the use of the internal security manager.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/util/ManagedThreadFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/ManagedThreadFactory.java
@@ -53,8 +53,7 @@ public class ManagedThreadFactory implements ThreadFactory {
   }
 
   public ManagedThreadFactory(String prefix) {
-    SecurityManager s = System.getSecurityManager();
-    myThreadGroup = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+    myThreadGroup = Thread.currentThread().getThreadGroup();
     this.prefix = prefix + "-" + factoryNumber.getAndIncrement() + "-";
   }
 


### PR DESCRIPTION
## Motivation

The internal SecurityManager is deprecated for future removal.

## Modification

We were using the SecurityManager to gain access to a ThreadGroup; however the default behaviour appears to return the current threads group, which doesn't need the SecurityManager at all.  So we have just removed the line to that class and get access to the current threads group manually.

## Result

No warnings about SecurityManager being deprecated.

## Testing

nothing changes.
