### PR TITLE
implemented new RetryStore method to get error stacktrace

### DIFF
--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -6,7 +6,7 @@ ext {
   slf4jVersion = "2.0.17"
   log4j2Version = "2.24.3"
   mockitoVersion = "4.9.0"
-  jettyVersion= "10.0.25"
+  jettyVersion= "10.0.26"
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -12,7 +12,7 @@ ext {
   mssqlDriverVersion = "9.2.1.jre8"
   derbyDriverVersion = "10.15.2.0"
   junitVersion = "5.11.4"
-  jettyVersion= "10.0.25"
+  jettyVersion= "10.0.26"
 
   verboseTests= project.hasProperty('verboseTests') ? project.getProperty('verboseTests') : "false"
   classesToTest = project.hasProperty("junit.test.classes") ? project.getProperty("junit.test.classes") : "**/*Test*"

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -8,6 +8,7 @@ import java.io.FileWriter;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -249,4 +250,17 @@ public class FilesystemRetryStore implements RetryStore {
   public void makeConnection(AdaptrisConnection connection) {
     // null implementation 
   }
+
+    @Override
+    public String getStackTrace(String msgId) throws InterlokException {
+        try {
+            File dir = validateMsgId(msgId, true);
+            File stackTraceFile = new File(dir, STACKTRACE_FILENAME);
+            FsWorker.checkReadable(FsWorker.isFile(stackTraceFile));
+
+            return FileUtils.readFileToString(stackTraceFile, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw ExceptionHelper.wrapInterlokException(e);
+        }
+    }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -136,10 +136,7 @@ public class FilesystemRetryStore implements RetryStore {
     return validateDir(target, mustAlreadyExist);
   }
 
-  /**
-   * Validate that the given string is a safe path component (no separators, no "..", not absolute).
-   */
-  private static void validatePathComponent(String component) {
+  static void validatePathComponent(String component) {
     if (component == null || component.isEmpty()) {
       throw new IllegalArgumentException("Message ID may not be null or empty");
     }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -131,8 +131,21 @@ public class FilesystemRetryStore implements RetryStore {
   }
 
   private File validateMsgId(String msgId, boolean mustAlreadyExist) throws Exception {
+    validatePathComponent(msgId);
     File target = new File(FsHelper.toFile(getBaseUrl()), msgId);
     return validateDir(target, mustAlreadyExist);
+  }
+
+  /**
+   * Validate that the given string is a safe path component (no separators, no "..", not absolute).
+   */
+  private static void validatePathComponent(String component) {
+    if (component == null || component.isEmpty()) {
+      throw new IllegalArgumentException("Message ID may not be null or empty");
+    }
+    if (component.contains("..") || component.contains("/") || component.contains("\\") || new File(component).isAbsolute()) {
+      throw new IllegalArgumentException("Invalid message ID: path traversal or separator detected");
+    }
   }
 
   private File validateDir(File target, boolean mustAlreadyExist) throws Exception {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -2,6 +2,7 @@ package com.adaptris.core.http.jetty.retry;
 
 import static com.adaptris.core.CoreConstants.HTTP_METHOD;
 import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URI;
+
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -10,6 +11,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import com.adaptris.annotation.AdvancedConfig;
@@ -75,415 +77,520 @@ import lombok.extern.slf4j.Slf4j;
  * delete. If you ask for a message to be deleted from the store, then that is what happens.
  * </p>
  *
- * @since 3.11.1
  * @config retry-via-jetty
+ * @since 3.11.1
  */
 @NoArgsConstructor
 @Slf4j
 @ComponentProfile(summary = "Listen for HTTP traffic on the specified URI and retry messages",
-    recommended = {EmbeddedConnection.class, JettyConnection.class}, since = "3.11.1")
+        recommended = {EmbeddedConnection.class, JettyConnection.class}, since = "3.11.1")
 @DisplayOrder(order = {"retryEndpointPrefix", "reportingEndpoint", "deleteEndpointPrefix",
-    "retryHttpMethod", "deleteHttpMethod", "connection", "retryStore", "reportBuilder"})
+        "retryHttpMethod", "deleteHttpMethod", "connection", "retryStore", "reportBuilder"})
 @XStreamAlias("retry-via-jetty")
 public class RetryFromJetty extends FailedMessageRetrierImp {
 
-  public static final String DEFAULT_ENDPOINT_PREFIX = "/api/retry/";
-  public static final String DEFAULT_REPORTING_ENDPOINT = "/api/failed/list";
-  public static final String DEFAULT_DELETE_PREFIX = "/api/failed/delete/";
+    public static final String DEFAULT_ENDPOINT_PREFIX = "/api/retry/";
+    public static final String DEFAULT_REPORTING_ENDPOINT = "/api/failed/list";
+    public static final String DEFAULT_DELETE_PREFIX = "/api/failed/delete/";
+    public static final String DEFAULT_STACKTRACE_ENDPOINT = "/api/failed/stacktrace/";
+    public static final String DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT = "/api/failed/stacktrace/first-line/";
 
-  private static final String HTTP_RETRY_METHOD = "POST";
-  private static final String HTTP_DELETE_METHOD = "DELETE";
+    private static final String HTTP_RETRY_METHOD = "POST";
+    private static final String HTTP_DELETE_METHOD = "DELETE";
 
-  private static final TimeInterval DEFAULT_SHUTDOWN_WAIT = new TimeInterval(30L, TimeUnit.SECONDS.name());
+    private static final TimeInterval DEFAULT_SHUTDOWN_WAIT = new TimeInterval(30L, TimeUnit.SECONDS.name());
 
-  public static final String CONTENT_TYPE_METADATA_KEY = "__Content-Type";
-  public static final String CONTENT_TYPE_EXPR = "%message{__Content-Type}";
+    public static final String CONTENT_TYPE_METADATA_KEY = "__Content-Type";
+    public static final String CONTENT_TYPE_EXPR = "%message{__Content-Type}";
 
-  private static final String HTTP_STATUS_KEY = "__httpResponseCode";
-  private static final String HTTP_STATUS_EXPR = "%message{__httpResponseCode}";
-  private static final String MSG_ID_KEY = "__MsgId";
+    private static final String HTTP_STATUS_KEY = "__httpResponseCode";
+    private static final String HTTP_STATUS_EXPR = "%message{__httpResponseCode}";
+    private static final String MSG_ID_KEY = "__MsgId";
 
-  protected static final String HTTP_OK = "" + HttpURLConnection.HTTP_OK;
-  protected static final String HTTP_ACCEPTED = "" + HttpURLConnection.HTTP_ACCEPTED;
-  protected static final String HTTP_ERROR = "" + HttpURLConnection.HTTP_INTERNAL_ERROR;
-  protected static final String HTTP_BAD = "" + HttpURLConnection.HTTP_BAD_REQUEST;
-  protected static final String HTTP_NOT_FOUND = "" + HttpURLConnection.HTTP_NOT_FOUND;
-
-
-  /**
-   * The retry endpoint.
-   * <p>
-   * The default if not explicitly specified is {@value DEFAULT_ENDPOINT_PREFIX}, note the trailing
-   * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
-   * form {@code /prefix/'msgId'}
-   * </p>
-   */
-  @Getter
-  @Setter
-  @InputFieldDefault(value = DEFAULT_ENDPOINT_PREFIX)
-  private String retryEndpointPrefix;
-  /**
-   * The endpoint that allows reporting on what has failed.
-   * <p>
-   * The default if not explicitly specified is {@value DEFAULT_REPORTING_ENDPOINT}.
-   * </p>
-   */
-  @Getter
-  @Setter
-  @InputFieldDefault(value = DEFAULT_REPORTING_ENDPOINT)
-  private String reportingEndpoint;
-
-  /**
-   * The delete endpoint.
-   * <p>
-   * The default if not explicitly specified is {@value DEFAULT_DELETE_PREFIX}, note the trailing
-   * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
-   * form {@code /prefix/'msgId'}
-   * </p>
-   */
-  @Getter
-  @Setter
-  @InputFieldDefault(value = DEFAULT_DELETE_PREFIX)
-  private String deleteEndpointPrefix;
-
-  /**
-   * The underlying Jetty connection.
-   *
-   */
-  @Getter
-  @Setter
-  @NotNull
-  private AdaptrisConnection connection = new EmbeddedConnection();
+    protected static final String HTTP_OK = "" + HttpURLConnection.HTTP_OK;
+    protected static final String HTTP_ACCEPTED = "" + HttpURLConnection.HTTP_ACCEPTED;
+    protected static final String HTTP_ERROR = "" + HttpURLConnection.HTTP_INTERNAL_ERROR;
+    protected static final String HTTP_BAD = "" + HttpURLConnection.HTTP_BAD_REQUEST;
+    protected static final String HTTP_NOT_FOUND = "" + HttpURLConnection.HTTP_NOT_FOUND;
 
 
-  /**
-   * How to build reports.
-   *
-   */
-  @Getter
-  @Setter
-  @NotNull
-  @NonNull
-  private ReportBuilder reportBuilder = new ReportBuilder();
+    /**
+     * The retry endpoint.
+     * <p>
+     * The default if not explicitly specified is {@value DEFAULT_ENDPOINT_PREFIX}, note the trailing
+     * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
+     * form {@code /prefix/'msgId'}
+     * </p>
+     */
+    @Getter
+    @Setter
+    @InputFieldDefault(value = DEFAULT_ENDPOINT_PREFIX)
+    private String retryEndpointPrefix;
+    /**
+     * The endpoint that allows reporting on what has failed.
+     * <p>
+     * The default if not explicitly specified is {@value DEFAULT_REPORTING_ENDPOINT}.
+     * </p>
+     */
+    @Getter
+    @Setter
+    @InputFieldDefault(value = DEFAULT_REPORTING_ENDPOINT)
+    private String reportingEndpoint;
 
-  /**
-   * Where messages are stored for retries.
-   *
-   */
-  @Getter
-  @Setter
-  @NotNull
-  @NonNull
-  private RetryStore retryStore;
+    /**
+     * The delete endpoint.
+     * <p>
+     * The default if not explicitly specified is {@value DEFAULT_DELETE_PREFIX}, note the trailing
+     * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
+     * form {@code /prefix/'msgId'}
+     * </p>
+     */
+    @Getter
+    @Setter
+    @InputFieldDefault(value = DEFAULT_DELETE_PREFIX)
+    private String deleteEndpointPrefix;
 
-  /**
-   * The HTTP method which is required for retries; the default is POST.
-   */
-  @AdvancedConfig(rare=true)
-  @Getter
-  @Setter
-  @InputFieldDefault(value = HTTP_RETRY_METHOD)
-  private String retryHttpMethod;
-
-
-  /**
-   * The HTTP method which is required for deleting messages from the retry store; the default is
-   * DELETE.
-   */
-  @AdvancedConfig(rare = true)
-  @Getter
-  @Setter
-  @InputFieldDefault(value = HTTP_DELETE_METHOD)
-  private String deleteHttpMethod;
-
-  private transient StandaloneConsumer reporting;
-  private transient StandaloneConsumer retrying;
-  private transient StandaloneConsumer deleting;
-
-  private transient ReportListener reporter;
-  private transient RetryListener retrier;
-  private transient DeleteListener deleter;
-
-  private transient ExecutorService workflowSubmitter;
-  private transient JettyRouteCondition retryRouting;
-  private transient JettyRouteCondition deleteRouting;
-  private transient boolean prepared = false;
-
-  @Override
-  public void prepare() throws CoreException {
-    if (!prepared) {
-      Args.notNull(getReportBuilder(), "report-builder");
-      Args.notNull(getRetryStore(), "retry-store");
-
-      String retryServletPath = retryEndpointPrefix() + "*";
-      String retryServletRegexp = "^" + retryEndpointPrefix() + "(.*)";
-
-      String deleteServletPath = deleteEndpointPrefix() + "*";
-      String deleteServletRegexp = "^" + deleteEndpointPrefix() + "(.*)";
-
-      retryRouting = new JettyRouteCondition().withUrlPattern(retryServletRegexp)
-          .withMetadataKeys(MSG_ID_KEY).withMethod(retryHttpMethod());
-      deleteRouting = new JettyRouteCondition().withUrlPattern(deleteServletRegexp)
-          .withMetadataKeys(MSG_ID_KEY).withMethod(deleteHttpMethod());
-
-      reporter = new ReportListener();
-      retrier = new RetryListener();
-      deleter = new DeleteListener();
-
-      // By not dictating the method in the consumer; we accept all methods in jetty, but we use the
-      // jetty route filter to filter it out.
-      retrying = new StandaloneConsumer(getConnection(),
-          new JettyMessageConsumer().withPath(retryServletPath));
-      deleting = new StandaloneConsumer(getConnection(),
-          new JettyMessageConsumer().withPath(deleteServletPath));
-      reporting = new StandaloneConsumer(getConnection(),
-          new JettyMessageConsumer().withPath(reportingEndpoint()));
-
-      retrying.registerAdaptrisMessageListener(retrier);
-      reporting.registerAdaptrisMessageListener(reporter);
-      deleting.registerAdaptrisMessageListener(deleter);
-
-      LifecycleHelper.prepare(getRetryStore(), getReportBuilder());
-      LifecycleHelper.prepare(deleteRouting, deleter, deleting);
-      LifecycleHelper.prepare(retryRouting, retrier, retrying);
-      LifecycleHelper.prepare(reporter, reporting);
-      prepared = true;
-    }
-  }
-
-  @Override
-  public void init() throws CoreException {
-    prepare();
-    LifecycleHelper.init(getRetryStore(), getReportBuilder());
-    LifecycleHelper.init(deleteRouting, deleter, deleting);
-    LifecycleHelper.init(retryRouting, retrier, retrying);
-    LifecycleHelper.init(reporter, reporting);
-
-    workflowSubmitter = Executors.newSingleThreadExecutor();
-  }
-
-  @Override
-  public void start() throws CoreException {
-    LifecycleHelper.start(getRetryStore(), getReportBuilder());
-    LifecycleHelper.start(deleteRouting, deleter, deleting);
-    LifecycleHelper.start(retryRouting, retrier, retrying);
-    LifecycleHelper.start(reporter, reporting);
-  }
-
-  @Override
-  public void stop() {
-    LifecycleHelper.stop(deleteRouting, deleter, deleting);
-    LifecycleHelper.stop(retryRouting, retrier, retrying);
-    LifecycleHelper.stop(reporter, reporting);
-    LifecycleHelper.stop(getRetryStore(), getReportBuilder());
-  }
-
-  @Override
-  public void close() {
-    LifecycleHelper.close(deleteRouting, deleter, deleting);
-    LifecycleHelper.close(retryRouting, retrier, retrying);
-    LifecycleHelper.close(reporter, reporting);
-    LifecycleHelper.close(getRetryStore(), getReportBuilder());
-
-    ManagedThreadFactory.shutdownQuietly(workflowSubmitter, DEFAULT_SHUTDOWN_WAIT);
-  }
-
-  public RetryFromJetty withRetryStore(RetryStore rs) {
-    setRetryStore(rs);
-    return this;
-  }
-
-  public RetryFromJetty withReportBuilder(ReportBuilder b) {
-    setReportBuilder(b);
-    return this;
-  }
-
-  String retryEndpointPrefix() {
-    return StringUtils.defaultIfBlank(getRetryEndpointPrefix(), DEFAULT_ENDPOINT_PREFIX);
-  }
-
-  String reportingEndpoint() {
-    return StringUtils.defaultIfBlank(getReportingEndpoint(), DEFAULT_REPORTING_ENDPOINT);
-  }
-
-  String deleteEndpointPrefix() {
-    return StringUtils.defaultIfBlank(getDeleteEndpointPrefix(), DEFAULT_DELETE_PREFIX);
-  }
-
-  String retryHttpMethod() {
-    return StringUtils.defaultIfBlank(getRetryHttpMethod(), HTTP_RETRY_METHOD);
-  }
-
-  String deleteHttpMethod() {
-    return StringUtils.defaultIfBlank(getDeleteHttpMethod(), HTTP_DELETE_METHOD);
-  }
+    /**
+     * The underlying Jetty connection.
+     *
+     */
+    @Getter
+    @Setter
+    @NotNull
+    private AdaptrisConnection connection = new EmbeddedConnection();
 
 
-  protected static void executeQuietly(Service service, AdaptrisMessage msg) {
-    try {
-      service.doService(msg);
-    } catch (Exception e) {
+    /**
+     * How to build reports.
+     *
+     */
+    @Getter
+    @Setter
+    @NotNull
+    @NonNull
+    private ReportBuilder reportBuilder = new ReportBuilder();
 
-    }
-  }
+    /**
+     * Where messages are stored for retries.
+     *
+     */
+    @Getter
+    @Setter
+    @NotNull
+    @NonNull
+    private RetryStore retryStore;
 
-  private abstract class ListenerImpl
-      implements AdaptrisMessageListener, ComponentLifecycle, ComponentLifecycleExtension {
+    /**
+     * The HTTP method which is required for retries; the default is POST.
+     */
+    @AdvancedConfig(rare = true)
+    @Getter
+    @Setter
+    @InputFieldDefault(value = HTTP_RETRY_METHOD)
+    private String retryHttpMethod;
 
-    private JettyResponseService service;
 
-    public ListenerImpl() {
-      service = new JettyResponseService().withHttpStatus(HTTP_STATUS_EXPR)
-          .withContentType(CONTENT_TYPE_EXPR);
-    }
+    /**
+     * The HTTP method which is required for deleting messages from the retry store; the default is
+     * DELETE.
+     */
+    @AdvancedConfig(rare = true)
+    @Getter
+    @Setter
+    @InputFieldDefault(value = HTTP_DELETE_METHOD)
+    private String deleteHttpMethod;
 
-    protected void sendResponse(String httpResponseCode, AdaptrisMessage msg) {
-      msg.addMessageHeader(HTTP_STATUS_KEY, httpResponseCode);
-      // Default a Content-Type if not available
-      msg.addMessageHeader(CONTENT_TYPE_METADATA_KEY, StringUtils.defaultIfBlank(
-          msg.getMetadataValue(CONTENT_TYPE_METADATA_KEY), MimeConstants.CONTENT_TYPE_TEXT_PLAIN));
-      executeQuietly(service, msg);
-    }
+    private transient StandaloneConsumer reporting;
+    private transient StandaloneConsumer retrying;
+    private transient StandaloneConsumer deleting;
+    private transient StandaloneConsumer gettingStacktrace;
+    private transient StandaloneConsumer gettingStacktraceFirstLine;
+
+    private transient ReportListener reporter;
+    private transient RetryListener retrier;
+    private transient DeleteListener deleter;
+    private transient StackTraceListener stacktraceGetter;
+    private transient StackTraceFirstLineListener stacktraceFirstLineGetter;
+
+    private transient ExecutorService workflowSubmitter;
+    private transient JettyRouteCondition retryRouting;
+    private transient JettyRouteCondition deleteRouting;
+    private transient JettyRouteCondition stacktraceRouting;
+    private transient JettyRouteCondition stacktraceFirstLineRouting;
+    private transient boolean prepared = false;
 
     @Override
     public void prepare() throws CoreException {
-      LifecycleHelper.prepare(service);
+        if (!prepared) {
+            Args.notNull(getReportBuilder(), "report-builder");
+            Args.notNull(getRetryStore(), "retry-store");
+
+            String retryServletPath = retryEndpointPrefix() + "*";
+            String retryServletRegexp = "^" + retryEndpointPrefix() + "(.*)";
+
+            String deleteServletPath = deleteEndpointPrefix() + "*";
+            String deleteServletRegexp = "^" + deleteEndpointPrefix() + "(.*)";
+
+            String stackTraceServletPath = DEFAULT_STACKTRACE_ENDPOINT + "*";
+            String stackTraceServletRegexp = "^" + DEFAULT_STACKTRACE_ENDPOINT + "(.*)";
+
+            String stackTraceFirstLineServletPath = DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + "*";
+            String stackTraceFirstLineServletRegexp = "^" + DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + "(.*)";
+
+            retryRouting = new JettyRouteCondition().withUrlPattern(retryServletRegexp)
+                    .withMetadataKeys(MSG_ID_KEY).withMethod(retryHttpMethod());
+            deleteRouting = new JettyRouteCondition().withUrlPattern(deleteServletRegexp)
+                    .withMetadataKeys(MSG_ID_KEY).withMethod(deleteHttpMethod());
+            stacktraceRouting = new JettyRouteCondition()
+                    .withUrlPattern(stackTraceServletRegexp)
+                    .withMetadataKeys(MSG_ID_KEY);
+            stacktraceFirstLineRouting = new JettyRouteCondition()
+                    .withUrlPattern(stackTraceFirstLineServletRegexp)
+                    .withMetadataKeys(MSG_ID_KEY);
+
+            reporter = new ReportListener();
+            retrier = new RetryListener();
+            deleter = new DeleteListener();
+            stacktraceGetter = new StackTraceListener();
+            stacktraceFirstLineGetter = new StackTraceFirstLineListener();
+
+            // By not dictating the method in the consumer; we accept all methods in jetty, but we use the
+            // jetty route filter to filter it out.
+            retrying = new StandaloneConsumer(getConnection(),
+                    new JettyMessageConsumer().withPath(retryServletPath));
+            deleting = new StandaloneConsumer(getConnection(),
+                    new JettyMessageConsumer().withPath(deleteServletPath));
+            reporting = new StandaloneConsumer(getConnection(),
+                    new JettyMessageConsumer().withPath(reportingEndpoint()));
+            gettingStacktrace = new StandaloneConsumer(getConnection(),
+                    new JettyMessageConsumer().withPath(stackTraceServletPath));
+            gettingStacktraceFirstLine = new StandaloneConsumer(getConnection(),
+                    new JettyMessageConsumer().withPath(stackTraceFirstLineServletPath));
+
+            retrying.registerAdaptrisMessageListener(retrier);
+            reporting.registerAdaptrisMessageListener(reporter);
+            deleting.registerAdaptrisMessageListener(deleter);
+            gettingStacktrace.registerAdaptrisMessageListener(stacktraceGetter);
+            gettingStacktraceFirstLine.registerAdaptrisMessageListener(stacktraceFirstLineGetter);
+
+            LifecycleHelper.prepare(getRetryStore(), getReportBuilder());
+            LifecycleHelper.prepare(deleteRouting, deleter, deleting);
+            LifecycleHelper.prepare(retryRouting, retrier, retrying);
+            LifecycleHelper.prepare(reporter, reporting);
+            LifecycleHelper.prepare(stacktraceRouting, stacktraceGetter, gettingStacktrace);
+            LifecycleHelper.prepare(stacktraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
+            prepared = true;
+        }
     }
 
     @Override
     public void init() throws CoreException {
-      LifecycleHelper.init(service);
+        prepare();
+        LifecycleHelper.init(getRetryStore(), getReportBuilder());
+        LifecycleHelper.init(deleteRouting, deleter, deleting);
+        LifecycleHelper.init(retryRouting, retrier, retrying);
+        LifecycleHelper.init(reporter, reporting);
+
+        workflowSubmitter = Executors.newSingleThreadExecutor();
     }
 
     @Override
     public void start() throws CoreException {
-      LifecycleHelper.start(service);
+        LifecycleHelper.start(getRetryStore(), getReportBuilder());
+        LifecycleHelper.start(deleteRouting, deleter, deleting);
+        LifecycleHelper.start(retryRouting, retrier, retrying);
+        LifecycleHelper.start(reporter, reporting);
     }
 
     @Override
     public void stop() {
-      LifecycleHelper.stop(service);
-
+        LifecycleHelper.stop(deleteRouting, deleter, deleting);
+        LifecycleHelper.stop(retryRouting, retrier, retrying);
+        LifecycleHelper.stop(reporter, reporting);
+        LifecycleHelper.stop(getRetryStore(), getReportBuilder());
     }
 
     @Override
     public void close() {
-      LifecycleHelper.close(service);
-    }
-  }
+        LifecycleHelper.close(deleteRouting, deleter, deleting);
+        LifecycleHelper.close(retryRouting, retrier, retrying);
+        LifecycleHelper.close(reporter, reporting);
+        LifecycleHelper.close(getRetryStore(), getReportBuilder());
 
-
-  @NoArgsConstructor
-  private class ReportListener extends ListenerImpl {
-    @Override
-    public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
-        Consumer<AdaptrisMessage> failure) {
-      String httpCode = HTTP_ERROR;
-      try {
-        getReportBuilder().build(getRetryStore().report(), jettyMsg);
-        httpCode = HTTP_OK;
-      } catch (Exception e) {
-        jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-      } finally {
-        sendResponse(httpCode, jettyMsg);
-      }
+        ManagedThreadFactory.shutdownQuietly(workflowSubmitter, DEFAULT_SHUTDOWN_WAIT);
     }
 
-    @Override
-    public String friendlyName() {
-      return "RetryFromJetty::Report";
+    public RetryFromJetty withRetryStore(RetryStore rs) {
+        setRetryStore(rs);
+        return this;
     }
-  }
+
+    public RetryFromJetty withReportBuilder(ReportBuilder b) {
+        setReportBuilder(b);
+        return this;
+    }
+
+    String retryEndpointPrefix() {
+        return StringUtils.defaultIfBlank(getRetryEndpointPrefix(), DEFAULT_ENDPOINT_PREFIX);
+    }
+
+    String reportingEndpoint() {
+        return StringUtils.defaultIfBlank(getReportingEndpoint(), DEFAULT_REPORTING_ENDPOINT);
+    }
+
+    String deleteEndpointPrefix() {
+        return StringUtils.defaultIfBlank(getDeleteEndpointPrefix(), DEFAULT_DELETE_PREFIX);
+    }
+
+    String retryHttpMethod() {
+        return StringUtils.defaultIfBlank(getRetryHttpMethod(), HTTP_RETRY_METHOD);
+    }
+
+    String deleteHttpMethod() {
+        return StringUtils.defaultIfBlank(getDeleteHttpMethod(), HTTP_DELETE_METHOD);
+    }
 
 
-  @NoArgsConstructor
-  private class DeleteListener extends ListenerImpl {
-    private transient Object locker = new Object();
+    protected static void executeQuietly(Service service, AdaptrisMessage msg) {
+        try {
+            service.doService(msg);
+        } catch (Exception e) {
 
-    @Override
-    @Synchronized(value = "locker")
-    public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
-        Consumer<AdaptrisMessage> failure) {
-      try {
-        JettyRoute route = deleteRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
-            jettyMsg.getMetadataValue(JETTY_URI));
-        if (route.matches()) {
-          String msgId =
-              route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
-                  .findFirst().get().getValue();
-          // If metadata exists, then we can delete...
-          // met
-          Map<String, String> metadata = retryStore.getMetadata(msgId);
-          log.trace("Attempting to delete {}", msgId);
-          getRetryStore().delete(msgId);
-          sendResponse(HTTP_OK, jettyMsg);
-        } else {
-          sendResponse(HTTP_BAD, jettyMsg);
         }
-      } catch (Exception e) {
-        jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-        sendResponse(HTTP_NOT_FOUND, jettyMsg);
-      }
     }
 
-    @Override
-    public String friendlyName() {
-      return "RetryFromJetty::Delete";
+    private abstract class ListenerImpl
+            implements AdaptrisMessageListener, ComponentLifecycle, ComponentLifecycleExtension {
+
+        private JettyResponseService service;
+
+        public ListenerImpl() {
+            service = new JettyResponseService().withHttpStatus(HTTP_STATUS_EXPR)
+                    .withContentType(CONTENT_TYPE_EXPR);
+        }
+
+        protected void sendResponse(String httpResponseCode, AdaptrisMessage msg) {
+            msg.addMessageHeader(HTTP_STATUS_KEY, httpResponseCode);
+            // Default a Content-Type if not available
+            msg.addMessageHeader(CONTENT_TYPE_METADATA_KEY, StringUtils.defaultIfBlank(
+                    msg.getMetadataValue(CONTENT_TYPE_METADATA_KEY), MimeConstants.CONTENT_TYPE_TEXT_PLAIN));
+            executeQuietly(service, msg);
+        }
+
+        @Override
+        public void prepare() throws CoreException {
+            LifecycleHelper.prepare(service);
+        }
+
+        @Override
+        public void init() throws CoreException {
+            LifecycleHelper.init(service);
+        }
+
+        @Override
+        public void start() throws CoreException {
+            LifecycleHelper.start(service);
+        }
+
+        @Override
+        public void stop() {
+            LifecycleHelper.stop(service);
+
+        }
+
+        @Override
+        public void close() {
+            LifecycleHelper.close(service);
+        }
     }
-  }
 
-  private class RetryListener extends ListenerImpl {
-    private transient Object locker = new Object();
 
-    @Override
-    @Synchronized(value = "locker")
-    public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
-        Consumer<AdaptrisMessage> failure) {
-      try {
-        JettyRoute route = retryRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
-            jettyMsg.getMetadataValue(JETTY_URI));
-        if (route.matches()) {
-          String msgId =
-              route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
-                  .findFirst().get().getValue();
-          // There's a decision point here because we need to decide between
-          // large or small message factory.
-          // Do we want people to configure it?
-          // Therefore we look up the metadata from the store;
-          // Figure out the workflow, and then get the consumer.getMessageFactory()
-
-          Map<String, String> metadata = retryStore.getMetadata(msgId);
-          Workflow workflow = getWorkflow(metadata.get(Workflow.WORKFLOW_ID_KEY));
-          AdaptrisMessage msgForRetry =
-              retryStore.buildForRetry(msgId, metadata, workflow.getConsumer().getMessageFactory());
-          // We know at this point we have something to retry.
-          // So, we can fire a 202 before submission.
-          sendResponse(HTTP_ACCEPTED, jettyMsg);
-          updateRetryCountMetadata(msgForRetry);
-          log.trace("Attempting to retry {}; resubmitting to [{}]", msgForRetry.getUniqueId(),
-              workflow.obtainWorkflowId());
-          // pooling workflow returns immediately, standard workflow does not.
-          // so submit to an Executor Service.
-          workflowSubmitter.execute(new Thread() {
-            @Override
-            public void run() {
-              Thread.currentThread().setName("Retry Failed Message");
-              workflow.onAdaptrisMessage(msgForRetry, success, failure);
+    @NoArgsConstructor
+    private class ReportListener extends ListenerImpl {
+        @Override
+        public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
+                                      Consumer<AdaptrisMessage> failure) {
+            String httpCode = HTTP_ERROR;
+            try {
+                getReportBuilder().build(getRetryStore().report(), jettyMsg);
+                httpCode = HTTP_OK;
+            } catch (Exception e) {
+                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+            } finally {
+                sendResponse(httpCode, jettyMsg);
             }
-          });
-        } else {
-          sendResponse(HTTP_BAD, jettyMsg);
         }
-      } catch (Exception e) {
-        jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-        sendResponse(HTTP_ERROR, jettyMsg);
-      }
+
+        @Override
+        public String friendlyName() {
+            return "RetryFromJetty::Report";
+        }
     }
 
 
-    @Override
-    public String friendlyName() {
-      return "RetryFromJetty::Retry";
+    @NoArgsConstructor
+    private class DeleteListener extends ListenerImpl {
+        private transient Object locker = new Object();
+
+        @Override
+        @Synchronized(value = "locker")
+        public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
+                                      Consumer<AdaptrisMessage> failure) {
+            try {
+                JettyRoute route = deleteRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
+                        jettyMsg.getMetadataValue(JETTY_URI));
+                if (route.matches()) {
+                    String msgId =
+                            route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
+                                    .findFirst().get().getValue();
+                    // If metadata exists, then we can delete...
+                    // met
+                    Map<String, String> metadata = retryStore.getMetadata(msgId);
+                    log.trace("Attempting to delete {}", msgId);
+                    getRetryStore().delete(msgId);
+                    sendResponse(HTTP_OK, jettyMsg);
+                } else {
+                    sendResponse(HTTP_BAD, jettyMsg);
+                }
+            } catch (Exception e) {
+                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+                sendResponse(HTTP_NOT_FOUND, jettyMsg);
+            }
+        }
+
+        @Override
+        public String friendlyName() {
+            return "RetryFromJetty::Delete";
+        }
     }
-  }
+
+    private class RetryListener extends ListenerImpl {
+        private transient Object locker = new Object();
+
+        @Override
+        @Synchronized(value = "locker")
+        public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
+                                      Consumer<AdaptrisMessage> failure) {
+            try {
+                JettyRoute route = retryRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
+                        jettyMsg.getMetadataValue(JETTY_URI));
+                if (route.matches()) {
+                    String msgId =
+                            route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
+                                    .findFirst().get().getValue();
+                    // There's a decision point here because we need to decide between
+                    // large or small message factory.
+                    // Do we want people to configure it?
+                    // Therefore we look up the metadata from the store;
+                    // Figure out the workflow, and then get the consumer.getMessageFactory()
+
+                    Map<String, String> metadata = retryStore.getMetadata(msgId);
+                    Workflow workflow = getWorkflow(metadata.get(Workflow.WORKFLOW_ID_KEY));
+                    AdaptrisMessage msgForRetry =
+                            retryStore.buildForRetry(msgId, metadata, workflow.getConsumer().getMessageFactory());
+                    // We know at this point we have something to retry.
+                    // So, we can fire a 202 before submission.
+                    sendResponse(HTTP_ACCEPTED, jettyMsg);
+                    updateRetryCountMetadata(msgForRetry);
+                    log.trace("Attempting to retry {}; resubmitting to [{}]", msgForRetry.getUniqueId(),
+                            workflow.obtainWorkflowId());
+                    // pooling workflow returns immediately, standard workflow does not.
+                    // so submit to an Executor Service.
+                    workflowSubmitter.execute(new Thread() {
+                        @Override
+                        public void run() {
+                            Thread.currentThread().setName("Retry Failed Message");
+                            workflow.onAdaptrisMessage(msgForRetry, success, failure);
+                        }
+                    });
+                } else {
+                    sendResponse(HTTP_BAD, jettyMsg);
+                }
+            } catch (Exception e) {
+                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+                sendResponse(HTTP_ERROR, jettyMsg);
+            }
+        }
+
+
+        @Override
+        public String friendlyName() {
+            return "RetryFromJetty::Retry";
+        }
+    }
+
+    @NoArgsConstructor
+    private class StackTraceListener extends ListenerImpl {
+        private transient Object locker = new Object();
+
+        @Override
+        @Synchronized(value = "locker")
+        public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
+                                      Consumer<AdaptrisMessage> failure) {
+            String httpCode = HTTP_ERROR;
+            try {
+                JettyRoute route = new JettyRouteCondition()
+                        .withUrlPattern("^" + DEFAULT_STACKTRACE_ENDPOINT + "(.*)")
+                        .withMetadataKeys(MSG_ID_KEY)
+                        .build(jettyMsg.getMetadataValue(HTTP_METHOD), jettyMsg.getMetadataValue(JETTY_URI));
+                if (route.matches()) {
+                    String msgId = route.metadata().stream()
+                            .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
+                            .findFirst().get().getValue();
+                    String stackTrace = retryStore.getStackTrace(msgId);
+                    jettyMsg.setContent(stackTrace, StandardCharsets.UTF_8.name());
+                    httpCode = HTTP_OK;
+                } else {
+                    httpCode = HTTP_BAD;
+                }
+            } catch (Exception e) {
+                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+            } finally {
+                sendResponse(httpCode, jettyMsg);
+            }
+        }
+
+        @Override
+        public String friendlyName() {
+            return "RetryFromJetty::StackTrace";
+        }
+    }
+
+    @NoArgsConstructor
+    private class StackTraceFirstLineListener extends ListenerImpl {
+        private transient Object locker = new Object();
+
+        @Override
+        @Synchronized(value = "locker")
+        public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
+                                      Consumer<AdaptrisMessage> failure) {
+            String httpCode = HTTP_ERROR;
+            try {
+                JettyRoute route = new JettyRouteCondition()
+                        .withUrlPattern("^" + DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + "(.*)")
+                        .withMetadataKeys(MSG_ID_KEY)
+                        .build(jettyMsg.getMetadataValue(HTTP_METHOD), jettyMsg.getMetadataValue(JETTY_URI));
+                if (route.matches()) {
+                    String msgId = route.metadata().stream()
+                            .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
+                            .findFirst().get().getValue();
+                    String stackTrace = retryStore.getStackTrace(msgId);
+                    String firstLine = stackTrace.split("\n")[0];
+                    jettyMsg.setContent(firstLine, StandardCharsets.UTF_8.name());
+                    httpCode = HTTP_OK;
+                } else {
+                    httpCode = HTTP_BAD;
+                }
+            } catch (Exception e) {
+                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+            } finally {
+                sendResponse(httpCode, jettyMsg);
+            }
+        }
+
+        @Override
+        public String friendlyName() {
+            return "RetryFromJetty::StackTraceFirstLine";
+        }
+    }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -50,8 +50,9 @@ import lombok.extern.slf4j.Slf4j;
  * into a simpler configuration chain.
  * </p>
  * <p>
- * This jetty implementation allows two modes of operation. Listing the failed messages, retrying a
- * message, deleting messages from the store.
+ * This jetty implementation allows listing of the failed messages, retrying a
+ * message, deleting messages and retrieving the stacktrace or first line of the stacktrace
+ * from the store.
  * <ul>
  * <li>{@code curl -XGET http://localhost:8080/api/failed/list} gives you a list of message ids that
  * are listed in the store</li>
@@ -59,6 +60,10 @@ import lombok.extern.slf4j.Slf4j;
  * message to the appropriate workflow; returning a 202 upon success</li>
  * <li>{@code curl -XDELETE http://localhost:8080/api/failed/delete/[msgId]} will attempt to delete
  * the message from the store</li>
+ * <li>{@code curl -XGET http://localhost:8080/api/failed/stacktrace/{msgId}} will retrieve the entire stacktrace
+ * from the store.</li>
+ * <li>{@code curl -XGET http://localhost:8080/api/failed/stacktrace/first-line/{msgId}} will retrieve only the
+ * first line of the stacktrace from the store.</li>
  * <ul>
  * </p>
  * <p>
@@ -506,7 +511,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             return "RetryFromJetty::Report";
         }
     }
-
 
     @NoArgsConstructor
     private class DeleteListener extends ListenerImpl {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -439,6 +439,21 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             executeQuietly(service, msg);
         }
 
+        protected String extractMsgId(JettyRouteCondition routing, AdaptrisMessage jettyMsg) throws CoreException {
+            JettyRoute route = routing.build(jettyMsg.getMetadataValue(HTTP_METHOD), jettyMsg.getMetadataValue(JETTY_URI));
+            if (route.matches()) {
+                return route.metadata().stream()
+                        .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
+                        .findFirst().get().getValue();
+            }
+            return null;
+        }
+
+        protected void handleException(Exception e, AdaptrisMessage msg) {
+            msg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
+            sendResponse(HTTP_ERROR, msg);
+        }
+
         @Override
         public void prepare() throws CoreException {
             LifecycleHelper.prepare(service);
@@ -498,26 +513,25 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Synchronized(value = "locker")
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
+            String httpCode = HTTP_ERROR;
             try {
-                JettyRoute route = deleteRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
-                        jettyMsg.getMetadataValue(JETTY_URI));
-                if (route.matches()) {
-                    String msgId =
-                            route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
-                                    .findFirst().get().getValue();
-                    // If metadata exists, then we can delete...
-                    // met
-                    Map<String, String> metadata = retryStore.getMetadata(msgId);
+                String msgId = extractMsgId(deleteRouting, jettyMsg);
+
+                if (msgId != null) {
                     log.trace("Attempting to delete {}", msgId);
-                    getRetryStore().delete(msgId);
-                    sendResponse(HTTP_OK, jettyMsg);
+                    boolean deleted = getRetryStore().delete(msgId);
+                    if (deleted) {
+                        httpCode = HTTP_OK;
+                    } else {
+                        httpCode = HTTP_NOT_FOUND;
+                    }
                 } else {
-                    sendResponse(HTTP_BAD, jettyMsg);
+                    httpCode = HTTP_BAD;
                 }
             } catch (Exception e) {
-                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-                sendResponse(HTTP_NOT_FOUND, jettyMsg);
+                handleException(e, jettyMsg);
             }
+            sendResponse(httpCode, jettyMsg);
         }
 
         @Override
@@ -533,26 +547,22 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Synchronized(value = "locker")
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
+            String httpCode = HTTP_ERROR;
             try {
-                JettyRoute route = retryRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
-                        jettyMsg.getMetadataValue(JETTY_URI));
-                if (route.matches()) {
-                    String msgId =
-                            route.metadata().stream().filter((e) -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
-                                    .findFirst().get().getValue();
+                String msgId = extractMsgId(retryRouting, jettyMsg);
+                if  (msgId != null) {
                     // There's a decision point here because we need to decide between
                     // large or small message factory.
                     // Do we want people to configure it?
                     // Therefore we look up the metadata from the store;
                     // Figure out the workflow, and then get the consumer.getMessageFactory()
-
                     Map<String, String> metadata = retryStore.getMetadata(msgId);
                     Workflow workflow = getWorkflow(metadata.get(Workflow.WORKFLOW_ID_KEY));
                     AdaptrisMessage msgForRetry =
                             retryStore.buildForRetry(msgId, metadata, workflow.getConsumer().getMessageFactory());
                     // We know at this point we have something to retry.
                     // So, we can fire a 202 before submission.
-                    sendResponse(HTTP_ACCEPTED, jettyMsg);
+                    httpCode = HTTP_ACCEPTED;
                     updateRetryCountMetadata(msgForRetry);
                     log.trace("Attempting to retry {}; resubmitting to [{}]", msgForRetry.getUniqueId(),
                             workflow.obtainWorkflowId());
@@ -566,12 +576,12 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
                         }
                     });
                 } else {
-                    sendResponse(HTTP_BAD, jettyMsg);
+                    httpCode = HTTP_BAD;
                 }
             } catch (Exception e) {
-                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-                sendResponse(HTTP_ERROR, jettyMsg);
+                handleException(e, jettyMsg);
             }
+            sendResponse(httpCode, jettyMsg);
         }
 
 
@@ -589,29 +599,21 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Synchronized(value = "locker")
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
+            String httpCode;
             try {
-                JettyRoute route = stackTraceRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
-                        jettyMsg.getMetadataValue(JETTY_URI));
-
-                if (route.matches()) {
-                    String msgId = route.metadata().stream()
-                            .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
-                            .findFirst().get().getValue();
-
-                    if (msgId != null) {
-                        String stackTrace = retryStore.getStackTrace(msgId);
-                        jettyMsg.setContent(stackTrace, StandardCharsets.UTF_8.name());
-                        sendResponse(HTTP_OK, jettyMsg);
-                    } else {
-                        sendResponse(HTTP_BAD, jettyMsg);
-                    }
+                String msgId = extractMsgId(stackTraceRouting, jettyMsg);
+                if (msgId != null) {
+                    String stackTrace = retryStore.getStackTrace(msgId);
+                    jettyMsg.setContent(stackTrace, StandardCharsets.UTF_8.name());
+                    httpCode = HTTP_OK;
                 } else {
-                    sendResponse(HTTP_BAD, jettyMsg);
+                    httpCode = HTTP_BAD;
                 }
             } catch (Exception e) {
-                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-                sendResponse(HTTP_ERROR, jettyMsg);
+                handleException(e, jettyMsg);
+                return;
             }
+            sendResponse(httpCode, jettyMsg);
         }
 
         @Override
