### PR TITLE
INTERLOK-4509: Add toggle for outputting text content only

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/path/XPathService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/path/XPathService.java
@@ -32,16 +32,13 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
+import com.adaptris.annotation.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import com.adaptris.annotation.AdapterComponent;
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.AutoPopulated;
-import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
@@ -210,6 +207,10 @@ public class XPathService extends ServiceImp {
   @Valid
   private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
 
+  @AdvancedConfig(rare = true)
+  @InputFieldDefault(value = "false")
+  private Boolean textOnly; // will force the output to be the text content of the node
+
   public XPathService() {
     this.setExecutions(new ArrayList<Execution>());
     this.setXmlSource(new StringPayloadDataInputParameter());
@@ -255,7 +256,11 @@ public class XPathService extends ServiceImp {
     Transformer transformer = TransformerFactory.newInstance().newTransformer();
     transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
     if (source.getNode().getNodeType() != Node.ATTRIBUTE_NODE) {
-      transformer.transform(source, xmlOutput);
+      if (!Boolean.TRUE.equals(textOnly)) {
+        transformer.transform(source, xmlOutput);
+      } else {
+        stringWriter.write(source.getNode().getTextContent());
+      }
     } else {
       stringWriter.write(source.getNode().getNodeValue());
     }
@@ -306,6 +311,14 @@ public class XPathService extends ServiceImp {
 
   public void setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder xml) {
     this.xmlDocumentFactoryConfig = xml;
+  }
+
+  public Boolean getTextOnly() {
+    return textOnly;
+  }
+
+  public void setTextOnly(Boolean textOnly) {
+    this.textOnly = textOnly;
   }
 
   DocumentBuilderFactoryBuilder documentFactoryBuilder(NamespaceContext namespaceCtx) {

--- a/interlok-core/src/test/java/com/adaptris/core/services/path/XPathServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/path/XPathServiceTest.java
@@ -86,6 +86,30 @@ public class XPathServiceTest
   }
 
   @Test
+  public void testPayloadSimpleValueXPathIntoMetadataTextOnly() throws Exception {
+    message.setContent(sampleXml, message.getContentEncoding());
+
+    MetadataDataOutputParameter metadataDataDestination1 = new MetadataDataOutputParameter("targetMetadataKey");
+
+    ConstantDataInputParameter constantDataDestination = new ConstantDataInputParameter("//some/random/xml/node2");
+
+    Execution execution = new Execution(constantDataDestination, metadataDataDestination1);
+
+    List<Execution> executions = new ArrayList<>();
+    executions.add(execution);
+
+    service.setXmlSource(new StringPayloadDataInputParameter());
+    service.setExecutions(executions);
+    execute(service, message);
+
+    assertEquals("<node2>value2</node2>", message.getMetadataValue("targetMetadataKey"));
+
+    service.setTextOnly(true);
+    execute(service, message);
+    assertEquals("value2", message.getMetadataValue("targetMetadataKey"));
+  }
+
+  @Test
   public void testPayloadAttributeValueXPathIntoMetadata() throws Exception {
     message.setContent(sampleXml, message.getContentEncoding());
 


### PR DESCRIPTION
## Motivation
https://adaptris.atlassian.net/browse/INTERLOK-4509

## Modification

- XPathService (add toggle for text only output)
- XPathServiceTest

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result
Users can add a <text-only>true</text-only> on the service to force output of text content.

<xpath-service>
	<unique-id>ExtractToMetadata</unique-id>
	<xml-source class="multi-payload-string-input-parameter">
	  <payload-id>xml-payload</payload-id>
	</xml-source>
        **<text-only>true</text-only>**
	<xpath-execution>
	  <source class="metadata-data-input-parameter">
		<metadata-key>xpath</metadata-key>
	  </source>
	  <target class="metadata-data-output-parameter">
		<metadata-key>result</metadata-key>
	  </target>
	</xpath-execution>
</xpath-service>

## Testing

See XPathServiceTest.testPayloadSimpleValueXPathIntoMetadataTextOnly()
