### PR TITLE
Bugfix/interlok 4622 support xincludes and dtd

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
@@ -331,19 +331,16 @@ public class EncodePasswordService extends ServiceImp {
    *
    * @param file
    * @return
-   * @throws IOException
+   * @throws ParserConfigurationException
    */
-  private Document readXMLDocument(File file) throws IOException, ParserConfigurationException {
+  private Document readXMLDocument(File file) throws ParserConfigurationException {
     Document doc = null;
     DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
     try {
         doc = dBuilder.parse(file);
-    } catch (SAXParseException e) {
+    } catch (SAXException | IOException e) {
         // Reattempt in case of XML snippets file without a root
         log.info("SAX Parse Exception encountered while encoding file - {} : {}", file.getName(), e.getMessage());
-    } catch (Exception e) {
-        //Handle malformed XMLs by logging the error
-        log.info("Exception encountered while encoding file - {} : {}", file.getName(), e.getMessage());
     }
     return doc;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
@@ -371,8 +371,7 @@ public class EncodePasswordService extends ServiceImp {
               } catch (PasswordException e) {
                   log.info("Password could not be decoded for line - {} ,exc - {}", line, e.getMessage());
               }
-
-              //
+              
               value = "'" + value + "'>";
           }
           line = line.replaceAll(passwordString, value);

--- a/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
@@ -256,7 +256,7 @@ public class EncodePasswordService extends ServiceImp {
         try {
           nodeValue = doEncodePassword(nodeValue);
         } catch (PasswordException e) {
-          log.debug("Password could not be decoded", e);
+          log.info("Password could not be decoded", e);
         }
         node.setTextContent(nodeValue);
       }
@@ -371,7 +371,7 @@ public class EncodePasswordService extends ServiceImp {
               } catch (PasswordException e) {
                   log.info("Password could not be decoded for line - {} ,exc - {}", line, e.getMessage());
               }
-              
+
               value = "'" + value + "'>";
           }
           line = line.replaceAll(passwordString, value);

--- a/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
@@ -221,26 +221,7 @@ public class EncodePasswordService extends ServiceImp {
                   }
 
                   if (tokens.size() >= 3) {
-                      String key = tokens.get(1).trim();
-                      String origValue = tokens.get(2).trim();
-                      String value = origValue;
-
-                      if (StringUtils.isNotBlank(key) && isPasswordKey(key.toLowerCase())) {
-                          //Sanitize the value
-                          if (value.endsWith(">"))
-                              value = value.substring(0, value.length() - 1);
-                          value = value.trim();
-                          if (value.startsWith("'") && value.endsWith("'")) {
-                              value = value.substring(1, value.length() - 1);
-                          }
-                          try {
-                              value = doEncodePassword(value);
-                          } catch (PasswordException e) {
-                              log.debug("Password could not be decoded", e);
-                          }
-                          value = "'" + value + "'>";
-                      }
-                      line = line.replaceAll(origValue, value);
+                      line = getEncryptedString(line, tokens.get(1).trim(), tokens.get(2).trim());
                   }
               }
               sb.append(line);
@@ -250,7 +231,7 @@ public class EncodePasswordService extends ServiceImp {
       Files.write(Paths.get(message.resolve(getFilePath())), sb.toString().getBytes());
   }
 
-  /**
+    /**
    * Recursive method to replace values in nodes that match the pattern
    *
    * @param node
@@ -338,8 +319,9 @@ public class EncodePasswordService extends ServiceImp {
    */
   private void encapsulateReferencedEntities(File file) throws IOException {
       String fileContent = Files.readString(file.toPath());
-      //letters, numbers, hyphens, underscores, dot only
+      //update content starting with space, > or comma to transform &string; to ${string}
       String updatedContent = fileContent.replaceAll("([>,\\s])&([a-zA-Z][a-zA-Z0-9\\-_.]*);", "$1\\${$2}");
+      //update strings to append xinclude for only strings starting space and format ${string}
       updatedContent = updatedContent.replaceAll("\\s\\$\\{([^}]*)\\}\\s", "<xi:include href=\"\\${xinclude.$1}\"/>");
       Files.writeString(file.toPath(), updatedContent);
   }