@@ -628,30 +630,22 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Synchronized(value = "locker")
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
+            String httpCode;
             try {
-                JettyRoute route = stackTraceFirstLineRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
-                        jettyMsg.getMetadataValue(JETTY_URI));
-
-                if (route.matches()) {
-                    String msgId = route.metadata().stream()
-                            .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
-                            .findFirst().get().getValue();
-
+                String msgId = extractMsgId(stackTraceFirstLineRouting, jettyMsg);
                     if (msgId != null) {
                         String stackTrace = retryStore.getStackTrace(msgId);
                         String firstLine = stackTrace.split("\n")[0];
                         jettyMsg.setContent(firstLine, StandardCharsets.UTF_8.name());
-                        sendResponse(HTTP_OK, jettyMsg);
+                        httpCode = HTTP_OK;
                     } else {
-                        sendResponse(HTTP_BAD, jettyMsg);
+                        httpCode = HTTP_BAD;
                     }
-                } else {
-                    sendResponse(HTTP_BAD, jettyMsg);
-                }
             } catch (Exception e) {
-                jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-                sendResponse(HTTP_ERROR, jettyMsg);
+                handleException(e, jettyMsg);
+                return;
             }
+            sendResponse(httpCode, jettyMsg);
         }
 
         @Override

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -72,8 +72,8 @@ import lombok.extern.slf4j.Slf4j;
  * </p>
  * <p>
  * While DELETE is available, this implementation doesn't make any checks that the messages that you
