### PR TITLE
INTERLOK-4422 Fix potential NPE when numRetries is not set

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/RetryingServiceWrapper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/RetryingServiceWrapper.java
@@ -101,7 +101,7 @@ public class RetryingServiceWrapper extends ServiceImp implements EventHandlerAw
     int currentRetries = 0;
     int maxRetries = numRetries();
     // Also test the "started" state of this service, in case we are trying to shutdown the Adapter, we then need to break this loop. 
-    while ((this.getNumRetries() == 0 || currentRetries <= maxRetries)
+    while ((maxRetries == 0 || currentRetries <= maxRetries)
         && this.retrieveComponentState().equals(StartedState.getInstance())) {
       try {
         this.getService().doService(msg);


### PR DESCRIPTION
## Motivation

We get a NPE when numRetries is not set in the RetryingServiceWrapper

## Modification

Don't use numRetries property directly but used the method numRetries() that return the default value if null.

## PR Checklist

- [x] been self-reviewed.

## Result

numRetries can be left empty without causing a NPE

## Testing

Configure the RetryingServiceWrapper and leave numRetries.
Then, run that service and make sure it works fine.