@@ -365,4 +347,37 @@ public class EncodePasswordService extends ServiceImp {
     }
     return doc;
   }
+
+  /**
+   * Encrypts the passed in password string value in a line.
+   * Eg. of a password string - 'password1'>
+   */
+  private String getEncryptedString(String line, String key, String passwordString) {
+      String value = passwordString;
+
+      if (StringUtils.isNotBlank(line) && StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value)) {
+          if (isPasswordKey(key.toLowerCase())) {
+              //Sanitize the value
+              if (value.endsWith(">"))
+                  value = value.substring(0, value.length() - 1);
+              value = value.trim();
+              if (value.startsWith("'") && value.endsWith("'")) {
+                  value = value.substring(1, value.length() - 1);
+              }
+
+              //Encrypt the sanitized password value
+              try {
+                  value = doEncodePassword(value);
+              } catch (PasswordException e) {
+                  log.info("Password could not be decoded for line - {} ,exc - {}", line, e.getMessage());
+              }
+
+              //
+              value = "'" + value + "'>";
+          }
+          line = line.replaceAll(passwordString, value);
+      }
+      return line;
+  }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/EncodePasswordService.java
@@ -27,11 +27,15 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
 import org.w3c.dom.*;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
@@ -67,9 +71,10 @@ public class EncodePasswordService extends ServiceImp {
   private static final String PREFIX_PORTABLE_PASSWORD = "PW:";
   private static final String PREFIX_PORTBALE_PASSWORD_2 = "AES_GCM:";
   private static final String EXTN_XML = ".xml";
+  private static final String EXTN_DTD = ".dtd";
   private static final String EXTN_PROPERTIES = ".properties";
   private static final String METADATA_KEY_PASSWORD_TOKENS = "passwordtokens";
-  private static final String XML_ELEMENT_ROOT = "root";
+  private static final String PREFIX_ENTITY = "<!ENTITY";
 
   private transient DocumentBuilderFactory dbFactory;
   private transient TransformerFactory transformerFactory;
@@ -106,6 +111,8 @@ public class EncodePasswordService extends ServiceImp {
         encodeValuesInPropertiesFile(message);
       } else if(file.getName().endsWith(EXTN_XML)) {
         encodeValuesInXmlFile(file);
+      } else if(file.getName().endsWith(EXTN_DTD)) {
+        encodeValuesInDtdFile(message);
       }
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
@@ -135,7 +142,7 @@ public class EncodePasswordService extends ServiceImp {
       if (line.contains("=")) {
         String key = line.substring(0, line.indexOf("=")).trim();
         String value = line.substring(line.indexOf("=") + 1).trim();
-        if (isPasswordKey(key.toLowerCase())) {
+        if (StringUtils.isNotBlank(key) && isPasswordKey(key.toLowerCase())) {
           try {
             if (value.startsWith(PREFIX_PORTABLE_PASSWORD)) {
               value = Password.encode(Password.decode(value), Password.PORTABLE_PASSWORD_2);
@@ -162,27 +169,85 @@ public class EncodePasswordService extends ServiceImp {
    * @throws IOException
    * @throws TransformerException
    */
-  protected void encodeValuesInXmlFile(File file) throws IOException, TransformerException, ParserConfigurationException {
+  protected void encodeValuesInXmlFile(File file) throws IOException, TransformerException, ParserConfigurationException, SAXException {
 
-    //Encapsulate the XML file for any entities referred
-    encapsulateReferencedEntities(file);
+      //Encapsulate the XML file for any entities referred
+      encapsulateReferencedEntities(file);
 
-    //Read XML document
-    Document doc = readXMLDocument(file);
-    if (doc == null) return;
+      dbFactory.setValidating(false);
+      dbFactory.setNamespaceAware(false);
+      // DON'T expand entity references - keep them as &entityName;
+      dbFactory.setExpandEntityReferences(false);
 
-    doc.getDocumentElement().normalize();
-    // Process the root element
-    replaceNodeValues(doc.getDocumentElement());
+      // Disable external entity loading
+      dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
-    // Write the updated XML to a new file
-    Transformer transformer = transformerFactory.newTransformer();
-    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-    transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+      //Read XML document
+      Document doc = readXMLDocument(file);
+      if (doc == null) return;
+      doc.getDocumentElement().normalize();
 
-    DOMSource source = new DOMSource(doc);
-    StreamResult result = new StreamResult(file);
-    transformer.transform(source, result);
+      // Process the root element
+      replaceNodeValues(doc.getDocumentElement());
+
+      // Write the updated XML to a new file
+      Transformer transformer = transformerFactory.newTransformer();
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+      transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+
+      DOMSource source = new DOMSource(doc);
+      StreamResult result = new StreamResult(file);
+      transformer.transform(source, result);
+  }
+
+    /**
+     * Finds and encodes values in the Dtd contained in Adaptris Message
+     *
+     * @param message
+     * @throws IOException
+     */
+    protected void encodeValuesInDtdFile(AdaptrisMessage message) throws IOException {
+      StringBuilder sb = new StringBuilder();
+      List<String> lines = Files.readAllLines(Paths.get(message.resolve(getFilePath())));
+      lines.forEach(line -> {
+          if(StringUtils.isNotEmpty(line)) {
+              if (line.startsWith(PREFIX_ENTITY)) {
+                  StringTokenizer tokenizer = new StringTokenizer(line);
+                  List<String> tokens = new ArrayList<>();
+                  while (tokenizer.hasMoreTokens()) {
+                      tokens.add(tokenizer.nextToken());
+                  }
+
+                  if (tokens.size() >= 3) {
+                      String key = tokens.get(1).trim();
+                      String origValue = tokens.get(2).trim();
+                      String value = origValue;
+
+                      if (StringUtils.isNotBlank(key) && isPasswordKey(key.toLowerCase())) {
+                          //Sanitize the value
+                          if (value.endsWith(">"))
+                              value = value.substring(0, value.length() - 1);
+                          value = value.trim();
+                          if (value.startsWith("'") && value.endsWith("'")) {
+                              value = value.substring(1, value.length() - 1);
+                          }
+                          try {
+                              value = doEncodePassword(value);
+                          } catch (PasswordException e) {
+                              log.debug("Password could not be decoded", e);
+                          }
+                          value = "'" + value + "'>";
+                      }
+                      line = line.replaceAll(origValue, value);
+                  }
+              }
+              sb.append(line);
+              sb.append(System.lineSeparator());
+          }
+      });
+      Files.write(Paths.get(message.resolve(getFilePath())), sb.toString().getBytes());
   }
 
   /**
@@ -274,7 +339,8 @@ public class EncodePasswordService extends ServiceImp {
   private void encapsulateReferencedEntities(File file) throws IOException {
       String fileContent = Files.readString(file.toPath());
       //letters, numbers, hyphens, underscores, dot only
-      String updatedContent = fileContent.replaceAll("&([a-zA-Z][a-zA-Z0-9\\-_.]*);", "\\${$1}");
+      String updatedContent = fileContent.replaceAll("([>,\\s])&([a-zA-Z][a-zA-Z0-9\\-_.]*);", "$1\\${$2}");
+      updatedContent = updatedContent.replaceAll("\\s\\$\\{([^}]*)\\}\\s", "<xi:include href=\"\\${xinclude.$1}\"/>");
       Files.writeString(file.toPath(), updatedContent);
   }
 
@@ -292,16 +358,10 @@ public class EncodePasswordService extends ServiceImp {
         doc = dBuilder.parse(file);
     } catch (SAXParseException e) {
         // Reattempt in case of XML snippets file without a root
-        Files.writeString(file.toPath(), "<"+XML_ELEMENT_ROOT+">" + Files.readString(file.toPath()) + "</"+XML_ELEMENT_ROOT+">");
-        try {
-            doc = dBuilder.parse(file);
-        } catch (SAXException e1) {
-            //Handle malformed XMLs by logging the error
-            log.info("Error encountered while encoding file - {} : {}", file.getName(), e.getMessage());
-        }
+        log.info("SAX Parse Exception encountered while encoding file - {} : {}", file.getName(), e.getMessage());
     } catch (Exception e) {
         //Handle malformed XMLs by logging the error
-        log.info("Error encountered while encoding file - {} : {}", file.getName(), e.getMessage());
+        log.info("Exception encountered while encoding file - {} : {}", file.getName(), e.getMessage());
     }
     return doc;
   }

--- a/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
@@ -51,6 +51,7 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
   private AdaptrisMessage msg;
 
   private static final String ADAPTER_CONFIG_FILE = "build/resources/test/validAdapter.xml";
+  private static final String INVALID_ADAPTER_CONFIG_FILE = "build/resources/test/invalidAdapter.xml";
   private static final String MESSAGE_HANDLER_FILE = "build/resources/test/message-handler.xml";
   private static final String ADAPTER_PROPERTIES_FILE = "build/resources/test/valid-local-vars.properties";
   private static final String ADAPTER_DTD_FILE = "build/resources/test/valid-local-vars.dtd";
@@ -88,6 +89,12 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
     assertFalse(jdbcPassword.startsWith(PREFIX_PORTBALE_PASSWORD_2));
     String sftpPassword = (String) xPath.evaluate("/adapter/shared-components/connections/standard-sftp-connection/authentication/default-password/text()", document, XPathConstants.STRING);
     assertFalse(sftpPassword.startsWith(PREFIX_PORTBALE_PASSWORD_2));
+
+      service.setFilePath(INVALID_ADAPTER_CONFIG_FILE);
+      execute(service, msg);
+      xmlString = Files.readString(new File(service.getFilePath()).toPath());
+      //Check till here , there should be no exception for an invalid xml file
+      assertTrue(true);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
@@ -143,4 +143,14 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
         List<String> pwdLines = lines.stream().filter(line -> line.trim().startsWith("<service")).collect(Collectors.toList());
         assertEquals(pwdLines.size(),1);
     }
+
+    @Test
+    public void testXIncludesInXML() throws Exception {
+        service.setFilePath(ADAPTER_CONFIG_FILE);
+        execute(service, msg);
+        List<String> lines = Files.readAllLines(Paths.get(service.getFilePath()));
+        List<String> eventHandlerLines = lines.stream().filter(line -> line.trim().contains("xinclude.event-handler")).collect(Collectors.toList());
+        assertEquals(eventHandlerLines.size(),1);
+        assertEquals(eventHandlerLines.get(0).trim(),"<xi:include href=\"${xinclude.event-handler}\"/>");
+    }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
@@ -53,6 +53,7 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
   private static final String ADAPTER_CONFIG_FILE = "build/resources/test/validAdapter.xml";
   private static final String MESSAGE_HANDLER_FILE = "build/resources/test/message-handler.xml";
   private static final String ADAPTER_PROPERTIES_FILE = "build/resources/test/valid-local-vars.properties";
+  private static final String ADAPTER_DTD_FILE = "build/resources/test/valid-local-vars.dtd";
   private static final String XML_WITHOUT_ROOT_FILE = "build/resources/test/services.xml";
   private static final String PASSWORD_PARAPHRASE = "PASSWORD, PASSPHRASE, SECRET, ROLEEXTERNALID";
   private static final String METADATA_KEY_PASSWORD_TOKENS = "passwordtokens";
@@ -96,6 +97,15 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
     List<String> lines = Files.readAllLines(Paths.get(service.getFilePath()));
     String pwdLine = lines.stream().filter(line -> line.startsWith("cirrus.broker.password")).collect(Collectors.toList()).get(0);
     assertTrue(pwdLine.substring(pwdLine.indexOf('=')+1).startsWith(PREFIX_PORTBALE_PASSWORD_2));
+  }
+
+  @Test
+  public void testEncodePasswordInDtd() throws Exception {
+    service.setFilePath(ADAPTER_DTD_FILE);
+    execute(service, msg);
+    List<String> lines = Files.readAllLines(Paths.get(service.getFilePath()));
+    String pwdLine = lines.stream().filter(line -> line.startsWith("<!ENTITY BROKER_PASSWORD")).collect(Collectors.toList()).get(0);
+    assertTrue(pwdLine.substring(("<!ENTITY BROKER_PASSWORD").length()+19).startsWith(PREFIX_PORTBALE_PASSWORD_2));
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
@@ -106,7 +106,7 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
     List<String> lines = Files.readAllLines(Paths.get(service.getFilePath()));
     String pwdLine = lines.stream().filter(line -> line.startsWith("<!ENTITY BROKER_PASSWORD")).collect(Collectors.toList()).get(0);
     assertTrue(pwdLine.substring(("<!ENTITY BROKER_PASSWORD").length()+19).startsWith(PREFIX_PORTBALE_PASSWORD_2));
-    assertFalse(pwdLine.substring(("<!ENTITY HUB_PASSWORD").length()+19).startsWith(PREFIX_PORTBALE_PASSWORD_2));
+    assertTrue(pwdLine.substring(("<!ENTITY HUB_PASSWORD").length()+22).startsWith(PREFIX_PORTBALE_PASSWORD_2));
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/EncodePasswordServiceTest.java
@@ -106,6 +106,7 @@ public class EncodePasswordServiceTest extends GeneralServiceExample {
     List<String> lines = Files.readAllLines(Paths.get(service.getFilePath()));
     String pwdLine = lines.stream().filter(line -> line.startsWith("<!ENTITY BROKER_PASSWORD")).collect(Collectors.toList()).get(0);
     assertTrue(pwdLine.substring(("<!ENTITY BROKER_PASSWORD").length()+19).startsWith(PREFIX_PORTBALE_PASSWORD_2));
+    assertFalse(pwdLine.substring(("<!ENTITY HUB_PASSWORD").length()+19).startsWith(PREFIX_PORTBALE_PASSWORD_2));
   }
 
   @Test

--- a/interlok-core/src/test/resources/invalidAdapter.xml
+++ b/interlok-core/src/test/resources/invalidAdapter.xml
@@ -1,0 +1,30 @@
+<!-- An incomplete adapter for negative testing -->
+<adapter>
+    <unique-id>v${ADAPTER_ID}</unique-id>
+    <start-up-event-imp>com.adaptris.core.event.StandardAdapterStartUpEvent</start-up-event-imp>
+    <heartbeat-event-imp>com.adaptris.core.HeartbeatEvent</heartbeat-event-imp>
+    <shared-components>
+        <connections>
+            <jms-connection>
+                <connection-error-handler class="jms-connection-error-handler"/>
+                <unique-id>cirrus-sonic-10-jms-connection</unique-id>
+                <user-name>${cirrus.broker.username}</user-name>
+                <password>MyPlainPassword</password>
+                <client-id>${sonic.client.id}-${env}</client-id>
+                <vendor-implementation class="advanced-sonic-mq-implementation">
+                    <broker-url>${cirrus.primary.broker.url}</broker-url>
+                    <connection-urls>${cirrus.backup.broker.url},${cirrus.primary.broker.url}</connection-urls>
+                    <connect-id>${sonic.client.id}-${env}</connect-id>
+                    <connection-factory-properties>
+                        <key-value-pair>
+                            <key>PingInterval</key>
+                            <value>30</value>
+                        </key-value-pair>
+                        <key-value-pair>
+                            <key>SocketConnectTimeout</key>
+                            <value>60000</value>
+                        </key-value-pair>
+                    </connection-factory-properties>
+                    <session-properties/>
+                </vendor-implementation>
+            </jms-connection>

--- a/interlok-core/src/test/resources/valid-local-vars.dtd
+++ b/interlok-core/src/test/resources/valid-local-vars.dtd
@@ -20,7 +20,7 @@
 <!ENTITY BACKUP_BROKER_URLS               'tcp://example1.adaptris.net:2506'>
 <!ENTITY BROKER_USERNAME                  'user'>
 <!ENTITY BROKER_PASSWORD                  'PASSWORD1'>
-<!ENTITY HUB_PASSWORD                     '$\{PASSWORD}'>
+<!ENTITY HUB_PASSWORD                     'AES_GCM:1234'>
 <!ENTITY HUB_INQUEUE                      'example::v2inbound'>
 <!ENTITY EVENT_QUEUE                      'example::v2eventqueue'>
 <!ENTITY DIR_ENV                          'example-test'>

--- a/interlok-core/src/test/resources/valid-local-vars.dtd
+++ b/interlok-core/src/test/resources/valid-local-vars.dtd
@@ -1,0 +1,27 @@
+<!--  Adapter Framework Handling -->
+<!ENTITY event-handler                    SYSTEM './example-config-includes/example-handler.xml'>
+<!ENTITY message-handler                  SYSTEM './example-config-includes/example-handler.xml'>
+<!ENTITY ehub-producer                    SYSTEM './example-config-includes/example-producer.xml'>
+
+<!-- Connections -->
+<!ENTITY connect-http-consume             SYSTEM './example-config-includes/example-http-consume.xml'>
+<!ENTITY connect-null-consume             SYSTEM './example-config-includes/example-null-consume.xml'>
+<!ENTITY connect-ptp-produce              SYSTEM './example-config-includes/example-ptp-produce.xml'>
+
+<!--  Adapter Framework Protocol Includes -->
+<!ENTITY fs-ptp                           SYSTEM './example-config-includes/fs/fs-ptp.xml'>
+<!ENTITY http-ptp                         SYSTEM './example-config-includes/http/http-ptp.xml'>
+<!ENTITY inbound-services                 SYSTEM './example-config-includes/example-inbound-services.xml'>
+
+<!-- GLOBAL PARAMETERS -->
+<!ENTITY ADAPTER_ID                       'adapter1'>
+
+<!ENTITY PRIMARY_BROKER_URL               'tcp://example1.adaptris.net:2506'>
+<!ENTITY BACKUP_BROKER_URLS               'tcp://example1.adaptris.net:2506'>
+<!ENTITY BROKER_USERNAME                  'user'>
+<!ENTITY BROKER_PASSWORD                  'example-password'>
+<!ENTITY HUB_INQUEUE                      'example::v2inbound'>
+<!ENTITY EVENT_QUEUE                      'example::v2eventqueue'>
+<!ENTITY DIR_ENV                          'example-test'>
+<!ENTITY ENV                              'tst'>
+<!ENTITY EXCEPTIONS_BASE                  'file:////opt/exceptions/example'>

--- a/interlok-core/src/test/resources/valid-local-vars.dtd
+++ b/interlok-core/src/test/resources/valid-local-vars.dtd
@@ -19,7 +19,8 @@
 <!ENTITY PRIMARY_BROKER_URL               'tcp://example1.adaptris.net:2506'>
 <!ENTITY BACKUP_BROKER_URLS               'tcp://example1.adaptris.net:2506'>
 <!ENTITY BROKER_USERNAME                  'user'>
-<!ENTITY BROKER_PASSWORD                  'example-password'>
+<!ENTITY BROKER_PASSWORD                  'PASSWORD1'>
+<!ENTITY HUB_PASSWORD                     '$\{PASSWORD}'>
 <!ENTITY HUB_INQUEUE                      'example::v2inbound'>
 <!ENTITY EVENT_QUEUE                      'example::v2eventqueue'>
 <!ENTITY DIR_ENV                          'example-test'>

--- a/interlok-core/src/test/resources/valid-local-vars.properties
+++ b/interlok-core/src/test/resources/valid-local-vars.properties
@@ -7,7 +7,7 @@ cirrus.backup.broker.url=tcp://broker2.example.com:2506
 
 jdbc.driver=com.mysql.jdbc.Driver
 jdbc.user=dbuser
-jdbc.password=dbpassword
+jdbc.password=PW:BHFYENGMWEYQ
 jdbc.connection.url=jdbc:mysql://localhost:3306/db
 
 sftp.connection.default.user=sftpuser

--- a/interlok-core/src/test/resources/validAdapter.xml
+++ b/interlok-core/src/test/resources/validAdapter.xml
@@ -99,6 +99,8 @@
             <unique-id>ecstatic-dubinsky</unique-id>
         </channel>
     </channel-list>
+    &event-handler;
+    &message-handler;
     <message-error-digester class="standard-message-error-digester">
         <unique-id>ErrorDigest</unique-id>
         <digest-max-size>100</digest-max-size>


### PR DESCRIPTION
## Motivation

Support for Xinclude and Dtd - https://telusagriculture.atlassian.net/browse/INTERLOK-4622

## Modification

Added logic to include xinclude for v3+ and dtd password encryption for v2 configs

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Interlok Upgrade process can now support Xincludes for v3+ configs and dtd password encryption

## Testing

Unit tests and by uploading Dtd files with passwords to the Upgrade Tool
