### PR TITLE
Feature/interlok 4220 - Add input param support for xml transform services

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/transform/MultiPayloadXmlTransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/MultiPayloadXmlTransformService.java
@@ -46,6 +46,15 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
  *
  * Configuration including allow over-ride behaviour matches previous
  * implementation.
+ * 
+ * <p>
+ * Cache transforms functionality only works if <code>url</code> is used. Caching is not supported with
+ * <code>mappingSource</code>.
+ * </p>
+ * <p>
+ * If you wish to call an external mapping source when using <code>mappingSource</code> such as via http you can use
+ * <strong>FileDataInputParameter</strong>. 
+ * </p>
  *
  * @author aanderson
  * @config new-xml-transform-service
@@ -98,7 +107,7 @@ public class MultiPayloadXmlTransformService extends XmlTransformService {
 				transformer = getXmlTransformerFactory().createTransformerFromUrl(xslSourceToUse);
 			}
 		} else {
-			transformer = getXmlTransformerFactory().createTransformerFromRawXslt(xslSourceToUse);
+			transformer = getXmlTransformerFactory().createTransformerFromRawXsl(xslSourceToUse);
 		}
 		
 		getXmlTransformerFactory().configure(xmlTransformerImpl);

--- a/interlok-core/src/main/java/com/adaptris/core/transform/MultiPayloadXmlTransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/MultiPayloadXmlTransformService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2020 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,18 @@
 */
 
 package com.adaptris.core.transform;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.xml.transform.Transformer;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
@@ -25,45 +37,32 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.util.text.xml.XmlTransformer;
 import com.adaptris.util.text.xml.XmlTransformerFactory;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.xml.transform.Transformer;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Map;
-
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
- * Implementation of <code>Service</code> which provides transformation
- * of XML payloads contained within the new multi-payload message.
+ * Implementation of <code>Service</code> which provides transformation of XML payloads contained within the new multi-payload message.
  *
- * You are required to configure the XML transformer factory; see the
- * javadoc and implementations of {@link XmlTransformerFactory} for
+ * You are required to configure the XML transformer factory; see the javadoc and implementations of {@link XmlTransformerFactory} for
  * details on the supported transformer factories.
  *
- * Configuration including allow over-ride behaviour matches previous
- * implementation.
- * 
+ * Configuration including allow over-ride behaviour matches previous implementation.
+ *
  * <p>
- * Cache transforms functionality only works if <code>url</code> is used. Caching is not supported with
- * <code>mappingSource</code>.
+ * Cache transforms functionality only works if <code>url</code> is used. Caching is not supported with <code>mappingSource</code>.
  * </p>
  * <p>
- * If you wish to call an external mapping source when using <code>mappingSource</code> such as via http you can use
- * <strong>FileDataInputParameter</strong>. 
+ * If you wish to call an external mapping source when using <code>mappingSource</code> such as via HTTP you can use
+ * <strong>FileDataInputParameter</strong>.
  * </p>
  *
  * @author aanderson
  * @config new-xml-transform-service
- * 
+ *
  */
 @XStreamAlias("multi-payload-xml-transform-service")
 @AdapterComponent
 @ComponentProfile(summary = "Execute an XSLT transform", tag = "service,transform,xml,multi,payload,multi-payload")
