### PR TITLE
INTERLOK-4537: Implement TruncatePayloadService

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/TruncatePayloadService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/TruncatePayloadService.java
@@ -1,0 +1,71 @@
+package com.adaptris.core;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.services.splitter.BytesSplitter;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Truncate the message payload based on byte size
+ */
+@XStreamAlias("truncate-payload-service")
+@AdapterComponent
+@ComponentProfile(summary = "Truncate the payload based on byte size", tag = "payload,truncate")
+public class TruncatePayloadService extends ServiceImp {
+  private transient Logger log = LoggerFactory.getLogger(TruncatePayloadService.class.getName());
+
+  private Integer bytes;
+
+  public Integer getBytes() {
+    return bytes;
+  }
+
+  public void setBytes(Integer bytes) {
+    this.bytes = bytes;
+  }
+
+  /**
+   * @param msg
+   *          The message whose payload to truncate.
+   */
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    int bytesTruncatedTo;
+    try (InputStream is = msg.getInputStream(); OutputStream os = msg.getOutputStream()) {
+      bytesTruncatedTo = BytesSplitter.truncate(is, getBytes(), os);
+    } catch (IOException ex) {
+      throw new ServiceException(ex);
+    }
+    log.debug("Truncated message payload to {} bytes", bytesTruncatedTo);
+  }
+
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  protected void initService() {
+    /* unused */
+  }
+
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  protected void closeService() {
+    /* unused */
+  }
+
+  /**
+   * {@inheritDoc}.
+   */
+  @Override
+  public void prepare() {
+    /* unused */
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/services/splitter/BytesSplitter.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/splitter/BytesSplitter.java
@@ -140,10 +140,8 @@ public class BytesSplitter extends MessageSplitterImp {
       AdaptrisMessage tmpMessage = factory.newMessage();
       try (OutputStream os = tmpMessage.getOutputStream()) {
         logR.trace("Working on split {}", numberOfMessages);
-        byte[] chunk = new byte[chunkSize];
-        int read = IOUtils.read(is, chunk);
+        int read = truncate(is, chunkSize, os);
         if (read == 0) return null;
-        os.write(chunk, 0, read);
       }
 
       numberOfMessages++;
@@ -156,6 +154,13 @@ public class BytesSplitter extends MessageSplitterImp {
       logR.trace("Split gave {} messages", numberOfMessages);
     }
 
-  };
+  }
+  public static int truncate(InputStream is, int chunkSize, OutputStream os) throws IOException {
+    byte[] chunk = new byte[chunkSize];
+    int read = IOUtils.read(is, chunk);
+    os.write(chunk, 0, read);
+    return read;
+  }
+
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/TruncatePayloadServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/TruncatePayloadServiceTest.java
@@ -1,0 +1,51 @@
+package com.adaptris.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.Charset;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TruncatePayloadServiceTest
+    extends com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase {
+  private final MultiPayloadMessageFactory messageFactory = new MultiPayloadMessageFactory();
+
+  private static final String ENCODING = "UTF-8";
+
+  private static final String CONTENT = "Bacon ipsum dolor amet bresaola ball tip flank, doner pork chop ham hock rump kielbasa pork loin beef burgdoggen short ribs tongue.";
+
+
+  @Test
+  public void testService() throws Exception {
+    TruncatePayloadService service = getService();
+    int length = CONTENT.length() - 10;
+    service.setBytes(length);
+    MultiPayloadAdaptrisMessage message = getMessage();
+    assertEquals(CONTENT, message.getContent());
+    assertEquals(CONTENT.length(), message.getSize());
+    // truncate 10
+    service.doService(message);
+    assertEquals(length, message.getSize());
+
+    // truncate all
+    length = 0;
+    service.setBytes(length);
+    service.doService(message);
+    assertEquals(length, message.getSize());
+  }
+
+  private MultiPayloadAdaptrisMessage getMessage() {
+    MultiPayloadAdaptrisMessage message = (MultiPayloadAdaptrisMessage) messageFactory.newMessage(MultiPayloadAdaptrisMessage.DEFAULT_PAYLOAD_ID, CONTENT,
+        ENCODING);
+    return message;
+  }
+
+  private TruncatePayloadService getService() {
+      return new TruncatePayloadService();
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig() {
+    return getService();
+  }
+}


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/jira/software/c/projects/INTERLOK/boards/2?selectedIssue=INTERLOK-4537

## Modification

- Added TruncatePayloadService which utilises some logic from BytesSplitter

## PR Checklist

- [x] been self-reviewed.
- [x ] Added javadocs for most classes and all non-trivial methods
- [ x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Ability to truncate the payload based on byte size

## Testing

See TruncatePayloadServiceTest
