### PR TITLE
Message Splitter which keep parent node

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathMessageSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathMessageSplitter.java
@@ -18,6 +18,9 @@ package com.adaptris.core.services.splitter;
 
 import static com.adaptris.core.util.XmlHelper.createDocument;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
@@ -25,6 +28,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -74,7 +78,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @author sellidge
  */
 @XStreamAlias("xpath-message-splitter")
-@DisplayOrder(order = {"xpath", "encoding", "copyMetadata", "copyObjectMetadata", "namespaceContext", "xmlDocumentFactoryConfig"})
+@DisplayOrder(order = {"xpath", "encoding", "copyMetadata", "copyObjectMetadata", "retainBranchNodes", "namespaceContext", "xmlDocumentFactoryConfig"})
 public class XpathMessageSplitter extends MessageSplitterImp {
 
   @NotBlank
@@ -85,6 +89,8 @@ public class XpathMessageSplitter extends MessageSplitterImp {
   private KeyValuePairSet namespaceContext;
   @AdvancedConfig(rare = true)
   private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
+  @AdvancedConfig(rare = true)
+  private boolean retainBranchNodes = false;
 
   public XpathMessageSplitter() {
     this(null, null);
@@ -186,6 +192,18 @@ public class XpathMessageSplitter extends MessageSplitterImp {
     this.xmlDocumentFactoryConfig = xml;
   }
 
+  public boolean isRetainBranchNodes() {
+    return retainBranchNodes;
+  }
+
+  /**
+   * Sets whether to retain the branch nodes
+   * @param retainBranchNodes
+   */
+  public void setRetainBranchNodes(boolean retainBranchNodes) {
+    this.retainBranchNodes = retainBranchNodes;
+  }
+
   DocumentBuilderFactoryBuilder documentFactoryBuilder() {
     return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
   }
@@ -217,13 +235,58 @@ public class XpathMessageSplitter extends MessageSplitterImp {
       nodeListIndex = 0;
     }
 
+    /**
+     * Depending on the value of retainBranchNodes, it will return the imported root node
+     * without any parent nodes included, or with parent nodes and their siblings included.
+     * @param document
+     * @param node
+     * @return
+     */
+    private Node buildRootNode(Document document, Node node) {
+      Node root = null;
+      if (isRetainBranchNodes()) {
+        Node ptr = node;
+        List<Node> l = new LinkedList<>();
+        while (ptr != null && ptr.getNodeType() == Node.ELEMENT_NODE) {
+          l.add(ptr);
+          ptr = ptr.getParentNode();
+        }
+        Collections.reverse(l);
+        Node prev = null;
+        for (Node curr : l) {
+          Node created;
+          if (curr.equals(node)) {
+            created = document.importNode(curr, true);
+          } else {
+            created = document.createElement(curr.getNodeName());
+          }
+          if (prev != null) {
+            for (Node prevSibling = curr.getPreviousSibling(); prevSibling != null; prevSibling = prevSibling.getPreviousSibling()) {
+              prev.appendChild(document.importNode(prevSibling, true));
+            }
+            prev.appendChild(created);
+            for (Node nextSibling = curr.getNextSibling(); nextSibling != null; nextSibling = nextSibling.getNextSibling()) {
+              prev.appendChild(document.importNode(nextSibling, true));
+            }
+          } else {
+            root = created;
+          }
+          prev = created;
+        }
+      } else {
+        root = document.importNode(node, true);
+      }
+      return root;
+    }
+
     @Override
     protected AdaptrisMessage constructAdaptrisMessage() throws Exception {
       if (nodeListIndex < nodeList.getLength()) {
         Node e = nodeList.item(nodeListIndex);
         Document splitXmlDoc = docBuilder.newDocument();
         Node dup = splitXmlDoc.importNode(e, true);
-        splitXmlDoc.appendChild(dup);
+        Node root = buildRootNode(splitXmlDoc, e);
+        splitXmlDoc.appendChild(root);
         AdaptrisMessage splitMsg = factory.newMessage("", encoding);
         XmlHelper.writeXmlDocument(splitXmlDoc, splitMsg, encoding);
         copyMetadata(msg, splitMsg);

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathMessageSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathMessageSplitter.java
@@ -90,7 +90,7 @@ public class XpathMessageSplitter extends MessageSplitterImp {
   @AdvancedConfig(rare = true)
   private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
   @AdvancedConfig(rare = true)
-  private boolean retainBranchNodes = false;
+  private Boolean retainBranchNodes = null;
 
   public XpathMessageSplitter() {
     this(null, null);
@@ -193,14 +193,14 @@ public class XpathMessageSplitter extends MessageSplitterImp {
   }
 
   public boolean isRetainBranchNodes() {
-    return retainBranchNodes;
+    return Boolean.TRUE.equals(retainBranchNodes);
   }
 
   /**
    * Sets whether to retain the branch nodes
    * @param retainBranchNodes
    */
-  public void setRetainBranchNodes(boolean retainBranchNodes) {
+  public void setRetainBranchNodes(Boolean retainBranchNodes) {
     this.retainBranchNodes = retainBranchNodes;
   }
 
@@ -261,12 +261,20 @@ public class XpathMessageSplitter extends MessageSplitterImp {
             created = document.createElement(curr.getNodeName());
           }
           if (prev != null) {
-            for (Node prevSibling = curr.getPreviousSibling(); prevSibling != null; prevSibling = prevSibling.getPreviousSibling()) {
-              prev.appendChild(document.importNode(prevSibling, true));
+            if (!curr.equals(node)) {
+              for (Node prevSibling = curr.getPreviousSibling(); prevSibling != null; prevSibling = prevSibling.getPreviousSibling()) {
+                if (prevSibling.getNodeType() == Node.ELEMENT_NODE) {
+                  prev.appendChild(document.importNode(prevSibling, true));
+                }
+              }
             }
             prev.appendChild(created);
-            for (Node nextSibling = curr.getNextSibling(); nextSibling != null; nextSibling = nextSibling.getNextSibling()) {
-              prev.appendChild(document.importNode(nextSibling, true));
+            if (!curr.equals(node)) {
+              for (Node nextSibling = curr.getNextSibling(); nextSibling != null; nextSibling = nextSibling.getNextSibling()) {
+                if (nextSibling.getNodeType() == Node.ELEMENT_NODE) {
+                  prev.appendChild(document.importNode(nextSibling, true));
+                }
+              }
             }
           } else {
             root = created;

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathMessageSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/XpathMessageSplitter.java
@@ -28,7 +28,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -192,7 +191,7 @@ public class XpathMessageSplitter extends MessageSplitterImp {
     this.xmlDocumentFactoryConfig = xml;
   }
 
-  public boolean isRetainBranchNodes() {
+  public boolean getRetainBranchNodes() {
     return Boolean.TRUE.equals(retainBranchNodes);
   }
 
@@ -244,7 +243,7 @@ public class XpathMessageSplitter extends MessageSplitterImp {
      */
     private Node buildRootNode(Document document, Node node) {
       Node root = null;
-      if (isRetainBranchNodes()) {
+      if (getRetainBranchNodes()) {
         Node ptr = node;
         List<Node> l = new LinkedList<>();
         while (ptr != null && ptr.getNodeType() == Node.ELEMENT_NODE) {
@@ -292,7 +291,6 @@ public class XpathMessageSplitter extends MessageSplitterImp {
       if (nodeListIndex < nodeList.getLength()) {
         Node e = nodeList.item(nodeListIndex);
         Document splitXmlDoc = docBuilder.newDocument();
-        Node dup = splitXmlDoc.importNode(e, true);
         Node root = buildRootNode(splitXmlDoc, e);
         splitXmlDoc.appendChild(root);
         AdaptrisMessage splitMsg = factory.newMessage("", encoding);

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitterCase.java
@@ -50,6 +50,23 @@ public abstract class SplitterCase extends SplitterServiceExample {
       + System.lineSeparator() + "</envelope>";
   public static final String LINE = "The quick brown fox jumps over the lazy dog";
 
+  public static final String XML_MESSAGE_WITH_SIBLINGS = """
+          <?xml version ="1.0" encoding="UTF-8"?>
+            <envelope>
+              <header>
+                <po>123123</po>
+              </header>
+              <body>
+                <document>one</document>
+                <document>two</document>
+                <document>three</document>
+              </body>
+              <trailer>
+                <x>123</x>
+              </trailer>
+            </envelope>
+          """;
+
 
   public static final String XML_WITH_DOCTYPE = "<?xml version=\"1.0\"?>\n" + "<!DOCTYPE document [\n"
       + "<!ENTITY LOCAL_ENTITY 'entity'>\n" + "<!ENTITY % StandardInfo SYSTEM \"../StandardInfo.dtd\">\n" + "%StandardInfo;\n"

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitterCase.java
@@ -57,9 +57,9 @@ public abstract class SplitterCase extends SplitterServiceExample {
                 <po>123123</po>
               </header>
               <body>
-                <document>one</document>
-                <document>two</document>
-                <document>three</document>
+                <document>1</document>
+                <document>2</document>
+                <document>3</document>
               </body>
               <trailer>
                 <x>123</x>

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathSplitterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathSplitterTest.java
@@ -168,6 +168,7 @@ public class XpathSplitterTest extends SplitterCase {
     }
     assertEquals(3, count);
 
+    // test with retainBranchNodes = true
     splitter = new XpathMessageSplitter("/envelope/body/document");
     splitter.setRetainBranchNodes(true);
     count = 0;

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathSplitterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathSplitterTest.java
@@ -167,18 +167,22 @@ public class XpathSplitterTest extends SplitterCase {
       }
     }
     assertEquals(3, count);
+  }
 
-    // test with retainBranchNodes = true
-    splitter = new XpathMessageSplitter("/envelope/body/document");
-    splitter.setRetainBranchNodes(true);
-    count = 0;
-    msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_MESSAGE_WITH_SIBLINGS);
+  @Test
+  public void testSplitRetainBranchNodes() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(XML_MESSAGE_WITH_SIBLINGS);
+    String obj = "ABCDEFG";
     msg.addObjectHeader(obj, obj);
+    XpathMessageSplitter splitter = new XpathMessageSplitter("/envelope/body/document");
+    splitter.setRetainBranchNodes(true);
+    XmlUtils xml = new XmlUtils();
+    int count = 0;
     try (CloseableIterable<AdaptrisMessage> closeable = splitter.splitMessage(msg)) {
       for (AdaptrisMessage m : closeable) {
         assertFalse(m.getObjectHeaders().containsKey(obj));
         xml.setSource(new ByteArrayInputStream(m.getPayload()));
-        assertNotNull(xml.getSingleNode("/envelope/body/document"));
+        assertEquals(xml.getSingleNode("/envelope/body/document/text()").getNodeValue(), String.valueOf(count+1));
         assertNotNull(xml.getSingleNode("/envelope/header/po"));
         assertNotNull(xml.getSingleNode("/envelope/trailer/x"));
         xml.reset();

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathSplitterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/XpathSplitterTest.java
@@ -182,6 +182,7 @@ public class XpathSplitterTest extends SplitterCase {
       for (AdaptrisMessage m : closeable) {
         assertFalse(m.getObjectHeaders().containsKey(obj));
         xml.setSource(new ByteArrayInputStream(m.getPayload()));
+        assertEquals(xml.getNodeList("/envelope/body/document").getLength(), 1);
         assertEquals(xml.getSingleNode("/envelope/body/document/text()").getNodeValue(), String.valueOf(count+1));
         assertNotNull(xml.getSingleNode("/envelope/header/po"));
         assertNotNull(xml.getSingleNode("/envelope/trailer/x"));


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-4469

## Modification

Added a flag on XpathMessageSplitter called "retainBranchNodes" which will retain the split node's parents and their siblings right up to the root node.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result
For a document:
<?xml version ="1.0" encoding="UTF-8"?>
            <envelope>
              <header>
                <po>123123</po>
              </header>
              <body>
                <document>one</document>
                <document>two</document>
                <document>three</document>
              </body>
              <trailer>
                <x>123</x>
              </trailer>
            </envelope>

When the flag = true, the split will end up as:

<?xml version ="1.0" encoding="UTF-8"?>
            <envelope>
              <header>
                <po>123123</po>
              </header>
              <body>
                <document>one</document>
              </body>
              <trailer>
                <x>123</x>
              </trailer>
            </envelope>

<?xml version ="1.0" encoding="UTF-8"?>
            <envelope>
              <header>
                <po>123123</po>
              </header>
              <body>
                <document>two</document>
              </body>
              <trailer>
                <x>123</x>
              </trailer>
            </envelope>

<?xml version ="1.0" encoding="UTF-8"?>
            <envelope>
              <header>
                <po>123123</po>
              </header>
              <body>
                <document>three</document>
              </body>
              <trailer>
                <x>123</x>
              </trailer>
            </envelope>

## Testing

See XpathSplitterTest.testSplit()
