### PR TITLE
INTERLOK-4445 Fix multi payload message mime encoder working with the encoding and decoding service.

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/transcoding/EncodingService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/transcoding/EncodingService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 
 package com.adaptris.core.services.transcoding;
 
-import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
@@ -28,7 +28,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Encodes the in flight message and sets the payload to the encoded output.
- * 
+ *
  * @config encoding-service
  *
  */
@@ -37,7 +37,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Encodes the message", tag = "service")
 public class EncodingService extends TranscodingService {
 
-  public EncodingService(){
+  public EncodingService() {
   }
 
   public EncodingService(AdaptrisMessageEncoder encoder) {
@@ -46,10 +46,15 @@ public class EncodingService extends TranscodingService {
 
   @Override
   public void transcodeMessage(AdaptrisMessage msg) throws ServiceException {
-    try (OutputStream out = msg.getOutputStream()) {
-      getEncoder().writeMessage(msg,out);
-    }
-    catch (Exception e) {
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      // INTERLOK-4445 When using a multipayload message there is an issue with
+      // MultiPayloadAdaptrisMessageImp#ByteFilterStream
+      // that resets the default payload when doing msg.getOutpuStream so we need to use a
+      // ByteArrayOutputStream first
+      // and then set the byte payload
+      getEncoder().writeMessage(msg, out);
+      msg.setPayload(out.toByteArray());
+    } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
     }
   }

--- a/interlok-core/src/test/java/com/adaptris/core/services/transcoding/EncodingServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/transcoding/EncodingServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.ByteArrayInputStream;
+
 import org.junit.jupiter.api.Test;
 
 import com.adaptris.core.AdaptrisMessage;
@@ -12,6 +14,9 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.MimeEncoder;
+import com.adaptris.core.MultiPayloadAdaptrisMessage;
+import com.adaptris.core.MultiPayloadMessageFactory;
+import com.adaptris.core.MultiPayloadMessageMimeEncoder;
 import com.adaptris.core.stubs.MockEncoder;
 import com.adaptris.core.stubs.StubMessageFactory;
 import com.adaptris.core.util.LifecycleHelper;
@@ -24,8 +29,7 @@ public class EncodingServiceTest extends TranscodingServiceCase {
     try {
       LifecycleHelper.init(service);
       fail();
-    }
-    catch (CoreException expected) {
+    } catch (CoreException expected) {
     }
     service.setEncoder(new MockEncoder());
     LifecycleHelper.init(service);
@@ -65,7 +69,6 @@ public class EncodingServiceTest extends TranscodingServiceCase {
     }
   }
 
-
   @Test
   public void testMockEncoder() throws Exception {
     EncodingService service = new EncodingService(new MockEncoder());
@@ -80,7 +83,7 @@ public class EncodingServiceTest extends TranscodingServiceCase {
     AdaptrisMessage msg = createSimpleMessage();
     execute(service, msg);
     MimeEncoder me = new MimeEncoder();
-    AdaptrisMessage encodedMessage  = me.decode(msg.getPayload());
+    AdaptrisMessage encodedMessage = me.decode(msg.getPayload());
     assertTrue(encodedMessage.headersContainsKey(TEST_METADATA_KEY));
     assertTrue(encodedMessage.headersContainsKey(TEST_METADATA_KEY_2));
     assertEquals(TEST_METADATA_VALUE, encodedMessage.getMetadataValue(TEST_METADATA_KEY));
@@ -88,11 +91,45 @@ public class EncodingServiceTest extends TranscodingServiceCase {
     assertEquals(TEST_PAYLOAD, new String(encodedMessage.getPayload()));
   }
 
+  @Test
+  public void testMultiPayloadMimeEncoder() throws Exception {
+    MultiPayloadMessageMimeEncoder encoder = new MultiPayloadMessageMimeEncoder();
+    encoder.setPayloadEncoding("base64");
+    encoder.setMetadataEncoding("base64");
+    EncodingService service = new EncodingService(encoder);
+
+    service.setMessageFactory(new MultiPayloadMessageFactory());
+    AdaptrisMessage msg = new MultiPayloadMessageFactory().newMessage(TEST_PAYLOAD);
+    msg.addMetadata(TEST_METADATA_KEY, TEST_METADATA_VALUE);
+    msg.addMetadata(TEST_METADATA_KEY_2, TEST_METADATA_VALUE_2);
+    ((MultiPayloadAdaptrisMessage) msg).addContent("second-payload-2", TEST_PAYLOAD + " 2");
+    ((MultiPayloadAdaptrisMessage) msg).switchPayload("default-payload");
+
+    execute(service, msg);
+
+    MultiPayloadMessageMimeEncoder me = encoder;
+    MultiPayloadAdaptrisMessage encodedMessage = (MultiPayloadAdaptrisMessage) decode(msg.getPayload(), me);
+    assertTrue(encodedMessage.headersContainsKey(TEST_METADATA_KEY));
+    assertTrue(encodedMessage.headersContainsKey(TEST_METADATA_KEY_2));
+    assertEquals(TEST_METADATA_VALUE, encodedMessage.getMetadataValue(TEST_METADATA_KEY));
+    assertEquals(TEST_METADATA_VALUE_2, encodedMessage.getMetadataValue(TEST_METADATA_KEY_2));
+    assertEquals(TEST_PAYLOAD, new String(encodedMessage.getPayload()));
+    assertEquals(TEST_PAYLOAD + " 2", new String(encodedMessage.getPayload("second-payload-2")));
+  }
+
   @Override
   protected Object retrieveObjectForSampleConfig() {
     EncodingService encodingService = new EncodingService();
     encodingService.setEncoder(new MimeEncoder());
     return encodingService;
+  }
+
+  public AdaptrisMessage decode(byte[] bytes, MultiPayloadMessageMimeEncoder encoder) throws CoreException {
+    try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
+      return encoder.readMessage(in);
+    } catch (Exception e) {
+      throw new CoreException(e);
+    }
   }
 
 }


### PR DESCRIPTION
## Motivation

When using a multipayload message there is an issue with MultiPayloadAdaptrisMessageImp#ByteFilterStream that resets the default payload when doing msg.getOutpuStream

## Modification

Use a ByteArrayOutputStream first and then set the byte payload

## PR Checklist

- [x] been self-reviewed.

## Result

The user can use EncodingService and DecodingService with multi payload message

## Testing

```xml
<encoding-service>
  <unique-id>to-mime-message</unique-id>
  <encoder class="com.adaptris.core.MultiPayloadMessageMimeEncoder"/>
</encoding-service>

<decoding-service>
  <unique-id>from-mime-message</unique-id>
  <encoder class="com.adaptris.core.MultiPayloadMessageMimeEncoder"/>
  <message-factory class="multi-payload-message-factory">
    <default-char-encoding>UTF-8</default-char-encoding>
    <default-payload-id>default-payload</default-payload-id>
  </message-factory>
</decoding-service>
```
Use a multi payload message with payload:
id: 'default-payload'
```
<xml>content</xml>
```
And metadata
```
key=value
```