### PR TITLE
INTERLOK-4285 Add MimePartSelectorToMetadata

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataTarget.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataTarget.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.services.metadata;
+
+import java.io.ByteArrayOutputStream;
+
+import com.adaptris.core.AdaptrisMessage;
+
+/**
+ * Enumeration of where the two types of metadata.
+ *
+ */
+public enum MetadataTarget {
+  /**
+   * Standard Metadata.
+   *
+   */
+  Standard {
+    @Override
+    public void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value) {
+      msg.addMetadata(key, value.toString());
+    }
+  },
+  /**
+   * Object Metadata.
+   *
+   */
+  Object {
+    @Override
+    public void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value) {
+      msg.addObjectHeader(key, value.toByteArray());
+    }
+  };
+
+  public abstract void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value);
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadToMetadataService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/PayloadToMetadataService.java
@@ -62,37 +62,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @DisplayOrder(order = {"key", "encoding", "metadataTarget"})
 public class PayloadToMetadataService extends ServiceImp {
 
-  /**
-   * Enumeration of where the two types of metadata.
-   * 
-   */
-  public enum MetadataTarget
- {
-    /**
-     * Standard Metadata.
-     * 
-     */
-    Standard {
-      @Override
-      void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value) {
-        msg.addMetadata(key, value.toString());
-      }
-    },
-    /**
-     * Object Metadata.
-     * 
-     */
-    Object {
-      @Override
-      void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value) {
-        msg.addObjectHeader(key, value.toByteArray());
-      }
-    };
-    
-    abstract void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value);
-  };
-
-
   @NotBlank
   @AffectsMetadata
   private String key;

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/FlattenMimeParts.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/FlattenMimeParts.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,18 +49,19 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Flatten any nested {@code MimeBodyParts} inside the payload.
- * 
+ *
  * <p>
- * Flattens the payload so that any nested {@code Multiparts} have their body parts added directly to the root multipart. This can
- * be useful if you are processing an email message; it can often contain both text and html versions of message body as a nested
- * multipart.
+ * Flattens the payload so that any nested {@code Multiparts} have their body parts added directly to the root multipart. This can be useful
+ * if you are processing an email message; it can often contain both text and html versions of message body as a nested multipart.
  * <p>
- * For example if you have a MIME message that contains 4 body parts; 3 that are plain text, and a 4th that is a multipart which
- * itself contains 3 text parts; then the resulting output will contain 6 parts; the 3 original plain text parts and the 3 nested
- * parts. Note that a {@code Content-Id} header will be generated for each part if it does not already exist. Headers will be
- * generally untouched, but boundary markers will change.
+ * For example if you have a MIME message that contains 4 body parts; 3 that are plain text, and a 4th that is a multipart which itself
+ * contains 3 text parts; then the resulting output will contain 6 parts; the 3 original plain text parts and the 3 nested parts. Note that
+ * a {@code Content-Id} header will be generated for each part if it does not already exist. Headers will be generally untouched, but
+ * boundary markers will change.
  * </p>
- * i.e. <pre> 
+ * i.e.
+ *
+ * <pre>
    {@code
 Mime-Version: 1.0
 Content-Type: multipart/mixed; boundary="----=_Part_3_815648243.1522235646062"
@@ -128,7 +129,7 @@ Content-Id: nested3
 ------=_Part_4_18130400.1522235646074--
    }
  * </pre>
- * 
+ *
  * @config flatten-mime-parts
  */
 @XStreamAlias("flatten-mime-parts")
