### PR TITLE
INTERLOK-4302 Make flyway a dependency of interlok-core

### DIFF
--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -101,6 +101,9 @@ dependencies {
 
   api ("org.apache.derby:derby:$derbyDriverVersion")
   api ("org.apache.derby:derbytools:$derbyDriverVersion")
+  
+  // INTERLOK-4302 Only used by the UI and interlok-flyway
+  api ("org.flywaydb:flyway-core:8.5.13")
 
   testImplementation ("junit:junit:4.13.2")
   testImplementation ("org.apache.activemq:artemis-jms-server:2.31.2")


### PR DESCRIPTION
## Motivation

When using flyway and mysql in the UI we now get an issue as we need flyway-mysql.jar in the lib dir but it’s not in the same class loader as flyway-core.jar and therefore we get a CNFE.

## Modification

Make flyway a dependency of interlok-core so the UI doesn't need to import it into its war file and that won't cause a jar conflict when using interlok-flyway and will work when using flyway-mysql.jar.

## PR Checklist

- [x] been self-reviewed.
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader

## Result

Everything should work fine when using the UI with flyway and mysql

## Testing

Build an instance of interlok with the interlok-core.jar from this branch and the UI for the related PR (https://github.com/adaptris/interlok-ui/pull/251) in interlok-ui project.
Add flyway-mysql.jar as a dependency and mysql-connector and it should work.