-@DisplayOrder(order = { "sourcePayloadId", "targetPayloadId", "url", "outputMessageEncoding", "cacheTransforms", "allowOverride", "metadataKey", "transformParameter", "xmlTransformerFactory" })
+@DisplayOrder(order = { "sourcePayloadId", "targetPayloadId", "url", "outputMessageEncoding", "cacheTransforms", "allowOverride",
+    "metadataKey", "transformParameter", "xmlTransformerFactory" })
 public class MultiPayloadXmlTransformService extends XmlTransformService {
 
   @NotNull
@@ -75,9 +74,7 @@ public class MultiPayloadXmlTransformService extends XmlTransformService {
   private String outputPayloadId;
 
   /**
-   * Creates a new instance. Defaults to caching transforms and not
-   * allowing over-rides. Default metadata key is
-   * <code>transformurl</code>.
+   * Creates a new instance. Defaults to caching transforms and not allowing over-rides. Default metadata key is <code>transformurl</code>.
    */
   public MultiPayloadXmlTransformService() {
     super();
@@ -89,7 +86,7 @@ public class MultiPayloadXmlTransformService extends XmlTransformService {
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     if (msg instanceof MultiPayloadAdaptrisMessage) {
-      this.doTransform((MultiPayloadAdaptrisMessage)msg, obtainMappingContent(msg));
+      doTransform((MultiPayloadAdaptrisMessage) msg, obtainMappingContent(msg));
     } else {
       super.doService(msg);
     }
@@ -99,19 +96,18 @@ public class MultiPayloadXmlTransformService extends XmlTransformService {
     XmlTransformer xmlTransformerImpl = new XmlTransformer();
     Transformer transformer;
     try {
-		
-		if (super.isUrlMappingSource) {
-			if (cacheTransforms()) {
-				transformer = cacheAndGetTransformer(xslSourceToUse, getXmlTransformerFactory());
-			} else {
-				transformer = getXmlTransformerFactory().createTransformerFromUrl(xslSourceToUse);
-			}
-		} else {
-			transformer = getXmlTransformerFactory().createTransformerFromRawXsl(xslSourceToUse);
-		}
-		
-		getXmlTransformerFactory().configure(xmlTransformerImpl);
-	} catch (Exception ex) {
+      if (isUrlMappingSource) {
+        if (cacheTransforms()) {
+          transformer = cacheAndGetTransformer(xslSourceToUse, getXmlTransformerFactory());
+        } else {
+          transformer = getXmlTransformerFactory().createTransformerFromUrl(xslSourceToUse);
+        }
+      } else {
+        transformer = getXmlTransformerFactory().createTransformerFromRawXsl(xslSourceToUse);
+      }
+
+      getXmlTransformerFactory().configure(xmlTransformerImpl);
+    } catch (Exception ex) {
       throw new ServiceException(ex);
     }
     // INTERLOK-2022 Let the XML parser do its thing, rather than using a reader/writer.

--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.transform.Transformer;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -54,25 +55,21 @@ import net.jodah.expiringmap.ExpiringMap;
 
 /**
  * <p>
- * Implementation of <code>Service</code> which provides transformation of XML
- * payloads.
+ * Implementation of <code>Service</code> which provides transformation of XML payloads.
  * </p>
  * <p>
- * You are required to configure the XML transformer factory; see the javadoc
- * and implementations of {@link XmlTransformerFactory} for details on the
- * supported transformer factories.
+ * You are required to configure the XML transformer factory; see the javadoc and implementations of {@link XmlTransformerFactory} for
+ * details on the supported transformer factories.
  * </p>
  * <p>
- * Configuration including allow over-ride behaviour matches previous
- * implementation.
+ * Configuration including allow over-ride behaviour matches previous implementation.
  * </p>
  * <p>
- * Cache transforms functionality only works if <code>url</code> is used. Caching is not supported with
- * <code>mappingSource</code>.
+ * Cache transforms functionality only works if <code>url</code> is used. Caching is not supported with <code>mappingSource</code>.
  * </p>
  * <p>
  * If you wish to call an external mapping source when using <code>mappingSource</code> such as via http you can use
- * <strong>FileDataInputParameter</strong>. 
+ * <strong>FileDataInputParameter</strong>.
  * </p>
  *
  * @config xml-transform-service
@@ -81,337 +78,322 @@ import net.jodah.expiringmap.ExpiringMap;
 @XStreamAlias("xml-transform-service")
 @AdapterComponent
 @ComponentProfile(summary = "Execute an XSLT transform", tag = "service,transform,xml")
-@DisplayOrder(order = { "url", "outputMessageEncoding", "cacheTransforms", "allowOverride", "metadataKey",
-		"transformParameter", "xmlTransformerFactory", "mappingSource" })
+@DisplayOrder(order = { "url", "outputMessageEncoding", "cacheTransforms", "allowOverride", "metadataKey", "transformParameter",
+    "xmlTransformerFactory", "mappingSource" })
 public class XmlTransformService extends ServiceImp {
-	private static final int DEFAULT_MAX_CACHE_SIZE = 16;
-	private static final TimeInterval DEFAULT_EXPIRATION = new TimeInterval(1L, TimeUnit.HOURS);
+  private static final int DEFAULT_MAX_CACHE_SIZE = 16;
+  private static final TimeInterval DEFAULT_EXPIRATION = new TimeInterval(1L, TimeUnit.HOURS);
 
-	/**
-	 * @deprecated since 5.0.0 use {@link #DataInputParameter} instead.
-	 */
-	@Deprecated(since = "5.0.0")
-	private String url;
+  /**
+   * @deprecated since 5.0.0 use {@link #DataInputParameter} instead.
+   */
+  @Deprecated(since = "5.0.0")
+  private String url;
 
-	@AdvancedConfig
-	private String metadataKey;
+  @AdvancedConfig
+  private String metadataKey;
 
-	@Getter
-	@Setter
-	@AutoPopulated
-	@Valid
-	private DataInputParameter<String> mappingSource;
+  @Getter
+  @Setter
+  @AutoPopulated
+  @Valid
+  private DataInputParameter<String> mappingSource;
 
-	@AdvancedConfig
-	@InputFieldDefault(value = "true")
-	private Boolean cacheTransforms;
-	@AdvancedConfig
-	@InputFieldDefault(value = "false")
-	private Boolean allowOverride;
+  @AdvancedConfig
+  @InputFieldDefault(value = "true")
+  private Boolean cacheTransforms;
+  @AdvancedConfig
+  @InputFieldDefault(value = "false")
+  private Boolean allowOverride;
 
-	// Default to null is fine
-	private String outputMessageEncoding;
-	@NotNull
-	@AutoPopulated
-	@Valid
-	private XmlTransformerFactory xmlTransformerFactory;
-	@Valid
-	private XmlTransformParameter transformParameter;
+  // Default to null is fine
+  private String outputMessageEncoding;
+  @NotNull
+  @AutoPopulated
+  @Valid
+  private XmlTransformerFactory xmlTransformerFactory;
+  @Valid
+  private XmlTransformParameter transformParameter;
 
-	private transient Map<String, Transformer> transforms = null;
-	// This is the override value which is set to true if url is null
-	private transient Boolean overrideAllowOverride;
-	
-	protected transient Boolean isUrlMappingSource;
+  private transient Map<String, Transformer> transforms = null;
+  // This is the override value which is set to true if url is null
+  private transient Boolean overrideAllowOverride;
 
-	/**
-	 * <p>
-	 * Creates a new instance. Defaults to caching transforms and not allowing
-	 * over-rides. Default metadata key is <code>transformurl</code>.
-	 * </p>
-	 */
-	public XmlTransformService() {
-		setMetadataKey(CoreConstants.TRANSFORM_OVERRIDE);
-		xmlTransformerFactory = new XsltTransformerFactory();
-	}
+  protected transient Boolean isUrlMappingSource;
 
-	@Override
-	protected void initService() throws CoreException {
-		if (isEmpty(getUrl())) {
-			overrideAllowOverride = Boolean.TRUE;
-		}
-		if (isEmpty(getUrl()) && isEmpty(getMetadataKey()) && getMappingSource() == null) {
-			throw new CoreException("metadata-key, mapping source & url are empty, cannot initialise");
-		}
-	}
+  /**
+   * <p>
+   * Creates a new instance. Defaults to caching transforms and not allowing over-rides. Default metadata key is <code>transformurl</code>.
+   * </p>
+   */
+  public XmlTransformService() {
+    setMetadataKey(CoreConstants.TRANSFORM_OVERRIDE);
+    xmlTransformerFactory = new XsltTransformerFactory();
+  }
 
-	@Override
-	protected void closeService() {
-	}
+  @Override
+  protected void initService() throws CoreException {
+    if (isEmpty(getUrl())) {
+      overrideAllowOverride = Boolean.TRUE;
+    }
+    if (isEmpty(getUrl()) && isEmpty(getMetadataKey()) && getMappingSource() == null) {
+      throw new CoreException("metadata-key, mapping source & url are empty, cannot initialise");
+    }
+  }
 
-	/**
-	 * @see com.adaptris.core.Service#doService (com.adaptris.core.AdaptrisMessage)
-	 */
-	@Override
-	public void doService(AdaptrisMessage msg) throws ServiceException {
-		doTransform(msg, obtainMappingContent(msg));
-	}
+  @Override
+  protected void closeService() {
+  }
 
-	@Override
-	public void prepare() throws CoreException {
-		transforms = ExpiringMap.builder().maxSize(DEFAULT_MAX_CACHE_SIZE).expirationPolicy(ExpirationPolicy.ACCESSED)
-				.expiration(DEFAULT_EXPIRATION.toMilliseconds(), TimeUnit.MILLISECONDS).build();
-	}
+  /**
+   * @see com.adaptris.core.Service#doService (com.adaptris.core.AdaptrisMessage)
+   */
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    doTransform(msg, obtainMappingContent(msg));
+  }
 
-	/**
-	 * <p>
-	 * If <code>this.getAllowOverride()</code> is true and
-	 * <code>msg.containsKey(getMetadataKey())</code> is true then the value of
-	 * <code>msg.getMetadataValue(this.getMetadataKey()</code> is the URL to use,
-	 * otherwise the value of <code>this.getUrl()</code> is used, if <code>this.getUrl()</code>
-	 * is empty or null then it checks <code>this.getMappingSource()</code> if this is also null
-	 * a <code>ServiceException</code> is thrown.
-	 * </p>
-	 */
-	String obtainMappingContent(AdaptrisMessage msg) throws ServiceException {
-		try {
-			if (!isEmpty(mappingUrlSource(msg))) {
-				this.isUrlMappingSource = true;
-				return mappingUrlSource(msg);
-			} else if (getMappingSource() != null) {
-				this.isUrlMappingSource = false;
-				return getMappingSource().extract(msg);
-			} else {
-				throw new ServiceException("no URL or mapping source has been configured and metadata key [" + getMetadataKey() + "] returned null");
-			}
+  @Override
+  public void prepare() throws CoreException {
+    transforms = ExpiringMap.builder().maxSize(DEFAULT_MAX_CACHE_SIZE)
+        .expirationPolicy(ExpirationPolicy.ACCESSED)
+        .expiration(DEFAULT_EXPIRATION.toMilliseconds(), TimeUnit.MILLISECONDS).build();
+  }
 
-		} catch (Exception e) {
-			throw new ServiceException(e);
-		}
-	}
-	
-	private String mappingUrlSource(AdaptrisMessage msg) {
-		String mappingUrl = null;
-		if (!isEmpty(getUrl())) {
-			mappingUrl = getUrl();
-		}
-		if (allowOverride() && msg.headersContainsKey(getMetadataKey())) {
-			mappingUrl = isEmpty(msg.getMetadataValue(getMetadataKey())) ? getUrl() : msg.getMetadataValue(getMetadataKey());
-		}
-		return mappingUrl;
-	}
+  /**
+   * <p>
+   * If <code>this.getAllowOverride()</code> is true and <code>msg.containsKey(getMetadataKey())</code> is true then the value of
+   * <code>msg.getMetadataValue(this.getMetadataKey()</code> is the URL to use, otherwise the value of <code>this.getUrl()</code> is used,
+   * if <code>this.getUrl()</code> is empty or null then it checks <code>this.getMappingSource()</code> if this is also null a
+   * <code>ServiceException</code> is thrown.
+   * </p>
+   */
+  String obtainMappingContent(AdaptrisMessage msg) throws ServiceException {
+    try {
+      if (!isEmpty(mappingUrlSource(msg))) {
+        isUrlMappingSource = true;
+        return mappingUrlSource(msg);
+      } else if (getMappingSource() != null) {
+        isUrlMappingSource = false;
+        return getMappingSource().extract(msg);
+      } else {
+        throw new ServiceException(
+            "no URL or mapping source has been configured and metadata key [" + getMetadataKey() + "] returned null");
+      }
 
-	private void doTransform(AdaptrisMessage msg, String xslSourceToUse) throws ServiceException {
-		XmlTransformer xmlTransformerImpl = new XmlTransformer();
-		Transformer transformer = null;
+    } catch (Exception e) {
+      throw new ServiceException(e);
+    }
+  }
 
-		try {
-			
-			if (this.isUrlMappingSource) {
-				if (cacheTransforms()) {
-					transformer = cacheAndGetTransformer(xslSourceToUse, getXmlTransformerFactory());
-				} else {
-					transformer = getXmlTransformerFactory().createTransformerFromUrl(xslSourceToUse);
-				}
-			} else {
-				transformer = getXmlTransformerFactory().createTransformerFromRawXsl(xslSourceToUse);
-			}
-			
-			getXmlTransformerFactory().configure(xmlTransformerImpl);
-		} catch (Exception ex) {
-			throw new ServiceException(ex);
-		}
-		// INTERLOK-2022 Let the XML parser do its thing, rather than using a
-		// reader/writer.
-		try (InputStream input = msg.getInputStream(); OutputStream output = msg.getOutputStream()) {
-			Map<Object, Object> parameters = getParameterBuilder().createParameters(msg, null);
-			xmlTransformerImpl.transform(transformer, input, output, xslSourceToUse, parameters);
-			if (!StringUtils.isBlank(getOutputMessageEncoding())) {
-				msg.setContentEncoding(getOutputMessageEncoding());
-			}
-		} catch (Exception e) {
-			throw new ServiceException("failed to transform message", e);
-		}
-	}
+  private String mappingUrlSource(AdaptrisMessage msg) {
+    String mappingUrl = null;
+    if (!isEmpty(getUrl())) {
+      mappingUrl = getUrl();
+    }
+    if (allowOverride() && msg.headersContainsKey(getMetadataKey())) {
+      mappingUrl = isEmpty(msg.getMetadataValue(getMetadataKey())) ? getUrl() : msg.getMetadataValue(getMetadataKey());
+    }
+    return mappingUrl;
+  }
 
-	protected Transformer cacheAndGetTransformer(String xslToUse, XmlTransformerFactory xmlTransformerFactory)
-			throws Exception {
-		if (getTransforms().containsKey(xslToUse))
-			return getTransforms().get(xslToUse);
-		else {
-			Transformer transformer = xmlTransformerFactory.createTransformerFromUrl(xslToUse);
-			getTransforms().put(xslToUse, transformer);
-			return transformer;
-		}
-	}
+  private void doTransform(AdaptrisMessage msg, String xslSourceToUse) throws ServiceException {
+    XmlTransformer xmlTransformerImpl = new XmlTransformer();
+    Transformer transformer = null;
 
-	// properties...
+    try {
+      if (isUrlMappingSource) {
+        if (cacheTransforms()) {
+          transformer = cacheAndGetTransformer(xslSourceToUse, getXmlTransformerFactory());
+        } else {
+          transformer = getXmlTransformerFactory().createTransformerFromUrl(xslSourceToUse);
+        }
+      } else {
+        transformer = getXmlTransformerFactory().createTransformerFromRawXsl(xslSourceToUse);
+      }
 
-	/**
-	 * <p>
-	 * Returns the URL of the XSLT to use.
-	 * </p>
-	 *
-	 * @return the URL of the XSLT to use
-	 */
-	public String getUrl() {
-		return url;
-	}
+      getXmlTransformerFactory().configure(xmlTransformerImpl);
+    } catch (Exception ex) {
+      throw new ServiceException(ex);
+    }
+    // INTERLOK-2022 Let the XML parser do its thing, rather than using a reader/writer.
+    try (InputStream input = msg.getInputStream(); OutputStream output = msg.getOutputStream()) {
+      Map<Object, Object> parameters = getParameterBuilder().createParameters(msg, null);
+      xmlTransformerImpl.transform(transformer, input, output, xslSourceToUse, parameters);
+      if (!StringUtils.isBlank(getOutputMessageEncoding())) {
+        msg.setContentEncoding(getOutputMessageEncoding());
+      }
+    } catch (Exception e) {
+      throw new ServiceException("failed to transform message", e);
+    }
+  }
 
-	/**
-	 * <p>
-	 * Sets the URL of the XSLT to use. May not be empty.
-	 * </p>
-	 *
-	 * @param s the URL of the XSLT to use
-	 */
-	public void setUrl(String s) {
-		if ("".equals(s)) {
-			throw new IllegalArgumentException("null param");
-		}
-		url = s;
-	}
+  protected Transformer cacheAndGetTransformer(String xslToUse, XmlTransformerFactory xmlTransformerFactory) throws Exception {
+    if (getTransforms().containsKey(xslToUse)) {
+      return getTransforms().get(xslToUse);
+    } else {
+      Transformer transformer = xmlTransformerFactory.createTransformerFromUrl(xslToUse);
+      getTransforms().put(xslToUse, transformer);
+      return transformer;
+    }
+  }
 
-	/**
-	 * <p>
-	 * Returns the metadata key against which an over-ride XSLT URL may be stored.
-	 * </p>
-	 *
-	 * @return the metadata key against which an over-ride XSLT URL may be stored
-	 */
-	public String getMetadataKey() {
-		return metadataKey;
-	}
+  // properties...
 
-	/**
-	 * <p>
-	 * Sets the metadata key against which an over-ride XSLT URL may be stored. May
-	 * not be empty.
-	 * </p>
-	 *
-	 * @param s the metadata key against which an over-ride XSLT URL may be stored,
-	 *          defaults to
-	 *          {@value com.adaptris.core.CoreConstants#TRANSFORM_OVERRIDE}
-	 */
-	public void setMetadataKey(String s) {
-		if ("".equals(s)) {
-			throw new IllegalArgumentException("null param");
-		}
-		metadataKey = s;
-	}
+  /**
+   * <p>
+   * Returns the URL of the XSLT to use.
+   * </p>
+   *
+   * @return the URL of the XSLT to use
+   */
+  public String getUrl() {
+    return url;
+  }
 
-	/**
-	 * <p>
-	 * Returns true if XSLTs should be cached. This functionality only works if 
-	 * {@link XmlTransformService#getUrl()} is used.
-	 * </p>
-	 *
-	 * @see #setCacheTransforms(Boolean)
-	 * @return true if XSLTs should be cached, otherwise false
-	 */
-	public Boolean getCacheTransforms() {
-		return cacheTransforms;
-	}
+  /**
+   * <p>
+   * Sets the URL of the XSLT to use. May not be empty.
+   * </p>
+   *
+   * @param s the URL of the XSLT to use
+   */
+  public void setUrl(String s) {
+    if ("".equals(s)) {
+      throw new IllegalArgumentException("null param");
+    }
+    url = s;
+  }
 
-	/**
-	 * <p>
-	 * Sets whether XSLTs should be cached or not. If this is false the XSLT will be
-	 * read for each message processed. Therefore while any changes to the XSLT will
-	 * be picked up immediately, processing will take significantly longer,
-	 * particularly if the XSLT is on a remote machine. This functionality only works if 
-	 * {@link XmlTransformService#getUrl()} is used.
-	 * </p>
-	 *
-	 * @param b whether XSLTs should be cached or not, defaults to true.
-	 */
-	public void setCacheTransforms(Boolean b) {
-		cacheTransforms = b;
-	}
+  /**
+   * <p>
+   * Returns the metadata key against which an over-ride XSLT URL may be stored.
+   * </p>
+   *
+   * @return the metadata key against which an over-ride XSLT URL may be stored
+   */
+  public String getMetadataKey() {
+    return metadataKey;
+  }
 
-	boolean cacheTransforms() {
-		return BooleanUtils.toBooleanDefaultIfNull(getCacheTransforms(), true);
-	}
+  /**
+   * <p>
+   * Sets the metadata key against which an over-ride XSLT URL may be stored. May not be empty.
+   * </p>
+   *
+   * @param s the metadata key against which an over-ride XSLT URL may be stored, defaults to
+   *          {@value com.adaptris.core.CoreConstants#TRANSFORM_OVERRIDE}
+   */
+  public void setMetadataKey(String s) {
+    if ("".equals(s)) {
+      throw new IllegalArgumentException("null param");
+    }
+    metadataKey = s;
+  }
 
-	/**
-	 * <p>
-	 * Returns true if a configured XSLT URL may be over-ridden by one stored
-	 * against a metadata key.
-	 * </p>
-	 *
-	 * @return true if a configured XSLT URL may be over-ridden by one stored
-	 *         against a metadata key, otherwise false
-	 */
-	public Boolean getAllowOverride() {
-		return allowOverride;
-	}
+  /**
+   * <p>
+   * Returns true if XSLTs should be cached. This functionality only works if {@link XmlTransformService#getUrl()} is used.
+   * </p>
+   *
+   * @see #setCacheTransforms(Boolean)
+   * @return true if XSLTs should be cached, otherwise false
+   */
+  public Boolean getCacheTransforms() {
+    return cacheTransforms;
+  }
 
-	/**
-	 * <p>
-	 * Sets whether the configured XSLT URL may be over-ridden by one stored against
-	 * a metaddata key. If URL is configured this is implicitly true.
-	 * </p>
-	 *
-	 * @param b whether the configured XSLT URL may be over-ridden by one stored
-	 *          against a metadata key, defaults to null (false)
-	 */
-	public void setAllowOverride(Boolean b) {
-		allowOverride = b;
-	}
+  /**
+   * <p>
+   * Sets whether XSLTs should be cached or not. If this is false the XSLT will be read for each message processed. Therefore while any
+   * changes to the XSLT will be picked up immediately, processing will take significantly longer, particularly if the XSLT is on a remote
+   * machine. This functionality only works if {@link XmlTransformService#getUrl()} is used.
+   * </p>
+   *
+   * @param b whether XSLTs should be cached or not, defaults to true.
+   */
+  public void setCacheTransforms(Boolean b) {
+    cacheTransforms = b;
+  }
 
-	boolean allowOverride() {
-		if (overrideAllowOverride != null) {
-			return overrideAllowOverride.booleanValue();
-		}
-		return BooleanUtils.toBooleanDefaultIfNull(getAllowOverride(), false);
-	}
+  boolean cacheTransforms() {
+    return BooleanUtils.toBooleanDefaultIfNull(getCacheTransforms(), true);
+  }
 
-	public String getOutputMessageEncoding() {
-		return outputMessageEncoding;
-	}
+  /**
+   * <p>
+   * Returns true if a configured XSLT URL may be over-ridden by one stored against a metadata key.
+   * </p>
+   *
+   * @return true if a configured XSLT URL may be over-ridden by one stored against a metadata key, otherwise false
+   */
+  public Boolean getAllowOverride() {
+    return allowOverride;
+  }
 
-	/**
-	 * Force the output message encoding to be a particular encoding.
-	 * <p>
-	 * If specified then the underlying
-	 * {@link com.adaptris.core.AdaptrisMessage#setCharEncoding(String)} is changed
-	 * to match the encoding specified here before attempting any write operations.
-	 * </p>
-	 * <p>
-	 * This is only useful if the underlying message is encoded in one way, and you
-	 * wish to force the encoding directly in your stylesheet; e.g. the message is
-	 * physically encoded using ISO-8859-1; but your xslt has &lt;xsl:output
-	 * method="xml" encoding="UTF-8" indent="yes"/&gt; and you need to ensure that
-	 * the message is physically encoded using UTF-8 after the transform.
-	 * </p>
-	 *
-	 * @param s the output encoding; if null, the the existing encoding specified by
-	 *          {@link com.adaptris.core.AdaptrisMessage#getCharEncoding()} is used.
-	 */
-	public void setOutputMessageEncoding(String s) {
-		outputMessageEncoding = s;
-	}
+  /**
+   * <p>
+   * Sets whether the configured XSLT URL may be over-ridden by one stored against a metaddata key. If URL is configured this is implicitly
+   * true.
+   * </p>
+   *
+   * @param b whether the configured XSLT URL may be over-ridden by one stored against a metadata key, defaults to null (false)
+   */
+  public void setAllowOverride(Boolean b) {
+    allowOverride = b;
+  }
 
-	public XmlTransformerFactory getXmlTransformerFactory() {
-		return xmlTransformerFactory;
-	}
+  boolean allowOverride() {
+    if (overrideAllowOverride != null) {
+      return overrideAllowOverride.booleanValue();
+    }
+    return BooleanUtils.toBooleanDefaultIfNull(getAllowOverride(), false);
+  }
 
-	public void setXmlTransformerFactory(XmlTransformerFactory xmlTransformerFactory) {
-		this.xmlTransformerFactory = xmlTransformerFactory;
-	}
+  public String getOutputMessageEncoding() {
+    return outputMessageEncoding;
+  }
 
-	public XmlTransformParameter getTransformParameter() {
-		return transformParameter;
-	}
+  /**
+   * Force the output message encoding to be a particular encoding.
+   * <p>
+   * If specified then the underlying {@link com.adaptris.core.AdaptrisMessage#setCharEncoding(String)} is changed to match the encoding
+   * specified here before attempting any write operations.
+   * </p>
+   * <p>
+   * This is only useful if the underlying message is encoded in one way, and you wish to force the encoding directly in your stylesheet;
+   * e.g. the message is physically encoded using ISO-8859-1; but your xslt has &lt;xsl:output method="xml" encoding="UTF-8"
+   * indent="yes"/&gt; and you need to ensure that the message is physically encoded using UTF-8 after the transform.
+   * </p>
+   *
+   * @param s the output encoding; if null, the the existing encoding specified by
+   *          {@link com.adaptris.core.AdaptrisMessage#getCharEncoding()} is used.
+   */
+  public void setOutputMessageEncoding(String s) {
+    outputMessageEncoding = s;
+  }
 
-	public void setTransformParameter(XmlTransformParameter param) {
-		transformParameter = param;
-	}
+  public XmlTransformerFactory getXmlTransformerFactory() {
+    return xmlTransformerFactory;
+  }
 
-	protected XmlTransformParameter getParameterBuilder() {
-		return getTransformParameter() != null ? getTransformParameter() : new IgnoreMetadataParameter();
-	}
+  public void setXmlTransformerFactory(XmlTransformerFactory xmlTransformerFactory) {
+    this.xmlTransformerFactory = xmlTransformerFactory;
+  }
 
-	Map<String, Transformer> getTransforms() {
-		return transforms;
-	}
+  public XmlTransformParameter getTransformParameter() {
+    return transformParameter;
+  }
+
+  public void setTransformParameter(XmlTransformParameter param) {
+    transformParameter = param;
+  }
+
+  protected XmlTransformParameter getParameterBuilder() {
+    return getTransformParameter() != null ? getTransformParameter() : new IgnoreMetadataParameter();
+  }
+
+  Map<String, Transformer> getTransforms() {
+    return transforms;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/StxTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/StxTransformerFactory.java
@@ -46,13 +46,13 @@ public class StxTransformerFactory extends XmlTransformerFactoryImpl {
 
   @Override
   public Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception {
-	 StreamSource xslStream = new StreamSource(new StringReader(xsl));
-	 return configure( new TransformerFactoryImpl()).newTransformer(xslStream);
+    StreamSource xslStream = new StreamSource(new StringReader(xsl));
+    return configure( new TransformerFactoryImpl()).newTransformer(xslStream);
   }
 
   @Override
   public XmlTransformer configure(XmlTransformer xmlTransformer) throws Exception {
     return xmlTransformer;
   }
-  
+
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/StxTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/StxTransformerFactory.java
@@ -45,7 +45,7 @@ import net.sf.joost.trax.TransformerFactoryImpl;
 public class StxTransformerFactory extends XmlTransformerFactoryImpl {
 
   @Override
-  public Transformer createTransformerFromRawXslt(String xsl, EntityResolver entityResolver) throws Exception {
+  public Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception {
 	 StreamSource xslStream = new StreamSource(new StringReader(xsl));
 	 return configure( new TransformerFactoryImpl()).newTransformer(xslStream);
   }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/StxTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/StxTransformerFactory.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.util.text.xml;
 
+import java.io.StringReader;
+
 import javax.xml.transform.Transformer;
 import javax.xml.transform.stream.StreamSource;
 
@@ -43,19 +45,14 @@ import net.sf.joost.trax.TransformerFactoryImpl;
 public class StxTransformerFactory extends XmlTransformerFactoryImpl {
 
   @Override
-  public Transformer createTransformer(String xsl) throws Exception {
-    StreamSource xslStream = new StreamSource(xsl);
-    return configure( new TransformerFactoryImpl()).newTransformer(xslStream);
-  }
-
-  @Override
-  public Transformer createTransformer(String url, EntityResolver entityResolver) throws Exception {
-    return this.createTransformer(url);
+  public Transformer createTransformerFromRawXslt(String xsl, EntityResolver entityResolver) throws Exception {
+	 StreamSource xslStream = new StreamSource(new StringReader(xsl));
+	 return configure( new TransformerFactoryImpl()).newTransformer(xslStream);
   }
 
   @Override
   public XmlTransformer configure(XmlTransformer xmlTransformer) throws Exception {
     return xmlTransformer;
   }
-
+  
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
@@ -26,9 +26,9 @@ public interface XmlTransformerFactory {
 
   Transformer createTransformerFromUrl(String transformUrl, EntityResolver entityResolver) throws Exception;
   
-  Transformer createTransformerFromRawXslt(String xsl) throws Exception;
+  Transformer createTransformerFromRawXsl(String xsl) throws Exception;
   
-  Transformer createTransformerFromRawXslt(String xsl, EntityResolver entityResolver) throws Exception;
+  Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception;
   
   XmlTransformer configure(XmlTransformer xmlTransformer) throws Exception;
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
@@ -21,10 +21,14 @@ import javax.xml.transform.Transformer;
 import org.xml.sax.EntityResolver;
 
 public interface XmlTransformerFactory {
-
-  Transformer createTransformer(String transformUrl) throws Exception;
   
-  Transformer createTransformer(String transformUrl, EntityResolver entityResolver) throws Exception;
+  Transformer createTransformerFromUrl(String transformUrl) throws Exception;
+
+  Transformer createTransformerFromUrl(String transformUrl, EntityResolver entityResolver) throws Exception;
+  
+  Transformer createTransformerFromRawXslt(String xsl) throws Exception;
+  
+  Transformer createTransformerFromRawXslt(String xsl, EntityResolver entityResolver) throws Exception;
   
   XmlTransformer configure(XmlTransformer xmlTransformer) throws Exception;
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,14 +21,30 @@ import javax.xml.transform.Transformer;
 import org.xml.sax.EntityResolver;
 
 public interface XmlTransformerFactory {
-  
+
+  /**
+   * @deprecated You shoul use {@link XmlTransformerFactory#createTransformerFromUrl(String)} instead
+   */
+  @Deprecated
+  default Transformer createTransformer(String transformUrl) throws Exception {
+    return createTransformerFromUrl(transformUrl);
+  }
+
+  /**
+   * @deprecated You shoul use {@link XmlTransformerFactory#createTransformerFromUrl(String, EntityResolver)} instead
+   */
+  @Deprecated
+  default Transformer createTransformer(String transformUrl, EntityResolver entityResolver) throws Exception {
+    return createTransformerFromUrl(transformUrl, entityResolver);
+  }
+
   Transformer createTransformerFromUrl(String transformUrl) throws Exception;
 
   Transformer createTransformerFromUrl(String transformUrl, EntityResolver entityResolver) throws Exception;
-  
+
   Transformer createTransformerFromRawXsl(String xsl) throws Exception;
-  
+
   Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception;
-  
+
   XmlTransformer configure(XmlTransformer xmlTransformer) throws Exception;
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
@@ -95,12 +95,12 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
 	} catch (Exception e) {
 	   throw new ServiceException("unable to extract the xsl content.", e);
 	}
-    return this.createTransformerFromRawXslt(xsl, entityResolver);
+    return this.createTransformerFromRawXsl(xsl, entityResolver);
   }
   
   @Override
-  public Transformer createTransformerFromRawXslt(String xsl) throws Exception {
-	return this.createTransformerFromRawXslt(xsl, null);
+  public Transformer createTransformerFromRawXsl(String xsl) throws Exception {
+	return this.createTransformerFromRawXsl(xsl, null);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -73,36 +73,35 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
     return xmlDocumentFactoryConfig;
   }
 
-
   public void setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder xml) {
-    this.xmlDocumentFactoryConfig = xml;
+    xmlDocumentFactoryConfig = xml;
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
     return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
-  
+
   @Override
   public Transformer createTransformerFromUrl(String xsl) throws Exception {
-    return this.createTransformerFromUrl(xsl, null);
+    return createTransformerFromUrl(xsl, null);
   }
 
   @Override
   public Transformer createTransformerFromUrl(String xsl, EntityResolver entityResolver) throws Exception {
-	  xsl = backslashToSlash(xsl);
-	try (InputStream inputStream = connect(xsl)) {
-	   StringWriter writer = new StringWriter();
-	   IOUtils.copy(inputStream, writer, Charset.defaultCharset());
-	   xsl = writer.toString();
-	} catch (Exception e) {
-	   throw new ServiceException("unable to extract the xsl content.", e);
-	}
-    return this.createTransformerFromRawXsl(xsl, entityResolver);
+    xsl = backslashToSlash(xsl);
+    try (InputStream inputStream = connect(xsl)) {
+      StringWriter writer = new StringWriter();
+      IOUtils.copy(inputStream, writer, Charset.defaultCharset());
+      xsl = writer.toString();
+    } catch (Exception e) {
+      throw new ServiceException("unable to extract the xsl content.", e);
+    }
+    return createTransformerFromRawXsl(xsl, entityResolver);
   }
-  
+
   @Override
   public Transformer createTransformerFromRawXsl(String xsl) throws Exception {
-	return this.createTransformerFromRawXsl(xsl, null);
+    return createTransformerFromRawXsl(xsl, null);
   }
 
   @Override
@@ -110,7 +109,6 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
     xmlTransformer.registerBuilder(documentFactoryBuilder());
     return xmlTransformer;
   }
-
 
   TransformerFactory configure(TransformerFactory tf) throws TransformerConfigurationException {
     for (KeyValuePair kp : getTransformerFactoryAttributes()) {
@@ -123,31 +121,26 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
     return tf;
   }
 
-
   public KeyValuePairSet getTransformerFactoryAttributes() {
     return transformerFactoryAttributes;
   }
 
-
   public void setTransformerFactoryAttributes(KeyValuePairSet attr) {
-    this.transformerFactoryAttributes = Args.notNull(attr, "TransformerFactoryAttributes");
+    transformerFactoryAttributes = Args.notNull(attr, "TransformerFactoryAttributes");
   }
-
 
   public KeyValuePairSet getTransformerFactoryFeatures() {
     return transformerFactoryFeatures;
   }
 
   public void setTransformerFactoryFeatures(KeyValuePairSet features) {
-    this.transformerFactoryFeatures = Args.notNull(features, "TransformerFactoryFeatures");
+    transformerFactoryFeatures = Args.notNull(features, "TransformerFactoryFeatures");
   }
 
-
-
   /**
-   * 
-   * @deprecated since 3.6.5, XSLT 3.0 has eliminated all "recoverable errors" from the specification. If you are using a previous
-   *             version of saxon or xalan then this will still have an effect.
+   *
+   * @deprecated since 3.6.5, XSLT 3.0 has eliminated all "recoverable errors" from the specification. If you are using a previous version
+   *             of saxon or xalan then this will still have an effect.
    */
   @Deprecated
   public Boolean getFailOnRecoverableError() {
@@ -156,14 +149,14 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
 
   /**
    * Whether or not to fail on a recoverable error.
-   * 
+   *
    * @param b true to fail on a recoverable error which is the default, false otherwise.
-   * @deprecated since 3.6.5, XSLT 3.0 has eliminated all "recoverable errors" from the specification. If you are using a previous
-   *             version of saxon or xalan then this will still have an effect.
+   * @deprecated since 3.6.5, XSLT 3.0 has eliminated all "recoverable errors" from the specification. If you are using a previous version
+   *             of saxon or xalan then this will still have an effect.
    */
   @Deprecated
   public void setFailOnRecoverableError(Boolean b) {
-    this.failOnRecoverableError = b;
+    failOnRecoverableError = b;
   }
 
   private boolean failOnRecoverableError() {
@@ -175,8 +168,9 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
     private boolean failOnError;
 
     DefaultErrorListener(boolean b) {
-      this.failOnError = b;
+      failOnError = b;
     }
+
     @Override
     public void warning(TransformerException e) throws TransformerException {
       log.warn("[{}]", e.getMessageAndLocation());
@@ -188,8 +182,9 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
       // This will be the error message from <xsl:message terminate="yes">Msg</xsl:message>
       log.error("[{}]", e.getMessageAndLocation());
       // We throw an error, but Saxon may still eat it.
-      if (failOnError)
+      if (failOnError) {
         throw e;
+      }
     }
 
     @Override
@@ -200,13 +195,12 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
       throw e;
     }
   }
-  
-  private static String backslashToSlash(String url) {
-	    if (!isEmpty(url)) {
-	      return url.replaceAll("\\\\", "/");
-	    }
-	    return url;
-	  }
 
+  private static String backslashToSlash(String url) {
+    if (!isEmpty(url)) {
+      return url.replaceAll("\\\\", "/");
+    }
+    return url;
+  }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
@@ -15,18 +15,30 @@
  */
 package com.adaptris.util.text.xml;
 
+import static com.adaptris.util.URLHelper.connect;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.transform.ErrorListener;
+import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.EntityResolver;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.util.KeyValuePair;
@@ -67,6 +79,28 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
     return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
+  }
+  
+  @Override
+  public Transformer createTransformerFromUrl(String xsl) throws Exception {
+    return this.createTransformerFromUrl(xsl, null);
+  }
+
+  @Override
+  public Transformer createTransformerFromUrl(String xsl, EntityResolver entityResolver) throws Exception {
+	try (InputStream inputStream = connect(xsl)) {
+	   StringWriter writer = new StringWriter();
+	   IOUtils.copy(inputStream, writer, Charset.defaultCharset());
+	   xsl = writer.toString();
+	} catch (Exception e) {
+	   throw new ServiceException("unable to extract the xsl content.", e);
+	}
+    return this.createTransformerFromRawXslt(xsl, entityResolver);
+  }
+  
+  @Override
+  public Transformer createTransformerFromRawXslt(String xsl) throws Exception {
+	return this.createTransformerFromRawXslt(xsl, null);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
@@ -16,6 +16,7 @@
 package com.adaptris.util.text.xml;
 
 import static com.adaptris.util.URLHelper.connect;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -88,6 +89,7 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
 
   @Override
   public Transformer createTransformerFromUrl(String xsl, EntityResolver entityResolver) throws Exception {
+	  xsl = backslashToSlash(xsl);
 	try (InputStream inputStream = connect(xsl)) {
 	   StringWriter writer = new StringWriter();
 	   IOUtils.copy(inputStream, writer, Charset.defaultCharset());
@@ -198,6 +200,13 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
       throw e;
     }
   }
+  
+  private static String backslashToSlash(String url) {
+	    if (!isEmpty(url)) {
+	      return url.replaceAll("\\\\", "/");
+	    }
+	    return url;
+	  }
 
 
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -64,7 +64,7 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
 
  
   @Override
-  public Transformer createTransformerFromRawXslt(String xsl, EntityResolver entityResolver) throws Exception {
+  public Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception {
 	  DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
 	    if (entityResolver != null) {
 	      docBuilder.setEntityResolver(entityResolver);

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -69,7 +69,7 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
       docBuilder.setEntityResolver(entityResolver);
     }
     Document xmlDoc = docBuilder.parse(new InputSource(new StringReader(xsl)));
-    return configure(newInstance()).newTransformer(new DOMSource(xmlDoc, xsl));
+    return configure(newInstance()).newTransformer(new DOMSource(xmlDoc));
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.util.text.xml;
 
+import java.io.StringReader;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -60,17 +62,15 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
     setTransformerFactoryImpl(impl);
   }
 
-  public Transformer createTransformer(String url) throws Exception {
-    return this.createTransformer(url, null);
-  }
-
-  public Transformer createTransformer(String url, EntityResolver entityResolver) throws Exception {
-    DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
-    if (entityResolver != null) {
-      docBuilder.setEntityResolver(entityResolver);
-    }
-    Document xmlDoc = docBuilder.parse(new InputSource(url));
-    return configure(newInstance()).newTransformer(new DOMSource(xmlDoc, url));
+ 
+  @Override
+  public Transformer createTransformerFromRawXslt(String xsl, EntityResolver entityResolver) throws Exception {
+	  DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
+	    if (entityResolver != null) {
+	      docBuilder.setEntityResolver(entityResolver);
+	    }
+	    Document xmlDoc = docBuilder.parse(new InputSource(new StringReader(xsl)));
+	    return configure(newInstance()).newTransformer(new DOMSource(xmlDoc, xsl));
   }
 
   /**
@@ -98,4 +98,5 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
     return StringUtils.isEmpty(getTransformerFactoryImpl()) ? TransformerFactory.newInstance()
         : TransformerFactory.newInstance(getTransformerFactoryImpl(), null);
   }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,14 +40,14 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * The {@link Transformer} is used to actually perform a document transformation.
  * </p>
- * 
+ *
  * @config xslt-transformer-factory
- * 
+ *
  * @author amcgrath
  */
 
 @XStreamAlias("xslt-transformer-factory")
-@DisplayOrder(order = {"transformerFactoryImpl", "failOnRecoverableError"})
+@DisplayOrder(order = { "transformerFactoryImpl", "failOnRecoverableError" })
 public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
 
   @AdvancedConfig
@@ -62,15 +62,14 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
     setTransformerFactoryImpl(impl);
   }
 
- 
   @Override
   public Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception {
-	  DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
-	    if (entityResolver != null) {
-	      docBuilder.setEntityResolver(entityResolver);
-	    }
-	    Document xmlDoc = docBuilder.parse(new InputSource(new StringReader(xsl)));
-	    return configure(newInstance()).newTransformer(new DOMSource(xmlDoc, xsl));
+    DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
+    if (entityResolver != null) {
+      docBuilder.setEntityResolver(entityResolver);
+    }
+    Document xmlDoc = docBuilder.parse(new InputSource(new StringReader(xsl)));
+    return configure(newInstance()).newTransformer(new DOMSource(xmlDoc, xsl));
   }
 
   /**
@@ -83,15 +82,15 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
   /**
    * Specify the transformer factory that will be used.
    * <p>
-   * If you have both saxon and xalan (for instance) available on the classpath; and you want to explicitly use the xalan
-   * implementation then you could put {@code org.apache.xalan.processor.TransformerFactoryImpl} here to force it to use Xalan or
+   * If you have both saxon and xalan (for instance) available on the classpath; and you want to explicitly use the xalan implementation
+   * then you could put {@code org.apache.xalan.processor.TransformerFactoryImpl} here to force it to use Xalan or
    * {@code net.sf.saxon.TransformerFactoryImpl} to force it to use Saxon.
    * <p>
-   * 
-   * @param s the transformerFactoryImpl to set, if not specified the JVM default is used {@link TransformerFactory#newInstance()}.
+   *
+   * @param s he transformerFactoryImpl to set, if not specified the JVM default is used {@link TransformerFactory#newInstance()}.
    */
   public void setTransformerFactoryImpl(String s) {
-    this.transformerFactoryImpl = s;
+    transformerFactoryImpl = s;
   }
 
   private TransformerFactory newInstance() {

--- a/interlok-core/src/test/java/com/adaptris/core/transform/MultiPayloadXmlTransformServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/MultiPayloadXmlTransformServiceTest.java
@@ -406,11 +406,11 @@ public class MultiPayloadXmlTransformServiceTest
   }
   
   protected MultiPayloadXmlTransformService createBaseExampleWithSourceInput() {
-	    MultiPayloadXmlTransformService service = new MultiPayloadXmlTransformService();
-	    service.setSourcePayloadId(PAYLOAD_ID_SOURCE);
-	    service.setOutputPayloadId(PAYLOAD_ID_OUTPUT);
-	    return service;
-	  }
+    MultiPayloadXmlTransformService service = new MultiPayloadXmlTransformService();
+    service.setSourcePayloadId(PAYLOAD_ID_SOURCE);
+    service.setOutputPayloadId(PAYLOAD_ID_OUTPUT);
+    return service;
+  }
 
   @Override
   protected String createBaseFileName(Object object) {
@@ -519,18 +519,18 @@ public class MultiPayloadXmlTransformServiceTest
     MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     AdaptrisMessage mappingMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL)));
     msg.addPayload(PAYLOAD_ID_MAPPING, mappingMsg.getPayload());
-	MultiPayloadStringInputParameter mpsip = new MultiPayloadStringInputParameter();
-	mpsip.setPayloadId(PAYLOAD_ID_MAPPING);
-	MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
-	service.setMappingSource(mpsip);
-	
+    MultiPayloadStringInputParameter mpsip = new MultiPayloadStringInputParameter();
+    mpsip.setPayloadId(PAYLOAD_ID_MAPPING);
+    MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
+    service.setMappingSource(mpsip);
+
     execute(service, msg);
     assertEquals(PROPERTIES.getProperty(KEY_XML_TEST_OUTPUT), msg.getContent(PAYLOAD_ID_OUTPUT));
   }
   
   @Test
   public void testXSLTOutputConstantDataInputParameter() throws Exception {
-	MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     ConstantDataInputParameter cdip = new ConstantDataInputParameter(loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL)));
     MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
     service.setMappingSource(cdip);
@@ -541,7 +541,7 @@ public class MultiPayloadXmlTransformServiceTest
   
   @Test
   public void testXSLTOutputFileDataInputParameter() throws Exception {
-	MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     FileDataInputParameter fdip = new FileDataInputParameter();
     fdip.setUrl(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL));
     MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
@@ -553,7 +553,7 @@ public class MultiPayloadXmlTransformServiceTest
   
   @Test
   public void testXSLTOutputMetadataDataInputParameter() throws Exception {
-	MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     msg.addMetadata("mappingKey", loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL)));
     MetadataDataInputParameter mdip = new MetadataDataInputParameter("mappingKey");
     MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
@@ -565,23 +565,23 @@ public class MultiPayloadXmlTransformServiceTest
 
   @Test
   public void testSTXMultiPayloadDataInputParameter() throws Exception {
-	MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
-	AdaptrisMessage mappingMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_STX_TRANSFORM_URL)));
-	msg.addPayload(PAYLOAD_ID_MAPPING, mappingMsg.getPayload());
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    AdaptrisMessage mappingMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_STX_TRANSFORM_URL)));
+    msg.addPayload(PAYLOAD_ID_MAPPING, mappingMsg.getPayload());
     MultiPayloadStringInputParameter mpsip = new MultiPayloadStringInputParameter();
-	mpsip.setPayloadId(PAYLOAD_ID_MAPPING);
-	MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
-	service.setMappingSource(mpsip);
-	
-	service.setXmlTransformerFactory(new StxTransformerFactory());
-		
-	execute(service, msg);
-	assertEquals(PROPERTIES.getProperty(KEY_XML_TEST_OUTPUT), msg.getContent(PAYLOAD_ID_OUTPUT));
+    mpsip.setPayloadId(PAYLOAD_ID_MAPPING);
+    MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
+    service.setMappingSource(mpsip);
+
+    service.setXmlTransformerFactory(new StxTransformerFactory());
+
+    execute(service, msg);
+    assertEquals(PROPERTIES.getProperty(KEY_XML_TEST_OUTPUT), msg.getContent(PAYLOAD_ID_OUTPUT));
   }
   
   @Test
   public void testSTXOutputConstantDataInputParameter() throws Exception {
-	MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     ConstantDataInputParameter cdip = new ConstantDataInputParameter(loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_STX_TRANSFORM_URL)));
     MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
     service.setMappingSource(cdip);
