### PR TITLE
adding a simple util class that can be used to translate objects into a hashcode

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/util/text/HashTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/HashTranslator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.util.text;
+
+
+/**
+ * Converts an Object into its hash code represenation
+
+ */
+
+public class HashTranslator  {
+
+	/**
+	 *<p>
+	 * Get the hash code representation of the Object passed to it.
+	 *</p>
+	 * @param obj {@link Object}
+	 * @return {@link Object#hashCode() hashCode} of the object, will return 0 if null.
+	 */
+	public static int getHashCode(Object object) {
+		if (object == null) {
+			return 0;
+		}
+		return object.hashCode();
+	}
+}

--- a/interlok-core/src/test/java/com/adaptris/util/text/HashTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/HashTranslatorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.util.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class HashTranslatorTest {
+	
+	@Test
+	public void testGenerateHashCode() {
+		String string1 = new String("test");
+		String string2 = new String("test");
+
+		assertEquals(string1.hashCode(), HashTranslator.getHashCode(string2));
+	}
+	
+	@Test
+	public void testGenerateHashCodeNotEquals() {
+		String string1 = new String("test");
+		String string2 = new String("doesn't match");
+
+		assertNotEquals(string1.hashCode(), HashTranslator.getHashCode(string2));
+	}
+	
+	@Test
+	public void testGenerateHashCodeNull() {
+		Object obj1 = null;
+		
+		assertEquals(0, HashTranslator.getHashCode(obj1));
+	}
+
+}


### PR DESCRIPTION
Adding a simple util class that can be used to translate objects into a hashcode.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [n/a] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".