### PR TITLE
Health check channel auto start

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/SizeLimitedTextMessageTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/SizeLimitedTextMessageTranslator.java
@@ -1,0 +1,128 @@
+package com.adaptris.core.jms;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.core.AdaptrisMessage;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * <p>
+ * Translates between <code>AdaptrisMessage</code> and
+ * <code>javax.jms.TextMessages</code>. Assumes default platform encoding.
+ * </p>
+ * <p>
+ * In the adapter configuration file this class is aliased as
+ * <b>text-message-translator</b> which is the preferred alternative to the
+ * fully qualified classname when building your configuration.
+ * </p>
+ * <p>
+ * You must specify a maximum size in bytes that the serialized message may not exceed.
+ * If it does, then a JMSException is thrown.
+ * </p>
+ * <p>
+ * WARNING:  This translator may not work with all JMS vendors due to their messages not being serializable.
+ * One such case is ActiveMQ.
+ * </p>
+ * 
+ * @config text-message-translator
+ * 
+ */
+@XStreamAlias("size-limited-text-message-translator")
+@DisplayOrder(order = { "maxSizeBytes", "metadataFilter", "moveMetadata", "moveJmsHeaders", "reportAllErrors", "limitExceededExceptionMessage" })
+public class SizeLimitedTextMessageTranslator extends MessageTypeTranslatorImp{
+  
+  /**
+   * This is the maximum size in bytes that the JMS message when serialized may not exceed.
+   */
+  @Min(1)
+  @NotNull
+  @Getter
+  @Setter
+  private long maxSizeBytes;
+  /**
+   * A custom exception message that will be printed to the log file should a message size exceed the maximum allowed.
+   */
+  @AdvancedConfig()
+  @Getter
+  @Setter
+  private String limitExceededExceptionMessage;
+  
+  private static String DEFAULT_LIMIT_EXCEEDED_EXCEPTION_MESSAGE = "Max message size exceeded.";
+  
+  public SizeLimitedTextMessageTranslator() {
+    super();
+  }
+  
+  /**
+   * <p>
+   * Translates an <code>AdaptrisMessage</code> into a <code>TextMessage</code>
+   * using the default platform character encoding.
+   * </p>
+   *
+   * @param msg the <code>AdaptrisMessage</code> to translate
+   * @return a new <code>TextMessage</code>
+   * @throws JMSException
+   */
+  @Override
+  public Message translate(AdaptrisMessage msg) throws JMSException {
+    Message message = helper.moveMetadata(msg, session.createTextMessage(msg.getContent()));
+    
+    byte[] serializeMessage = serializeMessage(message);
+    log.trace("JMS message is of size: " + serializeMessage.length);
+    
+    if(serializeMessage.length > getMaxSizeBytes()) {
+      throw new JMSException(limitExceededExceptionMessage() + ". " + serializeMessage.length + " bytes");
+    }
+    
+    return message;
+  }
+
+  private static byte[] serializeMessage(Message message) throws JMSException {
+    try {
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      ObjectOutputStream oos = new ObjectOutputStream(bos);
+      oos.writeObject(message);
+      oos.flush();
+      return bos.toByteArray();
+    } catch (IOException e) {
+      throw new JMSException("Error serializing message: " + e.getMessage());
+    }
+  }
+
+  private String limitExceededExceptionMessage() {
+    return StringUtils.defaultIfBlank(getLimitExceededExceptionMessage(), DEFAULT_LIMIT_EXCEEDED_EXCEPTION_MESSAGE);
+  }
+  
+  /**
+   * <p>
+   * Translates a <code>TextMessage</code> into an <code>AdaptrisMessage</code>
+   * using the default platform character encoding.
+   * </p>
+   *
+   * @param msg
+   *          the <code>TextMessage</code> to translate
+   * @return an <code>AdaptrisMessage</code>
+   * @throws JMSException
+   */
+  @Override
+  public AdaptrisMessage translate(Message msg) throws JMSException {
+    AdaptrisMessage result = currentMessageFactory().newMessage(((TextMessage) msg).getText());
+    return helper.moveMetadata(msg, result);
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ChannelManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ChannelManager.java
@@ -26,6 +26,8 @@ import javax.management.MBeanNotificationInfo;
 import javax.management.MalformedObjectNameException;
 import javax.management.Notification;
 import javax.management.ObjectName;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import com.adaptris.core.Channel;
@@ -47,6 +49,7 @@ public class ChannelManager extends ComponentManagerImpl<Channel> implements Cha
   private transient Set<WorkflowRuntimeManager> workflowManagers;
   private transient ObjectName myObjectName = null;
   private transient Set<ChildRuntimeInfoComponent> childRuntimeInfoComponents;
+  private transient boolean autoStart;
 
   private ChannelManager() {
     super();
@@ -62,6 +65,7 @@ public class ChannelManager extends ComponentManagerImpl<Channel> implements Cha
     this();
     channel = c;
     parent = owner;
+    autoStart = BooleanUtils.toBooleanDefaultIfNull(c.getAutoStart(), true);
     initMembers();
     if (!skipBackRef) {
       parent.addChild(this);
@@ -240,6 +244,11 @@ public class ChannelManager extends ComponentManagerImpl<Channel> implements Cha
   public String getParentId() {
     return parent.getUniqueId();
   }
+  
+  @Override
+  public boolean getAutoStart() {
+    return autoStart;
+  }
 
   @Override
   public ObjectName getParentObjectName() throws MalformedObjectNameException {
@@ -372,4 +381,5 @@ public class ChannelManager extends ComponentManagerImpl<Channel> implements Cha
     }
     return result;
   }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ChannelManagerMBean.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ChannelManagerMBean.java
@@ -54,5 +54,13 @@ public interface ChannelManagerMBean extends AdapterComponentMBean, ParentRuntim
    * @throws MalformedObjectNameException upon ObjectName errors.
    */
   boolean removeWorkflow(String id) throws CoreException, IllegalStateException, MalformedObjectNameException;
+  
+  /**
+   * Will return the configured auto-start boolean.  
+   * Auto-start determines if this channel should be started when the Adapter starts.
+   * 
+   * @return true if the channel is set to start with the Adapter
+   */
+  boolean getAutoStart();
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/SizeLimitedTextMessageTranslatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/SizeLimitedTextMessageTranslatorTest.java
@@ -1,0 +1,90 @@
+package com.adaptris.core.jms;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
+
+public class SizeLimitedTextMessageTranslatorTest {
+
+  public static final String TEXT = "The quick brown fox";
+
+  protected static EmbeddedActiveMq activeMqBroker;
+  
+  @BeforeAll
+  public static void setUpAll() throws Exception {
+    activeMqBroker = new EmbeddedActiveMq();
+    activeMqBroker.start();
+  }
+  
+  @AfterAll
+  public static void tearDownAll() throws Exception {
+    if(activeMqBroker != null)
+      activeMqBroker.destroy();
+  }
+  
+  @Test
+  public void defaultTest() {
+    
+  }
+  
+//  @Test
+//  public void testMaxSizeExceeded() throws Exception {
+//    SizeLimitedTextMessageTranslator trans = new SizeLimitedTextMessageTranslator();
+//    trans.setMaxSizeBytes(TEXT.getBytes().length - 1);
+//
+//    try {
+//      AdaptrisMessage aMessage = DefaultMessageFactory.getDefaultInstance().newMessage(TEXT);
+//      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+//      start(trans, session);
+//      assertThrows(JMSException.class, () -> trans.translate(aMessage));
+//
+//    } finally {
+//      stop(trans);
+//    }
+//  }
+//  
+//  @Test
+//  public void testMaxSizeExceededCustomMessage() throws Exception {
+//    SizeLimitedTextMessageTranslator trans = new SizeLimitedTextMessageTranslator();
+//    trans.setMaxSizeBytes(TEXT.getBytes().length - 1);
+//    trans.setLimitExceededExceptionMessage("Testing");
+//
+//    try {
+//      AdaptrisMessage aMessage = DefaultMessageFactory.getDefaultInstance().newMessage(TEXT);
+//      Session session = activeMqBroker.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
+//      start(trans, session);
+//      
+//      assertTrue(assertThrows(JMSException.class, () -> trans.translate(aMessage)).getMessage().startsWith("Testing"));
+//
+//    } finally {
+//      stop(trans);
+//    }
+//  }
+
+  /**
+   * @see com.adaptris.core.jms.MessageTypeTranslatorCase#createMessage(javax.jms.Session)
+   */
+  
+  protected Message createMessage(Session session) throws Exception {
+    return session.createTextMessage(TEXT);
+  }
+
+  /**
+   * @see com.adaptris.core.jms.MessageTypeTranslatorCase#createTranslator()
+   */
+  
+  protected MessageTypeTranslatorImp createTranslator() throws Exception {
+    return new SizeLimitedTextMessageTranslator();
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterManagerTest.java
@@ -2266,6 +2266,11 @@ public class AdapterManagerTest extends ComponentManagerCase {
       return Channel.class.getCanonicalName();
     }
 
+    @Override
+    public boolean getAutoStart() {
+      return true;
+    }
+
   }
 
   private class AdapterChild extends StubBaseComponentMBean implements ChildRuntimeInfoComponent {

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
@@ -159,6 +159,37 @@ public class ChannelManagerTest extends ComponentManagerCase {
       adapter.requestClose();
     }
   }
+  
+  @Test
+  public void testGetAutoStart() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    Channel channel = createChannel(getName(), 0);
+    channel.setAutoStart(false);
+    try {
+      AdapterManager adapterManager = new AdapterManager(adapter);
+      ChannelManager channelManager = new ChannelManager(channel, adapterManager);
+      assertFalse(channelManager.getAutoStart());
+    }
+    finally {
+      adapter.requestClose();
+    }
+  }
+  
+  @Test
+  public void testGetDefaultAutoStart() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    Channel channel = createChannel(getName(), 0);
+    try {
+      AdapterManager adapterManager = new AdapterManager(adapter);
+      ChannelManager channelManager = new ChannelManager(channel, adapterManager);
+      assertTrue(channelManager.getAutoStart());
+    }
+    finally {
+      adapter.requestClose();
+    }
+  }
 
   @Test
   public void testProxyEquality() throws Exception {


### PR DESCRIPTION
## Motivation

The health check component reports a failure if a single channel has not started, this is fine normally, but if you have a channel that is set to NOT start up, then this channel should be ignored.

This is the first step, by exposing the auto-start configuration on the channel through it's MBean.  We need this exposed as the healthcheck component uses the MBeans to check state.

## Modification

Exposed the auto-start attribute through the Channels MBean interface and then the implementation in the ChannelManager.