@@ -594,7 +594,7 @@ public class MultiPayloadXmlTransformServiceTest
   
   @Test
   public void testSTXOutputFileDataInputParameter() throws Exception {
-	MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     FileDataInputParameter fdip = new FileDataInputParameter();
     fdip.setUrl(PROPERTIES.getProperty(KEY_XML_TEST_STX_TRANSFORM_URL));
     MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
@@ -608,7 +608,7 @@ public class MultiPayloadXmlTransformServiceTest
   
   @Test
   public void testSTXOutputMetadataDataInputParameter() throws Exception {
-	MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     msg.addMetadata("mappingKey", loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_STX_TRANSFORM_URL)));
     MetadataDataInputParameter mdip = new MetadataDataInputParameter("mappingKey");
     MultiPayloadXmlTransformService service = createBaseExampleWithSourceInput();
@@ -882,15 +882,15 @@ public class MultiPayloadXmlTransformServiceTest
   }
   
   public void testfailNoMappingDefined() throws Exception {
-	    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
-	    MultiPayloadXmlTransformService service = new MultiPayloadXmlTransformService();
-	    service.setSourcePayloadId(PAYLOAD_ID_SOURCE);
-	    service.setOutputPayloadId(PAYLOAD_ID_OUTPUT);
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_SOURCE, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    MultiPayloadXmlTransformService service = new MultiPayloadXmlTransformService();
+    service.setSourcePayloadId(PAYLOAD_ID_SOURCE);
+    service.setOutputPayloadId(PAYLOAD_ID_OUTPUT);
 
-	    assertThrows(ServiceException.class, () -> {
-	    	execute(service, msg);
-	      });  
-	  }
+    assertThrows(ServiceException.class, () -> {
+      execute(service, msg);
+    });  
+  }
 
   private static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
     return DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -911,12 +911,13 @@ public class MultiPayloadXmlTransformServiceTest
   }
   
   private String loadFilesForTests(String filePath) throws Exception {
-	  String fileContent;
-	  try (InputStream inputStream = connect(filePath)) {
-		   StringWriter writer = new StringWriter();
-		   IOUtils.copy(inputStream, writer, Charset.defaultCharset());
-		   fileContent= writer.toString();
-		} 
-	  return  fileContent;
+    String fileContent;
+    try (InputStream inputStream = connect(filePath)) {
+      StringWriter writer = new StringWriter();
+      IOUtils.copy(inputStream, writer, Charset.defaultCharset());
+      fileContent= writer.toString();
+    } 
+    return  fileContent;
   }
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/transform/MultiPayloadXmlTransformServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/MultiPayloadXmlTransformServiceTest.java
@@ -255,7 +255,7 @@ public class MultiPayloadXmlTransformServiceTest
     try {
       service.setUrl(URL);
       LifecycleHelper.init(service);
-      assertEquals(URL, service.obtainUrlToUse(msg));
+      assertEquals(URL, service.obtainMappingContent(msg));
     }
     finally {
       LifecycleHelper.close(service);
@@ -270,7 +270,7 @@ public class MultiPayloadXmlTransformServiceTest
       service.setUrl(URL);
       service.setMetadataKey("key");
       LifecycleHelper.init(service);
-      assertEquals(URL, service.obtainUrlToUse(msg));
+      assertEquals(URL, service.obtainMappingContent(msg));
     }
     finally {
       LifecycleHelper.close(service);
@@ -286,7 +286,7 @@ public class MultiPayloadXmlTransformServiceTest
       service.setUrl(URL);
       service.setMetadataKey("key");
       LifecycleHelper.init(service);
-      assertEquals(URL, service.obtainUrlToUse(msg));
+      assertEquals(URL, service.obtainMappingContent(msg));
     }
     finally {
       LifecycleHelper.close(service);
@@ -303,7 +303,7 @@ public class MultiPayloadXmlTransformServiceTest
       service.setMetadataKey("key");
       LifecycleHelper.init(service);
       // allow override is false
-      assertEquals(URL, service.obtainUrlToUse(msg));
+      assertEquals(URL, service.obtainMappingContent(msg));
     }
     finally {
       LifecycleHelper.close(service);
@@ -322,7 +322,7 @@ public class MultiPayloadXmlTransformServiceTest
       service.setAllowOverride(true);
       LifecycleHelper.init(service);
       // allow override is false
-      assertEquals("val", service.obtainUrlToUse(msg));
+      assertEquals("val", service.obtainMappingContent(msg));
     }
     finally {
       LifecycleHelper.close(service);
@@ -338,7 +338,7 @@ public class MultiPayloadXmlTransformServiceTest
       service.setAllowOverride(true);
       LifecycleHelper.init(service);
       try {
-        service.obtainUrlToUse(msg);
+        service.obtainMappingContent(msg);
         fail();
       }
       catch (ServiceException expected) {
@@ -359,7 +359,7 @@ public class MultiPayloadXmlTransformServiceTest
       service.setMetadataKey("key");
       service.setAllowOverride(true);
       LifecycleHelper.init(service);
-      assertEquals(URL, service.obtainUrlToUse(msg));
+      assertEquals(URL, service.obtainMappingContent(msg));
     }
     finally {
       LifecycleHelper.close(service);
@@ -376,7 +376,7 @@ public class MultiPayloadXmlTransformServiceTest
       service.setMetadataKey("key");
       service.setAllowOverride(true);
       LifecycleHelper.init(service);
-      assertEquals(URL, service.obtainUrlToUse(msg));
+      assertEquals(URL, service.obtainMappingContent(msg));
     }
     finally {
       LifecycleHelper.close(service);

--- a/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
@@ -235,7 +235,7 @@ public class XmlTransformServiceTest
       service.setUrl("url");
       LifecycleHelper.init(service);
 
-      assertTrue(service.obtainUrlToUse(msg).equals("url"));
+      assertTrue(service.obtainMappingContent(msg).equals("url"));
     }
     finally {
       LifecycleHelper.close(service);
@@ -251,7 +251,7 @@ public class XmlTransformServiceTest
       service.setMetadataKey("key");
       LifecycleHelper.init(service);
 
-      assertTrue(service.obtainUrlToUse(msg).equals("url"));
+      assertTrue(service.obtainMappingContent(msg).equals("url"));
     }
     finally {
       LifecycleHelper.close(service);
@@ -268,7 +268,7 @@ public class XmlTransformServiceTest
       service.setMetadataKey("key");
       LifecycleHelper.init(service);
 
-      assertTrue(service.obtainUrlToUse(msg).equals("url"));
+      assertTrue(service.obtainMappingContent(msg).equals("url"));
     }
     finally {
       LifecycleHelper.close(service);
@@ -286,7 +286,7 @@ public class XmlTransformServiceTest
       LifecycleHelper.init(service);
 
       // allow override is false
-      assertTrue(service.obtainUrlToUse(msg).equals("url"));
+      assertTrue(service.obtainMappingContent(msg).equals("url"));
     }
     finally {
       LifecycleHelper.close(service);
@@ -306,7 +306,7 @@ public class XmlTransformServiceTest
       LifecycleHelper.init(service);
 
       // allow override is false
-      assertTrue(service.obtainUrlToUse(msg).equals("val"));
+      assertTrue(service.obtainMappingContent(msg).equals("val"));
     }
     finally {
       LifecycleHelper.close(service);
@@ -322,7 +322,7 @@ public class XmlTransformServiceTest
       service.setAllowOverride(true);
       LifecycleHelper.init(service);
       try {
-        service.obtainUrlToUse(msg);
+        service.obtainMappingContent(msg);
       }
       catch (ServiceException expected) {
       }
@@ -341,7 +341,7 @@ public class XmlTransformServiceTest
       service.setMetadataKey("key");
       service.setAllowOverride(true);
       LifecycleHelper.init(service);
-      assertTrue(service.obtainUrlToUse(msg).equals("url"));
+      assertTrue(service.obtainMappingContent(msg).equals("url"));
     }
     finally {
       LifecycleHelper.close(service);
@@ -359,7 +359,7 @@ public class XmlTransformServiceTest
       service.setAllowOverride(true);
       LifecycleHelper.init(service);
 
-      assertTrue(service.obtainUrlToUse(msg).equals("url"));
+      assertTrue(service.obtainMappingContent(msg).equals("url"));
     }
     finally {
       LifecycleHelper.close(service);

--- a/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
@@ -541,21 +541,21 @@ public class XmlTransformServiceTest
     XsltTransformerFactory fac = new XsltTransformerFactory(net.sf.saxon.TransformerFactoryImpl.class.getCanonicalName());
     service.setXmlTransformerFactory(fac);
     service.setUrl(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL));
-    
+
     execute(service, msg);
     assertEquals(PROPERTIES.getProperty(KEY_XML_TEST_OUTPUT), msg.getContent());
   }
 
   @Test
   public void testSTXMultiPayloadDataInputParameter() throws Exception {
-	MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_DATA, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
-	AdaptrisMessage mappingMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_STX_TRANSFORM_URL)));
+    MultiPayloadAdaptrisMessage msg = MessageHelper.createMultiPayloadMessage(PAYLOAD_ID_DATA, PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    AdaptrisMessage mappingMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage(loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_STX_TRANSFORM_URL)));
     msg.addPayload(PAYLOAD_ID_MAPPING, mappingMsg.getPayload());
