### PR TITLE
INTERLOK-4619: Fix relative paths for FileDataInputParameter mapping …

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/transform/XmlTransformService.java
@@ -27,6 +27,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.xml.transform.Transformer;
 
+import com.adaptris.core.common.FileParameter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -211,7 +212,13 @@ public class XmlTransformService extends ServiceImp {
           transformer = getXmlTransformerFactory().createTransformerFromUrl(xslSourceToUse);
         }
       } else {
-        transformer = getXmlTransformerFactory().createTransformerFromRawXsl(xslSourceToUse);
+          if (getMappingSource() instanceof FileParameter fileParameter) {
+              // for URL based sources, we need to pass the base URI into the InputSource so that resolution of
+              // paths occurs correctly
+              transformer = getXmlTransformerFactory().createTransformerFromRawXsl(xslSourceToUse, fileParameter.getUrl(), null);
+          } else {
+              transformer = getXmlTransformerFactory().createTransformerFromRawXsl(xslSourceToUse);
+          }
       }
 
       getXmlTransformerFactory().configure(xmlTransformerImpl);

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/StxTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/StxTransformerFactory.java
@@ -16,10 +16,8 @@
 
 package com.adaptris.util.text.xml;
 
-import java.io.StringReader;
-
 import javax.xml.transform.Transformer;
-import javax.xml.transform.stream.StreamSource;
+import javax.xml.transform.TransformerFactory;
 
 import org.xml.sax.EntityResolver;
 
@@ -46,8 +44,7 @@ public class StxTransformerFactory extends XmlTransformerFactoryImpl {
 
   @Override
   public Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception {
-    StreamSource xslStream = new StreamSource(new StringReader(xsl));
-    return configure( new TransformerFactoryImpl()).newTransformer(xslStream);
+      return createTransformerFromRawXsl(xsl, null, entityResolver);
   }
 
   @Override
@@ -55,4 +52,8 @@ public class StxTransformerFactory extends XmlTransformerFactoryImpl {
     return xmlTransformer;
   }
 
+    @Override
+    protected TransformerFactory newInstance() {
+        return new TransformerFactoryImpl();
+    }
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactory.java
@@ -46,5 +46,7 @@ public interface XmlTransformerFactory {
 
   Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception;
 
+  Transformer createTransformerFromRawXsl(String xsl, String baseUri, EntityResolver entityResolver) throws Exception;
+
   XmlTransformer configure(XmlTransformer xmlTransformer) throws Exception;
 }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XmlTransformerFactoryImpl.java
@@ -18,17 +18,21 @@ package com.adaptris.util.text.xml;
 import static com.adaptris.util.URLHelper.connect;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.ErrorListener;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -103,6 +107,23 @@ public abstract class XmlTransformerFactoryImpl implements XmlTransformerFactory
   public Transformer createTransformerFromRawXsl(String xsl) throws Exception {
     return createTransformerFromRawXsl(xsl, null);
   }
+
+    @Override
+    public Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception {
+        return createTransformerFromRawXsl(xsl, null, entityResolver);
+    }
+
+    @Override
+    public Transformer createTransformerFromRawXsl(String xsl, String baseUri, EntityResolver entityResolver) throws Exception {
+        DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
+        if (entityResolver != null) {
+            docBuilder.setEntityResolver(entityResolver);
+        }
+        StreamSource source = new StreamSource(new ByteArrayInputStream(xsl.getBytes()), baseUri);
+        return configure(newInstance()).newTransformer(source);
+    }
+
+    protected abstract TransformerFactory newInstance();
 
   @Override
   public XmlTransformer configure(XmlTransformer xmlTransformer) throws Exception {

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -16,8 +16,6 @@
 
 package com.adaptris.util.text.xml;
 
-import java.io.StringReader;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -77,17 +75,7 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
     return configure(newInstance()).newTransformer(new DOMSource(xmlDoc, url));
   }
 
-  @Override
-  public Transformer createTransformerFromRawXsl(String xsl, EntityResolver entityResolver) throws Exception {
-    DocumentBuilder docBuilder = documentFactoryBuilder().newDocumentBuilder(DocumentBuilderFactory.newInstance());
-    if (entityResolver != null) {
-      docBuilder.setEntityResolver(entityResolver);
-    }
-    Document xmlDoc = docBuilder.parse(new InputSource(new StringReader(xsl)));
-    return configure(newInstance()).newTransformer(new DOMSource(xmlDoc));
-  }
-
-  /**
+    /**
    * @return the transformerFactoryImpl
    */
   public String getTransformerFactoryImpl() {
@@ -109,7 +97,7 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
     transformerFactoryImpl = s;
   }
 
-  private TransformerFactory newInstance() {
+  protected TransformerFactory newInstance() {
     return StringUtils.isEmpty(getTransformerFactoryImpl()) ? TransformerFactory.newInstance()
         : TransformerFactory.newInstance(getTransformerFactoryImpl(), null);
   }

--- a/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/transform/XmlTransformServiceTest.java
@@ -515,7 +515,7 @@ public class XmlTransformServiceTest
   public void testXSLTOutputFileDataInputParameter() throws Exception {
     AdaptrisMessage msg = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_XML_TEST_INPUT));
     FileDataInputParameter fdip = new FileDataInputParameter();
-    fdip.setUrl(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_URL));
+    fdip.setUrl(PROPERTIES.getProperty(KEY_XML_TEST_TRANSFORM_WITH_IMPORT_URL));
     XmlTransformService service = new XmlTransformService();
     service.setMappingSource(fdip);
 


### PR DESCRIPTION
…source

## Motivation

https://telusagriculture.atlassian.net/browse/INTERLOK-4619

## Modification

Updated logic to support setting systemId (which the transformer needs to resolve relative URLs)

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result
For FileParameter source mappings, the systemId will be set on the transform Source and relative paths can now be resolved.


## Testing

See XmlTransformServiceTest.testXSLTOutputFileDataInputParameter() - I modified it to use an XSLT that has a relative import and it initially failed, after my changes it passed.