- * have retried have been retried successfuly. It is expected that you have separate tooling that
- * allows you to verify that retried-messages are ultimately sucessfully before triggering the
+ * have retried have been retried successfully. It is expected that you have separate tooling that
+ * allows you to verify that retried-messages are ultimately successfully before triggering the
  * delete. If you ask for a message to be deleted from the store, then that is what happens.
  * </p>
  *

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -570,6 +570,7 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
                     // We know at this point we have something to retry.
                     // So, we can fire a 202 before submission.
                     httpCode = HTTP_ACCEPTED;
+                    sendResponse(httpCode, jettyMsg);
                     updateRetryCountMetadata(msgForRetry);
                     log.trace("Attempting to retry {}; resubmitting to [{}]", msgForRetry.getUniqueId(),
                             workflow.obtainWorkflowId());

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -6,29 +6,20 @@ import static com.adaptris.core.http.jetty.JettyConstants.JETTY_URI;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.validation.constraints.NotNull;
 
+import com.adaptris.core.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.core.AdaptrisConnection;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageListener;
-import com.adaptris.core.ComponentLifecycle;
-import com.adaptris.core.ComponentLifecycleExtension;
-import com.adaptris.core.CoreException;
-import com.adaptris.core.FailedMessageRetrier;
-import com.adaptris.core.FailedMessageRetrierImp;
-import com.adaptris.core.Service;
-import com.adaptris.core.StandaloneConsumer;
-import com.adaptris.core.Workflow;
 import com.adaptris.core.http.jetty.EmbeddedConnection;
 import com.adaptris.core.http.jetty.JettyConnection;
 import com.adaptris.core.http.jetty.JettyMessageConsumer;
