### PR TITLE
new username and token required for owasp check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id "nebula.optional-base" version "7.0.0" apply false
   id "com.github.spotbugs" version "6.2.2" apply false
   id "org.sonarqube" version "6.2.0.5505"
-  id "org.owasp.dependencycheck" version "12.1.3" apply false
+  id "org.owasp.dependencycheck" version "12.1.6" apply false
   id "io.freefair.lombok" version "8.14" apply false
   id "org.gradle.test-retry" version "1.6.2" apply false
   id "org.barfuin.gradle.taskinfo" version "2.2.0"
@@ -237,6 +237,10 @@ subprojects { subproject ->
     failBuildOnCVSS = 7.0
     analyzers {
       assemblyEnabled=false
+      ossIndex {
+        username = System.getenv("OSS_INDEX_USERNAME")
+        password = System.getenv("OSS_INDEX_PASSWORD")
+      }
     }
     nvd {
       apiKey = System.getenv("NVD_API_KEY")


### PR DESCRIPTION
OWASP Dependency check uses the OSS Index from Sonatype which provides an index of security vulnerabilities for open source software. This now requires a email and token in order to run. This change introduces a environment variable for these.