### PR TITLE
INTERLOK-4206 Upgrade to jetty 9.4.53.v20231009

### DIFF
--- a/.github/workflows/publish-3.12.yml
+++ b/.github/workflows/publish-3.12.yml
@@ -1,0 +1,44 @@
+name: Publish 3.12 Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      interlok-version:
+        description: 'Interlok Version (e.g. 3.12.0.3-RELEASE)'
+        type: string
+        required: true
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: support/3.12.x
+        token: ${{ secrets.INTERLOKDEV_GITHUB_TOKEN }}
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v3
+      with:
+        java-version: 1.8
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: wrapper
+    - name: Gradle Build and Publish
+      run: |
+        echo "default.jdbc.storedproc.tests.enabled=false" >> ./interlok-core/build.properties
+        echo "junit.jms.tests.enabled=false" >> ./interlok-core/build.properties
+        ./gradlew -Djava.security.egd=file:/dev/./urandom -Dorg.gradle.console=plain --no-daemon -PverboseTests=true test publish -PinterlokCoreVersion=${{ inputs.interlok-version }} -PreleaseVersion=${{ inputs.interlok-version }} -PmavenPublishUrl=https://nexus.adaptris.net/nexus/content/repositories/releases
+      env:
+        ORG_GRADLE_PROJECT_repoUsername: deployment
+        ORG_GRADLE_PROJECT_repoPassword: ${{ secrets.NEXUS_REPO_PASSWORD }}
+    - name: Tag
+      run: |
+        interlokVersion=${{ inputs.interlok-version }}
+        # Remove -RELEASE from the version
+        tagVersion=${interlokVersion/-RELEASE/""}
+        git tag -a $tagVersion -m "Add tag $tagVersion"
+        git push origin --tags

--- a/interlok-client-jmx/build.gradle
+++ b/interlok-client-jmx/build.gradle
@@ -1,7 +1,7 @@
 ext {
   componentName='Interlok Client API/JMX'
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  log4j2Version = "2.17.0"
+  log4j2Version = "2.21.0"
   mockitoVersion = '3.7.0'
 }
 

--- a/interlok-client/build.gradle
+++ b/interlok-client/build.gradle
@@ -1,7 +1,7 @@
 ext {
   componentName='Interlok Client API'
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  log4j2Version = "2.17.0"
+  log4j2Version = "2.21.0"
   mockitoVersion = '3.7.0'
 }
 

--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -1,8 +1,8 @@
 ext {
   componentName='Interlok Common Classes'
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  slf4jVersion = '1.7.30'
-  log4j2Version = "2.17.0"
+  slf4jVersion = '1.7.36'
+  log4j2Version = "2.21.0"
   mockitoVersion = '3.7.0'
 }
 
