### PR TITLE
Update EncodingPasswordService to handle entities and xincludes

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
@@ -273,8 +273,8 @@ public class EncodePasswordService extends ServiceImp {
    */
   private void encapsulateReferencedEntities(File file) throws IOException {
       String fileContent = Files.readString(file.toPath());
-      //letters, numbers, hyphens, underscores only
-      String updatedContent = fileContent.replaceAll("&([a-zA-Z][a-zA-Z0-9\\-_]*);", "\\${$1}");
+      //letters, numbers, hyphens, underscores, dot only
+      String updatedContent = fileContent.replaceAll("&([a-zA-Z][a-zA-Z0-9\\-_.]*);", "\\${$1}");
       Files.writeString(file.toPath(), updatedContent);
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
@@ -18,7 +18,6 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -34,6 +33,7 @@ import java.util.stream.Collectors;
 
 import org.w3c.dom.*;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 import static com.adaptris.fs.FsWorker.checkReadable;
 import static com.adaptris.fs.FsWorker.isFile;
@@ -69,6 +69,7 @@ public class EncodePasswordService extends ServiceImp {
   private static final String EXTN_XML = ".xml";
   private static final String EXTN_PROPERTIES = ".properties";
   private static final String METADATA_KEY_PASSWORD_TOKENS = "passwordtokens";
+  private static final String XML_ELEMENT_ROOT = "root";
 
   private transient DocumentBuilderFactory dbFactory;
   private transient TransformerFactory transformerFactory;
@@ -158,16 +159,19 @@ public class EncodePasswordService extends ServiceImp {
    *  Finds and encodes value contained in an XML file
    *
    * @param file
-   * @throws ParserConfigurationException
-   * @throws SAXException
    * @throws IOException
    * @throws TransformerException
    */
-  protected void encodeValuesInXmlFile(File file) throws ParserConfigurationException, SAXException, IOException, TransformerException {
-    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-    Document doc = dBuilder.parse(file);
-    doc.getDocumentElement().normalize();
+  protected void encodeValuesInXmlFile(File file) throws IOException, TransformerException, ParserConfigurationException {
 
+    //Encapsulate the XML file for any entities referred
+    encapsulateReferencedEntities(file);
+
+    //Read XML document
+    Document doc = readXMLDocument(file);
+    if (doc == null) return;
+
+    doc.getDocumentElement().normalize();
     // Process the root element
     replaceNodeValues(doc.getDocumentElement());
 
@@ -180,7 +184,6 @@ public class EncodePasswordService extends ServiceImp {
     StreamResult result = new StreamResult(file);
     transformer.transform(source, result);
   }
-
 
   /**
    * Recursive method to replace values in nodes that match the pattern
@@ -214,6 +217,12 @@ public class EncodePasswordService extends ServiceImp {
     }
   }
 
+    /**
+     *
+     * @param nodeValue
+     * @return
+     * @throws PasswordException
+     */
   protected String doEncodePassword(String nodeValue) throws PasswordException {
     if (nodeValue.startsWith(PREFIX_PORTABLE_PASSWORD)) {
       return Password.encode(Password.decode(nodeValue), Password.PORTABLE_PASSWORD_2);
@@ -255,5 +264,49 @@ public class EncodePasswordService extends ServiceImp {
       }
     }
     return result;
+  }
+
+  /**
+   * Encapsulates reference entities within readable characters,
+   * eg, &ADAPTER_ID; is encapsulated to ${ADAPTER_ID}
+   *
+   */
+  private void encapsulateReferencedEntities(File file) throws IOException {
+      String fileContent = Files.readString(file.toPath());
+      //letters, numbers, hyphens, underscores only
+      String updatedContent = fileContent.replaceAll("&([a-zA-Z][a-zA-Z0-9\\-_]*);", "\\${$1}");
+      Files.writeString(file.toPath(), updatedContent);
+  }
+
+  /**
+   * Read an
+   *
+   * @param file
+   * @return
+   * @throws IOException
+   */
+  private Document readXMLDocument(File file) throws IOException, ParserConfigurationException {
+    Document doc = null;
+
+    DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+
+    try {
+        doc = dBuilder.parse(file);
+    } catch (SAXParseException e) {
+        // Reattempt in case of XML snippets file without a root
+        Files.writeString(file.toPath(), "<"+XML_ELEMENT_ROOT+">" + Files.readString(file.toPath()) + "</"+XML_ELEMENT_ROOT+">");
+        try {
+            doc = dBuilder.parse(file);
+        } catch (SAXException e1) {
+            //Handle malformed XMLs by logging the error
+            log.info("Error encountered while encoding file - {} : {}", file.getName(), e.getMessage());
+            return null;
+        }
+    } catch (Exception e) {
+        //Handle malformed XMLs by logging the error
+        log.info("Error encountered while encoding file - {} : {}", file.getName(), e.getMessage());
+        return null;
+    }
+    return doc;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
@@ -287,9 +287,7 @@ public class EncodePasswordService extends ServiceImp {
    */
   private Document readXMLDocument(File file) throws IOException, ParserConfigurationException {
     Document doc = null;
-
     DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-
     try {
         doc = dBuilder.parse(file);
     } catch (SAXParseException e) {
@@ -300,12 +298,10 @@ public class EncodePasswordService extends ServiceImp {
         } catch (SAXException e1) {
             //Handle malformed XMLs by logging the error
             log.info("Error encountered while encoding file - {} : {}", file.getName(), e.getMessage());
-            return null;
         }
     } catch (Exception e) {
         //Handle malformed XMLs by logging the error
         log.info("Error encountered while encoding file - {} : {}", file.getName(), e.getMessage());
-        return null;
     }
     return doc;
   }

--- a/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
@@ -51,7 +51,9 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
   private AdaptrisMessage msg;
 
   private static final String ADAPTER_CONFIG_FILE = "build/resources/test/validAdapter.xml";
+  private static final String MESSAGE_HANDLER_FILE = "build/resources/test/message-handler.xml";
   private static final String ADAPTER_PROPERTIES_FILE = "build/resources/test/valid-local-vars.properties";
+  private static final String XML_WITHOUT_ROOT_FILE = "build/resources/test/services.xml";
   private static final String PASSWORD_PARAPHRASE = "PASSWORD, PASSPHRASE, SECRET, ROLEEXTERNALID";
   private static final String METADATA_KEY_PASSWORD_TOKENS = "passwordtokens";
   private static final String PREFIX_PORTBALE_PASSWORD_2 = "AES_GCM:";
@@ -113,4 +115,22 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
       service.doService(msg);
     });
   }
+
+    @Test
+    public void testEncodePasswordInWithoutRootXML() throws Exception {
+        service.setFilePath(XML_WITHOUT_ROOT_FILE);
+        execute(service, msg);
+        List<String> lines = Files.readAllLines(Paths.get(service.getFilePath()));
+        List<String> pwdLines = lines.stream().filter(line -> line.trim().startsWith("<service")).collect(Collectors.toList());
+        assertEquals(pwdLines.size(),9);
+    }
+
+    @Test
+    public void testEncodePasswordParseErrorXML() throws Exception {
+        service.setFilePath(MESSAGE_HANDLER_FILE);
+        execute(service, msg);
+        List<String> lines = Files.readAllLines(Paths.get(service.getFilePath()));
+        List<String> pwdLines = lines.stream().filter(line -> line.trim().startsWith("<service")).collect(Collectors.toList());
+        assertEquals(pwdLines.size(),1);
+    }
 }

--- a/interlok-core/src/test/resources/message-handler.xml
+++ b/interlok-core/src/test/resources/message-handler.xml
@@ -1,0 +1,25 @@
+<!-- MESSAGE ERROR HANDLER -->
+<message-error-handler xsi:type="java:com.adaptris.core.StandardProcessingExceptionHandler">
+
+  <processing-exception-service xsi:type="java:com.adaptris.core.ServiceList">
+
+    <service xsi:type="java:com.adaptris.core.StandaloneProducer">
+      <connection xsi:type="java:com.adaptris.core.NullConnection"/>
+
+      <producer xsi:type="java:com.adaptris.core.fs.FsProducer">
+        <destination xsi:type="java:com.adaptris.core.ConfiguredProduceDestination">
+            <!-- Unparseable content below-->
+          <destination>&&&&&&&EXCEPTIONS_BASE</destination>
+        </destination>
+        <encoder xsi:type="java:com.adaptris.core.MimeEncoder">
+          <retain-unique-id>true</retain-unique-id>
+        </encoder>
+        <fs-worker xsi:type="java:com.adaptris.fs.OverwriteIfExistsWorker"/>
+        <create-dirs>true</create-dirs>
+      </producer>
+
+    </service>
+
+  </processing-exception-service>
+
+</message-error-handler>

--- a/interlok-core/src/test/resources/services.xml
+++ b/interlok-core/src/test/resources/services.xml
@@ -1,0 +1,68 @@
+<!-- Archive the message -->
+<service xsi:type="java:com.adaptris.core.StandaloneProducer">
+  <producer xsi:type="java:com.adaptris.core.fs.FsProducer">
+    <destination xsi:type="java:com.adaptris.core.ConfiguredProduceDestination">
+      <destination>file:////x/y/z</destination>
+    </destination>
+    <fs-worker xsi:type="java:com.adaptris.fs.OverwriteIfExistsWorker"/>
+    <create-dirs>true</create-dirs>
+  </producer>
+</service>
+
+<service xsi:type="java:com.adaptris.core.BranchingServiceCollection">
+  <first-service-id>service1</first-service-id>
+
+  <service xsi:type="java:com.adaptris.core.services.routing.SyntaxBranchingService">
+    <unique-id>service1</unique-id>
+
+    <syntax-identifier xsi:type="java:com.adaptris.core.services.routing.XpathSyntaxIdentifier">
+      <pattern>/X/A</pattern>
+      <destination>destination1</destination>
+    </syntax-identifier>
+    <syntax-identifier xsi:type="java:com.adaptris.core.services.routing.XpathSyntaxIdentifier">
+      <pattern>/X/B</pattern>
+      <destination>destination2</destination>
+    </syntax-identifier>
+    <syntax-identifier xsi:type="java:com.adaptris.core.services.routing.XpathSyntaxIdentifier">
+      <pattern>/X/C</pattern>
+      <destination>destination3</destination>
+    </syntax-identifier>
+  </service>
+
+  <service xsi:type="java:com.adaptris.core.ServiceList">
+    <unique-id>service2</unique-id>
+
+    <service xsi:type="java:com.adaptris.core.services.metadata.AddMetadataService">
+      <metadata-element>
+        <key>messageType</key>
+        <value>service2</value>
+      </metadata-element>
+    </service>
+
+  </service>
+
+  <service xsi:type="java:com.adaptris.core.ServiceList">
+    <unique-id>service3</unique-id>
+
+    <service xsi:type="java:com.adaptris.core.services.metadata.AddMetadataService">
+      <metadata-element>
+        <key>messageType</key>
+        <value>service3</value>
+      </metadata-element>
+    </service>
+
+  </service>
+
+  <service xsi:type="java:com.adaptris.core.ServiceList">
+    <unique-id>service4</unique-id>
+
+    <service xsi:type="java:com.adaptris.core.services.metadata.AddMetadataService">
+      <metadata-element>
+        <key>messageType</key>
+        <value>service4</value>
+      </metadata-element>
+    </service>
+
+  </service>
+
+</service>

--- a/interlok-core/src/test/resources/validAdapter.xml
+++ b/interlok-core/src/test/resources/validAdapter.xml
@@ -29,10 +29,10 @@
             </jms-connection>
             <jdbc-pooled-connection>
                 <unique-id>mysql-connection-demat-fiscale</unique-id>
-                <driver-imp>${jdbc.driver}</driver-imp>
-                <username>${jdbc.user}</username>
-                <password>${jdbc.password}</password>
-                <connect-url>${jdbc.connection.url}</connect-url>
+                <driver-imp>&jdbc.driver;</driver-imp>
+                <username>&jdbc.user;</username>
+                <password>&jdbc.password;</password>
+                <connect-url>&jdbc.connection.url;</connect-url>
             </jdbc-pooled-connection>
             <standard-sftp-connection>
                 <unique-id>sftp-connection</unique-id>


### PR DESCRIPTION
## Motivation

Update EncodingService to support xincludes and entities

## Modification
Changes done to address the improvement in Encoding Password Service to include - 
 - Support for v2 configs that have entities.
 - Support for v3+ configs that have xincludes.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

User is able to encode passwords in configuration files with entities and xincludes

## Testing

Unit test and with v3+ config files, eg, uk0000000012.zip, testing file by Juan
