### PR TITLE
INTERLOK-3834: Handle most file paths

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsConsumer.java
@@ -43,13 +43,29 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * File system implementation of <code>AdaptrisMessageConsumer</code> based on the <code>com.adaptris.fs</code> package.
  * </p>
  * <p>
- * The configured <code>Destination</code> may return a string in one of two formats
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
  * </p>
  * <ul>
- * <li>If a <code>file</code> based url is used. e.g. file:///c:/path/to/my/directory or file:////path/to/my/directory then the
- * patch is considered to be fully qualified</li>
- * <li>If just a path is returned, then it is considered to be relative to the current working directory. e.g. if /opt/fred is used,
- * and the adapter is installed to /opt/adapter, then the fully qualified name is /opt/adapter/opt/fred.</li>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
  * </ul>
  * <p>
  * On windows based platforms, you should always use a file based url.

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -42,6 +42,7 @@ import com.adaptris.interlok.util.FileFilterBuilder;
 public abstract class FsHelper {
 
   private static transient Logger log = LoggerFactory.getLogger(FsHelper.class);
+  private static final String WIN_DRIVE_REGEX = "^[a-zA-Z]{1}$"; //matches an alphabetic character exactly 1 time in the string.
 
   /**
    * Go straight to a {@link File} from a url style string.
@@ -53,6 +54,8 @@ public abstract class FsHelper {
       return createFileReference(createUrlFromString(s, true));
     } catch (IllegalArgumentException e) {
       // Catch it from createUrlFromString(), since it's probably c:/file.
+      // strip out any uri scheme
+      s = s.replaceFirst("file://", "");
       return new File(s);
     }
   }
@@ -76,7 +79,11 @@ public abstract class FsHelper {
    */
   public static File createFileReference(URL url, String charset) throws UnsupportedEncodingException {
     String charSetToUse = StringUtils.defaultIfBlank(charset, System.getProperty("file.encoding"));
-    String filename = URLDecoder.decode(url.getPath(), charSetToUse);
+    StringBuilder sb = new StringBuilder();
+    // include any relative parts captured in the authority part of the URL
+    if (url.getAuthority() != null && url.getAuthority().startsWith(".")) sb.append(url.getAuthority());
+    if (url.getPath() != null) sb.append(url.getPath());
+    String filename = URLDecoder.decode(sb.toString(), charSetToUse);
     // Cope with file://localhost/./config/blah -> /./config/blah is the result of getPath()
     // Munge that properly.
     if (filename.startsWith("/.")) {
@@ -88,32 +95,16 @@ public abstract class FsHelper {
   /**
    * Creates a {@link URL} based on the passed destination.
    * <p>
-   * If a {@code scheme} is present and is equal to {@code file} then the URL is deemed to be <strong>absolute</strong> and is used
-   * as is. If the {@code scheme} is null then the URL is considered a {@code "file"} URL, and <strong>relative</strong> to the
-   * current working directory.
+   * Supports URLs with both the {@code file scheme} and without. If you define a directory without any leading slash or
+   * if it starts with a slash is deemed to be an <strong>absolute</strong> path. If "./" or "../" is used at the start of your definition then
+   * the path is deemed to be <strong>relative</strong> . This is true when using the {@code file scheme} or not.
    * </p>
    * <p>
-   * Note that this method will not convert backslashes into forward slashes, so passing in a string like {@code ..\dir\} will fail
-   * with a URISyntaxException; use {@link #createUrlFromString(String, boolean)} to convert backslashes into forward slashes prior
-   * to processing.
+   * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+   * e.g. 'c://my/path' this is also valid.
    * </p>
-   *
-   * @param s the String to convert to a URL.
-   * @return a new URL
-   * @see #createUrlFromString(String, boolean)
-   * @deprecated use {@link #createUrlFromString(String, boolean)} since 3.0.3
-   */
-  @Deprecated
-  public static URL createUrlFromString(String s) throws IOException, URISyntaxException {
-    return createUrlFromString(s, false);
-  }
-
-  /**
-   * Creates a {@link URL} based on the passed destination.
    * <p>
-   * If a {@code scheme} is present and is equal to {@code file} then the URL is deemed to be <strong>absolute</strong> and is used
-   * as is. If the {@code scheme} is null then the URL is considered a {@code "file"} URL, and <strong>relative</strong> to the
-   * current working directory.
+   * Both / and \ slashes are supported.
    * </p>
    *
    * @param s the string to convert to a URL.
@@ -145,8 +136,12 @@ public abstract class FsHelper {
       return new URL(configuredUri.toString());
     }
     else {
-      if (scheme == null) {
-        return new URL("file:///" + configuredUri.toString());
+      boolean isWinDrive = scheme != null && scheme.matches(WIN_DRIVE_REGEX);
+      if (scheme == null || isWinDrive) {
+        if (!isWinDrive && !s.startsWith(File.separator)) {
+          if (!s.startsWith(".")) return new URL("file:///./" + configuredUri);
+        }
+        return new URL("file:///" + configuredUri);
       }
       else {
         throw new IllegalArgumentException("Illegal URL [" + s + "]");

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -53,7 +53,6 @@ public abstract class FsHelper {
     try {
       return createFileReference(createUrlFromString(s, true));
     } catch (IllegalArgumentException e) {
-      // Catch it from createUrlFromString(), since it's probably c:/file.
       return new File(s);
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsHelper.java
@@ -54,8 +54,6 @@ public abstract class FsHelper {
       return createFileReference(createUrlFromString(s, true));
     } catch (IllegalArgumentException e) {
       // Catch it from createUrlFromString(), since it's probably c:/file.
-      // strip out any uri scheme
-      s = s.replaceFirst("file://", "");
       return new File(s);
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/fs/FsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/FsProducer.java
@@ -47,7 +47,34 @@ import lombok.NonNull;
 import lombok.Setter;
 
 /**
+ * <p>
  * {@link com.adaptris.core.AdaptrisMessageProducer} implementation that writes to the file system.
+ * </p>
+ * <p>
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
+ * </p>
+ * <ul>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems The above is above is true plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
+ * </ul>
  *
  * @config fs-producer
  *

--- a/interlok-core/src/main/java/com/adaptris/core/fs/NonDeletingFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/fs/NonDeletingFsConsumer.java
@@ -41,17 +41,30 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * changes.
  * </p>
  * <p>
- * The configured <code>Destination</code> may return a string in one of two formats
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
  * </p>
  * <ul>
- * <li>If a <code>file</code> based url is used. e.g. file:///c:/path/to/my/directory or file:////path/to/my/directory then the
- * patch is considered to be fully qualified</li>
- * <li>If just a path is returned, then it is considered to be relative to the current working directory. e.g. if /opt/fred is used,
- * and the adapter is installed to /opt/adapter, then the fully qualified name is /opt/adapter/opt/fred.</li>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
  * </ul>
- * <p>
- * On windows based platforms, you should always use a file based url.
- * </p>
  *
  * @config non-deleting-fs-consumer
  *

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsConsumer.java
@@ -38,11 +38,30 @@ import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
  * <p>
  * File system implementation of <code>AdaptrisMessageConsumer</code> with large message support.
  * </p>
+ * <p>
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
+ * </p>
  * <ul>
- * <li>If a <code>file</code> based url is used. e.g. file:///c:/path/to/my/directory or file:////path/to/my/directory then the
- * patch is considered to be fully qualified</li>
- * <li>If just a path is returned, then it is considered to be relative to the current working directory. e.g. if /opt/fred is used,
- * and the adapter is installed to /opt/adapter, then the fully qualified name is /opt/adapter/opt/fred.</li>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
  * </ul>
  * <p>
  * On windows based platforms, you should always use a file based url.

--- a/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/lms/LargeFsProducer.java
@@ -34,19 +34,31 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * File system implementation of <code>AdaptrisMessageProducer</code> with large message support.
  * </p>
- * *
  * <p>
- * The configured <code>Destination</code> may return a string in one of two formats
+ * The configured <code>Base Directory URL</code> may return a string in one of two formats
  * </p>
  * <ul>
- * <li>If a <code>file</code> based url is used. e.g. file:///c:/path/to/my/directory or file:////path/to/my/directory then the
- * patch is considered to be fully qualified</li>
- * <li>If just a path is returned, then it is considered to be relative to the current working directory. e.g. if /opt/fred is used,
- * and the adapter is installed to /opt/adapter, then the fully qualified name is /opt/adapter/opt/fred.</li>
+ * <li>
+ * Supports URLs with both the {@code file scheme} and without.
+ * </li>
+ * <li>
+ * If you define a directory without any leading slash or
+ * if it starts with a slash is deemed to be an <strong>absolute</strong> path.
+ * </li>
+ * <li>
+ * If "./" or "../" is used at the start of your definition then
+ * the path is deemed to be <strong>relative</strong>.</li>
+ * <li>
+ * This is true whether using the {@code file scheme} or not.
+ * </li>
+ * <li>
+ * With Windows systems the above is above is true, plus if you simply define the <strong>absolute</strong> path including the drive letter
+ * e.g. 'c://my/path' this is also valid.
+ * </li>
+ * <li>
+ * Both / and \ slashes are supported.
+ * </li>
  * </ul>
- * <p>
- * On windows based platforms, you should always use a file based url.
- * </p>
  * <p>
  * Additionally the behaviour of this consumer is subtly different from the standard {@link FsProducer} :
  * </p>

--- a/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
@@ -121,8 +121,11 @@ public class FsHelperTest extends FsHelper {
     File f5 = FsHelper.toFile("./build.gradle");
     assertEquals("build.gradle", f4.getName());
     // will be "."
-    assertNotNull(f4.getParentFile());
-    assertNull(f4.getParentFile().getParentFile());
+    assertNotNull(f5.getParentFile());
+    assertNull(f5.getParentFile().getParentFile());
+
+    File f6 = FsHelper.toFile("http://localhost/./fred");
+    assertEquals("fred", f6.getName());
   }
 
 

--- a/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/fs/FsHelperTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
+import java.util.List;
 
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.oro.io.AwkFilenameFilter;
@@ -41,30 +42,36 @@ public class FsHelperTest extends FsHelper {
 
   @Test
   public void testUnixStyleFullURI() throws Exception {
-    assertNotNull(FsHelper.createUrlFromString("file:////home/fred"));
+    assertNotNull(FsHelper.createUrlFromString("file:////home/fred", true));
   }
 
   @Test
-  public void testUnixStyleURI() throws Exception {
-    URL url = FsHelper.createUrlFromString("/home/fred");
+  public void testUnixStyleAbsoluteURI() throws Exception {
+    URL url = FsHelper.createUrlFromString("/home/fred", true);
+    assertEquals("fred", new File(url.toURI()).getName());
+  }
+
+  @Test
+  public void testUnixStyleRelativeURI() throws Exception {
+    URL url = FsHelper.createUrlFromString("./home/fred", true);
     assertEquals("fred", new File(url.toURI()).getName());
   }
 
   @Test
   public void testWindowsFullURI() throws Exception {
-    URL url = FsHelper.createUrlFromString("file:///c:/home/fred");
+    URL url = FsHelper.createUrlFromString("file:///c:/home/fred", true);
     assertEquals("fred", new File(url.toURI()).getName());
   }
 
   @Test
   public void testFullURIWithColons() throws Exception {
-    URL url = FsHelper.createUrlFromString("file:///c:/home/fred/d:/home/fred");
+    URL url = FsHelper.createUrlFromString("file:///c:/home/fred/d:/home/fred", true);
     assertEquals("fred", new File(url.toURI()).getName());
   }
 
   @Test
   public void testCreateFileRef() throws Exception {
-    URL url = FsHelper.createUrlFromString("file:///home/fred");
+    URL url = FsHelper.createUrlFromString("file:///home/fred", true);
     assertEquals(new File("/home/fred"), FsHelper.createFileReference(url));
     assertEquals(new File("/home/fred"), FsHelper.createFileReference(url, "UTF-8"));
   }
@@ -72,7 +79,7 @@ public class FsHelperTest extends FsHelper {
   @Test
   public void testCreateFileRefWithSpaces() throws Exception {
     URL url = FsHelper
-        .createUrlFromString("file:///home/directory%20with/some/spaces");
+        .createUrlFromString("file:///home/directory%20with/some/spaces", true);
     File f = FsHelper.createFileReference(url);
     assertEquals(new File("/home/directory with/some/spaces"), f);
   }
@@ -85,13 +92,8 @@ public class FsHelperTest extends FsHelper {
 
   @Test
   public void testWindowsURI() throws Exception {
-    try {
-      FsHelper.createUrlFromString("c:/home/fred");
-    }
-    catch (IllegalArgumentException e) {
-      // This is expected. as c:/home/fred is in fact wrong.
-      // Other exceptions are not falid though.
-    }
+    URL url = FsHelper.createUrlFromString("c:/home/fred", true);
+    assertEquals("fred", new File(url.toURI()).getName());
   }
 
   @Test
@@ -125,10 +127,24 @@ public class FsHelperTest extends FsHelper {
 
 
   @Test
-  public void testRelativeURL() throws Exception {
-    File f = FsHelper.toFile("file://localhost/./fred");
-    assertEquals("fred", f.getName());
-    assertEquals("." + File.separator + "fred", f.getPath());
+  public void testRelativeAndOtherURLs() throws Exception {
+    for (List<String> data : List.of(
+            List.of("exceptions/duplicate", "duplicate", "." + File.separator + "exceptions" + File.separator + "duplicate"),
+            List.of("./exceptions/duplicate", "duplicate", "." + File.separator + "exceptions" + File.separator + "duplicate"),
+            List.of("../exceptions/duplicate", "duplicate", ".." + File.separator + "exceptions" + File.separator + "duplicate"),
+            List.of("file://localhost/./fred", "fred", "." + File.separator + "fred"),
+            List.of("file://localhost/./fred/wilma", "wilma", "." + File.separator + "fred" + File.separator + "wilma"),
+            List.of("file:./a/b.xml", "b.xml", "." + File.separator + "a" + File.separator + "b.xml"),
+            List.of("file://./a1/b1.xml", "b1.xml", "." + File.separator + "a1" + File.separator + "b1.xml"),
+            List.of("file://../a2/b2.xml", "b2.xml", ".." + File.separator + "a2" + File.separator + "b2.xml"),
+            List.of("file:///./a3/b3.xml", "b3.xml", "." + File.separator + "a3" + File.separator + "b3.xml"),
+            List.of("file:///a4/b4.xml", "b4.xml", File.separator + "a4" + File.separator + "b4.xml"),
+            List.of("file:////a5/b5.xml", "b5.xml", File.separator + "a5" + File.separator + "b5.xml")
+    )) {
+      File f = FsHelper.toFile(data.get(0));
+      assertEquals(data.get(1), f.getName());
+      assertEquals(data.get(2), f.getPath());
+    }
   }
 
   @Test
@@ -148,18 +164,37 @@ public class FsHelperTest extends FsHelper {
     String urlString3 = "../dir/";
     URL url3 = FsHelper.createUrlFromString(urlString3, true);
     assertTrue("file".equals(url3.getProtocol()));
+    assertTrue("/../dir/".equals(url3.getPath()));
+
+    String urlString4 = "..\\dir\\";
+    URL url4 = FsHelper.createUrlFromString(urlString4, true);
+    assertTrue("file".equals(url4.getProtocol()));
+    assertTrue("/../dir/".equals(url4.getPath()));
+
+    String urlString5 = "c:\\dir\\";
+    URL url5 = FsHelper.createUrlFromString(urlString5, true);
+    assertTrue("file".equals(url5.getProtocol()));
+    assertEquals("/c:/dir/", url5.getPath());
+
+    String urlString6 = "D:\\dir\\";
+    URL url6 = FsHelper.createUrlFromString(urlString6, true);
+    assertTrue("file".equals(url6.getProtocol()));
+    assertEquals("/D:/dir/", url6.getPath());
 
     tryExpectingException(() -> {
-      FsHelper.createUrlFromString("..\\dir\\");
+      FsHelper.createUrlFromString("..\\dir\\", false);
     });
     tryExpectingException(() -> {
-      FsHelper.createUrlFromString("c:\\dir\\");
+      FsHelper.createUrlFromString("c:\\dir\\", false);
     });
     tryExpectingException(() -> {
-      FsHelper.createUrlFromString("http://file/");
+      FsHelper.createUrlFromString("http://file/", true);
     });
     tryExpectingException(() -> {
-      FsHelper.createUrlFromString("file:\\\file\\");
+      FsHelper.createUrlFromString("5://file/", true);
+    });
+    tryExpectingException(() -> {
+      FsHelper.createUrlFromString("file:\\\file\\", true);
     });
     tryExpectingException(() -> {
       FsHelper.createUrlFromString(null, true);


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-3834

## Modification

Mostly FsHelper.java where the logic update was, other classes comments were changed as per https://github.com/adaptris/interlok/pull/1194

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Support URLs such as:
"exceptions/duplicate"
"./exceptions/duplicate"
"../exceptions/duplicate"
"file://localhost/./fred"
"file://localhost/./fred/wilma"
"file:./a/b.xml"
"file://./a1/b1.xml"
"file://../a2/b2.xml"
"file:///./a3/b3.xml"
"file:///a4/b4.xml"
"file:////a5/b5.xml"

## Testing

Run FsHelperTest.java
