### PR TITLE
INTERLOK-4621-Suppress warning issue with invalid whitespace for OWASP check

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -44,6 +44,12 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
+    CPE parsing issue with invalid whitespace in product name
+    ]]>    </notes>
+    <cve>CVE-2019-7401</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
     This CVE is a NPM Node/CVE... https://nvd.nist.gov/vuln/detail/CVE-2020-7712
     ]]>    </notes>
     <cve>CVE-2020-7712</cve>

--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -50,12 +50,6 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-    CVE-2025-5115 - Temporary suppression while upgrading
-    ]]>    </notes>
-    <cve>CVE-2025-5115</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
     This CVE is a NPM Node/CVE... https://nvd.nist.gov/vuln/detail/CVE-2020-7712
     ]]>    </notes>
     <cve>CVE-2020-7712</cve>

--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -50,6 +50,12 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
+    CVE-2025-5115 - Temporary suppression while upgrading
+    ]]>    </notes>
+    <cve>CVE-2025-5115</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
     This CVE is a NPM Node/CVE... https://nvd.nist.gov/vuln/detail/CVE-2020-7712
     ]]>    </notes>
     <cve>CVE-2020-7712</cve>

--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -6,7 +6,7 @@ ext {
   slf4jVersion = "2.0.17"
   log4j2Version = "2.24.3"
   mockitoVersion = "4.9.0"
-  jettyVersion= "10.0.26"
+  jettyVersion= "10.0.25"
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -6,7 +6,7 @@ ext {
   slf4jVersion = "2.0.17"
   log4j2Version = "2.24.3"
   mockitoVersion = "4.9.0"
-  jettyVersion= "10.0.25"
+  jettyVersion= "10.0.26"
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -12,7 +12,7 @@ ext {
   mssqlDriverVersion = "9.2.1.jre8"
   derbyDriverVersion = "10.15.2.0"
   junitVersion = "5.11.4"
-  jettyVersion= "10.0.26"
+  jettyVersion= "10.0.25"
 
   verboseTests= project.hasProperty('verboseTests') ? project.getProperty('verboseTests') : "false"
   classesToTest = project.hasProperty("junit.test.classes") ? project.getProperty("junit.test.classes") : "**/*Test*"

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -12,7 +12,7 @@ ext {
   mssqlDriverVersion = "9.2.1.jre8"
   derbyDriverVersion = "10.15.2.0"
   junitVersion = "5.11.4"
-  jettyVersion= "10.0.25"
+  jettyVersion= "10.0.26"
 
   verboseTests= project.hasProperty('verboseTests') ? project.getProperty('verboseTests') : "false"
   classesToTest = project.hasProperty("junit.test.classes") ? project.getProperty("junit.test.classes") : "**/*Test*"


### PR DESCRIPTION
## Motivation

Update OWASP Suppression exclusions to exclude CPE parsing issue CVE-2019-7401. 

## Modification

Modified the Suppression warnings list to suppress parsing issues with invalid whitespace in product name during dependency check

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Build is successfully published during gradle run

## Testing

Build publish should succeed on the Gradle Runner
