### PR TITLE
Making sure the URLConnection in the URLHelper can timeout.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/util/URLHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/util/URLHelper.java
@@ -49,6 +49,10 @@ public abstract class URLHelper {
     }
     URL url = new URL(loc.toString());
     URLConnection conn = url.openConnection();
+    
+    conn.setReadTimeout(30000); // set the timeout.
+    conn.setConnectTimeout(30000); // 10 seconds.
+    
     return conn.getInputStream();
   }
 

--- a/interlok-core/src/main/java/com/adaptris/util/URLHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/util/URLHelper.java
@@ -51,7 +51,7 @@ public abstract class URLHelper {
     URLConnection conn = url.openConnection();
     
     conn.setReadTimeout(30000); // set the timeout.
-    conn.setConnectTimeout(30000); // 10 seconds.
+    conn.setConnectTimeout(30000); // 30 seconds.
     
     return conn.getInputStream();
   }


### PR DESCRIPTION
## Motivation

It's possible for our URLHelper to never timeout while fetching a remote resource.

## Modification

Added timeouts for read and connect.

