### PR TITLE
INTERLOK-4530: Support for successOnFailure() override

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AbstractMessageEventGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AbstractMessageEventGenerator.java
@@ -1,0 +1,40 @@
+package com.adaptris.core;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldDefault;
+import org.apache.commons.lang3.BooleanUtils;
+
+/**
+ * Abstract class that generalises behaviour for subclasses that generate events
+ */
+public abstract class AbstractMessageEventGenerator implements MessageEventGenerator {
+
+    @AdvancedConfig(rare = true)
+    @InputFieldDefault(value = "false")
+    private Boolean successOnFail;
+
+
+    @Override
+    public boolean successOnFailure() {
+        return BooleanUtils.toBooleanDefaultIfNull(getSuccessOnFail(), false);
+    }
+
+    /**
+     * @return whether or not this service is configured to be marked as successful
+     * even if failure is encountered.
+     * @see #successOnFailure()
+     */
+    public Boolean getSuccessOnFail() {
+        return successOnFail;
+    }
+
+    /**
+     * whether or not this service is configured to be marked as successful
+     * even if failure is encountered.
+     *
+     * @param b true/false, default if not specified is false.
+     */
+    public void setSuccessOnFail(Boolean b) {
+        successOnFail = b;
+    }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageImp.java
@@ -281,24 +281,27 @@ public abstract class AdaptrisMessageImp implements AdaptrisMessage, Cloneable {
 
   @Override
   public void addEvent(MessageEventGenerator meg, boolean wasSuccessful) {
+    MessageEventGenerator _meg = Objects.requireNonNullElseGet(meg, () -> new MessageEventGenerator() {
+      @Override
+      public String createName() {
+        return "Unknown Event";
+      }
+
+      @Override
+      public String createQualifier() {
+        return "";
+      }
+
+      @Override
+      public boolean isTrackingEndpoint() {
+        return false;
+      }
+
+      @Override
+      public boolean successOnFailure() { return false; }
+    });
     messageLifeCycle.addMleMarker(
-        getNextMleMarker(Objects.requireNonNullElseGet(meg, () -> new MessageEventGenerator() {
-          @Override
-          public String createName() {
-            return "Unknown Event";
-          }
-
-          @Override
-          public String createQualifier() {
-            return "";
-          }
-
-          @Override
-          public boolean isTrackingEndpoint() {
-            return false;
-          }
-
-        }), wasSuccessful));
+        getNextMleMarker(_meg, wasSuccessful || _meg.successOnFailure())); // check if meg has overridden failure
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageWorkerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisMessageWorkerImp.java
@@ -33,7 +33,7 @@ import com.adaptris.core.util.ManagedThreadFactory;
  * Implementation of behaviour common to <code>AdaptrisMessageConsumer</code> and <code>AdaptrisMessageProducer</code>.
  * </p>
  */
-public abstract class AdaptrisMessageWorkerImp implements AdaptrisMessageWorker {
+public abstract class AdaptrisMessageWorkerImp extends AbstractMessageEventGenerator implements AdaptrisMessageWorker {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 

--- a/interlok-core/src/main/java/com/adaptris/core/MessageEventGenerator.java
+++ b/interlok-core/src/main/java/com/adaptris/core/MessageEventGenerator.java
@@ -59,4 +59,13 @@ public interface MessageEventGenerator {
    */
   boolean isTrackingEndpoint();
 
+  /**
+   * <p>
+   * If true then even on <code>Exception</code>, "wasSuccessful" will be true
+   * </p>
+   *
+   * @return continueOnFail
+   */
+  boolean successOnFailure();
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceCollectionImp.java
@@ -135,6 +135,35 @@ public abstract class ServiceCollectionImp extends AbstractCollection<Service> i
     return continueOnFail;
   }
 
+  @AdvancedConfig(rare = true)
+  @InputFieldDefault(value = "false")
+  private Boolean successOnFail;
+
+
+  @Override
+  public boolean successOnFailure() {
+    return BooleanUtils.toBooleanDefaultIfNull(getSuccessOnFail(), false);
+  }
+
+  /**
+   * @return whether or not this service is configured to be marked as successful
+   * even if failure is encountered.
+   * @see #successOnFailure()
+   */
+  public Boolean getSuccessOnFail() {
+    return successOnFail;
+  }
+
+  /**
+   * whether or not this service is configured to be marked as successful
+   * even if failure is encountered.
+   *
+   * @param b true/false, default if not specified is false.
+   */
+  public void setSuccessOnFail(Boolean b) {
+    successOnFail = b;
+  }
+
   public Boolean getEnabled() {
     return enabled;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ServiceImp.java
@@ -34,7 +34,7 @@ import com.adaptris.util.GuidGenerator;
  * <code>MessageEventGenerator</code> which returns the fully qualified name of the class.
  * </p>
  */
-public abstract class ServiceImp implements Service {
+public abstract class ServiceImp extends AbstractMessageEventGenerator implements Service {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 

--- a/interlok-core/src/main/java/com/adaptris/core/SharedServiceImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedServiceImpl.java
@@ -30,6 +30,35 @@ public abstract class SharedServiceImpl extends SharedComponent implements Servi
   @MarshallingCDATA
   private String comments;
 
+  @AdvancedConfig(rare = true)
+  @InputFieldDefault(value = "false")
+  private Boolean successOnFail;
+
+
+  @Override
+  public boolean successOnFailure() {
+    return BooleanUtils.toBooleanDefaultIfNull(getSuccessOnFail(), false);
+  }
+
+  /**
+   * @return whether or not this service is configured to be marked as successful
+   * even if failure is encountered.
+   * @see #successOnFailure()
+   */
+  public Boolean getSuccessOnFail() {
+    return successOnFail;
+  }
+
+  /**
+   * whether or not this service is configured to be marked as successful
+   * even if failure is encountered.
+   *
+   * @param b true/false, default if not specified is false.
+   */
+  public void setSuccessOnFail(Boolean b) {
+    successOnFail = b;
+  }
+
   protected transient EventHandler eventHandler;
   protected transient Logger log = LoggerFactory.getLogger(this.getClass());
 

--- a/interlok-core/src/main/java/com/adaptris/core/StandaloneConsumer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/StandaloneConsumer.java
@@ -39,7 +39,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("standalone-consumer")
 @AdapterComponent
 @ComponentProfile(summary = "Standalone wrapper for a consumer and connection", tag = "consumer,base")
-public class StandaloneConsumer implements AdaptrisMessageConsumer, StateManagedComponent, ComponentLifecycleExtension {
+public class StandaloneConsumer extends AbstractMessageEventGenerator implements AdaptrisMessageConsumer, StateManagedComponent, ComponentLifecycleExtension {
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
   private AdaptrisConnection connection;

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageCase.java
@@ -337,6 +337,27 @@ public abstract class AdaptrisMessageCase {
     assertEquals("1", msg1.getMetadataValue(CoreConstants.MLE_SEQUENCE_KEY));
   }
 
+
+  @Test
+  public void testAddMessageEventSuccessFailure() throws Exception {
+    AdaptrisMessage msg1 = createMessage();
+    StandaloneProducer meg = new StandaloneProducer();
+    msg1.addEvent(meg, true);
+    assertTrue(msg1.getMessageLifecycleEvent().getMleMarkers().get(0).getWasSuccessful());
+
+    msg1.addEvent(meg, false);
+    assertTrue(msg1.getMessageLifecycleEvent().getMleMarkers().get(0).getWasSuccessful());
+    assertFalse(msg1.getMessageLifecycleEvent().getMleMarkers().get(1).getWasSuccessful());
+
+    // set the success on fail override
+    meg.setSuccessOnFail(true);
+    msg1.addEvent(meg, true);
+    msg1.addEvent(meg, false);
+    assertTrue(msg1.getMessageLifecycleEvent().getMleMarkers().get(2).getWasSuccessful());
+    assertTrue(msg1.getMessageLifecycleEvent().getMleMarkers().get(3).getWasSuccessful());
+
+  }
+
   @Test
   public void testObjectMetadata() throws Exception {
     AdaptrisMessage msg1 = createMessage();

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageFactoryImplCase.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisMessageFactoryImplCase.java
@@ -167,6 +167,9 @@ public abstract class AdaptrisMessageFactoryImplCase {
 
       public void setIsTrackingEndpoint(Boolean b) {
       }
+
+      @Override
+      public boolean successOnFailure() { return false; }
     }, true);
 
     List keysToKeep = Arrays.asList(new String[]
@@ -214,6 +217,9 @@ public abstract class AdaptrisMessageFactoryImplCase {
         return false;
       }
       public void setIsTrackingEndpoint(Boolean b) {}
+
+      @Override
+      public boolean successOnFailure() { return false; }
     }, true);
 
     AdaptrisMessage dest = getMessageFactory().newMessage(orig, null);

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/StandardMessageErrorDigestTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/StandardMessageErrorDigestTest.java
@@ -523,6 +523,8 @@ public class StandardMessageErrorDigestTest extends ComponentManagerCase {
         return false;
       }
 
+      @Override
+      public boolean successOnFailure() { return false; }
     }, false);
     return msg;
   }

--- a/interlok-core/src/test/java/com/adaptris/core/stubs/MockStateManagedComponent.java
+++ b/interlok-core/src/test/java/com/adaptris/core/stubs/MockStateManagedComponent.java
@@ -16,20 +16,14 @@
 
 package com.adaptris.core.stubs;
 
-import com.adaptris.core.ClosedState;
-import com.adaptris.core.ComponentState;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.InitialisedState;
-import com.adaptris.core.StartedState;
-import com.adaptris.core.StateManagedComponent;
-import com.adaptris.core.StoppedState;
+import com.adaptris.core.*;
 
 /**
  * <p>
  * Mock implementation for testing.
  * </p>
  */
-public class MockStateManagedComponent implements StateManagedComponent {
+public abstract class MockStateManagedComponent extends AbstractMessageEventGenerator implements StateManagedComponent {
   private ComponentState state = ClosedState.getInstance();
 
   public MockStateManagedComponent() {


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-4530

## Modification

- Added a successOnFailure() override for event generating components
- Modified addEvent() method on AdaptrisMessageImp such that if wasSuccessful == false, use the value of successOnFailure()

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

For the relevant interlok components, if <success-on-failure>true</success-on-failure> then even if an exception is encountered, it will ensure the MLE marker's wasSuccessful = true.

## Testing

see AdaptrisMessageCase.testAddMessageEventSuccessFailure()
