### PR TITLE
Feature/interlok 4511

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/BytesSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/BytesSplitter.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.services.splitter;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.interlok.util.CloseableIterable;
+import com.adaptris.util.NumberUtils;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.*;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * <p>
+ * Split an AdaptrisMessage object based on bytes. Specify the <code>splitUnit</code> to be "BYTE" if splitting by number of bytes.
+ * Specify the <code>splitUnit</code> to be "CHUNK" if splitting into chunks of equal bytes (subject to rounding).
+ * <code>splitSize</code> controls the number of bytes/chunks to split by. <code>retainedSplits</code> can be specified to
+ * control the maximum number of splits to retain (defaults to 1). Specify -1 to retain all splits.
+ * </p>
+ * 
+ * @config bytes-splitter
+ */
+@XStreamAlias("bytes-splitter")
+@DisplayOrder(order = {"splitSize",  "splitUnit", "retainedSplits", "copyMetadata", "copyObjectMetadata"})
+public class BytesSplitter extends MessageSplitterImp {
+
+  private static final int DEFAULT_SPLIT = 10*1024*1024;
+  private static final int DEFAULT_RETAINED_SPLITS = 1;
+  private static final SplitUnit DEFAULT_SPLIT_UNIT = SplitUnit.BYTE;
+  public static final int RETAIN_ALL_SPLITS = -1;
+
+  @InputFieldDefault(value = "1")
+  private Integer retainedSplits = DEFAULT_RETAINED_SPLITS;
+  @InputFieldDefault(value = "10")
+  private Integer splitSize = DEFAULT_SPLIT;
+  @InputFieldDefault(value = "BYTE")
+  private String splitUnit;
+
+  public enum SplitUnit {
+    BYTE,
+    CHUNK
+  }
+
+  public BytesSplitter() {
+
+  }
+
+  public BytesSplitter(Integer splitSize) {
+    this();
+    setSplitSize(splitSize);
+  }
+
+  @Override
+  public CloseableIterable<AdaptrisMessage> splitMessage(final AdaptrisMessage msg) throws CoreException {
+    SplitUnit _splitUnit = splitUnit();
+    logR.trace("BytesSplitter splits into {} {}(s)", splitSize(), _splitUnit);
+    int chunkSize = _splitUnit == SplitUnit.CHUNK ? new BigDecimal(msg.getSize()).divide(new BigDecimal(splitSize), RoundingMode.HALF_UP).setScale(0, RoundingMode.HALF_UP).intValue() : splitSize;
+    try (InputStream is = msg.getInputStream()) {
+      return new BytesSplitGenerator(is, chunkSize, msg, selectFactory(msg));
+    } catch (IOException e) {
+      throw new CoreException(e);
+    }
+  }
+
+  public Integer getSplitSize() {
+    return splitSize;
+  }
+
+  public void setSplitSize(Integer splitSize) {
+    this.splitSize = splitSize;
+  }
+
+  public int splitSize() {
+    return splitSize != null ? splitSize : DEFAULT_SPLIT;
+  }
+
+  public String getSplitUnit() {
+    return splitUnit;
+  }
+
+  public void setSplitUnit(String splitUnit) {
+    this.splitUnit = splitUnit;
+  }
+
+  public SplitUnit splitUnit() {
+    return !StringUtils.isEmpty(splitUnit) ? SplitUnit.valueOf(splitUnit) : DEFAULT_SPLIT_UNIT;
+  }
+
+  public Integer getRetainedSplits() {
+    return retainedSplits;
+  }
+
+  public void setRetainedSplits(Integer retainedSplits) {
+    if (retainedSplits != null && retainedSplits >= RETAIN_ALL_SPLITS) this.retainedSplits = retainedSplits;
+    else this.retainedSplits = DEFAULT_RETAINED_SPLITS;
+  }
+
+  /**
+   * Read the BufferedReader line by line and return each line as an
+   * AdaptrisMessage. This implementation is NOT thread safe or reentrant!
+   */
+  private class BytesSplitGenerator extends SplitMessageIterator {
+    private int numberOfMessages;
+    private InputStream is;
+    private int chunkSize;
+
+    public BytesSplitGenerator(InputStream is, int chunkSize, AdaptrisMessage msg, AdaptrisMessageFactory factory) {
+      super(msg, factory);
+      this.is = is;
+      this.chunkSize = chunkSize;
+      logR.trace("Using message factory: {}", factory.getClass());
+    }
+
+    @Override
+    protected AdaptrisMessage constructAdaptrisMessage() throws IOException {
+      if (retainedSplits != RETAIN_ALL_SPLITS && numberOfMessages >= retainedSplits) return null;
+
+      AdaptrisMessage tmpMessage = factory.newMessage();
+      try (OutputStream os = tmpMessage.getOutputStream()) {
+        logR.trace("Working on split {}", numberOfMessages);
+        byte[] chunk = new byte[chunkSize];
+        int read = IOUtils.read(is, chunk);
+        if (read == 0) return null;
+        os.write(chunk, 0, read);
+      }
+
+      numberOfMessages++;
+      copyMetadata(msg, tmpMessage);
+      return tmpMessage;
+    }
+
+    @Override
+    public void close() throws IOException {
+      logR.trace("Split gave {} messages", numberOfMessages);
+    }
+
+  };
+
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/BytesSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/BytesSplitter.java
@@ -53,7 +53,7 @@ public class BytesSplitter extends MessageSplitterImp {
 
   @InputFieldDefault(value = "1")
   private Integer retainedSplits = DEFAULT_RETAINED_SPLITS;
-  @InputFieldDefault(value = "10")
+  @InputFieldDefault(value = "10485760")
   private Integer splitSize = DEFAULT_SPLIT;
   @InputFieldDefault(value = "BYTE")
   private String splitUnit;

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/BytesSplitterTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/BytesSplitterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.services.splitter;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.DefaultMessageFactory;
+import com.adaptris.core.Service;
+import com.adaptris.core.stubs.MockMessageProducer;
+import com.adaptris.core.stubs.StubMessageFactory;
+import com.adaptris.interlok.util.CloseableIterable;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Reader;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BytesSplitterTest extends SplitterCase {
+
+  private AdaptrisMessage msg;
+  private MockMessageProducer producer;
+  private BasicMessageSplitterService service;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    msg = createBytesMessageInput(new byte[50*1024*1024]);
+    producer = new MockMessageProducer();
+    service = createBasic(new BytesSplitter());
+    service.setProducer(producer);
+  }
+
+  @Override
+  protected BytesSplitter createSplitterForTests() {
+    return new BytesSplitter();
+  }
+
+  @Test
+  public void testSetMessageFactory() throws Exception {
+    MessageSplitterImp splitter = createSplitterForTests();
+    assertNull(splitter.getMessageFactory());
+    assertEquals(DefaultMessageFactory.class, splitter.selectFactory(new DefaultMessageFactory().newMessage()).getClass());
+
+    splitter.setMessageFactory(new StubMessageFactory());
+    assertEquals(StubMessageFactory.class, splitter.getMessageFactory().getClass());
+    assertEquals(StubMessageFactory.class, splitter.selectFactory(new DefaultMessageFactory().newMessage()).getClass());
+
+    splitter.setMessageFactory(null);
+    assertEquals(DefaultMessageFactory.class, splitter.selectFactory(new DefaultMessageFactory().newMessage()).getClass());
+    assertEquals(StubMessageFactory.class, splitter.selectFactory(new StubMessageFactory().newMessage()).getClass());
+  }
+
+  @Test
+  public void testDefaultSplit() throws Exception {
+    BytesSplitter s = new BytesSplitter();
+    List<AdaptrisMessage> msgs = toList(s.splitMessage(msg));
+    assertEquals(1, msgs.size());
+  }
+
+  @Test
+  public void testRetainAllSplit() throws Exception {
+    BytesSplitter s = new BytesSplitter();
+    s.setRetainedSplits(BytesSplitter.RETAIN_ALL_SPLITS);
+    List<AdaptrisMessage> msgs = toList(s.splitMessage(msg));
+    assertEquals(5, msgs.size());
+  }
+
+  @Test
+  public void testChunkSplit() throws Exception {
+    BytesSplitter s = new BytesSplitter();
+    s.setRetainedSplits(BytesSplitter.RETAIN_ALL_SPLITS);
+    s.setSplitUnit(BytesSplitter.SplitUnit.CHUNK.name());
+    s.setSplitSize(5);
+    List<AdaptrisMessage> msgs = toList(s.splitMessage(msg));
+    assertEquals(5, msgs.size());
+    msgs.forEach(msg -> assertEquals(10*1024*1024, msg.getSize()));
+  }
+
+  @Test
+  public void testChunkSplitRounding() throws Exception {
+    BytesSplitter s = new BytesSplitter();
+    s.setRetainedSplits(BytesSplitter.RETAIN_ALL_SPLITS);
+    s.setSplitUnit(BytesSplitter.SplitUnit.CHUNK.name());
+    s.setSplitSize(3);
+    List<AdaptrisMessage> msgs = toList(s.splitMessage(msg));
+    assertEquals(3, msgs.size());
+    assertEquals(17476267, msgs.get(0).getSize());
+    assertEquals(17476267, msgs.get(1).getSize());
+    assertEquals(17476266, msgs.get(2).getSize());
+
+  }
+
+  @Override
+  protected String createBaseFileName(Object object) {
+    return super.createBaseFileName(object) + "-BytesSplitter";
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    return null; // over-rides retrieveServices below instead
+  }
+
+  @Override
+  protected List<Service> retrieveObjectsForSampleConfig() {
+    return createExamples(new BytesSplitter());
+  }
+
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitterCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/splitter/SplitterCase.java
@@ -141,6 +141,11 @@ public abstract class SplitterCase extends SplitterServiceExample {
         out.toByteArray());
   }
 
+  public static AdaptrisMessage createBytesMessageInput(byte[] bytes) {
+    return AdaptrisMessageFactory.getDefaultInstance().newMessage(
+            bytes);
+  }
+
   @Test
   public void testSetMessageFactory() throws Exception {
     MessageSplitterImp splitter = createSplitterForTests();


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-4511

## Modification

- Added BytesSplitter
- Added BytesSplitterTest

## PR Checklist

- [x] been self-reviewed.
- [x ] Added javadocs for most classes and all non-trivial methods
- [ x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

I’ve opted to go with the split message method and introduced either splitting by number of bytes (called BytesSplitter), or number of chunks (of equal byte size). The user can specify the number of retained splits also.

So to truncate the payload to 500kb:

- splitUnit: “BYTE”
- splitSize: 512000
- retainedSplits: 1

## Testing

Run BytesSplitterTest
