### PR TITLE
INTERLOK-4309 Opens javax.management for jmx-jms to work.

### DIFF
--- a/interlok-boot/build.gradle
+++ b/interlok-boot/build.gradle
@@ -48,7 +48,7 @@ jar {
                "Implementation-Version": project.version,
                "Implementation-Vendor-Id": project.group,
                "Implementation-Vendor": organizationName,
-               "Add-Opens": "java.base/java.lang java.base/java.util",
+               "Add-Opens": "java.base/java.lang java.base/java.util java.management/javax.management",
                "Main-Class": "com.adaptris.interlok.boot.InterlokLauncher")
   }
   from ("$project.buildDir/spring-boot-loader") {


### PR DESCRIPTION
## Motivation

JMX Over JMS was not working because of javax.management was not opened
In fact, the opens flag was set into interlok-jmx-jms-common but it seems that it was too late.

## Modification

Opens javax.management.

## PR Checklist

- [x] been self-reviewed.

## Result

JMX over JMS should work.

## Testing

Build the adapter in https://github.com/interlok-testing/testing_activemq_jmx and replace interlok-boot.jar by the one from this branch.
Remove geronimo-jms_1.1_spec.jar, it seems that there is a conflict with jakarta.jms-api.jar.

Start the adapter and check that the UI can connect to the adapter using:
service:jmx:activemq:///tcp://localhost:61616?jmx.type=Topic&jmx.destination=jmxTopic
