### PR TITLE
Bug/interlok 4249

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/OffsetTimestampGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/timestamp/OffsetTimestampGenerator.java
@@ -18,11 +18,9 @@ package com.adaptris.core.services.metadata.timestamp;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.Date;
-import java.util.regex.Matcher;
 
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
-import javax.validation.constraints.Pattern;
 
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
@@ -44,9 +42,6 @@ import lombok.Setter;
  */
 @XStreamAlias("offset-timestamp-generator")
 public class OffsetTimestampGenerator implements TimestampGenerator {
-
-  private static final String OFFSET_VALIDATION_REGEX = "^\\-?P(?=\\w*\\d)(?:\\d+Y|Y)?(?:\\d+M|M)?(?:\\d+D|D)?(?:T(?:\\d+H|H)?(?:\\d+M|M)?(?:\\d+(?:\\­.\\d{1,2})?S|S)?)?$";
-  private static final String OFFSET_VALIDATION_MESSAGE = "Invalid offset pattern '%s', you must use the ISO8601 standard. I.e. 'P30D', '-P30D'";
 
   /**
    * Set the offset for the timestamp.
@@ -105,7 +100,6 @@ public class OffsetTimestampGenerator implements TimestampGenerator {
   @Getter
   @Setter
   @InputFieldHint(expression = true)
-  @Pattern(regexp = OFFSET_VALIDATION_REGEX, message = OFFSET_VALIDATION_MESSAGE)
   private String offset;
 
   public OffsetTimestampGenerator() {
@@ -125,14 +119,13 @@ public class OffsetTimestampGenerator implements TimestampGenerator {
         duration.addTo(timestamp);
       }
     } catch (Exception e) {
-      throw new ServiceException("Failed to parse " + offset + " using ISO8601", e);
+      throw new ServiceException("Failed to parse " + msg.resolve(offset) + " using ISO8601", e);
     }
     return timestamp;
   }
   
   @Override
   public void init() throws CoreException {
-    validateOffset();
   }
   
   @Override
@@ -145,16 +138,6 @@ public class OffsetTimestampGenerator implements TimestampGenerator {
   
   @Override
   public void close() {
-  }
- 
-  private void validateOffset() throws CoreException {
-    if (!isBlank(offset)) {
-      java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(OFFSET_VALIDATION_REGEX);
-      Matcher matcher = pattern.matcher(offset);
-      if (!matcher.find()) {
-        throw new CoreException(String.format(OFFSET_VALIDATION_MESSAGE, offset));
-      }
-    }
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/AddTimestampMetadataServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/AddTimestampMetadataServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceList;
 import com.adaptris.core.services.metadata.timestamp.LastMessageTimestampGenerator;
 import com.adaptris.core.services.metadata.timestamp.OffsetTimestampGenerator;
@@ -56,10 +57,7 @@ public class AddTimestampMetadataServiceTest extends MetadataServiceExample {
     initWithException(service);
     service.setMetadataKey(null);
     initWithException(service);
-    
-    service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, "invalid");
-    initWithException(service);
-    
+ 
     service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, "P30D");
     LifecycleHelper.init(service);
     service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, new LastMessageTimestampGenerator());
@@ -184,7 +182,7 @@ public class AddTimestampMetadataServiceTest extends MetadataServiceExample {
   public void testOffsetWithInvalidPattern() throws Exception {
     AdaptrisMessage m = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     AddTimestampMetadataService service = new AddTimestampMetadataService(DEFAULT_TS_FORMAT, KEY1, false, "invalid");
-    assertThrows(CoreException.class, ()->{
+    assertThrows(ServiceException.class, ()->{
       execute(service, m);
     }, "Failed with an invalid offset pattern");
   }


### PR DESCRIPTION
## Motivation

Due to Bug raised: https://github.com/adaptris/interlok/issues/1338

## Modification

Reverted the pattern annotation regex check and also the validation being done on init.
Small tweak to the exception message too so it shows the value of an expression(if used)

I have left the componenet lifecycle methods even though they are doing nothing now, just in case we ever do want to add functionality in the future.

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [n/a] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Behavious that is back in line with how the service worked prior to earlier changes that intorduced this bug.