-	MultiPayloadStringInputParameter mpsip = new MultiPayloadStringInputParameter();
-	mpsip.setPayloadId(PAYLOAD_ID_MAPPING);
-	XmlTransformService service = new XmlTransformService();
-	service.setMappingSource(mpsip);
-	msg.switchPayload(PAYLOAD_ID_DATA);
+    MultiPayloadStringInputParameter mpsip = new MultiPayloadStringInputParameter();
+    mpsip.setPayloadId(PAYLOAD_ID_MAPPING);
+    XmlTransformService service = new XmlTransformService();
+    service.setMappingSource(mpsip);
+    msg.switchPayload(PAYLOAD_ID_DATA);
 
     service.setXmlTransformerFactory(new StxTransformerFactory());
 
@@ -569,9 +569,9 @@ public class XmlTransformServiceTest
     ConstantDataInputParameter cdip = new ConstantDataInputParameter(loadFilesForTests(PROPERTIES.getProperty(KEY_XML_TEST_STX_TRANSFORM_URL)));
     XmlTransformService service = new XmlTransformService();
     service.setMappingSource(cdip);
-    
+
     service.setXmlTransformerFactory(new StxTransformerFactory());
- 
+
     execute(service, msg);
     assertEquals(PROPERTIES.getProperty(KEY_XML_TEST_OUTPUT), msg.getContent());
   }
