### PR TITLE
Added a timeout for the URLConnection in the URLHelper

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/util/URLHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/util/URLHelper.java
@@ -49,6 +49,10 @@ public abstract class URLHelper {
     }
     URL url = new URL(loc.toString());
     URLConnection conn = url.openConnection();
+    
+    conn.setReadTimeout(30000); // set the timeout.
+    conn.setConnectTimeout(30000); // 30 seconds.
+    
     return conn.getInputStream();
   }
 


### PR DESCRIPTION
## Motivation

Any service using the URLHelper to fetch a remote resource could spin forever, never timing out.
This would cause a hang.

## Modification

Simply added the read and connect timeouts defaulted to a sensible 30 seconds to the URLConnection  code in the URLHelper.

