### PR TITLE
INTERLOK-4187 Make flyway a dependency of interlok-core

### DIFF
--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -133,6 +133,8 @@ dependencies {
 
   api ("org.apache.derby:derby:$derbyDriverVersion")
   api ("org.apache.derby:derbytools:$derbyDriverVersion")
+  
+  api ("org.flywaydb:flyway-core:8.5.13")
 
   testImplementation ("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testImplementation ("org.junit.jupiter:junit-jupiter-engine:$junitVersion")


### PR DESCRIPTION
## Motivation

There is an issue with more recent versions of flyway  (8+ I think) where it needs extra jar for mysql and sqlserver (for licensing purposes).
The issue occurs if we use interlok-flyway and the UI at the same time and mysql or sqlserver.
We end up with two flyway-core.jar, one in the interlok lib dir and one in the webapp lib dir.
When the UI starts and load its spring config it will use its flyway-core.jar but will also find the mysql-flyway.jar that exists in the interlok lib dir.
This will cause some service discovery issue because of classloaders differences between the UI flyway-core.jar and the interlok mysql-flyway.jar:

```
java.util.ServiceConfigurationError: org.flywaydb.core.extensibility.Plugin: org.flywaydb.database.mysql.MySQLDatabaseType not a subtype
```

 So we should probably remove flyway-core.jar from the webapp war file and have it in the lib dir. Meaning interlok or interlok-common should always depend on flyway-core.jar.

## Modification

Make flyway a dependency of interlok-core so the UI doesn't need to import it into its war file and that won't cause a jar conflict when using interlok-flyway.

## PR Checklist

- [x] been self-reviewed.

## Result

In combination if removing flyway from the UI war file we should have no more error when using the UI with an external DB at the same time as interlok-flyway.

## Testing

The build should pass
