### PR TITLE
INTERLOK-4462: MetadataAppenderService - Add optional separator

### DIFF
--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -139,6 +139,7 @@ dependencies {
 
   testImplementation ("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testImplementation ("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+  testImplementation ("org.junit.jupiter:junit-jupiter-params:$junitVersion")
   testImplementation ("org.apache.activemq:artemis-jms-server:2.38.0")
   testImplementation ("oro:oro:2.0.8")
   testImplementation ("org.slf4j:jcl-over-slf4j:$slf4jVersion")

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataAppenderService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataAppenderService.java
@@ -28,6 +28,7 @@ import com.adaptris.annotation.AffectsMetadata;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.Args;
@@ -65,6 +66,7 @@ public class MetadataAppenderService extends MetadataServiceImpl {
   @NotNull
   @AutoPopulated
   @AffectsMetadata
+  @InputFieldDefault("")
   @Getter
   @Setter
   private String separator = DEFAULT_SEPARATOR;

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataAppenderService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataAppenderService.java
@@ -18,6 +18,9 @@ package com.adaptris.core.services.metadata;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.AdapterComponent;
@@ -30,6 +33,8 @@ import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Service to append multiple metadata keys together to form a new key.
@@ -56,6 +61,14 @@ public class MetadataAppenderService extends MetadataServiceImpl {
   @AffectsMetadata
   private String resultKey;
 
+  public static final String DEFAULT_SEPARATOR = "";
+  @NotNull
+  @AutoPopulated
+  @AffectsMetadata
+  @Getter
+  @Setter
+  private String separator = DEFAULT_SEPARATOR;
+
   /**
    * <p>
    * Creates a new instance.  Default key for result metatadata is
@@ -69,13 +82,11 @@ public class MetadataAppenderService extends MetadataServiceImpl {
 
   @Override
   public void doService(AdaptrisMessage msg) {
-    StringBuffer result = new StringBuffer();
-    for (String key : appendKeys) {
-      if (msg.getMetadataValue(key) != null) {
-        result.append(msg.getMetadataValue(key));
-      }
-    }
-    MetadataElement e = new MetadataElement(resultKey, result.toString());
+    String result = appendKeys.stream()
+            .map(key -> msg.getMetadataValue(key))
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining(separator));
+    MetadataElement e = new MetadataElement(resultKey, result);
     logMetadata("Added {}", e);
     msg.addMetadata(e);
   }
@@ -138,5 +149,12 @@ public class MetadataAppenderService extends MetadataServiceImpl {
   public void setResultKey(String string) {
     resultKey = Args.notBlank(string, "resultKey");
   }
+
+
+  /**
+   * Sets the separator to be used between concatenated metadata values
+   * @param string the separator between concatenated metadata values, may not be null
+   */
+  public void setSeparator(String string) { separator = Args.notNull(string, "separator"); }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataAppenderService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataAppenderService.java
@@ -29,6 +29,7 @@ import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.util.Args;
@@ -63,11 +64,11 @@ public class MetadataAppenderService extends MetadataServiceImpl {
   private String resultKey;
 
   public static final String DEFAULT_SEPARATOR = "";
-  @NotNull
+
   @AutoPopulated
   @AffectsMetadata
+  @InputFieldHint(style="BLANKABLE")
   @InputFieldDefault("")
-  @Getter
   @Setter
   private String separator = DEFAULT_SEPARATOR;
 
@@ -87,7 +88,7 @@ public class MetadataAppenderService extends MetadataServiceImpl {
     String result = appendKeys.stream()
             .map(key -> msg.getMetadataValue(key))
             .filter(Objects::nonNull)
-            .collect(Collectors.joining(separator));
+            .collect(Collectors.joining(getSeparator()));
     MetadataElement e = new MetadataElement(resultKey, result);
     logMetadata("Added {}", e);
     msg.addMetadata(e);
@@ -152,11 +153,11 @@ public class MetadataAppenderService extends MetadataServiceImpl {
     resultKey = Args.notBlank(string, "resultKey");
   }
 
-
   /**
-   * Sets the separator to be used between concatenated metadata values
-   * @param string the separator between concatenated metadata values, may not be null
+   * Gets the separator to be used between concatenated metadata values, returning the default
+   * if null
+   * @return separator, or default if null
    */
-  public void setSeparator(String string) { separator = Args.notNull(string, "separator"); }
+  public String getSeparator() { return separator == null ? DEFAULT_SEPARATOR : separator; }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataAppenderServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataAppenderServiceTest.java
@@ -153,6 +153,12 @@ public class MetadataAppenderServiceTest extends MetadataServiceExample {
     assertEquals(expected, msg.getMetadataValue(resultKey));
   }
 
+  @Test
+  public void testNullSeparator() throws CoreException {
+    service.setSeparator(null);
+    assertEquals(MetadataAppenderService.DEFAULT_SEPARATOR, service.getSeparator());
+  }
+
   static Stream<Arguments> testSeparatorProvider() {
     return Stream.of(
             Arguments.of((Object) new String[]{"key1", "val1"}),


### PR DESCRIPTION
## Motivation

A requirement for adding an optional separator to MetadataAppenderService. See https://adaptris.atlassian.net/browse/INTERLOK-4462

## Modification

- MetadataAppenderService: Added a String separator property
- MetadataAppenderService: Updated the existing doService() to use stream api and join
- MetadataAppenderServiceTest: added testSeparator(), testZeroKeys()
- build.gradle: Added junit-jupiter-params test dependency to keep DRY

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

- Let say I have k1=v1, k2=v2 and I append k1 and k2 to k3, the result will be k3=v1v2

## Testing

- Run MetadataAppenderServiceTest.testSeparator()
