### PR TITLE
INTERLOK-4498: Fix issue with ConfigurableEventHandler

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/RegexEventMatcher.java
+++ b/interlok-core/src/main/java/com/adaptris/core/RegexEventMatcher.java
@@ -40,8 +40,6 @@ public class RegexEventMatcher implements EventMatcher {
     @XStreamImplicit(itemFieldName = "match-type")
     private Set<String> matchTypes;
 
-    private transient Set<EventMatchType> matchTypeEnumSet;
-
     private transient Pattern compiledRegex;
 
     public RegexEventMatcher() {
@@ -56,7 +54,6 @@ public class RegexEventMatcher implements EventMatcher {
 
     public void setRegex(String regex) {
         this.regex = regex;
-        this.compiledRegex = Pattern.compile(regex);
     }
 
     public String getRegex() {
@@ -68,12 +65,19 @@ public class RegexEventMatcher implements EventMatcher {
     }
 
     public void setMatchTypes(Set<String> matchTypes) {
-        this.matchTypeEnumSet = matchTypes.stream().map(EventMatchType::valueOf).collect(Collectors.toSet());
         this.matchTypes = matchTypes;
+    }
+
+    private void compileRegexIfRequired() {
+        if (compiledRegex == null || !compiledRegex.pattern().equals(regex)) {
+            this.compiledRegex = Pattern.compile(regex);
+        }
     }
 
     @Override
     public boolean matches(Event event) {
+        Set<EventMatchType> matchTypeEnumSet = matchTypes.stream().map(EventMatchType::valueOf).collect(Collectors.toSet());
+        compileRegexIfRequired();
         for (EventMatchType matchType : matchTypeEnumSet) {
             if (compiledRegex.matcher((String) matchType.getProperty(event)).matches()) return true;
         }


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-4498

## Modification

Fix ConfigurableEventHandler logic based on xstream unmarshalling

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user

## Testing

How can I test this if I'm reviewing this.
