### PR TITLE
INTERLOK-4243 add an option to nodeToString do add XML Declaration

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/XmlHelper.java
@@ -39,7 +39,6 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -291,12 +290,10 @@ public class XmlHelper {
 
     try (StringReader in = new StringReader(s)) {
       result = docBuilder.parse(new InputSource(in));
-    }
-    catch (IOException | SAXException e) {
+    } catch (IOException | SAXException e) {
       if (newDocOnFailure) {
         result = docBuilder.newDocument();
-      }
-      else {
+      } else {
         throw e;
       }
     }
@@ -329,12 +326,10 @@ public class XmlHelper {
     Document result = null;
     try (InputStream docIn = in) {
       result = docBuilder.parse(new InputSource(docIn));
-    }
-    catch (IOException | SAXException e) {
+    } catch (IOException | SAXException e) {
       if (newDocOnFailure) {
         result = docBuilder.newDocument();
-      }
-      else {
+      } else {
         throw e;
       }
     }
@@ -436,9 +431,21 @@ public class XmlHelper {
    * @return The XML String representation of the Node.
    */
   public static String nodeToString(Node node) {
+    return nodeToString(node, true);
+  }
+  
+  /**
+   * Convert an XML Node into a String snippet.
+   *
+   * @param node The node to get as an XML String.
+   * @param omitXmlDeclaration whether or not to omit the xml declaration
+   *
+   * @return The XML String representation of the Node.
+   */
+  public static String nodeToString(Node node, boolean omitXmlDeclaration) {
     try (Writer out = new StringWriter()) {
       Transformer tf = TransformerFactory.newInstance().newTransformer();
-      tf.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+      tf.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, omitXmlDeclaration ? "yes" : "no");
       tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
       tf.setOutputProperty(OutputKeys.INDENT, "yes");
       tf.transform(new DOMSource(node), new StreamResult(out));
@@ -506,19 +513,16 @@ public class XmlHelper {
       try {
         System.setErr(divert);
         System.setOut(divert);
-      }
-      catch (SecurityException ignored) {
+      } catch (SecurityException ignored) {
         ;
       }
-
     }
 
     void resume() {
       try {
         System.setErr(stderr);
         System.setOut(stdout);
-      }
-      catch (SecurityException ignored) {
+      } catch (SecurityException ignored) {
         ;
       }
       divert.flush();

--- a/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
@@ -19,6 +19,7 @@ package com.adaptris.core.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
@@ -39,10 +40,13 @@ import com.adaptris.util.XmlUtils;
 
 @SuppressWarnings("deprecation")
 public class XmlHelperTest extends XmlHelper {
+  
   private static final String EXAMPLE_XML = "<document>\n   <content>text body</content>\n"
       + "   <attachment encoding=\"base64\" filename=\"attachment1.txt\">dp/HSJfonUsSMM7QRBSRfg==</attachment>\n"
       + "   <attachment encoding=\"base64\" filename=\"attachment2.txt\">OdjozpCZB9PbCCLZlKregQ</attachment>\n"
       + "</document>";
+  
+  private static final String XML_DECLARATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
   private static final String ILLEGAL_XML_CHAR = new String(new byte[] { (byte) 0x02 });
 
@@ -159,6 +163,14 @@ public class XmlHelperTest extends XmlHelper {
     Node n = XmlHelper.stringToNode(EXAMPLE_XML);
     String s = XmlHelper.nodeToString(n);
     assertEquals(EXAMPLE_XML, s);
+  }
+  
+  @Test
+  public void testStringToNodeWithXmlDeclaration() throws Exception {
+    Node n = XmlHelper.stringToNode(EXAMPLE_XML);
+    String s = XmlHelper.nodeToString(n, false);
+    assertTrue(s.startsWith(EXAMPLE_XML));
+    assertTrue(s.endsWith(XML_DECLARATION));
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/util/XmlHelperTest.java
@@ -40,12 +40,11 @@ import com.adaptris.util.XmlUtils;
 
 @SuppressWarnings("deprecation")
 public class XmlHelperTest extends XmlHelper {
-  
+
   private static final String EXAMPLE_XML = "<document>\n   <content>text body</content>\n"
       + "   <attachment encoding=\"base64\" filename=\"attachment1.txt\">dp/HSJfonUsSMM7QRBSRfg==</attachment>\n"
-      + "   <attachment encoding=\"base64\" filename=\"attachment2.txt\">OdjozpCZB9PbCCLZlKregQ</attachment>\n"
-      + "</document>";
-  
+      + "   <attachment encoding=\"base64\" filename=\"attachment2.txt\">OdjozpCZB9PbCCLZlKregQ</attachment>\n" + "</document>";
+
   private static final String XML_DECLARATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
   private static final String ILLEGAL_XML_CHAR = new String(new byte[] { (byte) 0x02 });
@@ -70,8 +69,7 @@ public class XmlHelperTest extends XmlHelper {
     assertEquals("text body", xu.getSingleTextItem("/document/content"));
     assertNotNull(createDocument(AdaptrisMessageFactory.getDefaultInstance().newMessage(EXAMPLE_XML),
         DocumentBuilderFactoryBuilderTest.createNamespaceContext()));
-    assertNotNull(
-        createDocument(AdaptrisMessageFactory.getDefaultInstance().newMessage(EXAMPLE_XML), (NamespaceContext) null));
+    assertNotNull(createDocument(AdaptrisMessageFactory.getDefaultInstance().newMessage(EXAMPLE_XML), (NamespaceContext) null));
 
   }
 
@@ -164,13 +162,13 @@ public class XmlHelperTest extends XmlHelper {
     String s = XmlHelper.nodeToString(n);
     assertEquals(EXAMPLE_XML, s);
   }
-  
+
   @Test
   public void testStringToNodeWithXmlDeclaration() throws Exception {
     Node n = XmlHelper.stringToNode(EXAMPLE_XML);
     String s = XmlHelper.nodeToString(n, false);
-    assertTrue(s.startsWith(EXAMPLE_XML));
-    assertTrue(s.endsWith(XML_DECLARATION));
+    assertTrue(s.startsWith(XML_DECLARATION));
+    assertTrue(s.endsWith(EXAMPLE_XML));
   }
 
 }


### PR DESCRIPTION
## Motivation

We need an xml helper method that can do nodeToString with the XML Declaration

## Modification

Add an option to nodeToString do add XML Declaration
Add a test

## PR Checklist

- [x] been self-reviewed.

## Result

There is a new nodeToString method that can add the XML Declaration. The default behaviour of nodeToString  remain the same.

## Testing

The build should pass.