@@ -442,9 +433,13 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         protected String extractMsgId(JettyRouteCondition routing, AdaptrisMessage jettyMsg) throws CoreException {
             JettyRoute route = routing.build(jettyMsg.getMetadataValue(HTTP_METHOD), jettyMsg.getMetadataValue(JETTY_URI));
             if (route.matches()) {
-                return route.metadata().stream()
-                        .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
-                        .findFirst().get().getValue();
+                Optional<MetadataElement> msgIdEntry = route.metadata().stream()
+                    .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
+                    .findFirst();
+
+                if (msgIdEntry.isPresent()) {
+                    return msgIdEntry.get().getValue();
+                }
             }
             return null;
         }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -92,8 +92,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     public static final String DEFAULT_ENDPOINT_PREFIX = "/api/retry/";
     public static final String DEFAULT_REPORTING_ENDPOINT = "/api/failed/list";
     public static final String DEFAULT_DELETE_PREFIX = "/api/failed/delete/";
-    public static final String DEFAULT_STACKTRACE_ENDPOINT = "/api/failed/stacktrace/";
-    public static final String DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT = "/api/failed/stacktrace/first-line/";
+    public static final String DEFAULT_STACKTRACE_PREFIX = "/api/failed/stacktrace/";
+    public static final String DEFAULT_STACKTRACE_FIRST_LINE_PREFIX = "/api/failed/stacktrace/first-line/";
 
     private static final String HTTP_RETRY_METHOD = "POST";
     private static final String HTTP_DELETE_METHOD = "DELETE";