@@ -138,10 +139,8 @@ public class FlattenMimeParts extends ServiceImp {
 
   private static final GuidGenerator GUID = new GuidGenerator();
 
-  private static final List<String> DISCARD = Arrays.asList(new String[]
-  {
-      MimeConstants.HEADER_CONTENT_LENGTH.toLowerCase(), MimeConstants.HEADER_CONTENT_TYPE.toLowerCase(),
-  });
+  private static final List<String> DISCARD = Arrays.asList(MimeConstants.HEADER_CONTENT_LENGTH.toLowerCase(),
+      MimeConstants.HEADER_CONTENT_TYPE.toLowerCase());
 
   public FlattenMimeParts() {
   }
@@ -166,9 +165,9 @@ public class FlattenMimeParts extends ServiceImp {
   }
 
   private void addHeaders(InternetHeaders hdrs, MultiPartOutput out) {
-    Enumeration e = hdrs.getAllHeaders();
-    while (e.hasMoreElements()) {
-      Header h = (Header) e.nextElement();
+    Enumeration<Header> headers = hdrs.getAllHeaders();
+    while (headers.hasMoreElements()) {
+      Header h = headers.nextElement();
       if (!DISCARD.contains(h.getName().toLowerCase())) {
         out.setHeader(h.getName(), h.getValue());
       }

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/InlineMimePartBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/InlineMimePartBuilder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2019 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,8 +21,8 @@ import javax.mail.internet.InternetHeaders;
 import javax.mail.internet.MimeBodyPart;
 import javax.validation.Valid;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -44,23 +44,22 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Builds a MIME Body part by rendering a byte array as the content of the part.
- * 
+ *
  * <p>
- * Used as part of a {@link MultipartMessageBuilder} service; this constructs a {@link MimeBodyPart} from the configured
- * {@code body} configuration. Depending on your use case you might opt to use {@link ByteArrayFromPayload} or
- * {@link ByteArrayFromMetadata} to generate the actual contents for the part.
+ * Used as part of a {@link MultipartMessageBuilder} service; this constructs a {@link MimeBodyPart} from the configured {@code body}
+ * configuration. Depending on your use case you might opt to use {@link ByteArrayFromPayload} or {@link ByteArrayFromMetadata} to generate
+ * the actual contents for the part.
  * </p>
  * <p>
  * You can also specify the various headers that will be associated with the {@link MimeBodyPart} such as the {@code Content-ID},
  * {@code Content-Type} or {@code Content-Transfer-Encoding}. Additional non standard headers can be added by configuring a
  * {@link #setPartHeaderFilter(MetadataFilter)} to filter out metadata to include as part of the MimeBodyPart headers.
  * </p>
- * 
- * @config inline-mime-body-part-builder
+ *
  * @since 3.9.0
  */
 @ComponentProfile(summary = "Builds a MIME Body part using a byte array", since = "3.9.0")
-@DisplayOrder(order = {"contentId", "contentType", "contentEncoding", "body", "partHeaderFilter"})
+@DisplayOrder(order = { "contentId", "contentType", "contentEncoding", "body", "partHeaderFilter" })
 @XStreamAlias("inline-mime-body-part-builder")
 public class InlineMimePartBuilder implements MimePartBuilder {
 
@@ -87,7 +86,6 @@ public class InlineMimePartBuilder implements MimePartBuilder {
 
   }
 
-
   @Override
   public MimeBodyPart build(AdaptrisMessage msg) throws Exception {
     InternetHeaders hdrs = new InternetHeaders();
@@ -104,14 +102,13 @@ public class InlineMimePartBuilder implements MimePartBuilder {
     return part;
   }
 
-
   public MessageWrapper<byte[]> getBody() {
     return body;
   }
 
   /**
    * Set where the body of the MimeBodyPart is going to come from.
-   * 
+   *
    * @param body the location of the body for the mime part; the default if not specified is the payload as a byte-array.
    * @see ByteArrayFromMetadata
    * @see ByteArrayFromObjectMetadata
@@ -127,11 +124,11 @@ public class InlineMimePartBuilder implements MimePartBuilder {
 
   /**
    * Set any additional headers that need to be set for this nested part.
-   * 
+   *
    * @param filter the metadata filter.
    */
   public void setPartHeaderFilter(MetadataFilter filter) {
-    this.partHeaderFilter = filter;
+    partHeaderFilter = filter;
   }
 
   public String getContentEncoding() {
@@ -140,19 +137,18 @@ public class InlineMimePartBuilder implements MimePartBuilder {
 
   /**
    * Set the Content-Transfer-Encoding for the part.
-   * 
+   *
    * <p>
-   * Set the encoding of the mime part; if the mime part contains text you probably don't need to
-   * specify this; any RFC2045 value is supported such as
-   * {@code base64,quoted-printable,uuencode,x-uuencode,x-uue,binary,7bit,8bit} and is passed
-   * directly to {@code MimeUtility#encode(java.io.OutputStream, String, String)}.
+   * Set the encoding of the mime part; if the mime part contains text you probably don't need to specify this; any RFC2045 value is
+   * supported such as {@code base64,quoted-printable,uuencode,x-uuencode,x-uue,binary,7bit,8bit} and is passed directly to
+   * {@code MimeUtility#encode(java.io.OutputStream, String, String)}.
    * </p>
-   * 
-   * @param s the Content-Transfer-Encoding, which supports the {@code %message{}} syntax to resolve
-   *        metadata, default is 'null', no encoding.
+   *
+   * @param s the Content-Transfer-Encoding, which supports the {@code %message{}} syntax to resolve metadata, default is 'null', no
+   *          encoding.
    */
   public void setContentEncoding(String s) {
-    this.contentEncoding = s;
+    contentEncoding = s;
   }
 
   public String getContentType() {
@@ -161,12 +157,12 @@ public class InlineMimePartBuilder implements MimePartBuilder {
 
   /**
    * Set the Content-Type for the part.
-   * 
-   * @param s the Content-Type, which supports the {@code %message{}} syntax to resolve metadata; if
-   *        not specified defaults to {@code application/octet-stream}
+   *
+   * @param s the Content-Type, which supports the {@code %message{}} syntax to resolve metadata; if not specified defaults to
+   *          {@code application/octet-stream}
    */
   public void setContentType(String s) {
-    this.contentType = s;
+    contentType = s;
   }
 
   public String getContentId() {
@@ -175,12 +171,12 @@ public class InlineMimePartBuilder implements MimePartBuilder {
 
   /**
    * Set the Content-ID for the part,
-   * 
-   * @param s the Content-ID, which supports the {@code %message{}} syntax to resolve metadata;
-   *        defaults to a new GUID if no value is specified.
+   *
+   * @param s the Content-ID, which supports the {@code %message{}} syntax to resolve metadata; defaults to a new GUID if no value is
+   *          specified.
    */
   public void setContentId(String s) {
-    this.contentId = s;
+    contentId = s;
   }
 
   public InlineMimePartBuilder withBody(MessageWrapper<byte[]> body) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelector.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelector.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,12 +17,16 @@
 package com.adaptris.core.services.mime;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+
 import java.util.Enumeration;
+
 import javax.mail.Header;
 import javax.mail.internet.MimeBodyPart;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -43,18 +47,18 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Choose a specific mime part from an existing multipart message to become the payload of the AdaptrisMessage.
- * 
+ *
  * @config mime-part-selector-service
- * 
- * 
+ *
+ *
  * @author lchan
  * @author $Author: lchan $
  */
 @XStreamAlias("mime-part-selector-service")
 @AdapterComponent
 @ComponentProfile(summary = "Select a mime-part from the message and discards the others", tag = "service")
-@DisplayOrder(order = {"selector", "markAsNonMime", "preserveHeadersAsMetadata", "headerPrefix", "preservePartHeadersAsMetadata",
-    "partHeaderPrefix"})
+@DisplayOrder(order = { "selector", "markAsNonMime", "preserveHeadersAsMetadata", "headerPrefix", "preservePartHeadersAsMetadata",
+    "partHeaderPrefix" })
 public class MimePartSelector extends ServiceImp {
 
   @AdvancedConfig
@@ -74,7 +78,6 @@ public class MimePartSelector extends ServiceImp {
   @NotNull
   @Valid
   private PartSelector selector;
-
 
   public MimePartSelector() {
   }
@@ -100,20 +103,17 @@ public class MimePartSelector extends ServiceImp {
             msg.removeMetadata(msg.getMetadata(CoreConstants.MSG_MIME_ENCODED));
           }
         }
-      }
-      else {
+      } else {
         log.warn("Could not select a MimePart for extraction, ignoring");
       }
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       throw new ServiceException(e);
     }
   }
 
-  private void addHeadersAsMetadata(Enumeration e, String prefix,
-                                    AdaptrisMessage msg) throws Exception {
-    while (e.hasMoreElements()) {
-      Header hdr = (Header) e.nextElement();
+  private void addHeadersAsMetadata(Enumeration<Header> headers, String prefix, AdaptrisMessage msg) throws Exception {
+    while (headers.hasMoreElements()) {
+      Header hdr = headers.nextElement();
       msg.addMetadata(prefix + hdr.getName(), hdr.getValue());
     }
   }
@@ -252,6 +252,5 @@ public class MimePartSelector extends ServiceImp {
   @Override
   public void prepare() throws CoreException {
   }
-
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelector.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelector.java
@@ -48,9 +48,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 /**
  * Choose a specific mime part from an existing multipart message to become the payload of the AdaptrisMessage.
  *
- * @config mime-part-selector-service
- *
- *
  * @author lchan
  * @author $Author: lchan $
  */

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelectorToMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelectorToMetadata.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.mime;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Choose one or more mime parts from an existing multipart message and add them as metadata of the AdaptrisMessage. The mime payload remain
+ * unchanged.
+ *
+ * @config mime-part-selector-service-to-metadata
+ *
+ */
+@XStreamAlias("mime-part-selector-service-to-metadata")
+@AdapterComponent
+@ComponentProfile(summary = "Select mime-parts from the message and put them into metadata", since = "5.0.1", tag = "service,mime")
+@DisplayOrder(order = { "selectors" })
+public class MimePartSelectorToMetadata extends ServiceImp {
+
+  /**
+   * The list of mime part selectors and metadata keys to add the content to.
+   */
+  @Getter
+  @Setter
+  @NotNull
+  @Valid
+  private List<PartSelectorToMetadata> selectors = new ArrayList<>();
+
+  public MimePartSelectorToMetadata() {
+  }
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    for (PartSelectorToMetadata partSelectorMetadata : getSelectors()) {
+      partSelectorMetadata.apply(msg);
+    }
+  }
+
+  @Override
+  protected void initService() throws CoreException {
+  }
+
+  @Override
+  protected void closeService() {
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelectorToMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelectorToMetadata.java
@@ -35,8 +35,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Choose one or more mime parts from an existing multipart message and add them as metadata of the AdaptrisMessage. The mime payload remain
- * unchanged.
+ * Choose one or more mime parts from an existing multipart message and add them as metadata of the AdaptrisMessage. The mime payload
+ * remains unchanged.
  *
  * @config mime-part-selector-service-to-metadata
  *

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelectorToMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MimePartSelectorToMetadata.java
@@ -37,9 +37,6 @@ import lombok.Setter;
 /**
  * Choose one or more mime parts from an existing multipart message and add them as metadata of the AdaptrisMessage. The mime payload
  * remains unchanged.
- *
- * @config mime-part-selector-service-to-metadata
- *
  */
 @XStreamAlias("mime-part-selector-service-to-metadata")
 @AdapterComponent

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/MultipartMessageBuilder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2019 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,11 +19,14 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.mail.internet.MimeBodyPart;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.StringUtils;
+
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.InputFieldDefault;
@@ -44,8 +47,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Constructs a multipart MIME payload from various sources.
- * 
- * @config multipart-message-builder
+ *
  * @since 3.9.0
  */
 @XStreamAlias("multipart-message-builder")
@@ -67,7 +69,7 @@ public class MultipartMessageBuilder extends ServiceImp {
   private MetadataFilter mimeHeaderFilter;
 
   public MultipartMessageBuilder() {
-    setMimeParts(new ArrayList<MimePartBuilder>());
+    setMimeParts(new ArrayList<>());
   }
 
   @Override
@@ -99,8 +101,7 @@ public class MultipartMessageBuilder extends ServiceImp {
   protected void closeService() {
   }
 
-  protected MultiPartOutput createOutputPart(AdaptrisMessage msg)
-      throws Exception {
+  protected MultiPartOutput createOutputPart(AdaptrisMessage msg) throws Exception {
     MultiPartOutput output = new MultiPartOutput(contentId(msg), mimeContentSubType(msg));
     MetadataCollection metadata = mimeHeaderFilter().filter(msg);
     metadata.forEach((e) -> {
@@ -109,18 +110,17 @@ public class MultipartMessageBuilder extends ServiceImp {
     return output;
   }
 
-
   public List<MimePartBuilder> getMimeParts() {
     return mimeParts;
   }
 
   /**
    * Specify what is going to build the mime message.
-   * 
+   *
    * @param parts the parts that will form the mime message.
    */
   public void setMimeParts(List<MimePartBuilder> parts) {
-    this.mimeParts = Args.notNull(parts, "mime-parts");
+    mimeParts = Args.notNull(parts, "mime-parts");
   }
 
   public MetadataFilter getMimeHeaderFilter() {
@@ -129,11 +129,11 @@ public class MultipartMessageBuilder extends ServiceImp {
 
   /**
    * Set any additional headers that need to be set for this Mime Message
-   * 
+   *
    * @param filter the metadata filter.
    */
   public void setMimeHeaderFilter(MetadataFilter filter) {
-    this.mimeHeaderFilter = filter;
+    mimeHeaderFilter = filter;
   }
 
   public String getContentId() {
@@ -142,14 +142,13 @@ public class MultipartMessageBuilder extends ServiceImp {
 
   /**
    * Set the Content-ID for the Multipart,
-   * 
-   * @param s the Content-ID, which supports the {@code %message{}} syntax to resolve metadata;
-   *        defaults to the messages unique id if no value is specified.
+   *
+   * @param s the Content-ID, which supports the {@code %message{}} syntax to resolve metadata; defaults to the messages unique id if no
+   *          value is specified.
    */
   public void setContentId(String s) {
-    this.contentId = s;
+    contentId = s;
   }
-
 
   public String getMimeContentSubType() {
     return mimeContentSubType;
@@ -157,12 +156,11 @@ public class MultipartMessageBuilder extends ServiceImp {
 
   /**
    * Set the sub type for the Multipart
-   * 
-   * @param sub the content subtype, which supports the {@code %message{}} syntax to resolve
-   *        metadata; defaults to 'mixed' if not specified.
+   *
+   * @param sub the content subtype, which supports the {@code %message{}} syntax to resolve metadata; defaults to 'mixed' if not specified.
    */
   public void setMimeContentSubType(String sub) {
-    this.mimeContentSubType = sub;
+    mimeContentSubType = sub;
   }
 
   public MultipartMessageBuilder withMimeHeaderFilter(MetadataFilter filter) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/PartSelectorToMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/PartSelectorToMetadata.java
@@ -1,0 +1,114 @@
+package com.adaptris.core.services.mime;
+
+import java.io.ByteArrayOutputStream;
+
+import javax.mail.internet.MimeBodyPart;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.MimeHelper;
+import com.adaptris.util.stream.StreamUtil;
+import com.adaptris.util.text.mime.BodyPartIterator;
+import com.adaptris.util.text.mime.PartSelector;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * Select a mime part with a selector and add it to a metadata
+ */
+@XStreamAlias("part-selector-to-metadata")
+@AdapterComponent
+@DisplayOrder(order = { "selector", "metadataKey", "metadataTarget" })
+public class PartSelectorToMetadata {
+
+  private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+
+  /**
+   * Enumeration of where the two types of metadata.
+   *
+   */
+  public enum MetadataTarget {
+    /**
+     * Standard Metadata.
+     *
+     */
+    Standard {
+      @Override
+      void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value) {
+        msg.addMetadata(key, value.toString());
+      }
+    },
+    /**
+     * Object Metadata.
+     *
+     */
+    Object {
+      @Override
+      void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value) {
+        msg.addObjectHeader(key, value.toByteArray());
+      }
+    };
+
+    abstract void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value);
+  }
+
+  /**
+   * The selector to select a mime part from the message
+   */
+  @NotNull
+  @NonNull
+  @Getter
+  @Setter
+  @Valid
+  private PartSelector selector;
+
+  /**
+   * The metadata key to add the mime part to
+   */
+  @NotNull
+  @NonNull
+  @Getter
+  @Setter
+  private String metadataKey;
+
+  /**
+   * The metadata target type: {@link MetadataTarget#Standard} or {@link MetadataTarget#Object} depending if the metadata is a string or an
+   * object.
+   */
+  @NotNull
+  @NonNull
+  @Getter
+  @Setter
+  @AutoPopulated
+  @InputFieldDefault(value = "Standard")
+  private MetadataTarget metadataTarget = MetadataTarget.Standard;
+
+  public void apply(AdaptrisMessage msg) throws ServiceException {
+    try {
+      BodyPartIterator mp = MimeHelper.createBodyPartIterator(msg);
+      MimeBodyPart part = getSelector().select(mp);
+      if (part != null) {
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        StreamUtil.copyAndClose(part.getInputStream(), bytesOut);
+        getMetadataTarget().apply(msg, getMetadataKey(), bytesOut);
+      } else {
+        log.warn("Could not select a MimePart to add to metadata {}, ignoring", getMetadataKey());
+      }
+    } catch (Exception e) {
+      throw new ServiceException(e);
+    }
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/mime/PartSelectorToMetadata.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/mime/PartSelectorToMetadata.java
@@ -15,6 +15,7 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.metadata.MetadataTarget;
 import com.adaptris.core.util.MimeHelper;
 import com.adaptris.util.stream.StreamUtil;
 import com.adaptris.util.text.mime.BodyPartIterator;
@@ -34,35 +35,6 @@ import lombok.Setter;
 public class PartSelectorToMetadata {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
-
-  /**
-   * Enumeration of where the two types of metadata.
-   *
-   */
-  public enum MetadataTarget {
-    /**
-     * Standard Metadata.
-     *
-     */
-    Standard {
-      @Override
-      void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value) {
-        msg.addMetadata(key, value.toString());
-      }
-    },
-    /**
-     * Object Metadata.
-     *
-     */
-    Object {
-      @Override
-      void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value) {
-        msg.addObjectHeader(key, value.toByteArray());
-      }
-    };
-
-    abstract void apply(AdaptrisMessage msg, String key, ByteArrayOutputStream value);
-  }
 
   /**
    * The selector to select a mime part from the message

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/PayloadToMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/PayloadToMetadataTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.services.metadata.PayloadToMetadataService.MetadataTarget;
 import com.adaptris.core.stubs.DefectiveMessageFactory;
 import com.adaptris.core.stubs.DefectiveMessageFactory.WhenToBreak;
 import com.adaptris.core.util.EncodingHelper.Encoding;
@@ -37,7 +36,6 @@ public class PayloadToMetadataTest extends MetadataServiceExample {
 
   private static final String DEFAULT_PAYLOAD = "zzzzzzzz";
   private static final String DEFAULT_METADATA_KEY = "helloMetadataKey";
-
 
   private PayloadToMetadataService createService(MetadataTarget target) {
     return new PayloadToMetadataService(DEFAULT_METADATA_KEY, target);
@@ -99,10 +97,10 @@ public class PayloadToMetadataTest extends MetadataServiceExample {
     assertTrue(msg.getObjectHeaders().containsKey(DEFAULT_METADATA_KEY));
   }
 
-
   @Override
   protected Object retrieveObjectForSampleConfig() {
     PayloadToMetadataService service = new PayloadToMetadataService("theMetadataKey", MetadataTarget.Standard);
     return service;
   }
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/mime/MimePartSelectorToMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/mime/MimePartSelectorToMetadataTest.java
@@ -34,7 +34,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreConstants;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.services.mime.PartSelectorToMetadata.MetadataTarget;
+import com.adaptris.core.services.metadata.MetadataTarget;
 import com.adaptris.util.text.mime.SelectByContentId;
 import com.adaptris.util.text.mime.SelectByPosition;
 

--- a/interlok-core/src/test/java/com/adaptris/core/services/mime/MimePartSelectorToMetadataTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/mime/MimePartSelectorToMetadataTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services.mime;
+
+import static com.adaptris.interlok.junit.scaffolding.util.MimeJunitHelper.PAYLOAD_1;
+import static com.adaptris.interlok.junit.scaffolding.util.MimeJunitHelper.PAYLOAD_2;
+import static com.adaptris.interlok.junit.scaffolding.util.MimeJunitHelper.PAYLOAD_3;
+import static com.adaptris.interlok.junit.scaffolding.util.MimeJunitHelper.create;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.mime.PartSelectorToMetadata.MetadataTarget;
+import com.adaptris.util.text.mime.SelectByContentId;
+import com.adaptris.util.text.mime.SelectByPosition;
+
+public class MimePartSelectorToMetadataTest extends MimeServiceExample {
+
+  @Override
+  protected MimePartSelectorToMetadata retrieveObjectForSampleConfig() {
+    return new MimePartSelectorToMetadata();
+  }
+
+  @Test
+  public void testGetPartSelectorToMetadata() throws Exception {
+    MimePartSelectorToMetadata service = new MimePartSelectorToMetadata();
+    List<PartSelectorToMetadata> selectors = new ArrayList<>();
+
+    PartSelectorToMetadata partSelectorToMetadataOne = new PartSelectorToMetadata();
+    partSelectorToMetadataOne.setMetadataKey("partContentOne");
+    partSelectorToMetadataOne.setSelector(new SelectByPosition(0));
+    selectors.add(partSelectorToMetadataOne);
+    PartSelectorToMetadata partSelectorToMetadataTwo = new PartSelectorToMetadata();
+    partSelectorToMetadataTwo.setMetadataKey("partContentTwo");
+    partSelectorToMetadataTwo.setSelector(new SelectByContentId("part2"));
+    selectors.add(partSelectorToMetadataTwo);
+    PartSelectorToMetadata partSelectorToMetadataThree = new PartSelectorToMetadata();
+    partSelectorToMetadataThree.setMetadataKey("partContentThree");
+    partSelectorToMetadataThree.setSelector(new SelectByContentId("part3"));
+    partSelectorToMetadataThree.setMetadataTarget(MetadataTarget.Object);
+    selectors.add(partSelectorToMetadataThree);
+    PartSelectorToMetadata partSelectorToMetadataDoesntExist = new PartSelectorToMetadata();
+    partSelectorToMetadataDoesntExist.setMetadataKey("partContentFour");
+    partSelectorToMetadataDoesntExist.setSelector(new SelectByContentId("partDoesntExist"));
+    selectors.add(partSelectorToMetadataDoesntExist);
+
+    service.setSelectors(selectors);
+
+    AdaptrisMessage msg = create();
+    execute(service, msg);
+
+    assertEquals(PAYLOAD_1, msg.getMetadataValue("partContentOne"));
+    assertEquals(PAYLOAD_2, msg.getMetadataValue("partContentTwo"));
+    assertArrayEquals(PAYLOAD_3.getBytes(), (byte[]) msg.getObjectHeaders().get("partContentThree"));
+    assertNull(msg.getMetadataValue("partContentFour"));
+  }
+
+  @Test
+  public void testGetPartSelectorToMetadataInvalidMime() throws Exception {
+    MimePartSelectorToMetadata service = new MimePartSelectorToMetadata();
+    List<PartSelectorToMetadata> selectors = new ArrayList<>();
+
+    PartSelectorToMetadata partSelectorToMetadataOne = new PartSelectorToMetadata();
+    partSelectorToMetadataOne.setMetadataKey("partContentOne");
+    partSelectorToMetadataOne.setSelector(new SelectByPosition(0));
+    selectors.add(partSelectorToMetadataOne);
+    PartSelectorToMetadata partSelectorToMetadataTwo = new PartSelectorToMetadata();
+    partSelectorToMetadataTwo.setMetadataKey("partContentTwo");
+    partSelectorToMetadataTwo.setSelector(new SelectByContentId("part2"));
+    selectors.add(partSelectorToMetadataTwo);
+    PartSelectorToMetadata partSelectorToMetadataThree = new PartSelectorToMetadata();
+    partSelectorToMetadataThree.setMetadataKey("partContentThree");
+    partSelectorToMetadataThree.setSelector(new SelectByContentId("part3"));
+    partSelectorToMetadataThree.setMetadataTarget(MetadataTarget.Object);
+    selectors.add(partSelectorToMetadataThree);
+    PartSelectorToMetadata partSelectorToMetadataDoesntExist = new PartSelectorToMetadata();
+    partSelectorToMetadataDoesntExist.setMetadataKey("partContentFour");
+    partSelectorToMetadataDoesntExist.setSelector(new SelectByContentId("partDoesntExist"));
+    selectors.add(partSelectorToMetadataDoesntExist);
+
+    service.setSelectors(selectors);
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata(CoreConstants.MSG_MIME_ENCODED, "true");
+
+    assertThrows(ServiceException.class, () -> execute(service, msg));
+  }
+
+  @Test
+  public void testPartSelectorToMetadataSetNullMetadataKey() throws Exception {
+    PartSelectorToMetadata partSelectorToMetadataThree = new PartSelectorToMetadata();
+    assertThrows(NullPointerException.class, () -> partSelectorToMetadataThree.setMetadataKey(null));
+  }
+
+  @Test
+  public void testPartSelectorToMetadataSetNullSelector() throws Exception {
+    PartSelectorToMetadata partSelectorToMetadataThree = new PartSelectorToMetadata();
+    assertThrows(NullPointerException.class, () -> partSelectorToMetadataThree.setSelector(null));
+  }
+
+  @Test
+  public void testPartSelectorToMetadataSetNullMetadataTarget() throws Exception {
+    PartSelectorToMetadata partSelectorToMetadataThree = new PartSelectorToMetadata();
+    assertThrows(NullPointerException.class, () -> partSelectorToMetadataThree.setMetadataTarget(null));
+  }
+
+}


### PR DESCRIPTION

## Motivation

We needed a way to select multiple mime parts and keep them without modifying the payload.

## Modification

Add a new MimePartSelectorToMetadata. It works in a similar way as MimePartSelector but allows to select multiple mime and store them into metadata. The mime payload remains unchanged.
Add tests.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations

## Result

We have a new MimePartSelectorToMetadata service

## Testing

The build and test should be successful.
This has already been tested in interlok-upgrade-tool.
