### PR TITLE
Bug/interlok 4325 - MultiPayloadAdaptrisMessage issue where original payload cannot be updated if content originated from an input stream.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
@@ -622,11 +622,13 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
 
   private class ByteFilterStream extends FilterOutputStream {
     private final String payloadId;
+    private Payload pl;
 
     ByteFilterStream(@NotNull String payloadId, ByteArrayOutputStream out) {
       super(out);
       this.payloadId = payloadId;
-      payloads.put(payloadId, new Payload(out));
+      this.pl = new Payload(out);
+      payloads.put(payloadId, pl);
     }
 
     @Override
@@ -639,7 +641,6 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
   private class Payload {
     String encoding = getFactory().getDefaultCharEncoding();
     private byte[] data;
-    private ByteArrayOutputStream stream;
 
     Payload(String encoding, @NotNull byte[] data) {
       this.encoding = encoding;
@@ -651,13 +652,10 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
     }
 
     Payload(@NotNull ByteArrayOutputStream stream) {
-      this.stream = stream;
+      this.data = stream.toByteArray();
     }
 
     byte[] payload() {
-      if (stream != null) {
-        return stream.toByteArray();
-      }
       return data;
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
@@ -626,7 +626,7 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
     ByteFilterStream(@NotNull String payloadId, ByteArrayOutputStream out) {
       super(out);
       this.payloadId = payloadId;
-      payloads.put(payloadId, new Payload(out));
+      addPayload(payloadId, ((ByteArrayOutputStream) super.out).toByteArray());
     }
 
     @Override
@@ -647,10 +647,6 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
 
     Payload(@NotNull byte[] data) {
       this.data = data;
-    }
-
-    Payload(@NotNull ByteArrayOutputStream stream) {
-      this.data = stream.toByteArray();
     }
 
     byte[] payload() {

--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
@@ -622,13 +622,11 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
 
   private class ByteFilterStream extends FilterOutputStream {
     private final String payloadId;
-    private Payload pl;
 
     ByteFilterStream(@NotNull String payloadId, ByteArrayOutputStream out) {
       super(out);
       this.payloadId = payloadId;
-      this.pl = new Payload(out);
-      payloads.put(payloadId, pl);
+      payloads.put(payloadId, new Payload(out));
     }
 
     @Override

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadAdaptrisMessageImpTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadAdaptrisMessageImpTest.java
@@ -4,13 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-public class MultiPayloadAdaptrisMessageImpTest {
+import com.adaptris.core.stubs.MessageHelper;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+
+public class MultiPayloadAdaptrisMessageImpTest extends BaseCase {
 
   private static String PAYLOAD = "Some payload";
+  private static String EXAMPLE_PAYLOAD_FILE = "example.payload.file";
 
   @Test
   public void testAddPayloadMessageHeader() {
@@ -61,6 +66,23 @@ public class MultiPayloadAdaptrisMessageImpTest {
 
     assertFalse(multiPayloadAdaptrisMessage.payloadHeadersContainsKey("key"));
     assertFalse(multiPayloadAdaptrisMessage.payloadHeadersContainsKey("another-payload", "key"));
+  }
+  
+  //Unit test added to test bug INTERLOK-4325 
+  @Test
+  public void testUpdatingOriginalPayloadFromInputStream() throws IOException {
+	System.out.println(PROPERTIES.getProperty(EXAMPLE_PAYLOAD_FILE));
+	MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage = MessageHelper.createMultiPayloadMessage("default-payload", PROPERTIES.getProperty(EXAMPLE_PAYLOAD_FILE));
+    System.out.println(multiPayloadAdaptrisMessage.getContent("default-payload"));
+    multiPayloadAdaptrisMessage.setContent("new payload", multiPayloadAdaptrisMessage.getContentEncoding());
+    
+
+    assertEquals("new payload", multiPayloadAdaptrisMessage.getContent());
+    
+    multiPayloadAdaptrisMessage.addContent("default-payload", "another payload", multiPayloadAdaptrisMessage.getContentEncoding());
+
+    assertEquals("another payload", multiPayloadAdaptrisMessage.getContent());
+
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadAdaptrisMessageImpTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadAdaptrisMessageImpTest.java
@@ -71,7 +71,7 @@ public class MultiPayloadAdaptrisMessageImpTest extends BaseCase {
   //Unit test added to test bug INTERLOK-4325 
   @Test
   public void testUpdatingOriginalPayloadFromInputStream() throws IOException {
-	MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage = MessageHelper.createMultiPayloadMessage("default-payload", PROPERTIES.getProperty(EXAMPLE_PAYLOAD_FILE));
+    MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage = MessageHelper.createMultiPayloadMessage("default-payload", PROPERTIES.getProperty(EXAMPLE_PAYLOAD_FILE));
     multiPayloadAdaptrisMessage.setContent("new payload", multiPayloadAdaptrisMessage.getContentEncoding());
     assertEquals("new payload", multiPayloadAdaptrisMessage.getContent());
     

--- a/interlok-core/src/test/java/com/adaptris/core/MultiPayloadAdaptrisMessageImpTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MultiPayloadAdaptrisMessageImpTest.java
@@ -71,18 +71,11 @@ public class MultiPayloadAdaptrisMessageImpTest extends BaseCase {
   //Unit test added to test bug INTERLOK-4325 
   @Test
   public void testUpdatingOriginalPayloadFromInputStream() throws IOException {
-	System.out.println(PROPERTIES.getProperty(EXAMPLE_PAYLOAD_FILE));
 	MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage = MessageHelper.createMultiPayloadMessage("default-payload", PROPERTIES.getProperty(EXAMPLE_PAYLOAD_FILE));
-    System.out.println(multiPayloadAdaptrisMessage.getContent("default-payload"));
     multiPayloadAdaptrisMessage.setContent("new payload", multiPayloadAdaptrisMessage.getContentEncoding());
-    
-
     assertEquals("new payload", multiPayloadAdaptrisMessage.getContent());
     
     multiPayloadAdaptrisMessage.addContent("default-payload", "another payload", multiPayloadAdaptrisMessage.getContentEncoding());
-
     assertEquals("another payload", multiPayloadAdaptrisMessage.getContent());
-
   }
-
 }

--- a/interlok-core/src/test/resources/example-payload.txt
+++ b/interlok-core/src/test/resources/example-payload.txt
@@ -1,0 +1,1 @@
+example payload

--- a/interlok-core/src/test/resources/unit-tests.properties.template
+++ b/interlok-core/src/test/resources/unit-tests.properties.template
@@ -233,3 +233,5 @@ junit.urlhelper.classpath=xstream-standard.xml
 
 junit.retry.baseUrl=file://localhost/@BUILD_DIR@/tmp/retry-store
 junit.jdbc.RetryStore.properties.file.destination=file:///@BUILD_DIR@/src/test/resources/retry-store.properties
+
+junit.example.payload.file=@BUILD_DIR@/resources/test/example-payload.txt


### PR DESCRIPTION
## Motivation

To Address a bug where when a multipayload message is created and we call the method
`public OutputStream getOutputStream(@NotNull String payloadId)` this was causing the Payload class to store a ByteArrayOutputStream against the variable 'stream' which meant that when you tried to update the payloads content logic in the payload() method was always setting the payload to the value originally stored against the variable 'stream'
## Modification

Added a new unit test and supproting files to:
A. prove the bug existed(as the unit test was failing as expected)
B. to show the bug is now fixed as the unit test now passes.

I also implemented a small fix within the inner class Payload so we no longer store the two different data types and then have logic to decide which one to retrive as when the data is retrieved it's always as a byte array so I altered the logic so we always store the data as a byte array. The way the class is used by the calling code has not changed.

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [] Checked that javadoc generation doesn't report errors - **_does report errors but these have been fixed in a PR that is yet to be merged(https://github.com/adaptris/interlok/pull/1254)_**
- [n/a] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user

they should not notice anything different.

## Testing

Run unit test without the code change and it will fail and the result shows the payload is not being updated from wha it originally was. After the code change is in place run the unit test again and you see it passes and what the test asserts is that the payload is updated and matches the new expected payload.