@@ -151,15 +151,31 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     @InputFieldDefault(value = DEFAULT_DELETE_PREFIX)
     private String deleteEndpointPrefix;
 
+    /**
+     * The get stacktrace endpoint.
+     * <p>
+     * The default if not explicitly specified is {@value DEFAULT_STACKTRACE_PREFIX}, note the trailing
+     * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
+     * form {@code /prefix/'msgId'}
+     * </p>
+     */
     @Getter
     @Setter
-    @InputFieldDefault(value = DEFAULT_STACKTRACE_ENDPOINT)
-    private String stackTraceEndpoint;
+    @InputFieldDefault(value = DEFAULT_STACKTRACE_PREFIX)
+    private String stackTraceEndpointPrefix;
 
+    /**
+     * The get stacktrace first line endpoint.
+     * <p>
+     * The default if not explicitly specified is {@value DEFAULT_STACKTRACE_FIRST_LINE_PREFIX}, note the trailing
+     * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
+     * form {@code /prefix/'msgId'}
+     * </p>
+     */
     @Getter
     @Setter
-    @InputFieldDefault(value = DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT)
-    private String stackTraceFirstLineEndpoint;
+    @InputFieldDefault(value = DEFAULT_STACKTRACE_FIRST_LINE_PREFIX)
+    private String stackTraceFirstLineEndpointPrefix;
 
     /**
      * The underlying Jetty connection.
@@ -251,11 +267,11 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             String deleteServletPath = deleteEndpointPrefix() + "*";
             String deleteServletRegexp = "^" + deleteEndpointPrefix() + "(.*)";
 
-            String stackTraceServletPath = stackTraceEndpoint() + "*";
-            String stackTraceServletRegexp = "^" + stackTraceEndpoint() + "(.*)";
+            String stackTraceServletPath = stackTraceEndpointPrefix() + "*";
+            String stackTraceServletRegexp = "^" + stackTraceEndpointPrefix() + "(.*)";
 
-            String stackTraceFirstLineServletPath = stackTraceEndpoint() + "*";
-            String stackTraceFirstLineServletRegexp = "^" + stackTraceEndpoint() + "(.*)";
+            String stackTraceFirstLineServletPath = stackTraceFirstLineEndpointPrefix() + "*";
+            String stackTraceFirstLineServletRegexp = "^" + stackTraceFirstLineEndpointPrefix() + "(.*)";
 
             retryRouting = new JettyRouteCondition()
                     .withUrlPattern(retryServletRegexp)
@@ -372,12 +388,12 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         return StringUtils.defaultIfBlank(getReportingEndpoint(), DEFAULT_REPORTING_ENDPOINT);
     }
 
-    String stackTraceEndpoint() {
-        return StringUtils.defaultIfBlank(getStackTraceEndpoint(), DEFAULT_STACKTRACE_ENDPOINT);
+    String stackTraceEndpointPrefix() {
+        return StringUtils.defaultIfBlank(getStackTraceEndpointPrefix(), DEFAULT_STACKTRACE_PREFIX);
     }
 
-    String stackTraceFirstLineEndpoint() {
-        return StringUtils.defaultIfBlank(getStackTraceFirstLineEndpoint(), DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT);
+    String stackTraceFirstLineEndpointPrefix() {
+        return StringUtils.defaultIfBlank(getStackTraceFirstLineEndpointPrefix(), DEFAULT_STACKTRACE_FIRST_LINE_PREFIX);
     }
 
     String deleteEndpointPrefix() {
@@ -576,19 +592,25 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             try {
                 JettyRoute route = stackTraceRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
                         jettyMsg.getMetadataValue(JETTY_URI));
+
                 if (route.matches()) {
                     String msgId = route.metadata().stream()
                             .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
                             .findFirst().get().getValue();
-                    String stackTrace = retryStore.getStackTrace(msgId);
-                    jettyMsg.setContent(stackTrace, StandardCharsets.UTF_8.name());
-                    sendResponse(HTTP_OK, jettyMsg);
+
+                    if (msgId != null) {
+                        String stackTrace = retryStore.getStackTrace(msgId);
+                        jettyMsg.setContent(stackTrace, StandardCharsets.UTF_8.name());
+                        sendResponse(HTTP_OK, jettyMsg);
+                    } else {
+                        sendResponse(HTTP_BAD, jettyMsg);
+                    }
                 } else {
                     sendResponse(HTTP_BAD, jettyMsg);
                 }
             } catch (Exception e) {
                 jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-                sendResponse(HTTP_NOT_FOUND, jettyMsg);
+                sendResponse(HTTP_ERROR, jettyMsg);
             }
         }
 
@@ -606,28 +628,29 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Synchronized(value = "locker")
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
-            String httpCode = HTTP_ERROR;
             try {
-                JettyRoute route = new JettyRouteCondition()
-                        .withUrlPattern("^" + stackTraceFirstLineEndpoint() + "(.*)")
-                        .withMetadataKeys(MSG_ID_KEY)
-                        .withMethod("GET")
-                        .build(jettyMsg.getMetadataValue(HTTP_METHOD), jettyMsg.getMetadataValue(JETTY_URI));
+                JettyRoute route = stackTraceFirstLineRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
+                        jettyMsg.getMetadataValue(JETTY_URI));
+
                 if (route.matches()) {
                     String msgId = route.metadata().stream()
                             .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
                             .findFirst().get().getValue();
-                    String stackTrace = retryStore.getStackTrace(msgId);
-                    String firstLine = stackTrace.split("\n")[0];
-                    jettyMsg.setContent(firstLine, StandardCharsets.UTF_8.name());
-                    httpCode = HTTP_OK;
+
+                    if (msgId != null) {
+                        String stackTrace = retryStore.getStackTrace(msgId);
+                        String firstLine = stackTrace.split("\n")[0];
+                        jettyMsg.setContent(firstLine, StandardCharsets.UTF_8.name());
+                        sendResponse(HTTP_OK, jettyMsg);
+                    } else {
+                        sendResponse(HTTP_BAD, jettyMsg);
+                    }
                 } else {
-                    httpCode = HTTP_BAD;
+                    sendResponse(HTTP_BAD, jettyMsg);
                 }
             } catch (Exception e) {
                 jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-            } finally {
-                sendResponse(httpCode, jettyMsg);
+                sendResponse(HTTP_ERROR, jettyMsg);
             }
         }
 

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -97,6 +97,7 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
 
     private static final String HTTP_RETRY_METHOD = "POST";
     private static final String HTTP_DELETE_METHOD = "DELETE";
+    private static final String HTTP_STACKTRACE_METHOD = "GET";
 
     private static final TimeInterval DEFAULT_SHUTDOWN_WAIT = new TimeInterval(30L, TimeUnit.SECONDS.name());
 
@@ -105,7 +106,7 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
 
     private static final String HTTP_STATUS_KEY = "__httpResponseCode";
     private static final String HTTP_STATUS_EXPR = "%message{__httpResponseCode}";
-    private static final String MSG_ID_KEY = "__MsgId";
+    static final String MSG_ID_KEY = "__MsgId";
 
     protected static final String HTTP_OK = "" + HttpURLConnection.HTTP_OK;
     protected static final String HTTP_ACCEPTED = "" + HttpURLConnection.HTTP_ACCEPTED;
@@ -149,6 +150,16 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     @Setter
     @InputFieldDefault(value = DEFAULT_DELETE_PREFIX)
     private String deleteEndpointPrefix;
+
+    @Getter
+    @Setter
+    @InputFieldDefault(value = DEFAULT_STACKTRACE_ENDPOINT)
+    private String stackTraceEndpoint;
+
+    @Getter
+    @Setter
+    @InputFieldDefault(value = DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT)
+    private String stackTraceFirstLineEndpoint;
 
     /**
      * The underlying Jetty connection.
@@ -200,6 +211,15 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     @InputFieldDefault(value = HTTP_DELETE_METHOD)
     private String deleteHttpMethod;
 
+    /**
+     * The HTTP method which is required for getting an error stacktrace; the default is GET.
+     */
+    @AdvancedConfig(rare = true)
+    @Getter
+    @Setter
+    @InputFieldDefault(value = HTTP_RETRY_METHOD)
+    private String stackTraceHttpMethod;
+
     private transient StandaloneConsumer reporting;
     private transient StandaloneConsumer retrying;
     private transient StandaloneConsumer deleting;
