### PR TITLE
INTERLOK-4531: Support for multi payload message in service tester

### DIFF
--- a/interlok-common/src/main/java/com/adaptris/interlok/types/SerializableInterlokMessageAdapter.java
+++ b/interlok-common/src/main/java/com/adaptris/interlok/types/SerializableInterlokMessageAdapter.java
@@ -1,0 +1,82 @@
+package com.adaptris.interlok.types;
+
+import lombok.NonNull;
+
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * A wrapper that adapts InterlokMessage to SerializableMessage and retains access to
+ * the underlying InterlokMessage
+ */
+public class SerializableInterlokMessageAdapter implements SerializableMessage {
+    private InterlokMessage message;
+    private String nextServiceId;
+    public SerializableInterlokMessageAdapter(@NonNull InterlokMessage m) {
+        this.message = m;
+    }
+
+    public InterlokMessage getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getUniqueId() {
+        return message.getUniqueId();
+    }
+
+    @Override
+    public void setUniqueId(String uniqueId) {
+        message.setUniqueId(uniqueId);
+    }
+
+    @Override
+    public String getContent() {
+        return message.getContent();
+    }
+
+    @Override
+    public void setContent(String payload) {
+        message.setContent(payload, getContentEncoding() != null ? getContentEncoding() : Charset.defaultCharset().name());
+    }
+
+    @Override
+    public Map<String, String> getMessageHeaders() {
+        return message.getMessageHeaders();
+    }
+
+    @Override
+    public void setMessageHeaders(Map<String, String> metadata) {
+        message.setMessageHeaders(metadata);
+    }
+
+    @Override
+    public void addMessageHeader(String key, String value) {
+        message.addMessageHeader(key, value);
+    }
+
+    @Override
+    public void removeMessageHeader(String key) {
+        message.removeMessageHeader(key);
+    }
+
+    @Override
+    public String getContentEncoding() {
+        return message.getContentEncoding();
+    }
+
+    @Override
+    public void setContentEncoding(String payloadEncoding) {
+        message.setContentEncoding(payloadEncoding);
+    }
+
+    @Override
+    public void setNextServiceId(String next) {
+        this.nextServiceId = next;
+    }
+
+    @Override
+    public String getNextServiceId() {
+        return this.nextServiceId;
+    }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/DefaultSerializableMessageTranslator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/DefaultSerializableMessageTranslator.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.adaptris.interlok.types.SerializableInterlokMessageAdapter;
 import com.adaptris.util.text.mime.MimeConstants;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -60,7 +61,12 @@ public class DefaultSerializableMessageTranslator implements SerializableMessage
 
   @Override
   public SerializableMessage translate(AdaptrisMessage message) throws CoreException {
-    SerializableAdaptrisMessage serializedMsg = new SerializableAdaptrisMessage();
+    SerializableMessage serializedMsg;
+    if (message instanceof MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage) {
+      serializedMsg = new SerializableInterlokMessageAdapter(multiPayloadAdaptrisMessage);
+    } else {
+       serializedMsg = new SerializableAdaptrisMessage();
+    }
     // It's a file message; arbitrarily too large?
     if (message instanceof FileBackedMessage && message.getSize() > DEFAULT_LMS_BOUNDARY) {
       serializedMsg.setContent(buildFileDetails(((FileBackedMessage) message).currentSource()));
@@ -70,12 +76,14 @@ public class DefaultSerializableMessageTranslator implements SerializableMessage
     }
     serializedMsg.setUniqueId(message.getUniqueId());
     serializedMsg.setContentEncoding(message.getContentEncoding());
-    serializedMsg.setMetadata(message.getMetadata());
+    message.getMetadata().forEach(metadataElement -> {
+      serializedMsg.addMessageHeader(metadataElement.getKey(), metadataElement.getValue());
+    });
     serializedMsg.setNextServiceId(message.getNextServiceId());
     
     // do we have a failed/error'd message?
     if(message.getObjectHeaders().containsKey(CoreConstants.OBJ_METADATA_EXCEPTION))
-      serializedMsg.addMetadata(CoreConstants.OBJ_METADATA_EXCEPTION, ((Throwable) message.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION)).getMessage());
+      serializedMsg.addMessageHeader(CoreConstants.OBJ_METADATA_EXCEPTION, ((Throwable) message.getObjectHeaders().get(CoreConstants.OBJ_METADATA_EXCEPTION)).getMessage());
       
     return serializedMsg;
   }
@@ -90,6 +98,15 @@ public class DefaultSerializableMessageTranslator implements SerializableMessage
       else {
         adaptrisMessage = messageFactory.newMessage(message.getContent(), message.getContentEncoding(),
             convertMap(message.getMessageHeaders()));
+      }
+
+      // support MultiPayloadAdaptrisMessage
+      if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage &&
+              message instanceof SerializableInterlokMessageAdapter messageAdapter &&
+              messageAdapter.getMessage() instanceof MultiPayloadAdaptrisMessage multiPayloadMessage) {
+          multiPayloadMessage.getPayloadIDs().forEach(payloadId -> {
+            multiPayloadAdaptrisMessage.addContent(payloadId, multiPayloadMessage.getContent(payloadId), multiPayloadMessage.getContentEncoding(payloadId));
+          });
       }
 
       if (MimeConstants.ENCODING_BASE64.equalsIgnoreCase(message.getMessageHeaders().get(CoreConstants.SERIALIZED_MESSAGE_ENCODING))) {

--- a/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MultiPayloadAdaptrisMessageImp.java
@@ -18,14 +18,7 @@ package com.adaptris.core;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,6 +30,7 @@ import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
 import com.adaptris.annotation.ComponentProfile;
@@ -308,7 +302,7 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
       payload = payloads.get(payloadId);
       payload.data = pb;
     } else {
-      payload = new Payload(pb);
+      payload = new Payload(getFactory().getDefaultCharEncoding(), pb);
     }
     payloads.put(payloadId, payload);
     currentPayloadId = payloadId;
@@ -636,21 +630,52 @@ public class MultiPayloadAdaptrisMessageImp extends AdaptrisMessageImp implement
     }
   }
 
-  private class Payload {
-    String encoding = getFactory().getDefaultCharEncoding();
+  public static class Payload {
+    AdaptrisMessageFactory factory;
+    @Getter
+    String encoding;
     private byte[] data;
 
-    Payload(String encoding, @NotNull byte[] data) {
-      this.encoding = encoding;
-      this.data = data;
+    public Payload() {
     }
 
-    Payload(@NotNull byte[] data) {
+    public Payload(String encoding, @NotNull byte[] data) {
+      this.encoding = encoding;
       this.data = data;
     }
 
     byte[] payload() {
       return data;
+    }
+
+    public String getPayload() { return getPayloadAsString(); }
+
+    public void setPayload(String payload) {
+      this.data = payload.getBytes(Charset.forName(encoding));
+    }
+
+    public String getPayloadAsString() {
+      try {
+        return new String(data, encoding);
+      } catch (UnsupportedEncodingException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+
+    public String getEncoding() {
+      return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+      this.encoding = encoding;
+    }
+
+    public byte[] getData() {
+      return data;
+    }
+
+    public void setData(byte[] data) {
+      this.data = data;
     }
   }
 }


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-4531

## Modification

- Made MultiPayloadAdaptrisMessage$Payload more like a bean
- Implemented a way to adapt MultiPayloadAdaptrisMessage into SerializableMessage

## PR Checklist

- [x] been self-reviewed.
- [x ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Clients of the library can now more easily use multi payload messages

## Testing


