### PR TITLE
Feature/interlok 4123 payload path encryption

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -242,16 +242,6 @@ public class FilesystemRetryStore implements RetryStore {
   }
 
   @Override
-  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
-  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
   public void updateRetryCount(String messageId) throws InterlokException {
    // null implementation
   }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -198,7 +198,6 @@ public class FilesystemRetryStore implements RetryStore {
   }
 
   @Override
-  @SuppressWarnings({"lgtm [java/path-injection]"})
   public boolean delete(String msgId) throws InterlokException {
     try {
       File target = new File(FsHelper.toFile(getBaseUrl()), msgId);
@@ -233,21 +232,21 @@ public class FilesystemRetryStore implements RetryStore {
 
   @Override
   public void acknowledge(String acknowledgeId) throws InterlokException {
- // null implementation
+    // null implementation
   }
 
   @Override
   public void deleteAcknowledged() throws InterlokException {
- // null implementation
+    // null implementation
   }
 
   @Override
   public void updateRetryCount(String messageId) throws InterlokException {
-   // null implementation
+    // null implementation
   }
 
   @Override
   public void makeConnection(AdaptrisConnection connection) {
-   // null implementation 
+    // null implementation 
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
@@ -20,7 +20,7 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
    * @implNote The default implementation just returns an empty list.
    */
   default Iterable<RemoteBlob> report() throws InterlokException {
-    return Collections.EMPTY_LIST;
+    return Collections.emptyList();
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
@@ -120,9 +120,13 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
    * 
    * @return a list of <code>AdaptrisMessage</code>s which meet the expiration
    * criteria.
+   * @implNote The default implementation throws an instance of
+   * {@link UnsupportedOperationException} and performs no other action.
    * @throws InterlokException wrapping any <code>Exception</code> which occurs
    */
-  List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException;
+  default List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
+    throw new UnsupportedOperationException("Not supported by implementation");
+  }
   
   /**
    * <p>
@@ -132,9 +136,13 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
    *
    * @return a list of <code>AdaptrisMessage</code>s which meet the criteria
    * for retrying
+   * @implNote The default implementation throws an instance of
+   * {@link UnsupportedOperationException} and performs no other action.
    * @throws InterlokException wrapping any <code>Exception</code> which occurs
    */
-  List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException;
+  default List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
+    throw new UnsupportedOperationException("Not supported by implementation");
+  }
   
   /**
    * <p>

--- a/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
@@ -6,15 +6,11 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ComponentLifecycle;
 import com.adaptris.core.ComponentLifecycleExtension;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.metadata.MetadataValueBranchingService;
 
 
 /**
- * 
- * @author jwickham
- * 
- * Interface for handling paths to be used.
- * Used to validate paths, extract data from paths and insert data back into paths.
- *
+ * Interface for {@link PathBuilder}.
  */
 
 public interface PathBuilder {

--- a/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
@@ -22,7 +22,7 @@ public interface PathBuilder extends ComponentLifecycle, ComponentLifecycleExten
   /**
    * Extract from a payloads path.
    * 
-   * @return a Map<String, String> containing key/value pairs. 
+   * @return a 'Map&lt;String, String&gt;' containing key/value pairs. 
    * <strong>key = payloads path.<strong>
    * <strong>value = path's content.<strong>
    */
@@ -33,7 +33,7 @@ public interface PathBuilder extends ComponentLifecycle, ComponentLifecycleExten
    * Insert values back into a payload.
    * 
    * <p>
-   *  The Map<String, String> 
+   *  The 'Map&lt;String, String&gt;'
    *  param should contain:
    *  <strong>key = payloads path.<strong>
    *  <strong>value = path's content to be inserted.<strong>

--- a/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
@@ -1,0 +1,45 @@
+package com.adaptris.core.security;
+
+import java.util.Map;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ComponentLifecycle;
+import com.adaptris.core.ComponentLifecycleExtension;
+import com.adaptris.core.ServiceException;
+
+
+/**
+ * 
+ * @author jwickham
+ * 
+ * Interface for handling paths to be used.
+ * Used to validate paths, extract data from paths and insert data back into paths.
+ *
+ */
+
+public interface PathBuilder extends ComponentLifecycle, ComponentLifecycleExtension {
+  
+  /**
+   * Extract from a payloads path.
+   * 
+   * @return a Map<String, String> containing key/value pairs. 
+   * <strong>key = payloads path.<strong>
+   * <strong>value = path's content.<strong>
+   */
+  
+  Map<String, String> extract(AdaptrisMessage msg) throws ServiceException;
+  
+  /**
+   * Insert values back into a payload.
+   * 
+   * <p>
+   *  The Map<String, String> 
+   *  param should contain:
+   *  <strong>key = payloads path.<strong>
+   *  <strong>value = path's content to be inserted.<strong>
+   *  <p>
+   */
+   
+  void insert(AdaptrisMessage msg, Map<String, String> pathKeyValuePairs) throws ServiceException;
+  
+}

--- a/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
@@ -17,7 +17,7 @@ import com.adaptris.core.ServiceException;
  *
  */
 
-public interface PathBuilder extends ComponentLifecycle, ComponentLifecycleExtension {
+public interface PathBuilder {
   
   /**
    * Extract from a payloads path.

--- a/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
@@ -16,7 +16,7 @@ import com.adaptris.core.services.metadata.MetadataValueBranchingService;
 public interface PathBuilder {
   
   /**
-   * Extract from a payloads path.
+   * Extract from a payload's path.
    * 
    * @return a 'Map&lt;String, String&gt;' containing key/value pairs. 
    * <strong>key = payloads path.<strong>

--- a/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PathBuilder.java
@@ -3,16 +3,11 @@ package com.adaptris.core.security;
 import java.util.Map;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.ComponentLifecycle;
-import com.adaptris.core.ComponentLifecycleExtension;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.services.metadata.MetadataValueBranchingService;
-
 
 /**
  * Interface for {@link PathBuilder}.
  */
-
 public interface PathBuilder {
   
   /**
@@ -22,7 +17,6 @@ public interface PathBuilder {
    * <strong>key = payloads path.<strong>
    * <strong>value = path's content.<strong>
    */
-  
   Map<String, String> extract(AdaptrisMessage msg) throws ServiceException;
   
   /**
@@ -35,7 +29,6 @@ public interface PathBuilder {
    *  <strong>value = path's content to be inserted.<strong>
    *  <p>
    */
-   
   void insert(AdaptrisMessage msg, Map<String, String> pathKeyValuePairs) throws ServiceException;
   
 }

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathDecryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathDecryptionService.java
@@ -71,7 +71,6 @@ public class PayloadPathDecryptionService extends CoreSecurityService {
             retrieveRemotePartner(msg));
         pathKeyValuePairs.put(xpathKey, output.getAsString());
       } catch (AdaptrisSecurityException e) {
-        e.printStackTrace();
         throw new ServiceException(EXCEPTION_MESSAGE);
       }
       

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathDecryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathDecryptionService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,64 +26,58 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.util.Args;
 import com.adaptris.security.Output;
 import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 
 /**
  * Decrypt part of a message using a configurable path.
  *
  * @config payload-path-decryption-service
- * 
+ *
  * @author jwickham / $Author: jwickham $
  */
 @XStreamAlias("payload-path-decryption-service")
 @AdapterComponent
 @ComponentProfile(summary = "Decrypt part of a message using a configurable path", tag = "service,security,path", since = "5.0.0")
-@DisplayOrder(order = { "localPartner", "remotePartner", "remotePartnerMetadataKey", "encryptionAlgorithm",
-    "keystoreUrls", "privateKeyPasswordProvider" })
+@DisplayOrder(order = { "localPartner", "remotePartner", "remotePartnerMetadataKey", "encryptionAlgorithm", "keystoreUrls",
+    "privateKeyPasswordProvider" })
 
 public class PayloadPathDecryptionService extends CoreSecurityService {
-  
+
   private static final String EXCEPTION_MESSAGE = "Failed to decrypt message";
 
   @NotNull
   @Valid
+  @NonNull
+  @Getter
+  @Setter
   private PathBuilder pathBuilder;
-  
-  
+
   public PayloadPathDecryptionService() {
     pathBuilder = new XpathBuilder();
   }
 
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
-    Map<String, String> pathKeyValuePairs;
-    pathKeyValuePairs = getPathBuilder().extract(msg);
+    Map<String, String> pathKeyValuePairs = getPathBuilder().extract(msg);
 
     for (Map.Entry<String, String> entry : pathKeyValuePairs.entrySet()) {
       String xpathKey = entry.getKey();
       String xpathValue = entry.getValue();
       try {
-        Output output = retrieveSecurityImplementation().verify(xpathValue.getBytes(), retrieveLocalPartner(),
-            retrieveRemotePartner(msg));
+        Output output = retrieveSecurityImplementation().verify(xpathValue.getBytes(), retrieveLocalPartner(), retrieveRemotePartner(msg));
         pathKeyValuePairs.put(xpathKey, output.getAsString());
       } catch (AdaptrisSecurityException e) {
-        throw new ServiceException(EXCEPTION_MESSAGE);
+        throw new ServiceException(EXCEPTION_MESSAGE, e);
       }
-      
+
       getPathBuilder().insert(msg, pathKeyValuePairs);
     }
-  }
-  
-  public PathBuilder getPathBuilder() {
-    return pathBuilder;
-  }
-
-  public void setPathBuilder(PathBuilder pathBuilder) {
-    this.pathBuilder = Args.notNull(pathBuilder, "pathBuilder");
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathDecryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathDecryptionService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.security;
+
+import java.util.Map;
+
+import javax.validation.Valid;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.security.Output;
+import com.adaptris.security.exc.AdaptrisSecurityException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Decrypt part of a message using a configurable path.
+ *
+ * @config payload-path-decryption-service
+ * 
+ * @author jwickham / $Author: jwickham $
+ */
+@XStreamAlias("payload-path-decryption-service")
+@AdapterComponent
+@ComponentProfile(summary = "Decrypt part of a message using a configurable path", tag = "service,security,path", since = "5.0.0")
+@DisplayOrder(order = { "localPartner", "remotePartner", "remotePartnerMetadataKey", "encryptionAlgorithm",
+    "keystoreUrls", "privateKeyPasswordProvider" })
+
+public class PayloadPathDecryptionService extends CoreSecurityService {
+
+  @Getter
+  @Setter
+  @Valid
+  private PathBuilder pathBuilder;
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+
+    Map<String, String> pathKeyValuePairs;
+    pathKeyValuePairs = getPathBuilder().extract(msg);
+
+    for (Map.Entry<String, String> entry : pathKeyValuePairs.entrySet()) {
+      String xpathKey = entry.getKey();
+      String xpathValue = entry.getValue();
+      System.out.println("BYTES: " + xpathValue.getBytes());
+      try {
+        Output output = retrieveSecurityImplementation().verify(xpathValue.getBytes(), retrieveLocalPartner(),
+            retrieveRemotePartner(msg));
+        pathKeyValuePairs.put(xpathKey, output.getAsString());
+      } catch (AdaptrisSecurityException e) {
+        e.printStackTrace();
+        throw new ServiceException("unable to encrypt");
+      }
+
+      getPathBuilder().insert(msg, pathKeyValuePairs);
+
+    }
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathDecryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathDecryptionService.java
@@ -18,6 +18,7 @@ package com.adaptris.core.security;
 
 import java.util.Map;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AdapterComponent;
@@ -30,7 +31,6 @@ import com.adaptris.security.Output;
 import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
-import lombok.NonNull;
 
 /**
  * Decrypt part of a message using a configurable path.
@@ -50,8 +50,13 @@ public class PayloadPathDecryptionService extends CoreSecurityService {
   private static final String EXCEPTION_MESSAGE = "Failed to decrypt message";
 
   @NotNull
-  @NonNull
+  @Valid
   private PathBuilder pathBuilder;
+  
+  
+  public PayloadPathDecryptionService() {
+    pathBuilder = new XpathBuilder();
+  }
 
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 
 /**
- * Perform encryption on part of a message using a configurable path.
+ * Encrypt part of a message using a configurable path.
  * 
  * @config payload-path-encryption-service
  * 

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
@@ -46,10 +46,12 @@ import lombok.NonNull;
     "keystoreUrls", "privateKeyPasswordProvider" })
 
 public class PayloadPathEncryptionService extends CoreSecurityService {
+  
+  private static final String EXCEPTION_MESSAGE = "Failed to encrypt message";
 
   @NotNull
   @NonNull
-  private PathBuilder pathBuilder = null;
+  private PathBuilder pathBuilder;
   
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
@@ -64,11 +66,11 @@ public class PayloadPathEncryptionService extends CoreSecurityService {
             retrieveRemotePartner(msg));
         pathKeyValuePairs.put(xpathKey, output.getAsString());
       } catch (AdaptrisSecurityException e) {
-        throw new ServiceException("unable to encrypt");
+        e.printStackTrace();
+        throw new ServiceException(EXCEPTION_MESSAGE);
       }
-
+      
       getPathBuilder().insert(msg, pathKeyValuePairs);
-
     }
   }
   

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,64 +26,59 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.util.Args;
 import com.adaptris.security.Output;
 import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 
 /**
  * Encrypt part of a message using a configurable path.
- * 
+ *
  * @config payload-path-encryption-service
- * 
+ *
  * @author jwickham / $Author: jwickham $
  */
 @XStreamAlias("payload-path-encryption-service")
 @AdapterComponent
 @ComponentProfile(summary = "Encrypt part of a message using a configurable path", tag = "service,security,path", since = "5.0.0")
-@DisplayOrder(order = { "localPartner", "remotePartner", "remotePartnerMetadataKey", "encryptionAlgorithm",
-    "keystoreUrls", "privateKeyPasswordProvider" })
+@DisplayOrder(order = { "localPartner", "remotePartner", "remotePartnerMetadataKey", "encryptionAlgorithm", "keystoreUrls",
+    "privateKeyPasswordProvider" })
 
 public class PayloadPathEncryptionService extends CoreSecurityService {
-  
+
   private static final String EXCEPTION_MESSAGE = "Failed to encrypt message";
 
   @NotNull
   @Valid
+  @NonNull
+  @Getter
+  @Setter
+
   private PathBuilder pathBuilder;
-   
-  
+
   public PayloadPathEncryptionService() {
     pathBuilder = new XpathBuilder();
   }
 
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
-    Map<String, String> pathKeyValuePairs;
-    pathKeyValuePairs = getPathBuilder().extract(msg);
+    Map<String, String> pathKeyValuePairs = getPathBuilder().extract(msg);
 
     for (Map.Entry<String, String> entry : pathKeyValuePairs.entrySet()) {
       String xpathKey = entry.getKey();
       String xpathValue = entry.getValue();
       try {
-        Output output = retrieveSecurityImplementation().encrypt(xpathValue.getBytes(), retrieveLocalPartner(),
-            retrieveRemotePartner(msg));
+        Output output = retrieveSecurityImplementation().encrypt(xpathValue.getBytes(), retrieveLocalPartner(), retrieveRemotePartner(msg));
         pathKeyValuePairs.put(xpathKey, output.getAsString());
       } catch (AdaptrisSecurityException e) {
-        throw new ServiceException(EXCEPTION_MESSAGE);
+        throw new ServiceException(EXCEPTION_MESSAGE, e);
       }
-      
+
       getPathBuilder().insert(msg, pathKeyValuePairs);
     }
-  }
-  
-  public PathBuilder getPathBuilder() {
-    return pathBuilder;
-  }
-
-  public void setPathBuilder(PathBuilder pathBuilder) {
-    this.pathBuilder = Args.notNull(pathBuilder, "pathBuilder");
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
@@ -18,6 +18,7 @@ package com.adaptris.core.security;
 
 import java.util.Map;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AdapterComponent;
@@ -30,7 +31,6 @@ import com.adaptris.security.Output;
 import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
-import lombok.NonNull;
 
 /**
  * Perform encryption on part of a message using a configurable path.
@@ -50,9 +50,14 @@ public class PayloadPathEncryptionService extends CoreSecurityService {
   private static final String EXCEPTION_MESSAGE = "Failed to encrypt message";
 
   @NotNull
-  @NonNull
+  @Valid
   private PathBuilder pathBuilder;
+   
   
+  public PayloadPathEncryptionService() {
+    pathBuilder = new XpathBuilder();
+  }
+
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     Map<String, String> pathKeyValuePairs;

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.security;
+
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.Args;
+import com.adaptris.security.Output;
+import com.adaptris.security.exc.AdaptrisSecurityException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.NonNull;
+
+/**
+ * Perform encryption on part of a message using a configurable path.
+ * 
+ * @config payload-path-encryption-service
+ * 
+ * @author jwickham / $Author: jwickham $
+ */
+@XStreamAlias("payload-path-encryption-service")
+@AdapterComponent
+@ComponentProfile(summary = "Encrypt part of a message using a configurable path", tag = "service,security,path", since = "5.0.0")
+@DisplayOrder(order = { "localPartner", "remotePartner", "remotePartnerMetadataKey", "encryptionAlgorithm",
+    "keystoreUrls", "privateKeyPasswordProvider" })
+
+public class PayloadPathEncryptionService extends CoreSecurityService {
+
+  @NotNull
+  @NonNull
+  private PathBuilder pathBuilder = null;
+  
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    Map<String, String> pathKeyValuePairs;
+    pathKeyValuePairs = getPathBuilder().extract(msg);
+
+    for (Map.Entry<String, String> entry : pathKeyValuePairs.entrySet()) {
+      String xpathKey = entry.getKey();
+      String xpathValue = entry.getValue();
+      try {
+        Output output = retrieveSecurityImplementation().encrypt(xpathValue.getBytes(), retrieveLocalPartner(),
+            retrieveRemotePartner(msg));
+        pathKeyValuePairs.put(xpathKey, output.getAsString());
+      } catch (AdaptrisSecurityException e) {
+        throw new ServiceException("unable to encrypt");
+      }
+
+      getPathBuilder().insert(msg, pathKeyValuePairs);
+
+    }
+  }
+  
+  public PathBuilder getPathBuilder() {
+    return pathBuilder;
+  }
+
+  public void setPathBuilder(PathBuilder pathBuilder) {
+    this.pathBuilder = Args.notNull(pathBuilder, "pathBuilder");
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/PayloadPathEncryptionService.java
@@ -71,7 +71,6 @@ public class PayloadPathEncryptionService extends CoreSecurityService {
             retrieveRemotePartner(msg));
         pathKeyValuePairs.put(xpathKey, output.getAsString());
       } catch (AdaptrisSecurityException e) {
-        e.printStackTrace();
         throw new ServiceException(EXCEPTION_MESSAGE);
       }
       

--- a/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
@@ -60,7 +60,7 @@ import lombok.Setter;
 @XStreamAlias("xpath-builder")
 @AdapterComponent
 @ComponentProfile(summary = "xpath builder to extract and insert", tag = "service,security,path", since = "5.0.0")
-@DisplayOrder(order = { "xpaths", "namespaceContext", "xmlDocumentFactoryConfig" })
+@DisplayOrder(order = { "xpath", "namespaceContext", "xmlDocumentFactoryConfig" })
 public class XpathBuilder implements PathBuilder {
 
   private static final String ENCRYPTED_ELEMENTS_WRAPPER_NODE_NAME = "encryptedNestedElements";

--- a/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
@@ -1,0 +1,182 @@
+package com.adaptris.core.security;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.Args;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+import com.adaptris.core.util.XmlHelper;
+import com.adaptris.util.KeyValuePairSet;
+import com.adaptris.util.text.xml.SimpleNamespaceContext;
+import com.adaptris.util.text.xml.XPath;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 
+ * @author jwickham
+ * 
+ *         Imp that expects an Xpath to be provided.
+ *
+ */
+
+@XStreamAlias("xpath-builder")
+@AdapterComponent
+@ComponentProfile(summary = "xpath builder to extract and insert", tag = "service,security,path", since = "4.8.9")
+@DisplayOrder(order = { "xpaths", "namespaceContext", "xmlDocumentFactoryConfig" })
+public class XpathBuilder implements PathBuilder {
+
+  private static final String NON_XML_EXCEPTION_MESSAGE = "Unable to create XML document";
+  private static final String INVALID_XPATH_EXCEPTION_MESSAGE = "Unable to evaluate if Xpath exists, please ensure the Xpath is valid";
+  private static final String XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE = "XPath [%s] does not match any nodes";
+
+  public XpathBuilder() {
+    this.setPaths(new ArrayList<String>());
+  }
+
+  @Getter
+  @Setter
+  @NotNull
+  @AutoPopulated
+  @XStreamImplicit(itemFieldName = "xpaths")
+  private List<String> paths;
+  @AdvancedConfig(rare = true)
+  @Valid
+  private KeyValuePairSet namespaceContext;
+  @AdvancedConfig(rare = true)
+  @Valid
+  private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notNull(getPaths(), "xpath");
+    Args.notNull(getNamespaceContext(), "namespaceContext");
+    }
+  
+  @Override
+  public Map<String, String> extract(AdaptrisMessage msg) throws ServiceException {
+    NamespaceContext namespaceContext = SimpleNamespaceContext.create(getNamespaceContext(), msg);
+    NodeList nodeList = null;
+    Document doc;
+    try {
+      doc = XmlHelper.createDocument(msg, documentFactoryBuilder(namespaceContext, msg));
+    } catch (ParserConfigurationException | IOException | SAXException e1) {
+      throw new ServiceException(NON_XML_EXCEPTION_MESSAGE);
+    }
+    Map<String, String> pathKeyValuePairs = new LinkedHashMap<>();
+    for (String path : this.getPaths()) {
+      try {
+        XPath xPathHandler = XPath.newXPathInstance(documentFactoryBuilder(namespaceContext, msg), namespaceContext);
+        nodeList = xPathHandler.selectNodeList(doc, path);
+      } catch (XPathExpressionException e) {
+        throw new ServiceException(INVALID_XPATH_EXCEPTION_MESSAGE);
+      }
+      if (nodeList.getLength() > 0) {
+        Node node = nodeList.item(0);
+        pathKeyValuePairs.put(path, node.getTextContent());
+      } else {
+        throw new ServiceException(String.format(XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE, path));
+      }
+    }
+
+    return pathKeyValuePairs;
+  }
+
+  @Override
+  public void insert(AdaptrisMessage msg, Map<String, String> pathKeyValuePairs) throws ServiceException {
+    NamespaceContext namespaceContext = SimpleNamespaceContext.create(getNamespaceContext(), msg);
+    NodeList nodeList = null;
+    Document doc;
+    try {
+      doc = XmlHelper.createDocument(msg, documentFactoryBuilder(namespaceContext, msg));
+      System.out.println(doc);
+    } catch (ParserConfigurationException | IOException | SAXException e1) {
+      throw new ServiceException(NON_XML_EXCEPTION_MESSAGE);
+    }
+    for (Map.Entry<String, String> entry : pathKeyValuePairs.entrySet()) {
+      String xpathKey = entry.getKey();
+      String xpathValue = entry.getValue();
+      try {
+        XPath xPathHandler = XPath.newXPathInstance(documentFactoryBuilder(namespaceContext, msg), namespaceContext);
+        nodeList = xPathHandler.selectNodeList(doc, xpathKey);
+      } catch (XPathExpressionException e) {
+        throw new ServiceException(INVALID_XPATH_EXCEPTION_MESSAGE);
+      }
+      if (nodeList.getLength() > 0) {
+        Node node = nodeList.item(0);
+        node.setTextContent(xpathValue);
+        System.out.println(node.getTextContent());
+      } else {
+        throw new ServiceException(String.format(XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE, xpathKey));
+      }
+    }
+    
+    try {
+      XmlHelper.writeXmlDocument(doc, msg, msg.getContentEncoding());
+    } catch (Exception e) {
+      throw new ServiceException("could not write to msg");
+    }
+  }
+
+  public KeyValuePairSet getNamespaceContext() {
+    return namespaceContext;
+  }
+
+  /**
+   * Set the namespace context for resolving namespaces.
+   * <ul>
+   * <li>The key is the namespace prefix</li>
+   * <li>The value is the namespace uri</li>
+   * </ul>
+   *
+   * @param namespaceContext
+   */
+  public void setNamespaceContext(KeyValuePairSet namespaceContext) {
+    this.namespaceContext = namespaceContext;
+  }
+
+  public DocumentBuilderFactoryBuilder getXmlDocumentFactoryConfig() {
+    return xmlDocumentFactoryConfig;
+  }
+
+  /**
+   * Set the document factory config
+   * 
+   * @param xmlDocumentFactoryConfig
+   */
+
+  public void setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig) {
+    this.xmlDocumentFactoryConfig = xmlDocumentFactoryConfig;
+  }
+
+  private DocumentBuilderFactoryBuilder documentFactoryBuilder(NamespaceContext namespaceCtx, AdaptrisMessage msg) {
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig(), namespaceCtx);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
@@ -99,23 +99,22 @@ public class XpathBuilder implements PathBuilder {
     Document doc = prepareXmlDoc(msg);
     Map<String, String> pathKeyValuePairs = new LinkedHashMap<>();
     for (String path : this.getPaths()) {
-      String xPathToExecute = msg == null ? path : msg.resolve(path);
-      node = prepareNode(doc, xPathToExecute, msg);
+      node = prepareNode(doc, msg.resolve(path), msg);
       try {
         XPath xPathHandler = XPath.newXPathInstance(documentFactoryBuilder(), createNamespaceCxt(msg));
-        node = xPathHandler.selectSingleNode(doc, xPathToExecute);
+        node = xPathHandler.selectSingleNode(doc, msg.resolve(path));
       } catch (XPathExpressionException e) {
-        throw new ServiceException(String.format(INVALID_XPATH_EXCEPTION_MESSAGE, xPathToExecute));
+        throw new ServiceException(String.format(INVALID_XPATH_EXCEPTION_MESSAGE, msg.resolve(path)));
       }
       if (node != null) {
         NodeList childNodeList = node.getChildNodes();
         if (childNodeList.getLength() > 1) {
-          pathKeyValuePairs.put(xPathToExecute, concatAndWrapNestedNodesToString(childNodeList));
+          pathKeyValuePairs.put(msg.resolve(path), concatAndWrapNestedNodesToString(childNodeList));
           continue;
         }
-        pathKeyValuePairs.put(xPathToExecute, node.getTextContent());
+        pathKeyValuePairs.put(msg.resolve(path), node.getTextContent());
       } else {
-        throw new ServiceException(String.format(XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE, xPathToExecute));
+        throw new ServiceException(String.format(XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE, msg.resolve(path)));
       }
     }
     

--- a/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
@@ -23,9 +23,7 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.util.KeyValuePairSet;
@@ -77,11 +75,6 @@ public class XpathBuilder implements PathBuilder {
   @AdvancedConfig(rare = true)
   @Valid
   private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
-
-  @Override
-  public void prepare() throws CoreException {
-    Args.notNull(getPaths(), "xpath");
-  }
 
   @Override
   public Map<String, String> extract(AdaptrisMessage msg) throws ServiceException {

--- a/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/security/XpathBuilder.java
@@ -19,7 +19,6 @@ import org.xml.sax.SAXException;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
@@ -57,7 +56,7 @@ public class XpathBuilder implements PathBuilder {
 
   private static final String NON_XML_EXCEPTION_MESSAGE = "Unable to create XML document";
   private static final String INVALID_XPATH_EXCEPTION_MESSAGE = "Unable to evaluate if Xpath [%s] exists, please ensure the Xpath is valid";
-  private static final String XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE = "XPath [%s] does not match any nodes";
+  private static final String XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE = "XPath [%s] does not match any nodes. Please ensure it exists and if used that the namespace context is correct";
   private static final String COULD_NOT_WRITE_TO_MSG_EXCEPTION_MESSAGE = "Could not write to msg";
 
   public XpathBuilder() {
@@ -69,7 +68,6 @@ public class XpathBuilder implements PathBuilder {
   @Getter
   @Setter
   @NotNull
-  @AutoPopulated
   @XStreamImplicit(itemFieldName = "xpaths")
   @InputFieldHint(expression = true)
   private List<String> paths;
@@ -110,7 +108,7 @@ public class XpathBuilder implements PathBuilder {
         throw new ServiceException(String.format(XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE, xPathToExecute));
       }
     }
-
+    
     return pathKeyValuePairs;
   }
 
@@ -204,6 +202,10 @@ public class XpathBuilder implements PathBuilder {
       throw new ServiceException(String.format(INVALID_XPATH_EXCEPTION_MESSAGE, xPath));
     }
   }
+  
+  //The below private methods are here so we can handle xml nodes that contain nested child nodes
+ //as we need to extract not only the text content but the entire xml 'structure'.
+//Possibly can be done in a more concise way.
 
   private String concatAndWrapNestedNodesToString(NodeList nestedNodeList) {
     StringBuilder sb = new StringBuilder();
@@ -239,5 +241,4 @@ public class XpathBuilder implements PathBuilder {
     }
     return true;
   }
-
 }

--- a/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
@@ -455,7 +455,7 @@ public class XmlHelper {
    * @return The Node of the XML String passed to it.
    * @throws Exception if unable to covnert to a node. This would
    * be expected if the String passed to it would not make well formed XML
-   * or would not XML at all.
+   * or is not XML at all.
    */
   public static Node stringToNode(String xmlString) throws Exception {
     return DocumentBuilderFactory.newInstance().newDocumentBuilder()

--- a/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
@@ -38,6 +38,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -444,6 +446,20 @@ public class XmlHelper {
     } catch (Exception e) {
       return null;
     }
+  }
+  
+  /**
+   * Convert a String into an XML Node.
+   *
+   * @param xmlString The xml string to covert to a Node.
+   * @return The Node of the XML String passed to it.
+   * @throws Exception if unable to covnert to a node. This would
+   * be expected if the String passed to it would not make well formed XML
+   * or would not XML at all.
+   */
+  public static Node stringToNode(String xmlString) throws Exception {
+    return DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        .parse(new ByteArrayInputStream(xmlString.getBytes())).getDocumentElement();
   }
 
   private static Transformer configure(Transformer serializer, String encoding)

--- a/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
@@ -453,13 +453,13 @@ public class XmlHelper {
    *
    * @param xmlString The xml string to covert to a Node.
    * @return The Node of the XML String passed to it.
-   * @throws Exception if unable to covnert to a node. This would
+   * @throws Exception if unable to convert to a node. This would
    * be expected if the String passed to it would not make well formed XML
    * or is not XML at all.
    */
   public static Node stringToNode(String xmlString) throws Exception {
-    return DocumentBuilderFactory.newInstance().newDocumentBuilder()
-        .parse(new ByteArrayInputStream(xmlString.getBytes())).getDocumentElement();
+    return createDocument(xmlString, DocumentBuilderFactoryBuilder.newInstance().withNamespaceAware(false))
+           .getDocumentElement();
   }
 
   private static Transformer configure(Transformer serializer, String encoding)
@@ -471,7 +471,6 @@ public class XmlHelper {
     serializer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "");
     return serializer;
   }
-
 
   private static class DefaultErrorHandler implements ErrorHandler {
 
@@ -529,4 +528,5 @@ public class XmlHelper {
       return out.toString();
     }
   }
+  
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
@@ -128,8 +128,7 @@ public class FilesystemRetryStoreTest {
       AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
       store.write(msg);
       Map<String, String> metadata = store.getMetadata(msg.getUniqueId());
-      AdaptrisMessage retry = store.buildForRetry(msg.getUniqueId(), store.getMetadata(msg.getUniqueId()),
-          new FileBackedMessageFactory());
+      AdaptrisMessage retry = store.buildForRetry(msg.getUniqueId(), metadata, new FileBackedMessageFactory());
       assertEquals(msg.getUniqueId(), retry.getUniqueId());
       assertEquals(msg.getMessageHeaders(), retry.getMessageHeaders());
     } finally {
@@ -143,7 +142,7 @@ public class FilesystemRetryStoreTest {
       FilesystemRetryStore store = new FilesystemRetryStore().withBaseUrl(INVALID_URL);
       try {
         LifecycleHelper.initAndStart(store);
-        AdaptrisMessage retry = store.buildForRetry("xxx", Collections.EMPTY_MAP);
+        store.buildForRetry("xxx", Collections.emptyMap());
       } finally {
         LifecycleHelper.stopAndClose(store);
       }
@@ -197,7 +196,7 @@ public class FilesystemRetryStoreTest {
 
       try {
         LifecycleHelper.initAndStart(store);
-        AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
+        new DefaultMessageFactory().newMessage("hello");
         store.report();
       } finally {
         LifecycleHelper.stopAndClose(store);

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
@@ -70,16 +70,6 @@ public class InMemoryRetryStore implements RetryStore {
   }
 
   @Override
-  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
-  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
   public void updateRetryCount(String messageId) throws InterlokException {
    // null implementation   
   }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -423,16 +423,6 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
     }
 
     @Override
-    public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
-      return null; // null implementation
-    }
-
-    @Override
-    public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
-      return null; // null implementation
-    }
-
-    @Override
     public void updateRetryCount(String messageId) throws InterlokException {
      // null implementation
     }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
@@ -39,6 +38,20 @@ public class RetryStoreTest implements RetryStore {
   }
 
   @Test
+  public void testDefaultObtainExpiredMessages() throws Exception {
+    Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+      obtainExpiredMessages();
+    });
+  }
+
+  @Test
+  public void testDefaultObtainMessagesToRetry() throws Exception {
+    Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+      obtainMessagesToRetry();
+    });
+  }
+
+  @Test
   public void testDefaultBuild() throws Exception {
     assertNull(buildForRetry(""));
   }
@@ -61,27 +74,27 @@ public class RetryStoreTest implements RetryStore {
 
   @Override
   public Map<String, String> getMetadata(String msgId) throws InterlokException {
-    return Collections.EMPTY_MAP;
+    return Collections.emptyMap();
   }
 
   @Override
   public void acknowledge(String acknowledgeId) throws InterlokException {
-   // null implementation
+    // null implementation
   }
 
   @Override
   public void deleteAcknowledged() throws InterlokException {
-   // null implementation   
+    // null implementation
   }
- 
+
   @Override
   public void updateRetryCount(String messageId) throws InterlokException {
- // null implementation
+    // null implementation
   }
 
   @Override
   public void makeConnection(AdaptrisConnection connection) {
-   // null implementation
+    // null implementation
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
@@ -73,18 +73,7 @@ public class RetryStoreTest implements RetryStore {
   public void deleteAcknowledged() throws InterlokException {
    // null implementation   
   }
-
-  @Override
-  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
-    return null; // null implementation
-  }
-
-  @Override
-  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
-    return null; // null implementation
-  }
-  
-
+ 
   @Override
   public void updateRetryCount(String messageId) throws InterlokException {
  // null implementation

--- a/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathDecryptionServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathDecryptionServiceTest.java
@@ -1,0 +1,10 @@
+package com.adaptris.core.security;
+
+public class PayloadPathDecryptionServiceTest extends PayloadPathSecurityServiceCase {
+
+  @Override
+  protected CoreSecurityService create() {
+    return new PayloadPathDecryptionService();
+  }
+ 
+}

--- a/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathEncryptionServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathEncryptionServiceTest.java
@@ -1,0 +1,10 @@
+package com.adaptris.core.security;
+
+public class PayloadPathEncryptionServiceTest extends PayloadPathSecurityServiceCase {
+
+  @Override
+  protected CoreSecurityService create() {
+    return new PayloadPathEncryptionService();
+  }
+  
+}

--- a/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathSecurityServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathSecurityServiceCase.java
@@ -1,0 +1,192 @@
+package com.adaptris.core.security;
+
+import static com.adaptris.core.security.JunitSecurityHelper.SECURITY_ALIAS;
+import static com.adaptris.core.security.JunitSecurityHelper.SECURITY_PASSWORD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.security.EncryptionAlgorithm;
+import com.adaptris.security.keystore.ConfiguredUrl;
+import com.adaptris.security.keystore.InlineKeystore;
+import com.adaptris.security.util.Constants;
+
+public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase{
+  
+  protected static final String EXAMPLE_KEYINFO = "<KeyInfo xmlns=\"http://www.w3.org/2000/09/xmldsig#\""
+      + "xmlns:tns=\"http://www.oasis-open.org/committees/ebxml-cppa/schema/cpp-cpa-2_0.xsd\">"
+      + "<KeyName>message_signing_cert-Key</KeyName>" + "<X509Data>" + "<X509Certificate>"
+      + "MIIElDCCA3ygAwIBAgIBADANBgkqhkiG9w0BAQQFADCBkjELMAkGA1UEBhMCVVMx"
+      + "CzAJBgNVBAgTAk1BMRAwDgYDVQQHEwdCZWRmb3JkMRcwFQYDVQQKEw5Tb25pYyBT"
+      + "b2Z0d2FyZTEMMAoGA1UECxMDRGV2MRMwEQYDVQQDEwpKb2UgU2FtcGxlMSgwJgYJ"
+      + "KoZIhvcNAQkBFhlqc2FtcGxlQHNvbmljc29mdHdhcmUuY29tMB4XDTA0MTEwMzIz"
+      + "MzUwNFoXDTA4MTEwMjIzMzUwNFowgZIxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJN"
+      + "QTEQMA4GA1UEBxMHQmVkZm9yZDEXMBUGA1UEChMOU29uaWMgU29mdHdhcmUxDDAK"
+      + "BgNVBAsTA0RldjETMBEGA1UEAxMKSm9lIFNhbXBsZTEoMCYGCSqGSIb3DQEJARYZ"
+      + "anNhbXBsZUBzb25pY3NvZnR3YXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP"
+      + "ADCCAQoCggEBANg0MJNWN1sxCfLbSGi+WVGBbqEVSExb50VEF4jxgdciJz8By3hb"
+      + "6naYdHoWcJl6GyGMEFROZGdOjBGqxcF3DD/bzHLB2Ge60UkJgEFP8eMYOLVYdjb/"
+      + "sAvXic+VKmnBp+DDnqeyozTp39/qxqhcP8VGiBHT97G9chTP6ZCLD2tK+t6zvJ+3"
+      + "1NexQj0P4OUw4I+uuuBaYmPGqFrpySaHA6BpJ5iY3CB28wqxzIt2xjz/MjqnHWWS"
+      + "YwNyjGs0O8+WO7FrQbW9WBGDQrEzANuB6l4O6GRVoMOKnuD407d2DOpIQBmg4m7T"
+      + "nTNVol/0lj6XC4leD2cSJg8EIU5pPwBnajUCAwEAAaOB8jCB7zAdBgNVHQ4EFgQU"
+      + "vtrk4IPUOLJyQXEA9aysK7l/Ce4wgb8GA1UdIwSBtzCBtIAUvtrk4IPUOLJyQXEA"
+      + "9aysK7l/Ce6hgZikgZUwgZIxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJNQTEQMA4G"
+      + "A1UEBxMHQmVkZm9yZDEXMBUGA1UEChMOU29uaWMgU29mdHdhcmUxDDAKBgNVBAsT"
+      + "A0RldjETMBEGA1UEAxMKSm9lIFNhbXBsZTEoMCYGCSqGSIb3DQEJARYZanNhbXBs"
+      + "ZUBzb25pY3NvZnR3YXJlLmNvbYIBADAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEB"
+      + "BAUAA4IBAQB7OjBSc18axpRbqOvLq5dO5t8TJtEoRFkopvbAxlSV4lt/c6IptfbO"
+      + "a4iRuBzjXufW+AgOV+eRtBaatcChvc5QI7TZuPp4k57bOG4GJCafEWo89SmVsWy/"
+      + "9XJU+fmuaTt72i3EEMOsiUWJJqVdcNxAdC2cGSKV1wP4nwhFI+WzdtpJKImEl9LY"
+      + "GDiqn9b96Oz2eH8FPA4qzNNkoA/36s/iPl1Zn3VF7mzR4jHe9aKUg/XvNWXpKAvd"
+      + "tItpX25JP3RhnzFrwriwUyFshUaF+J05O+6P2WilvUsX7+Q1prU7POnyizhdlvlt" + "6c+G3SjCAdM/oKJB1LSVLuxUzx0vTs2S"
+      + "</X509Certificate>" + "</X509Data>" + "</KeyInfo>";
+  
+  protected static final String XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n"
+      + "<root>\r\n"
+      + "   <xpath1>xpath1_result</xpath1>\r\n"
+      + "   <xpath2>xpath2_result</xpath2>\r\n"
+      + "   <xpath3>xpath3_result</xpath3>\r\n"
+      + "   <parent>\r\n"
+      + "      <child1>child1</child1>\r\n"
+      + "      <child2>child2</child2>\r\n"
+      + "   </parent>\r\n"
+      + "</root>\r\n";
+  
+  protected static final String JSON = "{\r\n"
+      + "    \"firstName\": \"John\",\r\n"
+      + "    \"lastName\": \"doe\",\r\n"
+      + "    \"age\": 26,\r\n"
+      + "    \"address\": {\r\n"
+      + "        \"streetAddress\": \"street\",\r\n"
+      + "        \"city\": \"city\",\r\n"
+      + "        \"postalCode\": \"TW12 3RR\"\r\n"
+      + "    },\r\n"
+      + "    \"phoneNumbers\": [\r\n"
+      + "        {\r\n"
+      + "            \"type\": \"mobile\",\r\n"
+      + "            \"number\": \"000-000-000\"\r\n"
+      + "        },\r\n"
+      + "        {\r\n"
+      + "            \"type\": \"home\",\r\n"
+      + "            \"number\": \"111-111-111\"\r\n"
+      + "        }\r\n"
+      + "    ]\r\n"
+      + "}";
+  
+  protected static final String XPATH_1 = "//xpath1";
+  protected static final String XPATH_2 = "//xpath2";
+  protected static final String XPATH_3 = "//xpath3";
+  
+  protected static final String JSON_SINGLE_OBJECT_PATH = "$.firstName";
+  protected static final String JSON_MULTI_OBJECT_PATH = "$.address";
+  protected static final String JSON_ARRAY_PATH = "$.phoneNumbers";
+  protected static final String JSON_EXPRESSION_PATH = "$.phoneNumbers[:1].type";
+  protected static final String JSON_INVALID_PATH = "invalid json path";
+  protected static final String JSON_NON_EXISTENT_PATH = "$.thirdName";
+  
+  @Test
+  public void testEncryptingDecryptingMultiplePathsWithConfiguredProvider() throws Exception {
+    List<String> path = new ArrayList<String>();
+    path.add(XPATH_1);
+    path.add(XPATH_2);
+    path.add(XPATH_3);
+    XpathBuilder xpathBuilder = new XpathBuilder();
+    xpathBuilder.setPaths(path);
+    PayloadPathEncryptionService payloadPathEncryptionService = new PayloadPathEncryptionService();
+    payloadPathEncryptionService.setPathBuilder(xpathBuilder);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
+    String url = createKeystore();
+    applyConfigForTests(payloadPathEncryptionService, url);
+    configureForConfiguredPrivateKey(payloadPathEncryptionService, PROPERTIES.getProperty(SECURITY_PASSWORD));
+    execute(payloadPathEncryptionService, msg);
+    PayloadPathDecryptionService payloadPathDecryptionService = new PayloadPathDecryptionService();
+    payloadPathDecryptionService.setPathBuilder(xpathBuilder);
+    applyConfigForTests(payloadPathDecryptionService, url);
+    configureForConfiguredPrivateKey(payloadPathDecryptionService, PROPERTIES.getProperty(SECURITY_PASSWORD));
+    execute(payloadPathDecryptionService, msg);
+    assertEquals(XML, msg.getContent());
+  }
+
+
+  
+  /**
+   * @see com.adaptris.core.ExampleConfigCase#retrieveObjectForSampleConfig()
+   */
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    CoreSecurityService s = create();
+    applyConfigForSamples(s);
+    return s;
+  }
+  
+  protected void applyConfigForTests(CoreSecurityService service, String url) {
+    applyConfigForTests(service, new ConfiguredUrl(url, PROPERTIES.getProperty(SECURITY_PASSWORD)));
+  }
+
+  protected void applyConfigForTests(CoreSecurityService service, ConfiguredUrl keystoreUrl) {
+    service.addKeystoreUrl(keystoreUrl);
+    service.setLocalPartner(PROPERTIES.getProperty(SECURITY_ALIAS));
+    service.setRemotePartner(PROPERTIES.getProperty(SECURITY_ALIAS));
+    configureForConfiguredPrivateKey(service, PROPERTIES.getProperty(SECURITY_PASSWORD));
+  }
+
+  protected void configureForLegacyProvider(CoreSecurityService service) {
+    service.setPrivateKeyPasswordProvider(new LegacyPrivateKeyPasswordProvider());
+  }
+
+  protected void configureForConfiguredPrivateKey(CoreSecurityService service, String password) {
+    ConfiguredPrivateKeyPasswordProvider configured = new ConfiguredPrivateKeyPasswordProvider();
+    configured.setEncodedPassword(password);
+    service.setPrivateKeyPasswordProvider(configured);
+  }
+  
+  protected static void applyConfigForSamples(CoreSecurityService service) {
+    try {
+      service.setLocalPartner("local partner alias in keystore");
+      service.setRemotePartner("remote partner alias in keystore");
+      service.addKeystoreUrl(new ConfiguredUrl("http://localhost/path/to/JKS/keystore?keystoreType="
+          + "JKS&keystorePassword=somePlainTextPassword"));
+      service.addKeystoreUrl(new ConfiguredUrl("file://localhost/path/to/a/X509/Certificate?keystoreType="
+          + "X509?keystoreAlias=CertificateAlias"));
+      service.addKeystoreUrl(new ConfiguredUrl("file://localhost/path/to/another/X509/Certificate?keystoreType="
+          + "X509?keystoreAlias=AnotherAlias"));
+      service.addKeystoreUrl(new ConfiguredUrl("http://host/path/to/a/PKCS12/Keystore?keystoreType="
+          + "PKCS12&keystoreAlias=PKCS12Alias",
+          "PW:AAAAEF+zZCbvHeIXDx8HUslqiYwAAAAQ3wi4/BVycX+uzc5zF4F6EQAAABD0hhpr46IrKSu7XxFhEAYN"));
+      // service.addKeystoreUrl(new ConfiguredUrl("http://host/path/to/keystore?keystoreType=" + "PKCS12&keystoreAlias=myalias",
+      // PROPERTIES.getProperty(SECURITY_PASSWORD)));
+      service.addKeystoreUrl(new ConfiguredUrl("http://host/path/to/a/JCE/keystore?keystoreType=JCEKS",
+          "ALTPW:AAAAEF+zZCbvHeIXDx8HUslqiYwAAAAQ3wi4/BVycX+uzc5zF4F6EQAAABD0hhpr46IrKSu7XxFhEAYN"));
+      // service.addKeystoreUrl(new ConfiguredUrl("http://host/path/to/keystore?keystoreType=" + "JCEKS&keystoreAlias=myalias",
+      // Password.encode(PROPERTIES.getProperty(SECURITY_PASSWORD), Password.NON_PORTABLE_PASSWORD)));
+
+      service.addKeystoreUrl(new ConfiguredUrl("file://local/path/to/anoter/JKS/keystore?keystoreType="
+          + "JKS&keystoreAlias=myalias",
+          "somePlainTextPassword"));
+      InlineKeystore inline = new InlineKeystore();
+      inline.setCertificate(EXAMPLE_KEYINFO);
+      inline.setType(Constants.KEYSTORE_XMLKEYINFO);
+      inline.setAlias("myAlias");
+      service.addKeystoreUrl(inline);
+      addEncryptionAlgsForFactoryType(service);
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  private static void addEncryptionAlgsForFactoryType(CoreSecurityService s) {
+    if (s.getSecurityFactory() == null) {
+      s.setEncryptionAlgorithm(new EncryptionAlgorithm("AES/CBC/PKCS5Padding", 256));
+      return;
+    }
+    return;
+  }
+  
+}

--- a/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathSecurityServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathSecurityServiceCase.java
@@ -18,8 +18,8 @@ import com.adaptris.security.keystore.ConfiguredUrl;
 import com.adaptris.security.keystore.InlineKeystore;
 import com.adaptris.security.util.Constants;
 
-public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase{
-  
+public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase {
+
   protected static final String EXAMPLE_KEYINFO = "<KeyInfo xmlns=\"http://www.w3.org/2000/09/xmldsig#\""
       + "xmlns:tns=\"http://www.oasis-open.org/committees/ebxml-cppa/schema/cpp-cpa-2_0.xsd\">"
       + "<KeyName>message_signing_cert-Key</KeyName>" + "<X509Data>" + "<X509Certificate>"
@@ -46,7 +46,8 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
       + "a4iRuBzjXufW+AgOV+eRtBaatcChvc5QI7TZuPp4k57bOG4GJCafEWo89SmVsWy/"
       + "9XJU+fmuaTt72i3EEMOsiUWJJqVdcNxAdC2cGSKV1wP4nwhFI+WzdtpJKImEl9LY"
       + "GDiqn9b96Oz2eH8FPA4qzNNkoA/36s/iPl1Zn3VF7mzR4jHe9aKUg/XvNWXpKAvd"
-      + "tItpX25JP3RhnzFrwriwUyFshUaF+J05O+6P2WilvUsX7+Q1prU7POnyizhdlvlt" + "6c+G3SjCAdM/oKJB1LSVLuxUzx0vTs2S"
+      + "tItpX25JP3RhnzFrwriwUyFshUaF+J05O+6P2WilvUsX7+Q1prU7POnyizhdlvlt"
+      + "6c+G3SjCAdM/oKJB1LSVLuxUzx0vTs2S"
       + "</X509Certificate>" + "</X509Data>" + "</KeyInfo>";
   
   public static final String XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
@@ -69,10 +70,10 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
   protected static final String XPATH_2 = "//xpath2";
   protected static final String XPATH_3 = "//xpath3";
   protected static final String XPATH_WITH_CHILDREN = "//parent";
-  
+
   @Test
   public void testEncryptingDecryptingSinglePathWithConfiguredProvider() throws Exception {
-    List<String> path = new ArrayList<String>();
+    List<String> path = new ArrayList<>();
     path.add(XPATH_1);
     XpathBuilder xpathBuilder = new XpathBuilder();
     xpathBuilder.setPaths(path);
@@ -90,10 +91,10 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     execute(payloadPathDecryptionService, msg);
     assertEquals(XML, msg.getContent());
   }
-  
+
   @Test
   public void testEncryptingDecryptingMultiplePathsWithConfiguredProvider() throws Exception {
-    List<String> path = new ArrayList<String>();
+    List<String> path = new ArrayList<>();
     path.add(XPATH_1);
     path.add(XPATH_2);
     path.add(XPATH_3);
@@ -113,10 +114,10 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     execute(payloadPathDecryptionService, msg);
     assertEquals(XML, msg.getContent());
   }
-  
+
   @Test
   public void testEncryptingDecryptingMultiplePathsWithLegacyProvider() throws Exception {
-    List<String> path = new ArrayList<String>();
+    List<String> path = new ArrayList<>();
     path.add(XPATH_1);
     path.add(XPATH_2);
     path.add(XPATH_3);
@@ -136,10 +137,10 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     execute(payloadPathDecryptionService, msg);
     assertEquals(XML, msg.getContent());
   }
-  
+
   @Test
   public void testEncryptingDecryptingParentPathWithConfiguredProvider() throws Exception {
-    List<String> path = new ArrayList<String>();
+    List<String> path = new ArrayList<>();
     path.add(XPATH_WITH_CHILDREN);
     XpathBuilder xpathBuilder = new XpathBuilder();
     xpathBuilder.setPaths(path);
@@ -157,10 +158,10 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     execute(payloadPathDecryptionService, msg);
     assertEquals(XML, msg.getContent());
   }
-  
+
   @Test
   public void testEncryptingDecryptingParentPathWithLegacyProvider() throws Exception {
-    List<String> path = new ArrayList<String>();
+    List<String> path = new ArrayList<>();
     path.add(XPATH_WITH_CHILDREN);
     XpathBuilder xpathBuilder = new XpathBuilder();
     xpathBuilder.setPaths(path);
@@ -178,10 +179,10 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     execute(payloadPathDecryptionService, msg);
     assertEquals(XML, msg.getContent());
   }
-  
+
   @Test
   public void testFailingToEncryptMessage() throws Exception {
-    List<String> path = new ArrayList<String>();
+    List<String> path = new ArrayList<>();
     path.add(XPATH_WITH_CHILDREN);
     XpathBuilder xpathBuilder = new XpathBuilder();
     xpathBuilder.setPaths(path);
@@ -198,10 +199,10 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
       execute(payloadPathEncryptionService, msg);
     });
   }
-  
+
   @Test
   public void testFailingToDecryptMessage() throws Exception {
-    List<String> path = new ArrayList<String>();
+    List<String> path = new ArrayList<>();
     path.add(XPATH_1);
     XpathBuilder xpathBuilder = new XpathBuilder();
     xpathBuilder.setPaths(path);
@@ -223,8 +224,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
       execute(payloadPathDecryptionService, msg);
     });
   }
-  
-  
+
   /**
    * @see com.adaptris.core.ExampleConfigCase#retrieveObjectForSampleConfig()
    */
@@ -234,7 +234,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     applyConfigForSamples(s);
     return s;
   }
-  
+
   protected void applyConfigForTests(CoreSecurityService service, String url) {
     applyConfigForTests(service, new ConfiguredUrl(url, PROPERTIES.getProperty(SECURITY_PASSWORD)));
   }
@@ -255,19 +255,18 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     configured.setEncodedPassword(password);
     service.setPrivateKeyPasswordProvider(configured);
   }
-  
+
   protected static void applyConfigForSamples(CoreSecurityService service) {
     try {
       service.setLocalPartner("local partner alias in keystore");
       service.setRemotePartner("remote partner alias in keystore");
-      service.addKeystoreUrl(new ConfiguredUrl("http://localhost/path/to/JKS/keystore?keystoreType="
-          + "JKS&keystorePassword=somePlainTextPassword"));
-      service.addKeystoreUrl(new ConfiguredUrl("file://localhost/path/to/a/X509/Certificate?keystoreType="
-          + "X509?keystoreAlias=CertificateAlias"));
-      service.addKeystoreUrl(new ConfiguredUrl("file://localhost/path/to/another/X509/Certificate?keystoreType="
-          + "X509?keystoreAlias=AnotherAlias"));
-      service.addKeystoreUrl(new ConfiguredUrl("http://host/path/to/a/PKCS12/Keystore?keystoreType="
-          + "PKCS12&keystoreAlias=PKCS12Alias",
+      service.addKeystoreUrl(
+          new ConfiguredUrl("http://localhost/path/to/JKS/keystore?keystoreType=" + "JKS&keystorePassword=somePlainTextPassword"));
+      service.addKeystoreUrl(
+          new ConfiguredUrl("file://localhost/path/to/a/X509/Certificate?keystoreType=" + "X509?keystoreAlias=CertificateAlias"));
+      service.addKeystoreUrl(
+          new ConfiguredUrl("file://localhost/path/to/another/X509/Certificate?keystoreType=" + "X509?keystoreAlias=AnotherAlias"));
+      service.addKeystoreUrl(new ConfiguredUrl("http://host/path/to/a/PKCS12/Keystore?keystoreType=" + "PKCS12&keystoreAlias=PKCS12Alias",
           "PW:AAAAEF+zZCbvHeIXDx8HUslqiYwAAAAQ3wi4/BVycX+uzc5zF4F6EQAAABD0hhpr46IrKSu7XxFhEAYN"));
       // service.addKeystoreUrl(new ConfiguredUrl("http://host/path/to/keystore?keystoreType=" + "PKCS12&keystoreAlias=myalias",
       // PROPERTIES.getProperty(SECURITY_PASSWORD)));
@@ -276,8 +275,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
       // service.addKeystoreUrl(new ConfiguredUrl("http://host/path/to/keystore?keystoreType=" + "JCEKS&keystoreAlias=myalias",
       // Password.encode(PROPERTIES.getProperty(SECURITY_PASSWORD), Password.NON_PORTABLE_PASSWORD)));
 
-      service.addKeystoreUrl(new ConfiguredUrl("file://local/path/to/anoter/JKS/keystore?keystoreType="
-          + "JKS&keystoreAlias=myalias",
+      service.addKeystoreUrl(new ConfiguredUrl("file://local/path/to/anoter/JKS/keystore?keystoreType=" + "JKS&keystoreAlias=myalias",
           "somePlainTextPassword"));
       InlineKeystore inline = new InlineKeystore();
       inline.setCertificate(EXAMPLE_KEYINFO);
@@ -285,18 +283,16 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
       inline.setAlias("myAlias");
       service.addKeystoreUrl(inline);
       addEncryptionAlgsForFactoryType(service);
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
-  
+
   private static void addEncryptionAlgsForFactoryType(CoreSecurityService s) {
     if (s.getSecurityFactory() == null) {
       s.setEncryptionAlgorithm(new EncryptionAlgorithm("AES/CBC/PKCS5Padding", 256));
       return;
     }
-    return;
   }
-  
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathSecurityServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathSecurityServiceCase.java
@@ -76,7 +76,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     List<String> path = new ArrayList<>();
     path.add(XPATH_1);
     XpathBuilder xpathBuilder = new XpathBuilder();
-    xpathBuilder.setPaths(path);
+    xpathBuilder.setXpaths(path);
     PayloadPathEncryptionService payloadPathEncryptionService = new PayloadPathEncryptionService();
     payloadPathEncryptionService.setPathBuilder(xpathBuilder);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -99,7 +99,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     path.add(XPATH_2);
     path.add(XPATH_3);
     XpathBuilder xpathBuilder = new XpathBuilder();
-    xpathBuilder.setPaths(path);
+    xpathBuilder.setXpaths(path);
     PayloadPathEncryptionService payloadPathEncryptionService = new PayloadPathEncryptionService();
     payloadPathEncryptionService.setPathBuilder(xpathBuilder);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -122,7 +122,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     path.add(XPATH_2);
     path.add(XPATH_3);
     XpathBuilder xpathBuilder = new XpathBuilder();
-    xpathBuilder.setPaths(path);
+    xpathBuilder.setXpaths(path);
     PayloadPathEncryptionService payloadPathEncryptionService = new PayloadPathEncryptionService();
     payloadPathEncryptionService.setPathBuilder(xpathBuilder);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -143,7 +143,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     List<String> path = new ArrayList<>();
     path.add(XPATH_WITH_CHILDREN);
     XpathBuilder xpathBuilder = new XpathBuilder();
-    xpathBuilder.setPaths(path);
+    xpathBuilder.setXpaths(path);
     PayloadPathEncryptionService payloadPathEncryptionService = new PayloadPathEncryptionService();
     payloadPathEncryptionService.setPathBuilder(xpathBuilder);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -164,7 +164,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     List<String> path = new ArrayList<>();
     path.add(XPATH_WITH_CHILDREN);
     XpathBuilder xpathBuilder = new XpathBuilder();
-    xpathBuilder.setPaths(path);
+    xpathBuilder.setXpaths(path);
     PayloadPathEncryptionService payloadPathEncryptionService = new PayloadPathEncryptionService();
     payloadPathEncryptionService.setPathBuilder(xpathBuilder);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -185,7 +185,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     List<String> path = new ArrayList<>();
     path.add(XPATH_WITH_CHILDREN);
     XpathBuilder xpathBuilder = new XpathBuilder();
-    xpathBuilder.setPaths(path);
+    xpathBuilder.setXpaths(path);
     PayloadPathEncryptionService payloadPathEncryptionService = new PayloadPathEncryptionService();
     payloadPathEncryptionService.setPathBuilder(xpathBuilder);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -205,7 +205,7 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     List<String> path = new ArrayList<>();
     path.add(XPATH_1);
     XpathBuilder xpathBuilder = new XpathBuilder();
-    xpathBuilder.setPaths(path);
+    xpathBuilder.setXpaths(path);
     PayloadPathEncryptionService payloadPathEncryptionService = new PayloadPathEncryptionService();
     payloadPathEncryptionService.setPathBuilder(xpathBuilder);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
@@ -291,7 +291,6 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
   private static void addEncryptionAlgsForFactoryType(CoreSecurityService s) {
     if (s.getSecurityFactory() == null) {
       s.setEncryptionAlgorithm(new EncryptionAlgorithm("AES/CBC/PKCS5Padding", 256));
-      return;
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathSecurityServiceCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/PayloadPathSecurityServiceCase.java
@@ -178,24 +178,6 @@ public abstract class PayloadPathSecurityServiceCase extends SecurityServiceCase
     });
   }
   
-  @Test
-  public void testFailingToDecryptMessage() throws Exception {
-    List<String> path = new ArrayList<String>();
-    path.add(XPATH_WITH_CHILDREN);
-    XpathBuilder xpathBuilder = new XpathBuilder();
-    xpathBuilder.setPaths(path);
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML);
-    String url = createKeystore();
-    PayloadPathDecryptionService payloadPathDecryptionService = new PayloadPathDecryptionService();
-    payloadPathDecryptionService.setPathBuilder(xpathBuilder);
-    applyConfigForTests(payloadPathDecryptionService, url);
-    configureForConfiguredPrivateKey(payloadPathDecryptionService, PROPERTIES.getProperty(SECURITY_PASSWORD));
-    Assertions.assertThrows(ServiceException.class, () -> {
-      execute(payloadPathDecryptionService, msg);
-    }, "Cannot decrypt data that is not encrypted");
-  }
-
-
   
   /**
    * @see com.adaptris.core.ExampleConfigCase#retrieveObjectForSampleConfig()

--- a/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
@@ -62,7 +62,7 @@ public class XpathBuilderTest {
   
   private static final String NON_XML_EXCEPTION_MESSAGE = "Unable to create XML document";
   private static final String INVALID_XPATH_EXCEPTION_MESSAGE = "Unable to evaluate if Xpath [%s] exists, please ensure the Xpath is valid";
-  private static final String XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE = "XPath [%s] does not match any nodes";
+  private static final String XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE = "XPath [%s] does not match any nodes. Please ensure it exists and if used that the namespace context is correct";
   
   private static Map<String, String> resultKeyValuePairs;
   private static List<String> xpath;
@@ -228,6 +228,20 @@ public class XpathBuilderTest {
       resultKeyValuePairs = xpathProvider.extract(msg);
     });
     assertEquals(NON_XML_EXCEPTION_MESSAGE, exception.getMessage());
+  }
+  
+  @Test
+  public void testMisMatchedNameSpace() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_WITH_NAMESPACE);
+    xpath.add(XPATH_1_WITH_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    KeyValuePairSet contextEntries = new KeyValuePairSet();
+    contextEntries.add(new KeyValuePair("wrong", "wrong"));
+    xpathProvider.setNamespaceContext(contextEntries);
+    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    });
+    assertEquals(String.format(XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE, XPATH_1_WITH_NAMESPACE), exception.getMessage());
   }
   
   private static KeyValuePairSet createContextEntries() {

--- a/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -61,29 +60,29 @@ public class XpathBuilderTest {
   private static final String XPATH_3_WITH_NAMESPACE = "//test:xpath3";
   private static final String XPATH_NON_EXISTENT = "//doesNotExist";
   private static final String XPATH_INVALID = "invalid xpath";
-  
+
   private static Map<String, String> resultKeyValuePairs;
   private static List<String> xpath;
   private static XpathBuilder xpathProvider;
-  
+
   @BeforeAll
   public static void setUp() {
-    resultKeyValuePairs  = new LinkedHashMap<String, String>();
-    xpath = new ArrayList<String>();
+    resultKeyValuePairs = new LinkedHashMap<>();
+    xpath = new ArrayList<>();
     xpathProvider = new XpathBuilder();
   }
-  
+
   @AfterEach
   public void tearDown() {
     resultKeyValuePairs.clear();
     xpath.clear();
   }
-  
+
   @Test
   public void testSingleXpathNoNameSpace() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
     xpath.add(XPATH_1_NO_NAMESPACE);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);
       xpathProvider.insert(msg, resultKeyValuePairs);
@@ -93,12 +92,12 @@ public class XpathBuilderTest {
     }
     assertEquals(XML_NO_NAMESPACE, msg.getContent());
   }
-  
+
   @Test
   public void testParentXpathNoNameSpace() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
     xpath.add(XPATH_PARENT_NAMESPACE);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);
       xpathProvider.insert(msg, resultKeyValuePairs);
@@ -108,12 +107,12 @@ public class XpathBuilderTest {
     }
     assertEquals(XML_NO_NAMESPACE, msg.getContent());
   }
-  
+
   @Test
   public void testXpathWithAttribute() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
     xpath.add(XPATH_WITH_ATTRIBUTE);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);
       xpathProvider.insert(msg, resultKeyValuePairs);
@@ -123,14 +122,14 @@ public class XpathBuilderTest {
     }
     assertEquals(XML_NO_NAMESPACE, msg.getContent());
   }
-  
+
   @Test
   public void testMultipleXpathsNoNameSpace() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
     xpath.add(XPATH_1_NO_NAMESPACE);
     xpath.add(XPATH_2_NO_NAMESPACE);
     xpath.add(XPATH_3_NO_NAMESPACE);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);
       xpathProvider.insert(msg, resultKeyValuePairs);
@@ -140,12 +139,12 @@ public class XpathBuilderTest {
     }
     assertEquals(XML_NO_NAMESPACE, msg.getContent());
   }
-  
+
   @Test
   public void testSingleXpathWithNameSpace() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_WITH_NAMESPACE);
     xpath.add(XPATH_1_WITH_NAMESPACE);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     xpathProvider.setNamespaceContext(createContextEntries());
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);
@@ -156,14 +155,14 @@ public class XpathBuilderTest {
     }
     assertEquals(XML_WITH_NAMESPACE, msg.getContent());
   }
-  
+
   @Test
   public void testMultipleXpathsWithNameSpace() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_WITH_NAMESPACE);
     xpath.add(XPATH_1_WITH_NAMESPACE);
     xpath.add(XPATH_2_WITH_NAMESPACE);
     xpath.add(XPATH_3_WITH_NAMESPACE);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     xpathProvider.setNamespaceContext(createContextEntries());
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);
@@ -174,13 +173,13 @@ public class XpathBuilderTest {
     }
     assertEquals(XML_WITH_NAMESPACE, msg.getContent());
   }
-  
+
   @Test
   public void testMetadataXpath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
     msg.addMetadata("xPath", XPATH_1_NO_NAMESPACE);
     xpath.add("%message{xPath}");
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);
       xpathProvider.insert(msg, resultKeyValuePairs);
@@ -190,7 +189,7 @@ public class XpathBuilderTest {
     }
     assertEquals(XML_NO_NAMESPACE, msg.getContent());
   }
-  
+
   @Test
   public void testMixtureOfXpaths() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
@@ -199,7 +198,7 @@ public class XpathBuilderTest {
     xpath.add(XPATH_2_NO_NAMESPACE);
     xpath.add(XPATH_WITH_ATTRIBUTE);
     xpath.add("%message{xPath}");
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);
       xpathProvider.insert(msg, resultKeyValuePairs);
@@ -209,12 +208,12 @@ public class XpathBuilderTest {
     }
     assertEquals(XML_NO_NAMESPACE, msg.getContent());
   }
- 
+
   @Test
   public void testExtractingNonExistentXpath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
     xpath.add(XPATH_NON_EXISTENT);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = xpathProvider.extract(msg);
     }, "Xpath does not exist.");
@@ -224,7 +223,7 @@ public class XpathBuilderTest {
   public void testExtractingInvalidXpath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
     xpath.add(XPATH_INVALID);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = xpathProvider.extract(msg);
     }, "Invalid Xpath.");
@@ -234,17 +233,17 @@ public class XpathBuilderTest {
   public void testExtractingNonXml() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(NOT_XML);
     xpath.add(XPATH_1_NO_NAMESPACE);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     assertThrows(ServiceException.class, () -> {
       resultKeyValuePairs = xpathProvider.extract(msg);
     }, "Non xml message.");
   }
-  
+
   @Test
   public void testExtractingMisMatchedNameSpace() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_WITH_NAMESPACE);
     xpath.add(XPATH_1_WITH_NAMESPACE);
-    xpathProvider.setPaths(xpath);
+    xpathProvider.setXpaths(xpath);
     KeyValuePairSet contextEntries = new KeyValuePairSet();
     contextEntries.add(new KeyValuePair("wrong", "wrong"));
     xpathProvider.setNamespaceContext(contextEntries);
@@ -252,7 +251,7 @@ public class XpathBuilderTest {
       resultKeyValuePairs = xpathProvider.extract(msg);
     }, "Xpath not found due to unexpected namespace name.");
   }
-  
+
   @Test
   public void testInsertingNonExistentXpath() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
@@ -279,7 +278,7 @@ public class XpathBuilderTest {
       xpathProvider.insert(msg, resultKeyValuePairs);
     }, "Not an XML file.");
   }
-  
+
   private static KeyValuePairSet createContextEntries() {
     KeyValuePairSet contextEntries = new KeyValuePairSet();
     contextEntries.add(new KeyValuePair("test", "www.test.com"));

--- a/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
@@ -46,7 +46,7 @@ public class XpathBuilderTest {
       + "      <test:child1>child1</test:child1>\n"
       + "      <test:child2>child2</test:child2>\n"
       + "   </test:parent>\n"
-      + "</root>";
+      + "</root>\n";
 
   private static final String NOT_XML = "not xml";
 

--- a/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
@@ -52,6 +52,7 @@ public class XpathBuilderTest {
 
   private static final String XPATH_WITH_ATTRIBUTE = "//parent/childName/@name";
   private static final String XPATH_1_NO_NAMESPACE = "//xpath1";
+  private static final String XPATH_PARENT_NAMESPACE = "//parent";
   private static final String XPATH_1_WITH_NAMESPACE = "//test:xpath1";
   private static final String XPATH_2_NO_NAMESPACE = "//xpath2";
   private static final String XPATH_2_WITH_NAMESPACE = "//test:xpath2";
@@ -85,6 +86,21 @@ public class XpathBuilderTest {
   public void testSingleXpathNoNameSpace() {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
     xpath.add(XPATH_1_NO_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+      xpathProvider.insert(msg, resultKeyValuePairs);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(XML_NO_NAMESPACE, msg.getContent());
+  }
+  
+  @Test
+  public void testParentXpathNoNameSpace() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_PARENT_NAMESPACE);
     xpathProvider.setPaths(xpath);
     try {
       resultKeyValuePairs = xpathProvider.extract(msg);

--- a/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/security/XpathBuilderTest.java
@@ -1,0 +1,240 @@
+package com.adaptris.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceException;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+
+public class XpathBuilderTest {
+
+  public static final String XML_NO_NAMESPACE = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n"
+      + "<root>\r\n"
+      + "   <xpath1>xpath1_result</xpath1>\r\n"
+      + "   <xpath2>xpath2_result</xpath2>\r\n"
+      + "   <xpath3>xpath3_result</xpath3>\r\n"
+      + "   <parent>\r\n"
+      + "      <child1>child1</child1>\r\n"
+      + "      <child2>child2</child2>\r\n"
+      + "   </parent>\r\n"
+      + "</root>\r\n";
+
+  public static final String XML_WITH_NAMESPACE = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><root xmlns:test=\"www.test.com\"><test:xpath1>xpath1_result</test:xpath1><test:xpath2>xpath2_result</test:xpath2>"
+      + "<test:xpath3>xpath3_result</test:xpath3></root>";
+
+  private static final String NOT_XML = "not xml";
+
+  private static final String XPATH_RELATIVE_ROOT = "./root";
+  private static final String XPATH_1_NO_NAMESPACE = "//xpath1";
+  private static final String XPATH_1_WITH_NAMESPACE = "//test:xpath1";
+  private static final String XPATH_2_NO_NAMESPACE = "//xpath2";
+  private static final String XPATH_2_WITH_NAMESPACE = "//test:xpath2";
+  private static final String XPATH_3_NO_NAMESPACE = "//xpath3";
+  private static final String XPATH_3_WITH_NAMESPACE = "//test:xpath3";
+  private static final String XPATH_NESTED = "//parent";
+  private static final String XPATH_NON_EXISTENT = "//doesNotExist";
+  private static final String XPATH_INVALID = "invalid xpath";
+  
+  private static final String NON_XML_EXCEPTION_MESSAGE = "Unable to create XML document";
+  private static final String INVALID_XPATH_EXCEPTION_MESSAGE = "Unable to evaluate if Xpath exists, please ensure the Xpath is valid";
+  private static final String XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE = "XPath [%s] does not match any nodes";
+  
+  private static Map<String, String> resultKeyValuePairs;
+  private static List<String> xpath;
+  private static XpathBuilder xpathProvider;
+  
+  @BeforeAll
+  public static void setUp() {
+    resultKeyValuePairs  = new LinkedHashMap<>();
+    xpath = new ArrayList<String>();
+    xpathProvider = new XpathBuilder();
+  }
+  
+  @AfterEach
+  public void tearDown() {
+    resultKeyValuePairs.clear();
+    xpath.clear();
+  }
+
+  @Test
+  public void testExtractingRelativeXpath() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_RELATIVE_ROOT);
+    xpathProvider.setPaths(xpath);
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(1, resultKeyValuePairs.size(), "LinkedHashMap should have 1 entry");
+  }
+  
+  @Test
+  public void testExtractingSingleXpathNoNameSpace() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_1_NO_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+      System.out.println(resultKeyValuePairs + "test");
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(1, resultKeyValuePairs.size(), "LinkedHashMap should have 1 entry");
+  }
+
+  @Test
+  public void testExtractingMultipleXpathsNoNameSpace() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_1_NO_NAMESPACE);
+    xpath.add(XPATH_2_NO_NAMESPACE);
+    xpath.add(XPATH_3_NO_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(3, resultKeyValuePairs.size(), "LinkedHashMap should have 3 entries");
+  }
+
+  @Test
+  public void testExtractingSingleXpathWithNameSpace() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_WITH_NAMESPACE);
+    xpath.add(XPATH_1_WITH_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    xpathProvider.setNamespaceContext(createContextEntries());
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(1, resultKeyValuePairs.size(), "LinkedHashMap should have 1 entry");
+  }
+
+  @Test
+  public void testExtractingMultipleXpathsWithNameSpace() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_WITH_NAMESPACE);
+    xpath.add(XPATH_1_WITH_NAMESPACE);
+    xpath.add(XPATH_2_WITH_NAMESPACE);
+    xpath.add(XPATH_3_WITH_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    xpathProvider.setNamespaceContext(createContextEntries());
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(3, resultKeyValuePairs.size(), "LinkedHashMap should have 3 entries");
+  }
+  
+  @Test
+  public void testExtractingNestedXpaths() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_NESTED);
+    xpathProvider.setPaths(xpath);
+    xpathProvider.setNamespaceContext(createContextEntries());
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    assertEquals(1, resultKeyValuePairs.size(), "LinkedHashMap should have 1 entry");
+  }
+
+  @Test
+  public void testExtractingNonExistentXpath() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_NON_EXISTENT);
+    xpathProvider.setPaths(xpath);
+    Throwable exception = Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    });
+    assertEquals(String.format(XPATH_DOES_NOT_EXIST_EXCEPTION_MESSAGE, XPATH_NON_EXISTENT), exception.getMessage());
+  }
+
+  @Test
+  public void testExtractingInvalidXpath() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_INVALID);
+    xpathProvider.setPaths(xpath);
+    Throwable exception = Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    });
+    assertEquals(INVALID_XPATH_EXCEPTION_MESSAGE, exception.getMessage());
+  }
+
+  @Test
+  public void testNonXml() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(NOT_XML);
+    xpath.add(XPATH_1_NO_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    Throwable exception =  Assertions.assertThrows(ServiceException.class, () -> {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+    });
+    assertEquals(NON_XML_EXCEPTION_MESSAGE, exception.getMessage());
+  }
+  
+  @Test
+  public void testSingleXpathNoNameSpace() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    AdaptrisMessage originalMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_1_NO_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+      xpathProvider.insert(msg, resultKeyValuePairs);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    System.out.println("original msg = " + originalMsg.getContent());
+    System.out.println("new msg = " + msg.getContent());
+    //assertEquals(msg.getContent(), originalMsg.getContent());
+  }
+  
+  @Test
+  public void testMultipleXpathsNoNameSpace() {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    AdaptrisMessage originalMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_NO_NAMESPACE);
+    xpath.add(XPATH_1_NO_NAMESPACE);
+    xpath.add(XPATH_2_NO_NAMESPACE);
+    xpath.add(XPATH_3_NO_NAMESPACE);
+    xpathProvider.setPaths(xpath);
+    try {
+      resultKeyValuePairs = xpathProvider.extract(msg);
+      xpathProvider.insert(msg, resultKeyValuePairs);
+    } catch (ServiceException e) {
+      e.printStackTrace();
+      fail();
+    }
+    System.out.println("original msg = " + originalMsg.getContent());
+    System.out.println("new msg = " + msg.getContent() + "end");
+  }
+  
+  private static KeyValuePairSet createContextEntries() {
+    KeyValuePairSet contextEntries = new KeyValuePairSet();
+    contextEntries.add(new KeyValuePair("test", "www.test.com"));
+    return contextEntries;
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -152,4 +153,12 @@ public class XmlHelperTest extends XmlHelper {
     Attr a = d.createAttribute("x");
     assertNull(XmlHelperTest.nodeToString(a));
   }
+
+  @Test
+  public void testStringToNode() throws Exception {
+    Node n = XmlHelper.stringToNode(EXAMPLE_XML);
+    String s = XmlHelper.nodeToString(n);
+    assertEquals(EXAMPLE_XML, s);
+  }
+
 }


### PR DESCRIPTION
## Motivation

Adding two new Interlok services and supporting classes that will allow you to encrypt/decrypt a payload with a pointable path.

## Modification

Two new service classes have been added: PayloadPathEncryptionService & PayloadPathDecryptionService - these classes extend the CoreSecurityService abstract class so they have enherited all of the actual encryption/decryption functionality from this.
A new Interface: PathBuilder 
A class that implements the Interface: XpathBuilder
Test classes for the above that have been added.
A small update to the XMLHelper class, a new method to convert a string to a node.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Two new services that you can define paths for that will encrypt/decrypt the content of those paths in a given message.

## Testing

To test this you can unzip the file which is a v5 adapter installation with all the required files: https://cloud.adaptris.net/index.php/s/goVlkU0fJJKWg8P

So do the following:

1. unzip and make sure your %JAVA_HOME% is pointing to a Java 17 installation.
2. loads up the project 'PathSecurityTesting' which is configured to fire off 4 messages every second(2 json, 2 xml) each of those will have a message that also runs through a jolt or xslt mapping.
4. If your home path is different to 'C:\Adaptris\' then update the keystore URLS to your home path.
5. You can also run the service tester in the UI or using the command: java -jar lib\interlok-boot.jar -serviceTest src\test\interlok\service-test.xml

The service tests should pass with the asseration that the payload matches the input(except in the two cases where we are transforming the data and then decrypting which will then match the expected mapped payload with decrypted data)

Even with 4 messages going through a second the adapter seems to be running ok and not struggling or taking up too much memory.