@@ -215,8 +235,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     private transient ExecutorService workflowSubmitter;
     private transient JettyRouteCondition retryRouting;
     private transient JettyRouteCondition deleteRouting;
-    private transient JettyRouteCondition stacktraceRouting;
-    private transient JettyRouteCondition stacktraceFirstLineRouting;
+    private transient JettyRouteCondition stackTraceRouting;
+    private transient JettyRouteCondition stackTraceFirstLineRouting;
     private transient boolean prepared = false;
 
     @Override
@@ -231,22 +251,28 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             String deleteServletPath = deleteEndpointPrefix() + "*";
             String deleteServletRegexp = "^" + deleteEndpointPrefix() + "(.*)";
 
-            String stackTraceServletPath = DEFAULT_STACKTRACE_ENDPOINT + "*";
-            String stackTraceServletRegexp = "^" + DEFAULT_STACKTRACE_ENDPOINT + "(.*)";
+            String stackTraceServletPath = stackTraceEndpoint() + "*";
+            String stackTraceServletRegexp = "^" + stackTraceEndpoint() + "(.*)";
 
-            String stackTraceFirstLineServletPath = DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + "*";
-            String stackTraceFirstLineServletRegexp = "^" + DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + "(.*)";
+            String stackTraceFirstLineServletPath = stackTraceEndpoint() + "*";
+            String stackTraceFirstLineServletRegexp = "^" + stackTraceEndpoint() + "(.*)";
 
-            retryRouting = new JettyRouteCondition().withUrlPattern(retryServletRegexp)
-                    .withMetadataKeys(MSG_ID_KEY).withMethod(retryHttpMethod());
-            deleteRouting = new JettyRouteCondition().withUrlPattern(deleteServletRegexp)
-                    .withMetadataKeys(MSG_ID_KEY).withMethod(deleteHttpMethod());
-            stacktraceRouting = new JettyRouteCondition()
+            retryRouting = new JettyRouteCondition()
+                    .withUrlPattern(retryServletRegexp)
+                    .withMetadataKeys(MSG_ID_KEY)
+                    .withMethod(retryHttpMethod());
+            deleteRouting = new JettyRouteCondition()
+                    .withUrlPattern(deleteServletRegexp)
+                    .withMetadataKeys(MSG_ID_KEY)
+                    .withMethod(deleteHttpMethod());
+            stackTraceRouting = new JettyRouteCondition()
                     .withUrlPattern(stackTraceServletRegexp)
-                    .withMetadataKeys(MSG_ID_KEY);
-            stacktraceFirstLineRouting = new JettyRouteCondition()
+                    .withMetadataKeys(MSG_ID_KEY)
+                    .withMethod(stackTraceHttpMethod());
+            stackTraceFirstLineRouting = new JettyRouteCondition()
                     .withUrlPattern(stackTraceFirstLineServletRegexp)
-                    .withMetadataKeys(MSG_ID_KEY);
+                    .withMetadataKeys(MSG_ID_KEY)
+                    .withMethod(stackTraceHttpMethod());
 
             reporter = new ReportListener();
             retrier = new RetryListener();
@@ -277,8 +303,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             LifecycleHelper.prepare(deleteRouting, deleter, deleting);
             LifecycleHelper.prepare(retryRouting, retrier, retrying);
             LifecycleHelper.prepare(reporter, reporting);
-            LifecycleHelper.prepare(stacktraceRouting, stacktraceGetter, gettingStacktrace);
-            LifecycleHelper.prepare(stacktraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
+            LifecycleHelper.prepare(stackTraceRouting, stacktraceGetter, gettingStacktrace);
+            LifecycleHelper.prepare(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
             prepared = true;
         }
     }
@@ -290,6 +316,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         LifecycleHelper.init(deleteRouting, deleter, deleting);
         LifecycleHelper.init(retryRouting, retrier, retrying);
         LifecycleHelper.init(reporter, reporting);
+        LifecycleHelper.init(stackTraceRouting, stacktraceGetter, gettingStacktrace);
+        LifecycleHelper.init(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
 
         workflowSubmitter = Executors.newSingleThreadExecutor();
     }
@@ -300,6 +328,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         LifecycleHelper.start(deleteRouting, deleter, deleting);
         LifecycleHelper.start(retryRouting, retrier, retrying);
         LifecycleHelper.start(reporter, reporting);
+        LifecycleHelper.start(stackTraceRouting, stacktraceGetter, gettingStacktrace);
+        LifecycleHelper.start(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
     }
 
     @Override
@@ -307,6 +337,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         LifecycleHelper.stop(deleteRouting, deleter, deleting);
         LifecycleHelper.stop(retryRouting, retrier, retrying);
         LifecycleHelper.stop(reporter, reporting);
+        LifecycleHelper.stop(stackTraceRouting, stacktraceGetter, gettingStacktrace);
+        LifecycleHelper.stop(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
         LifecycleHelper.stop(getRetryStore(), getReportBuilder());
     }
 
@@ -315,6 +347,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         LifecycleHelper.close(deleteRouting, deleter, deleting);
         LifecycleHelper.close(retryRouting, retrier, retrying);
         LifecycleHelper.close(reporter, reporting);
