### PR TITLE
removed the default message encoding of utf-8

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadMessageFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadMessageFactory.java
@@ -53,7 +53,7 @@ public class MultiPayloadMessageFactory extends AdaptrisMessageFactory {
   private static final Logger log = LoggerFactory.getLogger(MultiPayloadMessageFactory.class);
 
   @AdvancedConfig(rare = true)
-  private String defaultCharEncoding = "UTF-8";
+  private String defaultCharEncoding;
 
   private String defaultPayloadId = MultiPayloadAdaptrisMessage.DEFAULT_PAYLOAD_ID;
 
@@ -228,10 +228,6 @@ public class MultiPayloadMessageFactory extends AdaptrisMessageFactory {
   /**
    * Set the default character encoding to be applied to the message upon
    * creation.
-   * <p>
-   * If not explicitly configured, then the platform default character encoding
-   * will be used.
-   * </p>
    *
    * @param s
    *          the defaultCharEncoding to set


### PR DESCRIPTION
## Motivation

We have a Interlok inst that is using multi payload messaging, and when it processes a message that has iso-8859-1 encoding, the output is trash, because the MPMF has a default of utf-8 encoding.

## Modification

I updated the MultiPayloadMessageFactory to remove the default value in the defaultCharEncoding.
This change is inline with how the DefaultMessageFactory works.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked the display of the component in the UI

## Result

When using a MultiPayloadMessageFactory to process messages, if you use a non utf-8 encoding, then the messae output should not be garbage.

## Testing

setup a consumer like
`<jms-consumer>
  <message-factory class="multi-payload-message-factory">
    <default-payload-id>inbound-xml-payload</default-payload-id>
  </message-factory>
  <!-- etc -->
</jms-consumer>`

process message, produce somewhere, check output