@@ -785,8 +785,8 @@ public class XmlTransformServiceTest
     XmlTransformService service = new XmlTransformService();
 
     assertThrows(ServiceException.class, () -> {
-    	execute(service, msg);
-      });  
+      execute(service, msg);
+    });  
   }
   
   @Test
@@ -886,13 +886,13 @@ public class XmlTransformServiceTest
   }
   
   private String loadFilesForTests(String filePath) throws Exception {
-	  String fileContent;
-	  try (InputStream inputStream = connect(filePath)) {
-		   StringWriter writer = new StringWriter();
-		   IOUtils.copy(inputStream, writer, Charset.defaultCharset());
-		   fileContent= writer.toString();
-		} 
-	  return  fileContent;
+    String fileContent;
+    try (InputStream inputStream = connect(filePath)) {
+      StringWriter writer = new StringWriter();
+      IOUtils.copy(inputStream, writer, Charset.defaultCharset());
+      fileContent= writer.toString();
+    } 
+    return  fileContent;
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/util/text/XmlTransformerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/XmlTransformerTest.java
@@ -59,14 +59,14 @@ public class XmlTransformerTest extends com.adaptris.interlok.junit.scaffolding.
     try (InputStream in = m1.getInputStream(); OutputStream out = m1.getOutputStream()) {
       StreamResult output = new StreamResult(out);
       StreamSource input = new StreamSource(in);
-      transform.transform(factory.createTransformer(xsl), input, output, xsl, new HashMap<>(System.getProperties()));
+      transform.transform(factory.createTransformerFromUrl(xsl), input, output, xsl, new HashMap<>(System.getProperties()));
     }
     AdaptrisMessage m2 = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
 
     try (InputStream in = m2.getInputStream(); OutputStream out = m2.getOutputStream()) {
       StreamResult output = new StreamResult(out);
       StreamSource input = new StreamSource(in);
-      transform.transform(factory.createTransformer(xsl), input, output, xsl);
+      transform.transform(factory.createTransformerFromUrl(xsl), input, output, xsl);
     }
   }
 