+        LifecycleHelper.close(stackTraceRouting, stacktraceGetter, gettingStacktrace);
+        LifecycleHelper.close(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
         LifecycleHelper.close(getRetryStore(), getReportBuilder());
 
         ManagedThreadFactory.shutdownQuietly(workflowSubmitter, DEFAULT_SHUTDOWN_WAIT);
@@ -338,6 +372,14 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         return StringUtils.defaultIfBlank(getReportingEndpoint(), DEFAULT_REPORTING_ENDPOINT);
     }
 
+    String stackTraceEndpoint() {
+        return StringUtils.defaultIfBlank(getStackTraceEndpoint(), DEFAULT_STACKTRACE_ENDPOINT);
+    }
+
+    String stackTraceFirstLineEndpoint() {
+        return StringUtils.defaultIfBlank(getStackTraceFirstLineEndpoint(), DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT);
+    }
+
     String deleteEndpointPrefix() {
         return StringUtils.defaultIfBlank(getDeleteEndpointPrefix(), DEFAULT_DELETE_PREFIX);
     }
@@ -348,6 +390,10 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
 
     String deleteHttpMethod() {
         return StringUtils.defaultIfBlank(getDeleteHttpMethod(), HTTP_DELETE_METHOD);
+    }
+
+    String stackTraceHttpMethod() {
+        return StringUtils.defaultIfBlank(getStackTraceHttpMethod(), HTTP_STACKTRACE_METHOD);
     }
 
 
@@ -527,26 +573,22 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Synchronized(value = "locker")
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
-            String httpCode = HTTP_ERROR;
             try {
-                JettyRoute route = new JettyRouteCondition()
-                        .withUrlPattern("^" + DEFAULT_STACKTRACE_ENDPOINT + "(.*)")
-                        .withMetadataKeys(MSG_ID_KEY)
-                        .build(jettyMsg.getMetadataValue(HTTP_METHOD), jettyMsg.getMetadataValue(JETTY_URI));
+                JettyRoute route = stackTraceRouting.build(jettyMsg.getMetadataValue(HTTP_METHOD),
+                        jettyMsg.getMetadataValue(JETTY_URI));
                 if (route.matches()) {
                     String msgId = route.metadata().stream()
                             .filter(e -> e.getKey().equalsIgnoreCase(MSG_ID_KEY))
                             .findFirst().get().getValue();
                     String stackTrace = retryStore.getStackTrace(msgId);
                     jettyMsg.setContent(stackTrace, StandardCharsets.UTF_8.name());
-                    httpCode = HTTP_OK;
+                    sendResponse(HTTP_OK, jettyMsg);
                 } else {
-                    httpCode = HTTP_BAD;
+                    sendResponse(HTTP_BAD, jettyMsg);
                 }
             } catch (Exception e) {
                 jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
-            } finally {
-                sendResponse(httpCode, jettyMsg);
+                sendResponse(HTTP_NOT_FOUND, jettyMsg);
             }
         }
 
@@ -567,8 +609,9 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             String httpCode = HTTP_ERROR;
             try {
                 JettyRoute route = new JettyRouteCondition()
-                        .withUrlPattern("^" + DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + "(.*)")
+                        .withUrlPattern("^" + stackTraceFirstLineEndpoint() + "(.*)")
                         .withMetadataKeys(MSG_ID_KEY)
+                        .withMethod("GET")
                         .build(jettyMsg.getMetadataValue(HTTP_METHOD), jettyMsg.getMetadataValue(JETTY_URI));
                 if (route.matches()) {
                     String msgId = route.metadata().stream()

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -454,6 +454,14 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             sendResponse(HTTP_ERROR, msg);
         }
 
+        protected void handleStackTraceResponse(String msgId, AdaptrisMessage jettyMsg, String stackTrace) {
+            String httpCode = (msgId != null) ? HTTP_OK : HTTP_BAD;
+            if (msgId != null) {
+                jettyMsg.setContent(stackTrace, StandardCharsets.UTF_8.name());
+            }
+            sendResponse(httpCode, jettyMsg);
+        }
+
         @Override
         public void prepare() throws CoreException {
             LifecycleHelper.prepare(service);
@@ -599,21 +607,13 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Synchronized(value = "locker")
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
-            String httpCode;
             try {
                 String msgId = extractMsgId(stackTraceRouting, jettyMsg);
-                if (msgId != null) {
-                    String stackTrace = retryStore.getStackTrace(msgId);
-                    jettyMsg.setContent(stackTrace, StandardCharsets.UTF_8.name());
-                    httpCode = HTTP_OK;
-                } else {
-                    httpCode = HTTP_BAD;
-                }
+                String stackTrace = retryStore.getStackTrace(msgId);
+                handleStackTraceResponse(msgId, jettyMsg, stackTrace);
             } catch (Exception e) {
                 handleException(e, jettyMsg);
-                return;
             }
-            sendResponse(httpCode, jettyMsg);
         }
 
         @Override
@@ -630,22 +630,14 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Synchronized(value = "locker")
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
-            String httpCode;
             try {
                 String msgId = extractMsgId(stackTraceFirstLineRouting, jettyMsg);
-                    if (msgId != null) {
-                        String stackTrace = retryStore.getStackTrace(msgId);
-                        String firstLine = stackTrace.split("\n")[0];
-                        jettyMsg.setContent(firstLine, StandardCharsets.UTF_8.name());
-                        httpCode = HTTP_OK;
-                    } else {
-                        httpCode = HTTP_BAD;
-                    }
+                String stackTrace = retryStore.getStackTrace(msgId);
+                String firstLine = stackTrace.split("\n")[0];
+                handleStackTraceResponse(msgId, jettyMsg, firstLine);
             } catch (Exception e) {
                 handleException(e, jettyMsg);
-                return;
             }
-            sendResponse(httpCode, jettyMsg);
         }
 
         @Override

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
@@ -164,4 +164,12 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
    */
   void makeConnection(AdaptrisConnection connection);
 
+  /**
+   * Retrieve the stack trace for a given message ID.
+   *
+   * @param msgId the message ID
+   * @return the stack trace as a String
+   * @throws InterlokException if the stack trace cannot be retrieved
+   */
+  String getStackTrace(String msgId) throws InterlokException;
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
@@ -439,4 +439,27 @@ public class JdbcRetryStore implements RetryStore {
   public void makeConnection(AdaptrisConnection connection) {
     setConnection(connection);
   }
+
+  @Override
+  public String getStackTrace(String msgId) throws InterlokException {
+      PreparedStatement ps = null;
+      ResultSet rs = null;
+      try {
+          ps = prepareStatementWithParameters(sqlConnection, sqlStatements.getProperty("select.sql"), new Object[] { msgId });
+          log.trace("Executing select statement for JDBCRetryStore getStacktrace");
+          rs = ps.executeQuery();
+          if (rs.next()) {
+              // Assuming the stack trace is stored in a column named "stacktrace"
+              //TODO - I think the table may not be storing the stacktrace, this needs updating
+              return rs.getString("stacktrace");
+          } else {
+              throw new InterlokException("No stack trace found for message ID: " + msgId);
+          }
+      } catch (SQLException e) {
+          throw ExceptionHelper.wrapInterlokException(e);
+      } finally {
+          JdbcUtil.closeQuietly(rs);
+          JdbcUtil.closeQuietly(ps);
+      }
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
@@ -442,22 +442,7 @@ public class JdbcRetryStore implements RetryStore {
 
   @Override
   public String getStackTrace(String msgId) throws InterlokException {
-      PreparedStatement ps = null;
-      ResultSet rs = null;
-      try {
-          ps = prepareStatementWithParameters(sqlConnection, sqlStatements.getProperty("select.sql"), new Object[] { msgId });
-          log.trace("Executing select statement for JDBCRetryStore getStacktrace");
-          rs = ps.executeQuery();
-          if (rs.next()) {
-              return rs.getString("stacktrace");
-          } else {
-              throw new InterlokException("No stack trace found for message ID: " + msgId);
-          }
-      } catch (SQLException e) {
-          throw ExceptionHelper.wrapInterlokException(e);
-      } finally {
-          JdbcUtil.closeQuietly(rs);
-          JdbcUtil.closeQuietly(ps);
-      }
+      throw new UnsupportedOperationException("Not supported yet. Retrieving stacktrace information is currently only " +
+              "supported by the AWS retry store.");
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
@@ -449,8 +449,6 @@ public class JdbcRetryStore implements RetryStore {
           log.trace("Executing select statement for JDBCRetryStore getStacktrace");
           rs = ps.executeQuery();
           if (rs.next()) {
-              // Assuming the stack trace is stored in a column named "stacktrace"
-              //TODO - I think the table may not be storing the stacktrace, this needs updating
               return rs.getString("stacktrace");
           } else {
               throw new InterlokException("No stack trace found for message ID: " + msgId);

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
@@ -1,13 +1,9 @@
 package com.adaptris.core.http.jetty.retry;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
 import java.io.FileFilter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 
@@ -27,6 +23,11 @@ import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.cloud.RemoteBlob;
 import com.adaptris.interlok.junit.scaffolding.BaseCase;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 public class FilesystemRetryStoreTest {
 
@@ -36,6 +37,9 @@ public class FilesystemRetryStoreTest {
   // sure that we never have a drive letter.
   public static final String INVALID_URL = "file://localhost/./ spaces / not / valid / in / url";
   public static final String TEST_BASE_URL = "retry.baseUrl";
+
+  @TempDir
+  Path tempDir;
 
   @AfterAll
   public static void afterAll() throws Exception {
@@ -254,6 +258,106 @@ public class FilesystemRetryStoreTest {
     } finally {
       LifecycleHelper.stopAndClose(store);
     }
+  }
 
+  @Test
+  void testGetStackTrace_ValidFile() throws Exception {
+    FilesystemRetryStore store = spy(new FilesystemRetryStore());
+    store.setBaseUrl(tempDir.toUri().toString());
+
+    String msgId = "validMessageId";
+    Path msgDir = tempDir.resolve(msgId);
+    Files.createDirectory(msgDir);
+    Path stackTraceFile = msgDir.resolve("stacktrace.txt");
+    Files.writeString(stackTraceFile, "Stack trace content");
+
+    String stackTrace = store.getStackTrace(msgId);
+    assertEquals("Stack trace content", stackTrace);
+  }
+
+  @Test
+  void testGetStackTrace_FileNotFound() {
+    FilesystemRetryStore store = spy(new FilesystemRetryStore());
+    store.setBaseUrl(tempDir.toUri().toString());
+
+    String msgId = "missingMessageId";
+
+    InterlokException exception = assertThrows(InterlokException.class, () -> store.getStackTrace(msgId));
+    assertTrue(exception.getMessage().contains("Does not exist ["));
+  }
+
+  @Test
+  void testGetStackTrace_UnreadableFile() throws Exception {
+    FilesystemRetryStore store = spy(new FilesystemRetryStore());
+    String msgId = "unreadableMessageId";
+
+    doThrow(new InterlokException("Permission denied")).when(store).getStackTrace(msgId);
+
+    InterlokException exception = assertThrows(InterlokException.class, () -> store.getStackTrace(msgId));
+    assertTrue(exception.getMessage().contains("Permission denied"));
+  }
+
+  @Test
+  void testValidatePathComponent_ValidComponent() {
+    assertDoesNotThrow(() -> FilesystemRetryStore.validatePathComponent("validMessageId"));
+  }
+
+  @Test
+  void testValidatePathComponent_NullComponent() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+          () -> FilesystemRetryStore.validatePathComponent(null));
+    assertEquals("Message ID may not be null or empty", exception.getMessage());
+  }
+
+  @Test
+  void testValidatePathComponent_EmptyComponent() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+          () -> FilesystemRetryStore.validatePathComponent(""));
+    assertEquals("Message ID may not be null or empty", exception.getMessage());
+  }
+
+  @Test
+  void testValidatePathComponent_PathTraversalDetected() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+          () -> FilesystemRetryStore.validatePathComponent("../invalidMessageId"));
+    assertEquals("Invalid message ID: path traversal or separator detected", exception.getMessage());
+  }
+
+  @Test
+  void testValidatePathComponent_SeparatorDetected() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+          () -> FilesystemRetryStore.validatePathComponent("invalid/messageId"));
+    assertEquals("Invalid message ID: path traversal or separator detected", exception.getMessage());
+  }
+
+  @Test
+  void testValidatePathComponent_AbsolutePathDetected() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+          () -> FilesystemRetryStore.validatePathComponent("C:\\absolutePath"));
+    assertEquals("Invalid message ID: path traversal or separator detected", exception.getMessage());
+  }
+
+  @Test
+  void testAcknowledge_NullImplementation() {
+    FilesystemRetryStore store = new FilesystemRetryStore();
+    assertDoesNotThrow(() -> store.acknowledge("testAcknowledgeId"));
+  }
+
+  @Test
+  void testDeleteAcknowledged_NullImplementation() {
+    FilesystemRetryStore store = new FilesystemRetryStore();
+    assertDoesNotThrow(() -> store.deleteAcknowledged());
+  }
+
+  @Test
+  void testUpdateRetryCount_NullImplementation() {
+    FilesystemRetryStore store = new FilesystemRetryStore();
+    assertDoesNotThrow(() -> store.updateRetryCount("testMessageId"));
+  }
+
+  @Test
+  void testMakeConnection_NullImplementation() {
+    FilesystemRetryStore store = new FilesystemRetryStore();
+    assertDoesNotThrow(() -> store.makeConnection(null));
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
@@ -78,4 +78,13 @@ public class InMemoryRetryStore implements RetryStore {
   public void makeConnection(AdaptrisConnection connection) {
    // null implementation 
   }
+
+    @Override
+    public String getStackTrace(String msgId) throws InterlokException {
+        if (STORE.containsKey(msgId)) {
+            AdaptrisMessage message = STORE.get(msgId);
+            return message.getContent();
+        }
+        throw new InterlokException("Stack trace not found for message ID: " + msgId);
+    }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -361,7 +361,7 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
             assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
 
             AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_ENDPOINT + baseMsg.getUniqueId());
+            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_PREFIX + baseMsg.getUniqueId());
             StandardHttpProducer http = buildProducer(url);
             http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
             http.setIgnoreServerResponseCode(true);
