### PR TITLE
INTERLOK-4419 Support multi payload message when doing an applyService

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/MimeEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MimeEncoder.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.util.text.mime.BodyPartIterator;
@@ -70,6 +72,7 @@ public class MimeEncoder extends MimeEncoderImpl<OutputStream, InputStream> {
         output.addPart(asMimePart((Exception) msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION)),
             EXCEPTION_CONTENT_ID);
       }
+      writeNextServiceId(output, msg);
       output.writeTo(target);
       target.flush();
     } catch (Exception e) {

--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadMessageMimeEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadMessageMimeEncoder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,27 +16,29 @@
 
 package com.adaptris.core;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import javax.activation.DataHandler;
+import javax.activation.DataSource;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeBodyPart;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.util.text.mime.BodyPartIterator;
 import com.adaptris.util.text.mime.MimeConstants;
 import com.adaptris.util.text.mime.MultiPartOutput;
-import org.apache.commons.io.IOUtils;
-
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeBodyPart;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
- * Multi-payload message MIME encoder. Encode a multi-payload message
- * with each payload as a separate MIME block.
+ * Multi-payload message MIME encoder. Encode a multi-payload message with each payload as a separate MIME block.
  *
  * <pre>{@code
  * <encoder class="com.adaptris.core.MultiPayloadMessageMimeEncoder">
@@ -51,8 +53,10 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
  * @since 3.9.3
  */
 
-@ComponentProfile(summary = "A multi-payload message MIME encoder/decoder", tag = "multi-payload,MIME,encode,decode", since="3.9.3")
+@ComponentProfile(summary = "A multi-payload message MIME encoder/decoder", tag = "multi-payload,MIME,encode,decode", since = "3.9.3")
 public class MultiPayloadMessageMimeEncoder extends MimeEncoderImpl<OutputStream, InputStream> {
+
+  protected static final String CURRENT_PAYLOAD_ID = "AdaptrisMessage/current-payload-id";
 
   public MultiPayloadMessageMimeEncoder() {
     super();
@@ -63,11 +67,13 @@ public class MultiPayloadMessageMimeEncoder extends MimeEncoderImpl<OutputStream
   public void writeMessage(AdaptrisMessage msg, OutputStream target) throws CoreException {
     try {
       MultiPartOutput output = new MultiPartOutput(msg.getUniqueId());
-      if (msg instanceof MultiPayloadAdaptrisMessage) {
-        MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage)msg;
+      if (msg instanceof MultiPayloadAdaptrisMessage message) {
         for (String id : message.getPayloadIDs()) {
           message.switchPayload(id);
           output.addPart(payloadAsMimePart(message), PAYLOAD_CONTENT_ID + "/" + id);
+        }
+        if (StringUtils.isNotEmpty(message.getCurrentPayloadId())) {
+          output.setHeader(CURRENT_PAYLOAD_ID, message.getCurrentPayloadId());
         }
       } else {
         output.addPart(payloadAsMimePart(msg), PAYLOAD_CONTENT_ID);
@@ -76,13 +82,14 @@ public class MultiPayloadMessageMimeEncoder extends MimeEncoderImpl<OutputStream
       if (msg.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION)) {
         output.addPart(asMimePart((Exception) msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION)), EXCEPTION_CONTENT_ID);
       }
+      writeNextServiceId(output, msg);
       output.writeTo(target);
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }
 
-  protected MimeBodyPart payloadAsMimePart(MultiPayloadAdaptrisMessage m) throws Exception {
+  private MimeBodyPart payloadAsMimePart(MultiPayloadAdaptrisMessage m) throws Exception {
     MimeBodyPart p = new MimeBodyPart();
     p.setDataHandler(new DataHandler(new MessageDataSource(m)));
     if (!isEmpty(getPayloadEncoding())) {
@@ -94,7 +101,7 @@ public class MultiPayloadMessageMimeEncoder extends MimeEncoderImpl<OutputStream
   @Override
   public AdaptrisMessage readMessage(InputStream source) throws CoreException {
     try {
-      MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage)currentMessageFactory().newMessage();
+      MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage) currentMessageFactory().newMessage();
       BodyPartIterator input = new BodyPartIterator(source);
       boolean deleteDefault = addPartsToMessage(input, message);
       if (deleteDefault) {
@@ -114,15 +121,18 @@ public class MultiPayloadMessageMimeEncoder extends MimeEncoderImpl<OutputStream
       if (!id.startsWith(PAYLOAD_CONTENT_ID)) {
         continue;
       }
-      if (id.length() > PAYLOAD_CONTENT_ID.length() + 1 ) {
+      if (id.length() > PAYLOAD_CONTENT_ID.length() + 1) {
         id = id.substring(PAYLOAD_CONTENT_ID.length() + 1);
         message.switchPayload(id);
         deleteDefault = true;
       }
-      try (InputStream payloadIn = payloadPart.getInputStream();
-           OutputStream out = message.getOutputStream()) {
+      try (InputStream payloadIn = payloadPart.getInputStream(); OutputStream out = message.getOutputStream()) {
         IOUtils.copy(payloadIn, out);
       }
+    }
+    String currentPayloadId = input.getHeaders().getHeader(CURRENT_PAYLOAD_ID, null);
+    if (StringUtils.isNotEmpty(currentPayloadId)) {
+      message.switchPayload(currentPayloadId);
     }
     MimeBodyPart metadataPart = Args.notNull(input.getBodyPart(METADATA_CONTENT_ID), "metadata");
     try (InputStream metadata = metadataPart.getInputStream()) {
@@ -130,6 +140,9 @@ public class MultiPayloadMessageMimeEncoder extends MimeEncoderImpl<OutputStream
     }
     if (retainUniqueId()) {
       message.setUniqueId(input.getMessageID());
+    }
+    if (retainNextServiceId()) {
+      message.setNextServiceId(StringUtils.trimToEmpty(input.getHeaders().getHeader(NEXT_SERVICE_ID, null)));
     }
     return deleteDefault;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMimeEncoder.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/FileBackedMimeEncoder.java
@@ -27,6 +27,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Implementation of {@code AdaptrisMessageEncoder} that stores payload and metadata as a mime-encoded multipart message.
  * <p>
@@ -58,6 +60,7 @@ public class FileBackedMimeEncoder extends MimeEncoderImpl<File, File> {
         output.addPart(asMimePart((Exception) msg.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION)),
             EXCEPTION_CONTENT_ID);
       }
+      writeNextServiceId(output, msg);
       try (OutputStream out = new FileOutputStream(target)) {
         // If we are file backed, then lets assume we're large, and we stream to disk first...
         if (factory instanceof FileBackedMessageFactory) {

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterComponentChecker.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterComponentChecker.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,13 @@ import static com.adaptris.core.util.LifecycleHelper.prepare;
 import static com.adaptris.core.util.LifecycleHelper.stopAndClose;
 import static com.adaptris.core.util.ServiceUtil.rewriteConnectionsForTesting;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.AdaptrisMessage;
@@ -30,30 +37,38 @@ import com.adaptris.core.AllowsRetriesConnection;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.DefaultSerializableMessageTranslator;
+import com.adaptris.core.MimeEncoderImpl;
+import com.adaptris.core.MultiPayloadMessageFactory;
+import com.adaptris.core.MultiPayloadMessageMimeEncoder;
 import com.adaptris.core.Service;
+import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.interlok.types.SerializableMessage;
 
 /**
  * Implementation of {@link AdapterComponentCheckerMBean} for use by the GUI to check components.
- * 
+ *
  * @author lchan
- * 
+ *
  */
-public class AdapterComponentChecker extends ChildRuntimeInfoComponentImpl
-    implements AdapterComponentCheckerMBean {
+public class AdapterComponentChecker extends ChildRuntimeInfoComponentImpl implements AdapterComponentCheckerMBean {
   private transient AdapterManager parent;
   private transient DefaultSerializableMessageTranslator messageTranslator;
+  private transient MimeEncoderImpl<OutputStream, InputStream> mimeEncoder;
 
   private AdapterComponentChecker() {
     super();
     messageTranslator = new DefaultSerializableMessageTranslator();
+    messageTranslator.registerMessageFactory(new MultiPayloadMessageFactory());
+    mimeEncoder = new MultiPayloadMessageMimeEncoder();
+    mimeEncoder.setRetainUniqueId(true);
+    mimeEncoder.setRetainNextServiceId(true);
   }
 
   public AdapterComponentChecker(AdapterManager owner) {
     this();
     parent = owner;
   }
-  
+
   @Override
   protected String getType() {
     return COMPONENT_CHECKER_TYPE;
@@ -103,11 +118,43 @@ public class AdapterComponentChecker extends ChildRuntimeInfoComponentImpl
     try {
       initAndStart(service);
       service.doService(msg);
-    }
-    finally {
+    } finally {
       stopAndClose(service);
     }
     return messageTranslator.translate(msg);
+  }
+
+  @Override
+  public String applyService(String xml, String mimeEncodedMsg, boolean rewriteConnections) throws CoreException {
+    AdaptrisMarshaller marshaller = DefaultMarshaller.getDefaultMarshaller();
+    Service service = (Service) marshaller.unmarshal(xml);
+    if (rewriteConnections) {
+      service = rewriteConnectionsForTesting(service);
+    }
+
+    try {
+      AdaptrisMessage msg = decode(mimeEncodedMsg);
+      initAndStart(service);
+      service.doService(msg);
+      return encode(msg);
+    } catch (IOException ioe) {
+      throw ExceptionHelper.wrapServiceException(ioe);
+    } finally {
+      stopAndClose(service);
+    }
+  }
+
+  public AdaptrisMessage decode(String mimeEncodedMsg) throws IOException, CoreException {
+    try (ByteArrayInputStream in = new ByteArrayInputStream(mimeEncodedMsg.getBytes(StandardCharsets.UTF_8))) {
+      return mimeEncoder.readMessage(in);
+    }
+  }
+
+  private String encode(AdaptrisMessage msg) throws IOException, CoreException {
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      mimeEncoder.writeMessage(msg, out);
+      return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterComponentCheckerMBean.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterComponentCheckerMBean.java
@@ -61,5 +61,16 @@ public interface AdapterComponentCheckerMBean extends BaseComponentMBean {
    * @throws CoreException wrapping any other exception
    */
   SerializableMessage applyService(String xml, SerializableMessage msg, boolean rewriteConnections) throws CoreException;
+  
+  /**
+   * Apply the configured services to the MIME encoded msg. This also support multi payload mime encoded message.
+   * 
+   * @param xml String XML representation of the service (or service-list)
+   * @param mimeEncodedMsg the MIME encoded message.
+   * @param rewriteConnections use {@link AdaptrisConnection#cloneForTesting()} to generate a new connection.
+   * @return the result of applying these services as MIME encoded message.
+   * @throws CoreException wrapping any other exception
+   */
+  String applyService(String xml, String mimeEncodedMsg, boolean rewriteConnections) throws CoreException;
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/MimeEncoderTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/MimeEncoderTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,9 +44,6 @@ public class MimeEncoderTest {
 
   private MimeEncoder mimeEncoder;
 
-  
-  
-
   @BeforeEach
   public void setUp() throws Exception {
     mimeEncoder = new MimeEncoder();
@@ -73,16 +70,18 @@ public class MimeEncoderTest {
 
   @Test
   public void testRoundTrip() throws Exception {
-
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
     msg.addMetadata(METADATA_KEY, METADATA_VALUE);
+    msg.setNextServiceId("nextServiceId");
     ByteArrayOutputStream out = new ByteArrayOutputStream();
+    mimeEncoder.setRetainNextServiceId(true);
     mimeEncoder.writeMessage(msg, out);
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     AdaptrisMessage result = mimeEncoder.readMessage(in);
     assertEquals(METADATA_VALUE, result.getMetadataValue(METADATA_KEY));
     assertEquals(STANDARD_PAYLOAD, result.getContent());
     assertTrue(MessageDigest.isEqual(STANDARD_PAYLOAD.getBytes(), result.getPayload()));
+    assertEquals(msg.getNextServiceId(), result.getNextServiceId());
   }
 
   @Test
@@ -92,24 +91,21 @@ public class MimeEncoderTest {
     try {
       mimeEncoder.writeMessage(msg, null);
       fail();
+    } catch (CoreException e) {
     }
-    catch (CoreException e) {
-    }
- }
+  }
 
   @Test
   public void testDecode_Exception() {
     try {
       mimeEncoder.decode(null);
       fail();
-    }
-    catch (CoreException e) {
+    } catch (CoreException e) {
     }
   }
 
   @Test
   public void testRoundTrip_WithOddChars() throws Exception {
-
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD_NON_JUST_ALPHA);
     msg.addMetadata(METADATA_KEY, METADATA_VALUE);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -138,7 +134,6 @@ public class MimeEncoderTest {
 
   @Test
   public void testRoundTrip_Encoded() throws Exception {
-
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
     msg.addMetadata(METADATA_KEY, METADATA_VALUE);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -154,7 +149,6 @@ public class MimeEncoderTest {
 
   @Test
   public void testRoundTrip_EncodedEncodePlainDecoder() throws Exception {
-
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
     msg.addMetadata(METADATA_KEY, METADATA_VALUE);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -171,7 +165,6 @@ public class MimeEncoderTest {
 
   @Test
   public void testRoundTrip_EncodeMetadataWithBackslash() throws Exception {
-
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
     msg.addMetadata(METADATA_KEY, "blah\\blah");
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -184,7 +177,6 @@ public class MimeEncoderTest {
 
   @Test
   public void testRoundTrip_PreserveUniqueId() throws Exception {
-
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
     msg.addMetadata(METADATA_KEY, METADATA_VALUE);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -208,7 +200,6 @@ public class MimeEncoderTest {
 
   @Test
   public void testRoundTrip_UseConvenienceMethods() throws Exception {
-
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(STANDARD_PAYLOAD);
     msg.addMetadata(METADATA_KEY, METADATA_VALUE);
     AdaptrisMessage result = mimeEncoder.decode(mimeEncoder.encode(msg));
@@ -227,23 +218,19 @@ public class MimeEncoderTest {
 
   @Test
   public void testDecode_NoPayloadPart() throws Exception {
-
     try {
       mimeEncoder.decode(createMimeOutput(false, true));
       fail();
-    }
-    catch (CoreException e) {
+    } catch (CoreException e) {
     }
   }
 
   @Test
   public void testDecode_NoMetadataPart() throws Exception {
-
     try {
       mimeEncoder.decode(createMimeOutput(true, false));
       fail();
-    }
-    catch (CoreException e) {
+    } catch (CoreException e) {
     }
   }
 


### PR DESCRIPTION
## Motivation

We need to support multi payload message in service tester and in the UI

## Modification

Add a new JMX applyService method that take a string mime message that will be converted to a multi payload message.
The current applyService that takes a SerializableAdaptrisMessage remained untouched and will still work the same only with single payload message

## PR Checklist

- [x] been self-reviewed.

## Result

The user can use the new applyService method to send a multi payload (and also single payload message that will be transformed to multi payload message).

## Testing

That will be easier to test when the work in the UI is done for INTERLOK-4387.
In the meantime you can use JMX directly to call `AdapterComponentCheckerMBean#applyService(String xml, String mimeEncodedMsg, boolean rewriteConnections)` for a service that work with multi payload message with a mime message like:

```
Message-ID: f00d406b-88e4-4565-85c0-3e5766a9fb07
Mime-Version: 1.0
Content-Type: multipart/mixed; 
	boundary="----=_Part_0_686349795.1728349176787"
AdaptrisMessage/current-payload-id: payload-1
AdaptrisMessage/next-service-id: nextServiceId
Content-Length: 1627

------=_Part_0_686349795.1728349176787
Content-Id: AdaptrisMessage/payload/payload-2

Bacon ipsum dolor amet tri-tip bacon kielbasa flank rump pork belly. Pastrami pork t-bone ground round tenderloin, capicola bresaola ham turducken. Rump turkey boudin biltong, doner short loin swine t-bone buffalo pastrami capicola pork loin alcatra beef ribs jerky. Landjaeger chicken cupim corned beef venison. Jerky turducken pork chop burgdoggen. Landjaeger shankle chislic alcatra flank ribeye, short loin swine corned beef drumstick ham hock tri-tip filet mignon. Pastrami boudin turkey, tongue landjaeger ham hock ball tip cupim ground round ribeye pork loin pig sirloin shoulder.
------=_Part_0_686349795.1728349176787
Content-Id: AdaptrisMessage/payload/payload-1

Cupcake ipsum dolor sit amet bonbon cotton candy ice cream. Pudding chocolate sweet lemon drops carrot cake pastry sweet roll. Wafer cheesecake lemon drops. Fruitcake tiramisu chocolate cake dessert gummies fruitcake bear claw brownie. Bear claw dessert marshmallow chocolate bar. Gummies bonbon oat cake tootsie roll. Tiramisu topping jelly beans powder souffle carrot cake. Gummi bears gingerbread tart pie. Oat cake danish gummies fruitcake. Cake icing sweet roll. Sweet roll cake cheesecake gingerbread. Cake brownie pastry. Lemon drops apple pie caramels sweet jelly beans oat cake jujubes dessert wafer. Oat cake sweet roll fruitcake croissant gummies sweet halvah croissant dessert.
------=_Part_0_686349795.1728349176787
Content-Id: AdaptrisMessage/metadata

#
#Tue Oct 08 09:59:36 JST 2024
key=value

------=_Part_0_686349795.1728349176787--
```