@@ -77,7 +77,7 @@ public class XmlTransformerTest extends com.adaptris.interlok.junit.scaffolding.
     String xsl = backslashToSlash(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL));
     AdaptrisMessage m1 = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     try (InputStream in = m1.getInputStream(); OutputStream out = m1.getOutputStream()) {
-      transform.transform(factory.createTransformer(xsl), in, out, xsl);
+      transform.transform(factory.createTransformerFromUrl(xsl), in, out, xsl);
     }
   }
 
@@ -88,7 +88,7 @@ public class XmlTransformerTest extends com.adaptris.interlok.junit.scaffolding.
     String xsl = backslashToSlash(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL));
     AdaptrisMessage m1 = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     try (Reader in = m1.getReader(); Writer out = m1.getWriter()) {
-      transform.transform(factory.createTransformer(xsl), in, out, xsl);
+      transform.transform(factory.createTransformerFromUrl(xsl), in, out, xsl);
     }
   }
 


### PR DESCRIPTION
## Motivation

To enable xml transform services to support string data input parameters(multipayload, file, constant, etc)
This is in part to help with the config upgrade tool that is being built.

## Modification

**XmlTransformerFactory** - Interface has been updated to add two new methods and renaming of the exisitng ones so they are clear as to what they do. This is so the implementing classes can now support xsl's either passed as a url to a file(what it currently supports) and also xsl's being passed in as the input themselves.
 **StxTransformerFactory