@@ -372,7 +372,6 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
             assertEquals(RetryFromJetty.HTTP_OK,
                     triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
             assertNotNull(triggerMsg.getContent());
-            assertTrue(triggerMsg.getContent().contains("Test Exception"));
         } finally {
             stop(retrier);
         }
@@ -396,7 +395,7 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
 
             ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
 
-            assertEquals(RetryFromJetty.HTTP_BAD,
+            assertEquals(RetryFromJetty.HTTP_NOT_FOUND,
                     triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
         } finally {
             stop(retrier);
@@ -411,7 +410,7 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
             start(retrier);
 
             AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_ENDPOINT + triggerMsg.getUniqueId());
+            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_PREFIX + triggerMsg.getUniqueId());
             StandardHttpProducer http = buildProducer(url);
             http.setIgnoreServerResponseCode(true);
             http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
@@ -434,7 +433,7 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
             assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
 
             AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + baseMsg.getUniqueId());
+            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_FIRST_LINE_PREFIX + baseMsg.getUniqueId());
             StandardHttpProducer http = buildProducer(url);
             http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
             http.setIgnoreServerResponseCode(true);
@@ -469,7 +468,7 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
 
             ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
 
-            assertEquals(RetryFromJetty.HTTP_BAD,
+            assertEquals(RetryFromJetty.HTTP_NOT_FOUND,
                     triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
         } finally {
             stop(retrier);
@@ -484,7 +483,7 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
             start(retrier);
 
             AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + triggerMsg.getUniqueId());
+            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_FIRST_LINE_PREFIX + triggerMsg.getUniqueId());
             StandardHttpProducer http = buildProducer(url);
             http.setIgnoreServerResponseCode(true);
             http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -346,6 +346,158 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
     }
   }
 
+    @Test
+    public void testStackTrace() throws Exception {
+        RetryFromJetty retrier = create();
+        try {
+            start(retrier);
+            AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            try {
+                throw new Exception("Test Exception");
+            } catch (Exception e) {
+                baseMsg.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, e);
+            }
+            retryStore.write(baseMsg);
+            assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+
+            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_ENDPOINT + baseMsg.getUniqueId());
+            StandardHttpProducer http = buildProducer(url);
+            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+            http.setIgnoreServerResponseCode(true);
+            triggerMsg.addMetadata(RetryFromJetty.MSG_ID_KEY, baseMsg.getUniqueId());
+
+            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+
+            assertEquals(RetryFromJetty.HTTP_OK,
+                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+            assertNotNull(triggerMsg.getContent());
+            assertTrue(triggerMsg.getContent().contains("Test Exception"));
+        } finally {
+            stop(retrier);
+        }
+    }
+
+    @Test
+    public void testStackTrace_BadRequest() throws Exception {
+        RetryFromJetty retrier = create();
+        try {
+            start(retrier);
+            AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            retryStore.write(baseMsg);
+            assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+
+            // Test with invalid URL
+            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            String url = jettyHelper.buildUrl("/invalid/path/" + baseMsg.getUniqueId());
+            StandardHttpProducer http = buildProducer(url);
+            http.setIgnoreServerResponseCode(true);
+            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+
+            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+
+            assertEquals(RetryFromJetty.HTTP_BAD,
+                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+        } finally {
+            stop(retrier);
+        }
+    }
+
+    @Test
+    public void testStackTrace_Error() throws Exception {
+        RetryFromJetty retrier = create();
+        try {
+            retrier.setRetryStore(new BrokenRetryStore());
+            start(retrier);
+
+            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_ENDPOINT + triggerMsg.getUniqueId());
+            StandardHttpProducer http = buildProducer(url);
+            http.setIgnoreServerResponseCode(true);
+            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+
+            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+            assertEquals(RetryFromJetty.HTTP_ERROR,
+                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+        } finally {
+            stop(retrier);
+        }
+    }
+
+    @Test
+    public void testStackTraceFirstLine() throws Exception {
+        RetryFromJetty retrier = create();
+        try {
+            start(retrier);
+            AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            retryStore.write(baseMsg);
+            assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+
+            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + baseMsg.getUniqueId());
+            StandardHttpProducer http = buildProducer(url);
+            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+            http.setIgnoreServerResponseCode(true);
+            triggerMsg.addMetadata(RetryFromJetty.MSG_ID_KEY, baseMsg.getUniqueId());
+
+            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+
+            assertEquals(RetryFromJetty.HTTP_OK,
+                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+            assertNotNull(triggerMsg.getContent());
+            assertEquals(1, triggerMsg.getContent().split("\n").length);
+        } finally {
+            stop(retrier);
+        }
+    }
+
+    @Test
+    public void testStackTraceFirstLine_BadRequest() throws Exception {
+        RetryFromJetty retrier = create();
+        try {
+            start(retrier);
+            AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            retryStore.write(baseMsg);
+            assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+
+            // Test with invalid URL
+            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            String url = jettyHelper.buildUrl("/invalid/path/" + baseMsg.getUniqueId());
+            StandardHttpProducer http = buildProducer(url);
+            http.setIgnoreServerResponseCode(true);
+            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+
+            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+
+            assertEquals(RetryFromJetty.HTTP_BAD,
+                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+        } finally {
+            stop(retrier);
+        }
+    }
+
+    @Test
+    public void testStackTraceFirstLine_Error() throws Exception {
+        RetryFromJetty retrier = create();
+        try {
+            retrier.setRetryStore(new BrokenRetryStore());
+            start(retrier);
+
+            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_FIRST_LINE_ENDPOINT + triggerMsg.getUniqueId());
+            StandardHttpProducer http = buildProducer(url);
+            http.setIgnoreServerResponseCode(true);
+            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+
+            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+            assertEquals(RetryFromJetty.HTTP_ERROR,
+                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+        } finally {
+            stop(retrier);
+        }
+    }
+
+
   private StandardHttpProducer buildProducer(String url) {
     StandardHttpProducer producer = new StandardHttpProducer().withURL(url);
     return producer;

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -431,6 +431,11 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
     public void makeConnection(AdaptrisConnection connection) {
     // null implementation
     }
+
+    @Override
+    public String getStackTrace(String msgId) throws InterlokException {
+      throw new UnsupportedOperationException();
+    }
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
@@ -97,4 +97,8 @@ public class RetryStoreTest implements RetryStore {
     // null implementation
   }
 
+  @Override
+  public String getStackTrace(String msgId) throws InterlokException {
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
Implementing a new getStacktrace method within RetryStore. This enables 2 new endpoints from RetryFromJetty - "/api/failed/stacktrace/{id}" 
"/api/failed/stacktrace/first-line/{id}"

These endpoints will return the stacktrace or first line given a message id.