### PR TITLE
INTERLOK-4312 We can now enable/disable each service

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/BranchingServiceCollection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/BranchingServiceCollection.java
@@ -89,10 +89,14 @@ public class BranchingServiceCollection extends ServiceCollectionImp {
       log.debug("next service id [{}]", nextServiceId);
       try {
         service = this.getService(nextServiceId);
-        service.doService(msg);
-
-        msg.addEvent(service, true);
-        log.debug("service [{}] applied", friendlyName(service));
+        if(service.enabled()) {
+          service.doService(msg);
+  
+          msg.addEvent(service, true);
+          log.debug("service [{}] applied", friendlyName(service));
+        } else {
+          log.trace("service [{}] skipped, not enabled", friendlyName(service));
+        }
       }
       catch (ServiceException e) {
         msg.addEvent(service, false);

--- a/interlok-core/src/main/java/com/adaptris/core/CloneMessageServiceList.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CloneMessageServiceList.java
@@ -77,20 +77,22 @@ public class CloneMessageServiceList extends ServiceListBase {
   @Override
   protected void applyServices(AdaptrisMessage msg) throws ServiceException {
     for (Service service : getServices()) {
-      try {
-        AdaptrisMessage clonedMessage = (AdaptrisMessage) msg.clone();
-        if (haltProcessing(clonedMessage)) {
-          break;
+      if(service.enabled()) {
+        try {
+          AdaptrisMessage clonedMessage = (AdaptrisMessage) msg.clone();
+          if (haltProcessing(clonedMessage)) {
+            break;
+          }
+          service.doService(clonedMessage);
+          log.debug("service [{}] applied", friendlyName(service));
+          captureMetadata(msg, clonedMessage, selectFilter());
         }
-        service.doService(clonedMessage);
-        log.debug("service [{}] applied", friendlyName(service));
-        captureMetadata(msg, clonedMessage, selectFilter());
-      }
-      catch (CloneNotSupportedException e) {
-        throw new ServiceException(e);
-      }
-      catch (Exception e) {
-        handleException(service, msg, e);
+        catch (CloneNotSupportedException e) {
+          throw new ServiceException(e);
+        }
+        catch (Exception e) {
+          handleException(service, msg, e);
+        }
       }
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/Service.java
+++ b/interlok-core/src/main/java/com/adaptris/core/Service.java
@@ -16,7 +16,6 @@
 
 package com.adaptris.core;
 
-
 /**
  * <p>
  * Implementations of <code>Service</code> apply aribtrary functionality to
@@ -27,7 +26,7 @@ package com.adaptris.core;
  */
 public interface Service extends AdaptrisComponent, MessageEventGenerator, StateManagedComponent,
     ComponentLifecycleExtension, ConfigComment {
-
+  
   /**
    * <p>
    * Apply the service to the message.
@@ -69,5 +68,18 @@ public interface Service extends AdaptrisComponent, MessageEventGenerator, State
    * @return continueOnFail
    */
   boolean continueOnFailure();
+  
+  /**
+   * <p>
+   * If true this service will run the <code>LifecycleHelper</code> methods and be executed in the 
+   * workflow for each message.  If false, this service will not run the <code>LifecycleHelper</code> 
+   * or execute during the workflow's processing.
+   * </p>
+   *
+   * @return continueOnFail
+   */
+  default boolean enabled() {
+    return true;
+  }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
@@ -135,7 +135,7 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
     return continueOnFail;
   }
 
-  public Boolean isEnabled() {
+  public Boolean getEnabled() {
     return enabled;
   }
 
@@ -144,7 +144,7 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
   }
   
   public boolean enabled() {
-    return BooleanUtils.toBooleanDefaultIfNull(isEnabled(), true);
+    return BooleanUtils.toBooleanDefaultIfNull(getEnabled(), true);
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
@@ -51,6 +51,8 @@ public abstract class ServiceImp implements Service {
   private Boolean isTrackingEndpoint;
   @MarshallingCDATA
   private String comments;
+  @InputFieldDefault(value = "true")
+  private Boolean enabled;
 
   /**
    * <p>
@@ -98,6 +100,18 @@ public abstract class ServiceImp implements Service {
   @Override
   public String createQualifier() {
     return defaultIfEmpty(getUniqueId(), "");
+  }
+
+  public Boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
+  
+  public boolean enabled() {
+    return BooleanUtils.toBooleanDefaultIfNull(isEnabled(), true);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
@@ -102,7 +102,7 @@ public abstract class ServiceImp implements Service {
     return defaultIfEmpty(getUniqueId(), "");
   }
 
-  public Boolean isEnabled() {
+  public Boolean getEnabled() {
     return enabled;
   }
 
@@ -111,7 +111,7 @@ public abstract class ServiceImp implements Service {
   }
   
   public boolean enabled() {
-    return BooleanUtils.toBooleanDefaultIfNull(isEnabled(), true);
+    return BooleanUtils.toBooleanDefaultIfNull(getEnabled(), true);
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceList.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceList.java
@@ -86,21 +86,23 @@ public class ServiceList extends ServiceListBase {
     ListIterator<Service> itr = this.listIterator();
     while (itr.hasNext()) {
       Service service = itr.next();
-      String serviceName = friendlyName(service);
-      if (haltProcessing(msg)) {
-        break;
-      }
-      msg.setNextServiceId("");
-      log.debug("Executing doService on [{}]", serviceName);
-      try {
-        service.doService(msg);
-        msg.addEvent(service, true);
-        // Should we resolveNext *regardless of exception?*
-        itr = resolveNext(itr, msg.getNextServiceId());
-      } catch (Exception e) {
-        // add fail event
-        msg.addEvent(service, false);
-        handleException(service, msg, e);
+      if(service.enabled()) {
+        String serviceName = friendlyName(service);
+        if (haltProcessing(msg)) {
+          break;
+        }
+        msg.setNextServiceId("");
+        log.debug("Executing doService on [{}]", serviceName);
+        try {
+          service.doService(msg);
+          msg.addEvent(service, true);
+          // Should we resolveNext *regardless of exception?*
+          itr = resolveNext(itr, msg.getNextServiceId());
+        } catch (Exception e) {
+          // add fail event
+          msg.addEvent(service, false);
+          handleException(service, msg, e);
+        }
       }
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceList.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceList.java
@@ -103,6 +103,8 @@ public class ServiceList extends ServiceListBase {
           msg.addEvent(service, false);
           handleException(service, msg, e);
         }
+      } else {
+        log.trace("Service [{}] skipped, not enabled", friendlyName(service));
       }
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/SharedComponent.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedComponent.java
@@ -1,12 +1,13 @@
 package com.adaptris.core;
 
-import java.util.Arrays;
 import java.util.Properties;
+
 import javax.naming.CompositeName;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.InvalidNameException;
 import javax.naming.NamingException;
+
 import com.adaptris.core.util.ExceptionHelper;
 
 public class SharedComponent {

--- a/interlok-core/src/main/java/com/adaptris/core/SharedServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedServiceImpl.java
@@ -124,7 +124,7 @@ public abstract class SharedServiceImpl extends SharedComponent implements Servi
     return continueOnFail;
   }
 
-  public Boolean isEnabled() {
+  public Boolean getEnabled() {
     return enabled;
   }
 
@@ -133,7 +133,7 @@ public abstract class SharedServiceImpl extends SharedComponent implements Servi
   }
   
   public boolean enabled() {
-    return BooleanUtils.toBooleanDefaultIfNull(isEnabled(), true);
+    return BooleanUtils.toBooleanDefaultIfNull(getEnabled(), true);
   }
 
   public void setContinueOnFail(Boolean b) {

--- a/interlok-core/src/main/java/com/adaptris/core/SharedServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedServiceImpl.java
@@ -22,6 +22,8 @@ public abstract class SharedServiceImpl extends SharedComponent implements Servi
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean continueOnFail;
+  @InputFieldDefault(value = "true")
+  private Boolean enabled;
   @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "false")
   private Boolean isTrackingEndpoint;
@@ -120,6 +122,18 @@ public abstract class SharedServiceImpl extends SharedComponent implements Servi
 
   public Boolean getContinueOnFail() {
     return continueOnFail;
+  }
+
+  public Boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
+  
+  public boolean enabled() {
+    return BooleanUtils.toBooleanDefaultIfNull(isEnabled(), true);
   }
 
   public void setContinueOnFail(Boolean b) {

--- a/interlok-core/src/test/java/com/adaptris/core/BranchingServiceCollectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/BranchingServiceCollectionTest.java
@@ -17,6 +17,7 @@
 package com.adaptris.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -103,6 +104,19 @@ public class BranchingServiceCollectionTest
     assertEquals(eh, s.retrieveEventHandler());
   }
 
+  @Test
+  public void testEnabledDefault() {
+    BranchingServiceCollection sc = createServiceCollection();
+    assertTrue(sc.enabled());
+  }
+  
+  @Test
+  public void testDisabled() {
+    BranchingServiceCollection sc = createServiceCollection();
+    sc.setEnabled(false);
+    assertFalse(sc.enabled());
+  }
+  
   @Test
   public void testSetFirstServiceId() throws Exception {
     BranchingServiceCollection services = createServiceCollection();
@@ -341,6 +355,7 @@ public class BranchingServiceCollectionTest
     doThrow(new ServiceException("Expected")).when(mockFailingService).doService(any(AdaptrisMessage.class));
     when(mockFailingService.getUniqueId()).thenReturn(FIRST_SERVICE_ID);
     when(mockFailingService.createName()).thenReturn(Service.class.getName());
+    when(mockFailingService.enabled()).thenReturn(true);
 
     when(mockOutOfStateHandler.isInCorrectState(mockFailingService)).thenReturn(true);
 
@@ -369,6 +384,7 @@ public class BranchingServiceCollectionTest
     doThrow(new ServiceException("Expected")).when(mockFailingService).doService(any(AdaptrisMessage.class));
     when(mockFailingService.getUniqueId()).thenReturn(FIRST_SERVICE_ID);
     when(mockFailingService.createName()).thenReturn(Service.class.getName());
+    when(mockFailingService.enabled()).thenReturn(true);
 
     when(mockOutOfStateHandler.isInCorrectState(mockFailingService)).thenReturn(true);
 

--- a/interlok-core/src/test/java/com/adaptris/core/SharedServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/SharedServiceTest.java
@@ -68,6 +68,19 @@ public class SharedServiceTest
     sharedService.setContinueOnFail(Boolean.TRUE);
     assertTrue(sharedService.continueOnFailure());
   }
+  
+  @Test
+  public void testEnabledDefault() {
+    SharedService sharedService = new SharedService(getName());
+    assertTrue(sharedService.enabled());
+  }
+  
+  @Test
+  public void testDisabled() {
+    SharedService sharedService = new SharedService(getName());
+    sharedService.setEnabled(false);
+    assertFalse(sharedService.enabled());
+  }
 
   @Test
   public void testIsTrackingEndpoint() {


### PR DESCRIPTION
## Motivation

We would like the option to disable a service/list in a workflow, such that it's lifecycle methods do not execute and it will be skipped in the workflows execution..

## Modification

Added an "enabled" boolean property to the Service interface.
Service lists now check that property when requesting each service to init/start/stop/close.  Additionally the flag is checked before the service is executed.

Because this new property uses a java.util.Boolean rather than a boolean, the value can be null.
You should therefore use the public method "enabled()" which returns a standard boolean, defaulting to true if not set.
We default to true in the Service interface just in case there are external service implementations that implement the Service interface instead of extending ServiceImp.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked the display of the component in the UI

## Result

A new property named "enabled" now exists for every service, which can be configured in the UI.

## Testing

Simply create a workflow and disable a service.  During execution of the workflow the service will not run and a trace log will tell you a service has been skipped because it is disabled.
