### PR TITLE
Implement MessageUniqueIdService

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageFactory.java
@@ -16,19 +16,18 @@
 
 package com.adaptris.core;
 
-import java.io.UnsupportedEncodingException;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.Set;
-
-import javax.validation.Valid;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.util.GuidGenerator;
 import com.adaptris.util.IdGenerator;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+
+import javax.validation.Valid;
+import java.io.UnsupportedEncodingException;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * <p>
@@ -242,7 +241,7 @@ public abstract class AdaptrisMessageFactory {
     this.uniqueIdGenerator = s;
   }
 
-  protected IdGenerator uniqueIdGenerator() {
+  public IdGenerator uniqueIdGenerator() {
     return Optional.ofNullable(getUniqueIdGenerator()).orElse(DEFAULT_GENERATOR);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/CloneMessageServiceList.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CloneMessageServiceList.java
@@ -16,20 +16,25 @@
 
 package com.adaptris.core;
 
-import static com.adaptris.core.util.LoggingHelper.friendlyName;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import javax.validation.Valid;
-import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.RemoveAllMetadataFilter;
+import com.adaptris.core.util.MessageHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.ObjectUtils;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static com.adaptris.core.util.LoggingHelper.friendlyName;
 
 /**
  * Implementation of {@linkplain ServiceCollection} that creates a new clone of {@linkplain com.adaptris.core.AdaptrisMessage} for each configured
@@ -61,6 +66,10 @@ public class CloneMessageServiceList extends ServiceListBase {
   @Valid
   private MetadataFilter overrideMetadataFilter;
 
+  @Getter
+  @Setter
+  private boolean newUniqueIdPerMessage = false;
+
   public CloneMessageServiceList() {
     super();
   }
@@ -74,12 +83,21 @@ public class CloneMessageServiceList extends ServiceListBase {
     this(Arrays.asList(list));
   }
 
+  private AdaptrisMessage cloneMessage(AdaptrisMessage msg) throws CloneNotSupportedException{
+    AdaptrisMessage clonedMessage = (AdaptrisMessage) msg.clone();
+    if (newUniqueIdPerMessage) {
+      String newUniqueId = MessageHelper.generateNewMessageUniqueId(clonedMessage);
+      clonedMessage.setUniqueId(newUniqueId);
+    }
+    return clonedMessage;
+  }
+
   @Override
   protected void applyServices(AdaptrisMessage msg) throws ServiceException {
     for (Service service : getServices()) {
       if(service.enabled()) {
         try {
-          AdaptrisMessage clonedMessage = (AdaptrisMessage) msg.clone();
+          AdaptrisMessage clonedMessage = cloneMessage(msg);
           if (haltProcessing(clonedMessage)) {
             break;
           }

--- a/interlok-core/src/main/java/com/adaptris/core/CloneMessageServiceList.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CloneMessageServiceList.java
@@ -20,6 +20,7 @@ import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.core.metadata.RemoveAllMetadataFilter;
 import com.adaptris.core.util.MessageHelper;
@@ -66,8 +67,12 @@ public class CloneMessageServiceList extends ServiceListBase {
   @Valid
   private MetadataFilter overrideMetadataFilter;
 
+  /**
+   * If set to true, generates a new unique id per cloned message. Defaults to false.
+   */
   @Getter
   @Setter
+  @InputFieldDefault(value = "false")
   private boolean newUniqueIdPerMessage = false;
 
   public CloneMessageServiceList() {

--- a/interlok-core/src/main/java/com/adaptris/core/services/MessageUniqueIdService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/MessageUniqueIdService.java
@@ -1,15 +1,45 @@
 package com.adaptris.core.services;
 
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.Args;
 import com.adaptris.core.util.MessageHelper;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * This service generates a new message unique id and sets it on the message
+ * This service sets the configured or generated message id on the message.
+ * WARNING: It is generally not recommended to alter the message id but if it is necessary
+ * this service should be used with care and only at the beginning of the workflow.
  */
+@XStreamAlias("message-unique-id-service")
+@AdapterComponent
+@ComponentProfile(summary = "Sets the configured or generated message id on the message", tag = "service")
 public class MessageUniqueIdService extends ServiceImp {
+
+    /**
+     * Set to true to generate a message unique id. This overrides the default behaviour of setting based
+     * on <code>messageUniqueId</code>. Defaults to false.
+     */
+    @Getter
+    @Setter
+    @InputFieldDefault(value = "false")
+    private boolean generate = false;
+
+    /**
+     * The message unique id to set on the message. Can be an expression.
+     */
+    @Getter
+    @Setter
+    @InputFieldHint(expression = true)
+    private String messageUniqueId;
 
     @Override
     protected void initService() throws CoreException {
@@ -23,12 +53,12 @@ public class MessageUniqueIdService extends ServiceImp {
 
     @Override
     public void doService(AdaptrisMessage msg) throws ServiceException {
-        String newUniqueId = MessageHelper.generateNewMessageUniqueId(msg);
+        String newUniqueId = generate ? MessageHelper.generateNewMessageUniqueId(msg) : msg.resolve(messageUniqueId);
         msg.setUniqueId(newUniqueId);
     }
 
     @Override
     public void prepare() throws CoreException {
-
+        if (!generate) Args.notBlank(messageUniqueId, "messageUniqueId");
     }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/MessageUniqueIdService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/MessageUniqueIdService.java
@@ -1,0 +1,34 @@
+package com.adaptris.core.services;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.MessageHelper;
+
+/**
+ * This service generates a new message unique id and sets it on the message
+ */
+public class MessageUniqueIdService extends ServiceImp {
+
+    @Override
+    protected void initService() throws CoreException {
+
+    }
+
+    @Override
+    protected void closeService() {
+
+    }
+
+    @Override
+    public void doService(AdaptrisMessage msg) throws ServiceException {
+        String newUniqueId = MessageHelper.generateNewMessageUniqueId(msg);
+        msg.setUniqueId(newUniqueId);
+    }
+
+    @Override
+    public void prepare() throws CoreException {
+
+    }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/util/MessageHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/util/MessageHelper.java
@@ -1,6 +1,15 @@
 package com.adaptris.core.util;
 
-import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.lms.FileBackedMessage;
+import com.adaptris.util.IdGenerator;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -8,18 +17,22 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.lms.FileBackedMessage;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
+import static com.adaptris.core.CoreConstants.OBJ_METADATA_EXCEPTION;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public class MessageHelper {
+
+  /**
+   * Generate a new message unique id from the src message's factory's id generator
+   * @param src
+   * @return a new message unique id
+   */
+  public static String generateNewMessageUniqueId(AdaptrisMessage src) {
+    IdGenerator generator = src.getFactory().uniqueIdGenerator();
+    return generator.create(src);
+  }
 
   /**
    * Copy the payload from the src to the destination message.

--- a/interlok-core/src/test/java/com/adaptris/core/CloneMessageServiceListTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/CloneMessageServiceListTest.java
@@ -111,13 +111,15 @@ public class CloneMessageServiceListTest
     try {
       LifecycleHelper.initAndStart(service1);
       service1.doService(msg);
-      assertTrue(messageUniqueIds.size() == 1 && messageUniqueIds.contains(msg.getUniqueId()));
+      assertEquals(1, messageUniqueIds.size());
+      assertTrue(messageUniqueIds.contains(msg.getUniqueId()));
 
       messageUniqueIds.clear();
 
       LifecycleHelper.initAndStart(service2);
       service2.doService(msg);
-      assertTrue(messageUniqueIds.size() == 2 && !messageUniqueIds.contains(msg.getUniqueId()));
+      assertEquals(2, messageUniqueIds.size());
+      assertFalse(messageUniqueIds.contains(msg.getUniqueId()));
 
     }
     finally {

--- a/interlok-core/src/test/java/com/adaptris/core/services/MessageUniqueIdServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/MessageUniqueIdServiceTest.java
@@ -19,8 +19,12 @@ package com.adaptris.core.services;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.GeneralServiceExample;
+import com.adaptris.core.MetadataElement;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -29,12 +33,44 @@ public class MessageUniqueIdServiceTest extends GeneralServiceExample {
 
 
   @Test
-  public void testService() throws Exception {
+  public void testSettingAndResolvingUniqueId() throws Exception {
+    String MSG_ID = "%message{message-id}";
+    String newUniqueId = UUID.randomUUID().toString();
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    msg.addMetadata(new MetadataElement("message-id", newUniqueId));
     String originalUniqueId = msg.getUniqueId();
-    execute(new MessageUniqueIdService(), msg);
+    MessageUniqueIdService service = new MessageUniqueIdService();
+    service.setGenerate(false);
+    service.setMessageUniqueId(MSG_ID);
+
+    // test resolving
+    execute(service, msg);
     assertNotNull(msg.getUniqueId());
     assertNotEquals(msg.getUniqueId(), originalUniqueId);
+    assertEquals(msg.getUniqueId(), newUniqueId);
+
+    // test setting
+    newUniqueId = UUID.randomUUID().toString();
+    service.setMessageUniqueId(newUniqueId);
+    execute(service, msg);
+    assertNotNull(msg.getUniqueId());
+    assertNotEquals(msg.getUniqueId(), originalUniqueId);
+    assertEquals(msg.getUniqueId(), newUniqueId);
+
+  }
+
+  @Test
+  public void testGenerateUniqueId() throws Exception {
+    final String MSG_ID = "test";
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    String originalUniqueId = msg.getUniqueId();
+    MessageUniqueIdService service = new MessageUniqueIdService();
+    service.setGenerate(true);
+    service.setMessageUniqueId(MSG_ID);
+    execute(service, msg);
+    assertNotNull(msg.getUniqueId());
+    assertNotEquals(msg.getUniqueId(), originalUniqueId);
+    assertNotEquals(msg.getUniqueId(), MSG_ID);
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/services/MessageUniqueIdServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/MessageUniqueIdServiceTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core.services;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.GeneralServiceExample;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+public class MessageUniqueIdServiceTest extends GeneralServiceExample {
+
+
+  @Test
+  public void testService() throws Exception {
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage();
+    String originalUniqueId = msg.getUniqueId();
+    execute(new MessageUniqueIdService(), msg);
+    assertNotNull(msg.getUniqueId());
+    assertNotEquals(msg.getUniqueId(), originalUniqueId);
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    return new MessageUniqueIdService();
+  }
+
+}


### PR DESCRIPTION
Implement config to generate new unique id for CloneMessageServiceList

## Motivation

There is a requirement to generate a new message id and set it on the message.

## Modification

- The way of obtaining the id generator from the message's factory is by calling uniqueIdGenerator(), however this needed to be changed to public access instead of protected. The logic to generate message unique id is in MessageHelper.
- Did not know what impact to things that depend on the message id such as events, or whether there is a need to correlate the new message ids with the original are needed?


## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result
- Users will be able to configure a MessageUniqueIdService which generates a new message id.
- Users will be able to configure CloneMessageServiceList with 'newUniqueIdPerMessage' property to control whether a new message id is generated per cloned message.


## Testing
- Run the tests for MessageUniqueIdServiceTest and CloneMessageServiceListTest
