### PR TITLE
INTERLOK-4430 When using a URL to configure a xml transform service w…

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
@@ -68,8 +68,11 @@ import net.jodah.expiringmap.ExpiringMap;
  * Cache transforms functionality only works if <code>url</code> is used. Caching is not supported with <code>mappingSource</code>.
  * </p>
  * <p>
+ * File path context when using XSL import functionality only works if <code>url</code> is used. Caching is not supported with <code>mappingSource</code>.
+ * </p>
+ * <p>
  * If you wish to call an external mapping source when using <code>mappingSource</code> such as via http you can use
- * <strong>FileDataInputParameter</strong>.
+ * <strong>FileDataInputParameter</strong>. However that will not keep the file path context when using XSL import.
  * </p>
  *
  * @config xml-transform-service
@@ -84,15 +87,14 @@ public class XmlTransformService extends ServiceImp {
   private static final int DEFAULT_MAX_CACHE_SIZE = 16;
   private static final TimeInterval DEFAULT_EXPIRATION = new TimeInterval(1L, TimeUnit.HOURS);
 
-  /**
-   * @deprecated since 5.0.0 use {@link #DataInputParameter} instead.
-   */
-  @Deprecated(since = "5.0.0")
   private String url;
 
   @AdvancedConfig
   private String metadataKey;
 
+  /**
+   * Use mapping-source to use an inline mapping instead of a URL
+   */
   @Getter
   @Setter
   @AutoPopulated
@@ -254,6 +256,7 @@ public class XmlTransformService extends ServiceImp {
   /**
    * <p>
    * Sets the URL of the XSLT to use. May not be empty.
+   * Using a URL will keep file path context when using XSL import. 
    * </p>
    *
    * @param s the URL of the XSLT to use

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
@@ -23,7 +23,7 @@ import org.xml.sax.EntityResolver;
 public interface XmlTransformerFactory {
 
   /**
-   * @deprecated You shoul use {@link XmlTransformerFactory#createTransformerFromUrl(String)} instead
+   * @deprecated You should use {@link XmlTransformerFactory#createTransformerFromUrl(String)} instead
    */
   @Deprecated
   default Transformer createTransformer(String transformUrl) throws Exception {
@@ -31,7 +31,7 @@ public interface XmlTransformerFactory {
   }
 
   /**
-   * @deprecated You shoul use {@link XmlTransformerFactory#createTransformerFromUrl(String, EntityResolver)} instead
+   * @deprecated You should use {@link XmlTransformerFactory#createTransformerFromUrl(String, EntityResolver)} instead
    */
   @Deprecated
   default Transformer createTransformer(String transformUrl, EntityResolver entityResolver) throws Exception {

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -62,6 +62,21 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
     setTransformerFactoryImpl(impl);
   }
 
+  /**
+   * Override {@link XmlTransformerFactoryImpl#createTransformerFromUrl(String, EntityResolver)} so when using a URL we build the XML
+   * document directly from the URL instead of the InputSream of the URL file content. Doing this allows the transformer to have the file
+   * location context and therefore the import statement in the XSL can use relative path.
+   */
+  @Override
+  public Transformer createTransformerFromUrl(String url, EntityResolver entityResolver) throws Exception {
+    DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
+    if (entityResolver != null) {
+      docBuilder.setEntityResolver(entityResolver);
+    }
+    Document xmlDoc = docBuilder.parse(new InputSource(url));
+    return configure(newInstance()).newTransformer(new DOMSource(xmlDoc, url));
+  }
+
   @Override
   public Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception {
     DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
@@ -87,7 +102,8 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
    * {@code net.sf.saxon.TransformerFactoryImpl} to force it to use Saxon.
    * <p>
    *
-   * @param s he transformerFactoryImpl to set, if not specified the JVM default is used {@link TransformerFactory#newInstance()}.
+   * @param s
+   *          he transformerFactoryImpl to set, if not specified the JVM default is used {@link TransformerFactory#newInstance()}.
    */
   public void setTransformerFactoryImpl(String s) {
     transformerFactoryImpl = s;

--- a/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
@@ -75,6 +75,7 @@ public class XmlTransformServiceTest
 
   public static final String KEY_XML_TEST_INPUT = "XmlTransformService.outputTestMessage";
   public static final String KEY_XML_TEST_TRANSFORM_URL = "XmlTransformService.outputTestTransform";
+  public static final String KEY_XML_TEST_TRANSFORM_WITH_IMPORT_URL = "XmlTransformService.outputTestTransformWithImport";
   public static final String KEY_XML_TEST_TRANSFORM_URL_XSL_MESSAGE = "XmlTransformService.outputTestTransformWithXslMessage";
   public static final String KEY_XML_TEST_INVALID_TRANSFORM_URL = "XmlTransformService.outputTestInvalidTransform";
   public static final String KEY_XML_TEST_FATAL_TRANSFORM_URL = "XmlTransformService.outputTestFatalTransform";
@@ -863,7 +864,6 @@ public class XmlTransformServiceTest
     }
   }
 
-
   private static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
     DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = domFactory.newDocumentBuilder();
@@ -876,9 +876,9 @@ public class XmlTransformServiceTest
   }
 
   // INTERLOK-3101, Saxon-9.9.1-4 onwards throws a different Exception.
-  private void assertExceptionCause(Exception e, Class...classes) {
+  private void assertExceptionCause(Exception e, Class<?>...classes) {
     assertNotNull(e.getCause());
-    List<Class> validClasses = Arrays.asList(classes);
+    List<Class<?>> validClasses = Arrays.asList(classes);
     Throwable t = e.getCause();
     boolean matches =
         validClasses.stream().anyMatch((clazz) -> clazz.isAssignableFrom(t.getClass()));

--- a/interlok-core/src/test/java/com/adaptris/util/text/XmlTransformerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/XmlTransformerTest.java
@@ -17,17 +17,21 @@ package com.adaptris.util.text;
 
 import static com.adaptris.core.transform.XmlTransformServiceTest.KEY_XML_TEST_INPUT;
 import static com.adaptris.core.transform.XmlTransformServiceTest.KEY_XML_TEST_TRANSFORM_URL;
+import static com.adaptris.core.transform.XmlTransformServiceTest.KEY_XML_TEST_TRANSFORM_WITH_IMPORT_URL;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,6 +71,31 @@ public class XmlTransformerTest extends com.adaptris.interlok.junit.scaffolding.
       StreamResult output = new StreamResult(out);
       StreamSource input = new StreamSource(in);
       transform.transform(factory.createTransformerFromUrl(xsl), input, output, xsl);
+    }
+  }
+
+  @Test
+  public void testTransform_WithImport() throws Exception {
+    XmlTransformerFactory factory = new XsltTransformerFactory();
+    XmlTransformer transform = factory.configure(new XmlTransformer());
+    transform.registerBuilder(DocumentBuilderFactoryBuilder.newInstance());
+    String xsl = backslashToSlash(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_WITH_IMPORT_URL));
+    AdaptrisMessage m1 = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    try (InputStream in = m1.getInputStream(); OutputStream out = m1.getOutputStream()) {
+      transform.transform(factory.createTransformerFromUrl(xsl), in, out, xsl);
+    }
+  }
+
+  @Test
+  public void testTransform_FromRawXsl() throws Exception {
+    XmlTransformerFactory factory = new XsltTransformerFactory();
+    XmlTransformer transform = factory.configure(new XmlTransformer());
+    transform.registerBuilder(DocumentBuilderFactoryBuilder.newInstance());
+    String xsl = backslashToSlash(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL));
+    String xslContent = IOUtils.toString(new URI(xsl), StandardCharsets.UTF_8);
+    AdaptrisMessage m1 = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
+    try (InputStream in = m1.getInputStream(); OutputStream out = m1.getOutputStream()) {
+      transform.transform(factory.createTransformerFromRawXsl(xslContent), in, out, xsl);
     }
   }
 

--- a/interlok-core/src/test/resources/transform/simple-transform-xsl-import.xsl
+++ b/interlok-core/src/test/resources/transform/simple-transform-xsl-import.xsl
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<xsl:stylesheet 
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" 
+  xmlns:java="http://xml.apache.org/xslt/java" exclude-result-prefixes="java">
+  
+  <xsl:import href="./simple-transform.xsl"/>
+   
+</xsl:stylesheet>

--- a/interlok-core/src/test/resources/unit-tests.properties.template
+++ b/interlok-core/src/test/resources/unit-tests.properties.template
@@ -93,6 +93,7 @@ junit.XmlValidationServiceTest.input.xml=@BASE_DIR@/src/test/resources/transform
 
 junit.XmlTransformService.outputNodeTransform=file:///@BASE_DIR@/src/test/resources/transform/simple-node-transform.xsl
 junit.XmlTransformService.outputTestTransform=file:///@BASE_DIR@/src/test/resources/transform/simple-transform.xsl
+junit.XmlTransformService.outputTestTransformWithImport=file:///@BASE_DIR@/src/test/resources/transform/simple-transform-xsl-import.xsl
 junit.XmlTransformService.outputTestTransformWithXslMessage=file:///@BASE_DIR@/src/test/resources/transform/simple-transform-xsl-message.xsl
 junit.XmlTransformService.outputTestInvalidTransform=file:///@BASE_DIR@/src/test/resources/transform/simple-invalid-transform.xsl
 junit.XmlTransformService.outputTestFatalTransform=file:///@BASE_DIR@/src/test/resources/transform/simple-fatal-transform.xsl


### PR DESCRIPTION

This should allow us to keep the relative path import working.

## Motivation

We did some work 6-12 months ago where we enabled InputParameters rather than a simple input string as the source for your XSL.

This essentially has changed the xml transformer creation in that we don’t give the URL of the XSL to the transformer factory, but instead an input stream of the file XSL content.  The unintentional consequence of this is that now the transformer no longer has file location context.  Which means, that if you have an import statement in your XSL that is relative to the source XSL the transformer cannot resolve it.

## Modification

When using a URL to configure a xml transform service we directly create a transformer using the url rather than the content of the xsl retrived from the url. This should allow us to keep the relative path import working.

Added test to make sure that's working0

Remove deprecation of url as this is the only way of using xsl:import and caching.

## PR Checklist

- [x] been self-reviewed.

## Result

The user should be able to use the XML transform service as before the changes made for the migration tool when using a URL.
Meaning that if they us an import with relative path, the relative path will be calculated from the url.
If using a string content for the XML transform service it should work the same (not working with import).

## Testing

With the interlok-core.jar from this PR

Have two xslt in the same dir:

simple-transform-xsl-import.xsl:
```xml
<?xml version='1.0' encoding='utf-8' ?>
<xsl:stylesheet 
  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" 
  xmlns:java="http://xml.apache.org/xslt/java" exclude-result-prefixes="java">
  
  <xsl:param name="world"/>
  
  <xsl:output method="text"/>
  
  <xsl:template match="/">  
    <xsl:value-of select="//payload"/>
    <xsl:value-of select="$world"/>
  </xsl:template>
   
</xsl:stylesheet>
```
and

simple-transform.xsl
```xml
<?xml version='1.0' encoding='utf-8' ?>
<xsl:stylesheet 
  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" 
  xmlns:java="http://xml.apache.org/xslt/java" exclude-result-prefixes="java">
  
  <xsl:import href="./simple-transform.xsl"/>
   
</xsl:stylesheet>
```

A message with payload:

```xml
<message>
  <payload>Hello</payload>
</message>
```
And service XML
```xml
<xml-transform-service>
  <unique-id>prickly-curie</unique-id>
  <mapping-source class="file-data-input-parameter">
    <url>file:///paht/to/simple-transform-xsl-import.xsl</url>
  </mapping-source>
</xml-transform-service>
```