@@ -19,7 +19,7 @@ dependencies {
 
   compile ("org.slf4j:slf4j-api:$slf4jVersion")
   compile ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
-  compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.36.v20210114")
+  compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.53.v20231009")
   compile "org.slf4j:jul-to-slf4j:$slf4jVersion", optional
   compile "org.apache.logging.log4j:log4j-core:$log4j2Version", optional
   compile "org.apache.logging.log4j:log4j-api:$log4j2Version", optional

--- a/interlok-common/src/main/java/com/adaptris/core/management/webserver/JettyServerManager.java
+++ b/interlok-common/src/main/java/com/adaptris/core/management/webserver/JettyServerManager.java
@@ -24,6 +24,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.servlet.Servlet;
+import javax.servlet.ServletContext;
+import org.eclipse.jetty.security.Authenticator;
+import org.eclipse.jetty.security.Authenticator.AuthConfiguration;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.IdentityService;
+import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -164,7 +170,9 @@ public class JettyServerManager implements ServerManager {
       log.trace("No ROOT WebAppContext, creating one");
       root = new WebAppContext();
       root.setContextPath("/");
+      root.setSecurityHandler(defaultSecurityStub());
       URL defaultsURL = findDefaultDescriptorXML();
+      log.trace("Using default descriptor [{}]", defaultsURL);
       root.setDefaultsDescriptor(defaultsURL.toString());
       root.setConfigurations(new Configuration[]
       {
@@ -182,6 +190,27 @@ public class JettyServerManager implements ServerManager {
       }
     }
     return root;
+  }
+
+  // Will be reconfigured as required, in the absence of explicit config
+  // 9.4.44.v20210927 causes JASPI to come into play which ultimately causes
+  // a NPE because not everything required by jaspi is in play...
+  // This is related to javaee / java.auth.security.message
+  // c.f. SecurityHandler#doStart() -> and the section about
+  // getKnownAuthenticatorFactories()...
+  static SecurityHandler defaultSecurityStub() {
+    ConstraintSecurityHandler defaultSecurity = new ConstraintSecurityHandler();
+    defaultSecurity.setAuthenticatorFactory(new Authenticator.Factory() {
+
+      @Override
+      public Authenticator getAuthenticator(Server server, ServletContext context,
+          AuthConfiguration configuration, IdentityService identityService,
+          LoginService loginService) {
+        return null;
+      }
+
+    });
+    return defaultSecurity;
   }
 
   private URL findDefaultDescriptorXML() {

--- a/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-failsafe.xml
+++ b/interlok-common/src/main/resources/com/adaptris/core/management/webserver/jetty-failsafe.xml
@@ -140,7 +140,7 @@
       <Set name="handlers">
         <Array type="org.eclipse.jetty.server.Handler">
           <Item>
-            <Ref id="RewriteHandler"></Ref>
+            <Ref refid="RewriteHandler"></Ref>
           </Item>
           <Item>
              <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
@@ -175,7 +175,7 @@
     <Arg>
       <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
         <Set name="contexts">
-          <Ref id="Contexts" />
+          <Ref refid="Contexts" />
         </Set>
         <Call name="setContextAttribute">
           <Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
@@ -203,7 +203,7 @@
               <Set name="scanInterval"><Property name="jetty.deploy.scanInterval" default="120"/></Set>
               <Set name="extractWars"><Property name="jetty.deploy.extractWars" default="true"/></Set>
               <Set name="configurationClasses">
-                <Ref id="plusConfig" />
+                <Ref refid="plusConfig" />
               </Set>
               <Set name="configurationManager">
                 <New class="org.eclipse.jetty.deploy.PropertiesConfigurationManager">

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -6,7 +6,7 @@ ext {
   activeMqVersion='5.16.0'
   bouncyCastleVersion='1.68'
   mysqlDriverVersion='8.0.22'
-  slf4jVersion = '1.7.30'
+  slf4jVersion = '1.7.36'
   mockitoVersion = '3.7.0'
 
   verboseTests= project.hasProperty('verboseTests') ? project.getProperty('verboseTests') : "false"
@@ -87,7 +87,7 @@ dependencies {
   compile ("org.glassfish.external:opendmk_jdmkrt_jar:1.0-b01-ea")
   compile ("javax.xml.bind:jaxb-api:2.3.1")
   compile ("com.jcraft:jsch:0.1.55")
-  compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.36.v20210114")
+  compile ("org.eclipse.jetty.aggregate:jetty-all:9.4.53.v20231009")
   compile ("javax.servlet:javax.servlet-api:4.0.1")
   compile ("net.sf.joost:joost:0.9.1")
   compile ("org.quartz-scheduler:quartz:2.3.2") {

--- a/interlok-core/src/main/resources/META-INF/templates/template-jetty.xml
+++ b/interlok-core/src/main/resources/META-INF/templates/template-jetty.xml
@@ -141,11 +141,11 @@
         <Array type="org.eclipse.jetty.server.Handler">
           <!-- Uncomment this to enable the legacy API handler if you need it
           <Item>
-            <Ref id="LegacyAPI"></Ref>
+            <Ref refid="LegacyAPI"></Ref>
           </Item>
           -->
           <Item>
-            <Ref id="RewriteHandler"></Ref>
+            <Ref refid="RewriteHandler"></Ref>
           </Item>
           <Item>
              <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
@@ -180,7 +180,7 @@
     <Arg>
       <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">
         <Set name="contexts">
-          <Ref id="Contexts" />
+          <Ref refid="Contexts" />
         </Set>
         <Call name="setContextAttribute">
           <Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
@@ -208,7 +208,7 @@
               <Set name="scanInterval"><Property name="jetty.deploy.scanInterval" default="120"/></Set>
               <Set name="extractWars"><Property name="jetty.deploy.extractWars" default="true"/></Set>
               <Set name="configurationClasses">
-                <Ref id="plusConfig" />
+                <Ref refid="plusConfig" />
               </Set>
               <Set name="configurationManager">
                 <New class="org.eclipse.jetty.deploy.PropertiesConfigurationManager">

--- a/interlok-logging/build.gradle
+++ b/interlok-logging/build.gradle
@@ -1,7 +1,7 @@
 ext {
   componentName='Interlok Logging'
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  log4j2Version = "2.17.0"
+  log4j2Version = "2.21.0"
 }
 
 // In this section you declare the dependencies for your production and test code


### PR DESCRIPTION
## Motivation

Fix CVE-2023-44487 and the jetty-failsafe.xml

## Modification

Upgrade to jetty 9.4.53.v20231009 and fix jetty-failsafe.xml to not use the same id multiple times
Also bump log4j to 2.21.0 and slf4j to 1.7.36

## PR Checklist

- [x] been self-reviewed.

## Result

No more vulnerability

## Testing

The build should be successful and we should be able to start interlok with jetty enabled.
