### PR TITLE
INTERLOK-4450 Add interlok-jetty-configurable-key-security-handler into Interlok core

### DIFF
--- a/interlok-core-apt/src/main/java/com/adaptris/annotation/ComponentProfile.java
+++ b/interlok-core-apt/src/main/java/com/adaptris/annotation/ComponentProfile.java
@@ -48,7 +48,7 @@ public @interface ComponentProfile {
    * @return an array of classes
    * @since 3.2.0
    */
-  Class[]recommended() default {};
+  Class[] recommended() default {};
 
   /**
    * Returns an array of strings that contains metadata keys that may be created or have an effect on the behaviour of this

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/ConfigurableKeySecurityHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/ConfigurableKeySecurityHandler.java
@@ -1,0 +1,95 @@
+package com.adaptris.core.http.jetty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.constraints.NotBlank;
+
+import org.eclipse.jetty.security.Authenticator;
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.util.security.Constraint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.management.webserver.SecurityHandlerWrapper;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Jetty Security Handler Wrapper which allows works with API keys.
+ */
+@XStreamAlias("jetty-configurable-key-security-handler")
+@DisplayOrder(order = { "apiKeyHeader", "apiKey", "paths" })
+public class ConfigurableKeySecurityHandler implements SecurityHandlerWrapper {
+
+  protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+
+  static final String ROLE_NAME = "KEY_BASED";
+  static final String USERNAME = "KEY";
+
+  /**
+   * Header key used to retrieve the API key
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  private String apiKeyHeader;
+
+  /**
+   * API key to check against. This can be an environment variable e.g. <code>%env{API_KEY}</code> or a system property e.g.
+   * <code>%sysprop{api.key}</code>
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  @InputFieldHint(style = "PASSWORD", external = true)
+  private String apiKey;
+
+  /**
+   * List of url paths to protect using the provided API key
+   */
+  @Getter
+  @Setter
+  @XStreamImplicit(itemFieldName = "url-path")
+  private List<String> paths;
+
+  public ConfigurableKeySecurityHandler() {
+    paths = new ArrayList<>();
+  }
+
+  @Override
+  public SecurityHandler createSecurityHandler() throws Exception {
+    ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
+    Authenticator authenticator = new KeyAuthenticator(USERNAME, getApiKeyHeader());
+    securityHandler.setAuthenticator(authenticator);
+    LoginService loginService = new KeyLoginService(USERNAME, ExternalResolver.resolve(getApiKey()), ROLE_NAME);
+    securityHandler.setLoginService(loginService);
+
+    log.debug("Created configurable key security handler");
+
+    Constraint constraint = new Constraint();
+    constraint.setName(authenticator.getAuthMethod());
+    constraint.setRoles(new String[] { ROLE_NAME });
+    constraint.setAuthenticate(true);
+
+    for (String path : getPaths()) {
+      ConstraintMapping constraintMapping = new ConstraintMapping();
+      constraintMapping.setConstraint(constraint);
+      constraintMapping.setPathSpec(path);
+
+      log.debug("Adding path [{}] with constraint [{}] to security handler", path, constraint);
+      securityHandler.addConstraintMapping(constraintMapping);
+    }
+    return securityHandler;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/ConfigurableKeySecurityHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/ConfigurableKeySecurityHandler.java
@@ -14,6 +14,8 @@ import org.eclipse.jetty.util.security.Constraint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.management.webserver.SecurityHandlerWrapper;
@@ -28,6 +30,8 @@ import lombok.Setter;
  * Jetty Security Handler Wrapper which allows works with API keys.
  */
 @XStreamAlias("jetty-configurable-key-security-handler")
+@AdapterComponent
+@ComponentProfile(summary = "Jetty Security Handler Wrapper which allows works with API keys.", tag = "jetty,security", since = "5.0.4")
 @DisplayOrder(order = { "apiKeyHeader", "apiKey", "paths" })
 public class ConfigurableKeySecurityHandler implements SecurityHandlerWrapper {
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/KeyAuthenticator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/KeyAuthenticator.java
@@ -1,0 +1,62 @@
+package com.adaptris.core.http.jetty;
+
+import java.io.IOException;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.security.ServerAuthException;
+import org.eclipse.jetty.security.UserAuthentication;
+import org.eclipse.jetty.security.authentication.DeferredAuthentication;
+import org.eclipse.jetty.security.authentication.LoginAuthenticator;
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.UserIdentity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+class KeyAuthenticator extends LoginAuthenticator {
+
+  static final String AUTH_METHOD = "KEY";
+
+  @Getter
+  private final String username;
+  @Getter
+  private final String headerName;
+
+  @Override
+  public String getAuthMethod() {
+    return AUTH_METHOD;
+  }
+
+  @Override
+  public Authentication validateRequest(ServletRequest req, ServletResponse res, boolean mandatory) throws ServerAuthException {
+    HttpServletRequest request = (HttpServletRequest) req;
+    HttpServletResponse response = (HttpServletResponse) res;
+    String password = request.getHeader(getHeaderName());
+    try {
+      if (!mandatory) {
+        return new DeferredAuthentication(this);
+      }
+      UserIdentity user = login(getUsername(), password, request);
+      if (user != null) {
+        return new UserAuthentication(getAuthMethod(), user);
+      } else {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        return Authentication.SEND_FAILURE;
+      }
+    } catch (IOException e) {
+      throw new ServerAuthException(e);
+    }
+  }
+
+  @Override
+  public boolean secureResponse(ServletRequest request, ServletResponse response, boolean mandatory, Authentication.User validatedUser)
+      throws ServerAuthException {
+    return true;
+  }
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/KeyLoginService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/KeyLoginService.java
@@ -1,0 +1,35 @@
+package com.adaptris.core.http.jetty;
+
+import java.util.List;
+
+import org.eclipse.jetty.security.AbstractLoginService;
+import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.UserPrincipal;
+import org.eclipse.jetty.util.security.Credential;
+
+import lombok.Getter;
+
+class KeyLoginService extends AbstractLoginService {
+
+  @Getter
+  private final List<RolePrincipal> roles;
+  @Getter
+  private final UserPrincipal userPrincipal;
+
+  KeyLoginService(String username, String credential, String role) {
+    userPrincipal = new UserPrincipal(username, Credential.getCredential(credential));
+    var rolePrincipal = new RolePrincipal(role);
+    roles = List.of(rolePrincipal);
+  }
+
+  @Override
+  protected List<RolePrincipal> loadRoleInfo(UserPrincipal user) {
+    return getRoles();
+  }
+
+  @Override
+  protected UserPrincipal loadUserInfo(String username) {
+    return getUserPrincipal();
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/ConfigurableKeySecurityHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/ConfigurableKeySecurityHandlerTest.java
@@ -1,0 +1,51 @@
+package com.adaptris.core.http.jetty;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.util.security.Constraint;
+import org.junit.jupiter.api.Test;
+
+class ConfigurableKeySecurityHandlerTest {
+
+  @Test
+  void createSecurityHandler() throws Exception {
+    ConfigurableKeySecurityHandler securityHandlerWrapper = new ConfigurableKeySecurityHandler();
+    securityHandlerWrapper.setApiKeyHeader("apiKey");
+    securityHandlerWrapper.setApiKey("1234");
+    securityHandlerWrapper.setPaths(Collections.singletonList("/api/*"));
+    SecurityHandler result = securityHandlerWrapper.createSecurityHandler();
+
+    assertTrue(result instanceof ConstraintSecurityHandler);
+    ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) result;
+
+    assertTrue(securityHandler.getAuthenticator() instanceof KeyAuthenticator);
+    KeyAuthenticator keyAuthenticator = (KeyAuthenticator) securityHandler.getAuthenticator();
+    assertEquals(ConfigurableKeySecurityHandler.USERNAME, keyAuthenticator.getUsername());
+    assertEquals("apiKey", keyAuthenticator.getHeaderName());
+
+    assertTrue(securityHandler.getLoginService() instanceof KeyLoginService);
+    KeyLoginService keyLoginService = (KeyLoginService) securityHandler.getLoginService();
+    assertEquals(ConfigurableKeySecurityHandler.USERNAME, keyLoginService.getUserPrincipal().getName());
+    assertEquals(ConfigurableKeySecurityHandler.ROLE_NAME, keyLoginService.getRoles().get(0).getName());
+
+    List<ConstraintMapping> constraintMappings = securityHandler.getConstraintMappings();
+    assertEquals(1, constraintMappings.size());
+
+    ConstraintMapping constraintMapping = constraintMappings.get(0);
+    assertEquals("/api/*", constraintMapping.getPathSpec());
+
+    Constraint constraint = constraintMapping.getConstraint();
+
+    assertEquals(KeyAuthenticator.AUTH_METHOD, constraint.getName());
+    assertEquals(1, constraint.getRoles().length);
+    assertEquals(ConfigurableKeySecurityHandler.ROLE_NAME, constraint.getRoles()[0]);
+    assertTrue(constraint.getAuthenticate());
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/KeyAuthenticatorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/KeyAuthenticatorTest.java
@@ -1,0 +1,95 @@
+package com.adaptris.core.http.jetty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.security.Principal;
+
+import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.security.UserAuthentication;
+import org.eclipse.jetty.security.UserPrincipal;
+import org.eclipse.jetty.security.authentication.DeferredAuthentication;
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.util.security.Credential;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class KeyAuthenticatorTest {
+
+  @Test
+  void getAuthMethod() {
+    KeyAuthenticator authenticator = new KeyAuthenticator("key", "apiKey");
+    assertEquals("KEY", authenticator.getAuthMethod());
+  }
+
+  @Test
+  void validateRequest() throws Exception {
+    KeyAuthenticator authenticator = Mockito.spy(new KeyAuthenticator("key", "apiKey"));
+    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(req.getHeader("apiKey")).thenReturn("1234");
+    HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+    Mockito.doReturn(createDummyUserIdentity()).when(authenticator).login(eq("key"), eq("1234"), any());
+    Authentication result = authenticator.validateRequest(req, res, true);
+    assertNotNull(result);
+    assertTrue(result instanceof UserAuthentication);
+    UserAuthentication userAuthentication = (UserAuthentication) result;
+    assertEquals("username", userAuthentication.getUserIdentity().getUserPrincipal().getName());
+  }
+
+  @Test
+  void validateRequestFailed() throws Exception {
+    KeyAuthenticator authenticator = Mockito.spy(new KeyAuthenticator("key", "apiKey"));
+    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+    HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+    Mockito.doReturn(null).when(authenticator).login(any(), any(), any());
+    Authentication result = authenticator.validateRequest(req, res, true);
+    assertTrue(result instanceof Authentication.Failure);
+    Mockito.verify(res).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+
+  @Test
+  void validateRequestNotMandatory() throws Exception {
+    KeyAuthenticator authenticator = Mockito.spy(new KeyAuthenticator("key", "apiKey"));
+    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+    HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+    Mockito.doReturn(null).when(authenticator).login(any(), any(), any());
+    Authentication result = authenticator.validateRequest(req, res, false);
+    assertTrue(result instanceof DeferredAuthentication);
+  }
+
+  @Test
+  void secureResponse() throws Exception {
+    KeyAuthenticator authenticator = new KeyAuthenticator("key", "apiKey");
+    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+    HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+    Authentication.User user = Mockito.mock(Authentication.User.class);
+    assertTrue(authenticator.secureResponse(req, res, true, user));
+  }
+
+  private UserIdentity createDummyUserIdentity() {
+    return new UserIdentity() {
+      @Override
+      public Subject getSubject() {
+        return null;
+      }
+
+      @Override
+      public Principal getUserPrincipal() {
+        return new UserPrincipal("username", Credential.getCredential("1234"));
+      }
+
+      @Override
+      public boolean isUserInRole(String role, Scope scope) {
+        return true;
+      }
+    };
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/KeyLoginServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/KeyLoginServiceTest.java
@@ -1,0 +1,26 @@
+package com.adaptris.core.http.jetty;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.UserPrincipal;
+import org.eclipse.jetty.util.security.Credential;
+import org.junit.jupiter.api.Test;
+
+class KeyLoginServiceTest {
+
+  @Test
+  void loadInfo() {
+    KeyLoginService loginService = new KeyLoginService("key", "1234", "role");
+    UserPrincipal userPrincipal = loginService.loadUserInfo("key");
+    assertEquals("key", userPrincipal.getName());
+    assertTrue(userPrincipal.authenticate(Credential.getCredential("1234")));
+    assertFalse(userPrincipal.authenticate(Credential.getCredential("5678")));
+    List<RolePrincipal> roles = loginService.loadRoleInfo(userPrincipal);
+    assertEquals(1, roles.size());
+    assertEquals("role", roles.get(0).getName());
+  }
+
+}


### PR DESCRIPTION
## Motivation

The custom components were used a lot but hard to maintain as not part of the Interlok distribution

## Modification

- Add ConfigurableKeySecurityHandler and its config classes
- Add tests

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.

## Result

There is a new jetty security handler that can handle keys

## Testing

That has already been tested.
The unit tests should pass.