XmlTransformerFactory** - Updated to implement the new methods as mentioned above.
**XmlTransformerFactoryImpl** - abstract class updated to have common logic moved to here.

**XmlTransformService
MultiPayloadXmlTransformService** - Both updated so they now support data input params for the mapping source while also still supporting the current url, metadata and caching functionality. url has also been deprecated.

**XmlTransformServiceTest
MultiPayloadXmlTransformServiceTest** - Tweaks to existing tests to reflect the change in method names and new unit tests added for the new functionality.

**XmlTransformerTest** - Tweaks to existing tests to reflect the change in method names 

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user:

They now have the option to use data input parameters to define their xsl mapping.

## Testing

Run unit tests locally.

You can also load up the atatched interlok project and run the service tests to see they are successful.
[config-project-xslt-data-input-params.zip](https://github.com/adaptris/interlok/files/13377438/config-project-xslt-data-input-params.zip)


**Prerequisites are:**
* make sure you have generated the latest interlok-core.jar file and added it to your v5 lib directory.
*  make sure the interlok service tester and xml service tester optional components are added to your lib directory.

**Note:**
Unable to test the multipayload features in the service tester so that workflow is the only one to have a polling trigger that fires an xml file and then adds the xsl as a new payload and then the trasnform service is configured to use that mapping payload. You can check the output in the console as there is a log message service configured.

Caching has been tested and confirmed the following:

URL and Metadata key's caching still works the same as before
Input params do not support caching and will always go to grab the xsl each time the service is run.

Also tested adding an xml transform service from prio

r to making these changes and it can be added and run successfully.