### PR TITLE
Amend  function to return error messages for failed messages

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStore.java
@@ -67,6 +67,7 @@ public class FilesystemRetryStore implements RetryStore {
   private static final String PAYLOAD_FILE_NAME = "payload.blob";
   private static final String METADATA_FILE_NAME = "metadata.properties";
   private static final String STACKTRACE_FILENAME = "stacktrace.txt";
+  public static final String NAME_ERROR_LINE_SEPERATOR = " - ";
 
   /**
    * The base URL {@code file:///...} where we can discover files.
@@ -194,13 +195,20 @@ public class FilesystemRetryStore implements RetryStore {
   }
 
   @Override
-  public Iterable<RemoteBlob> report() throws InterlokException {
+  public Iterable<RemoteBlob> report(boolean includeErrorMessage) throws InterlokException {
     List<RemoteBlob> result = new ArrayList<>();
     try {
       File target = validateDir(FsHelper.toFile(getBaseUrl()), false);
       File[] files = fsWorker.listFiles(target, DirectoryFileFilter.DIRECTORY);
       for (File msgId : files) {
-        Optional.ofNullable(createForReport(msgId)).ifPresent((blob) -> result.add(blob));
+        String errorMessageLine = null;
+        if (includeErrorMessage) {
+          try {
+              errorMessageLine = getStacktraceFirstLine(msgId.getName());
+          } catch (Exception ignored) {
+          }
+        }
+        Optional.ofNullable(createForReport(msgId, errorMessageLine)).ifPresent(result::add);
       }
     } catch (Exception e) {
       throw ExceptionHelper.wrapInterlokException(e);
@@ -218,7 +226,7 @@ public class FilesystemRetryStore implements RetryStore {
     }
   }
 
-  protected static RemoteBlob createForReport(File baseDir) {
+  protected static RemoteBlob createForReport(File baseDir, String errorMessageLine) {
     // assert that both metadata & payload files exist.
     try {
       File payload = new File(baseDir, PAYLOAD_FILE_NAME);
@@ -227,11 +235,18 @@ public class FilesystemRetryStore implements RetryStore {
           FileUtils.directoryContains(baseDir, metadata)})) {
         // Return the size of the payload file, but other things like
         // last modified can be derived from the directory.
+        String name = baseDir.getName();
+        if (errorMessageLine != null) {
+            name += NAME_ERROR_LINE_SEPERATOR + errorMessageLine;
+        }
+
         return new RemoteBlob.Builder()
-            .setLastModified(baseDir.lastModified()).setName(baseDir.getName())
-            .setSize(payload.length()).build();
+            .setLastModified(baseDir.lastModified())
+            .setName(name)
+            .setSize(payload.length())
+            .build();
       }
-    } catch (Exception e) {
+    } catch (Exception ignored) {
     }
     return null;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -51,8 +51,7 @@ import lombok.extern.slf4j.Slf4j;
  * </p>
  * <p>
  * This jetty implementation allows listing of the failed messages, retrying a
- * message, deleting messages and retrieving the stacktrace or first line of the stacktrace
- * from the store.
+ * message, deleting messages and retrieving the stacktrace from the store.
  * <ul>
  * <li>{@code curl -XGET http://localhost:8080/api/failed/list} gives you a list of message ids that
  * are listed in the store</li>
@@ -62,15 +61,17 @@ import lombok.extern.slf4j.Slf4j;
  * the message from the store</li>
  * <li>{@code curl -XGET http://localhost:8080/api/failed/stacktrace/{msgId}} will retrieve the entire stacktrace
  * from the store.</li>
- * <li>{@code curl -XGET http://localhost:8080/api/failed/stacktrace/first-line/{msgId}} will retrieve only the
- * first line of the stacktrace from the store.</li>
  * <ul>
+ * </p>
+ * <p>
+ * By default, when listing failed messages, the first line of the stacktrace (error message) is included
+ * in the report if available. This can be disabled by setting the {@code includeErrorMessage} metadata key to {@code false}.
  * </p>
  * <p>
  * While DELETE is available, this implementation doesn't make any checks that the messages that you
  * have retried have been retried successfully. It is expected that you have separate tooling that
  * allows you to verify that retried-messages are ultimately successfully before triggering the
- * delete. If you ask for a message to be deleted from the store, then that is what happens.
+ * delete method. If you ask for a message to be deleted from the store, then that is what happens.
  * </p>
  *
  * @config retry-via-jetty
@@ -89,7 +90,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     public static final String DEFAULT_REPORTING_ENDPOINT = "/api/failed/list";
     public static final String DEFAULT_DELETE_PREFIX = "/api/failed/delete/";
     public static final String DEFAULT_STACKTRACE_PREFIX = "/api/failed/stacktrace/";
-    public static final String DEFAULT_STACKTRACE_FIRST_LINE_PREFIX = "/api/failed/stacktrace/first-line/";
 
     private static final String HTTP_RETRY_METHOD = "POST";
     private static final String HTTP_DELETE_METHOD = "DELETE";
@@ -100,7 +100,7 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     public static final String CONTENT_TYPE_METADATA_KEY = "__Content-Type";
     public static final String CONTENT_TYPE_EXPR = "%message{__Content-Type}";
 
-    private static final String HTTP_STATUS_KEY = "__httpResponseCode";
+    static final String HTTP_STATUS_KEY = "__httpResponseCode";
     private static final String HTTP_STATUS_EXPR = "%message{__httpResponseCode}";
     static final String MSG_ID_KEY = "__MsgId";
 
@@ -161,19 +161,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     private String stackTraceEndpointPrefix;
 
     /**
-     * The get stacktrace first line endpoint.
-     * <p>
-     * The default if not explicitly specified is {@value DEFAULT_STACKTRACE_FIRST_LINE_PREFIX}, note the trailing
-     * {@code "/"}. The expectation is that when clients interact with the endpoint it will be in the
-     * form {@code /prefix/'msgId'}
-     * </p>
-     */
-    @Getter
-    @Setter
-    @InputFieldDefault(value = DEFAULT_STACKTRACE_FIRST_LINE_PREFIX)
-    private String stackTraceFirstLineEndpointPrefix;
-
-    /**
      * The underlying Jetty connection.
      *
      */
@@ -202,6 +189,11 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     @NotNull
     @NonNull
     private RetryStore retryStore;
+
+    @AdvancedConfig(rare = true)
+    @Getter
+    @Setter
+    private String includeErrorMessageFlagMetadataKey = "includeErrorMessage";
 
     /**
      * The HTTP method which is required for retries; the default is POST.
@@ -236,19 +228,16 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     private transient StandaloneConsumer retrying;
     private transient StandaloneConsumer deleting;
     private transient StandaloneConsumer gettingStacktrace;
-    private transient StandaloneConsumer gettingStacktraceFirstLine;
 
     private transient ReportListener reporter;
     private transient RetryListener retrier;
     private transient DeleteListener deleter;
     private transient StackTraceListener stacktraceGetter;
-    private transient StackTraceFirstLineListener stacktraceFirstLineGetter;
 
     private transient ExecutorService workflowSubmitter;
     private transient JettyRouteCondition retryRouting;
     private transient JettyRouteCondition deleteRouting;
     private transient JettyRouteCondition stackTraceRouting;
-    private transient JettyRouteCondition stackTraceFirstLineRouting;
     private transient boolean prepared = false;
 
     @Override
@@ -266,9 +255,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             String stackTraceServletPath = stackTraceEndpointPrefix() + "*";
             String stackTraceServletRegexp = "^" + stackTraceEndpointPrefix() + "(.*)";
 
-            String stackTraceFirstLineServletPath = stackTraceFirstLineEndpointPrefix() + "*";
-            String stackTraceFirstLineServletRegexp = "^" + stackTraceFirstLineEndpointPrefix() + "(.*)";
-
             retryRouting = new JettyRouteCondition()
                     .withUrlPattern(retryServletRegexp)
                     .withMetadataKeys(MSG_ID_KEY)
@@ -281,16 +267,11 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
                     .withUrlPattern(stackTraceServletRegexp)
                     .withMetadataKeys(MSG_ID_KEY)
                     .withMethod(stackTraceHttpMethod());
-            stackTraceFirstLineRouting = new JettyRouteCondition()
-                    .withUrlPattern(stackTraceFirstLineServletRegexp)
-                    .withMetadataKeys(MSG_ID_KEY)
-                    .withMethod(stackTraceHttpMethod());
 
             reporter = new ReportListener();
             retrier = new RetryListener();
             deleter = new DeleteListener();
             stacktraceGetter = new StackTraceListener();
-            stacktraceFirstLineGetter = new StackTraceFirstLineListener();
 
             // By not dictating the method in the consumer; we accept all methods in jetty, but we use the
             // jetty route filter to filter it out.
@@ -302,21 +283,17 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
                     new JettyMessageConsumer().withPath(reportingEndpoint()));
             gettingStacktrace = new StandaloneConsumer(getConnection(),
                     new JettyMessageConsumer().withPath(stackTraceServletPath));
-            gettingStacktraceFirstLine = new StandaloneConsumer(getConnection(),
-                    new JettyMessageConsumer().withPath(stackTraceFirstLineServletPath));
 
             retrying.registerAdaptrisMessageListener(retrier);
             reporting.registerAdaptrisMessageListener(reporter);
             deleting.registerAdaptrisMessageListener(deleter);
             gettingStacktrace.registerAdaptrisMessageListener(stacktraceGetter);
-            gettingStacktraceFirstLine.registerAdaptrisMessageListener(stacktraceFirstLineGetter);
 
             LifecycleHelper.prepare(getRetryStore(), getReportBuilder());
             LifecycleHelper.prepare(deleteRouting, deleter, deleting);
             LifecycleHelper.prepare(retryRouting, retrier, retrying);
             LifecycleHelper.prepare(reporter, reporting);
             LifecycleHelper.prepare(stackTraceRouting, stacktraceGetter, gettingStacktrace);
-            LifecycleHelper.prepare(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
             prepared = true;
         }
     }
@@ -329,7 +306,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         LifecycleHelper.init(retryRouting, retrier, retrying);
         LifecycleHelper.init(reporter, reporting);
         LifecycleHelper.init(stackTraceRouting, stacktraceGetter, gettingStacktrace);
-        LifecycleHelper.init(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
 
         workflowSubmitter = Executors.newSingleThreadExecutor();
     }
@@ -341,7 +317,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         LifecycleHelper.start(retryRouting, retrier, retrying);
         LifecycleHelper.start(reporter, reporting);
         LifecycleHelper.start(stackTraceRouting, stacktraceGetter, gettingStacktrace);
-        LifecycleHelper.start(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
     }
 
     @Override
@@ -350,7 +325,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         LifecycleHelper.stop(retryRouting, retrier, retrying);
         LifecycleHelper.stop(reporter, reporting);
         LifecycleHelper.stop(stackTraceRouting, stacktraceGetter, gettingStacktrace);
-        LifecycleHelper.stop(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
         LifecycleHelper.stop(getRetryStore(), getReportBuilder());
     }
 
@@ -360,7 +334,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         LifecycleHelper.close(retryRouting, retrier, retrying);
         LifecycleHelper.close(reporter, reporting);
         LifecycleHelper.close(stackTraceRouting, stacktraceGetter, gettingStacktrace);
-        LifecycleHelper.close(stackTraceFirstLineRouting, stacktraceFirstLineGetter, gettingStacktraceFirstLine);
         LifecycleHelper.close(getRetryStore(), getReportBuilder());
 
         ManagedThreadFactory.shutdownQuietly(workflowSubmitter, DEFAULT_SHUTDOWN_WAIT);
@@ -388,10 +361,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         return StringUtils.defaultIfBlank(getStackTraceEndpointPrefix(), DEFAULT_STACKTRACE_PREFIX);
     }
 
-    String stackTraceFirstLineEndpointPrefix() {
-        return StringUtils.defaultIfBlank(getStackTraceFirstLineEndpointPrefix(), DEFAULT_STACKTRACE_FIRST_LINE_PREFIX);
-    }
-
     String deleteEndpointPrefix() {
         return StringUtils.defaultIfBlank(getDeleteEndpointPrefix(), DEFAULT_DELETE_PREFIX);
     }
@@ -407,7 +376,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     String stackTraceHttpMethod() {
         return StringUtils.defaultIfBlank(getStackTraceHttpMethod(), HTTP_STACKTRACE_METHOD);
     }
-
 
     protected static void executeQuietly(Service service, AdaptrisMessage msg) {
         try {
@@ -491,13 +459,19 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
 
 
     @NoArgsConstructor
-    private class ReportListener extends ListenerImpl {
+    class ReportListener extends ListenerImpl {
         @Override
         public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
                                       Consumer<AdaptrisMessage> failure) {
             String httpCode = HTTP_ERROR;
+            boolean includeErrorMessage = true;
+
+            if (jettyMsg.getMetadata(includeErrorMessageFlagMetadataKey) != null && jettyMsg.getMetadataValue(includeErrorMessageFlagMetadataKey) != null) {
+                includeErrorMessage = Boolean.parseBoolean(jettyMsg.getMetadataValue(includeErrorMessageFlagMetadataKey));
+            }
+
             try {
-                getReportBuilder().build(getRetryStore().report(), jettyMsg);
+                getReportBuilder().build(getRetryStore().report(includeErrorMessage), jettyMsg);
                 httpCode = HTTP_OK;
             } catch (Exception e) {
                 jettyMsg.setContent(ExceptionUtils.getRootCauseMessage(e), StandardCharsets.UTF_8.name());
@@ -619,30 +593,6 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         @Override
         public String friendlyName() {
             return "RetryFromJetty::StackTrace";
-        }
-    }
-
-    @NoArgsConstructor
-    private class StackTraceFirstLineListener extends ListenerImpl {
-        private transient Object locker = new Object();
-
-        @Override
-        @Synchronized(value = "locker")
-        public void onAdaptrisMessage(AdaptrisMessage jettyMsg, Consumer<AdaptrisMessage> success,
-                                      Consumer<AdaptrisMessage> failure) {
-            try {
-                String msgId = extractMsgId(stackTraceFirstLineRouting, jettyMsg);
-                String stackTrace = retryStore.getStackTrace(msgId);
-                String firstLine = stackTrace.split("\n")[0];
-                handleStackTraceResponse(msgId, jettyMsg, firstLine);
-            } catch (Exception e) {
-                handleException(e, jettyMsg);
-            }
-        }
-
-        @Override
-        public String friendlyName() {
-            return "RetryFromJetty::StackTraceFirstLine";
         }
     }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryFromJetty.java
@@ -14,17 +14,13 @@ import java.util.function.Consumer;
 import javax.validation.constraints.NotNull;
 
 import com.adaptris.core.*;
+import com.adaptris.core.http.jetty.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.core.http.jetty.EmbeddedConnection;
-import com.adaptris.core.http.jetty.JettyConnection;
-import com.adaptris.core.http.jetty.JettyMessageConsumer;
-import com.adaptris.core.http.jetty.JettyResponseService;
-import com.adaptris.core.http.jetty.JettyRouteCondition;
 import com.adaptris.core.http.jetty.JettyRouteCondition.JettyRoute;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.ManagedThreadFactory;
@@ -90,6 +86,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     public static final String DEFAULT_REPORTING_ENDPOINT = "/api/failed/list";
     public static final String DEFAULT_DELETE_PREFIX = "/api/failed/delete/";
     public static final String DEFAULT_STACKTRACE_PREFIX = "/api/failed/stacktrace/";
+
+    public static final String DEFAULT_INCLUDE_ERROR_MESSAGE_FLAG_METADATA_KEY = "includeErrorMessageFlag";
 
     private static final String HTTP_RETRY_METHOD = "POST";
     private static final String HTTP_DELETE_METHOD = "DELETE";
@@ -193,7 +191,8 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
     @AdvancedConfig(rare = true)
     @Getter
     @Setter
-    private String includeErrorMessageFlagMetadataKey = "includeErrorMessage";
+    @InputFieldDefault(value = DEFAULT_INCLUDE_ERROR_MESSAGE_FLAG_METADATA_KEY)
+    private String includeErrorMessageFlagMetadataKey;
 
     /**
      * The HTTP method which is required for retries; the default is POST.
@@ -273,6 +272,10 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             deleter = new DeleteListener();
             stacktraceGetter = new StackTraceListener();
 
+            JettyMessageConsumer reportingConsumer = new JettyMessageConsumer()
+                .withPath(reportingEndpoint());
+            reportingConsumer.setParameterHandler(new MetadataParameterHandler());
+
             // By not dictating the method in the consumer; we accept all methods in jetty, but we use the
             // jetty route filter to filter it out.
             retrying = new StandaloneConsumer(getConnection(),
@@ -280,7 +283,7 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             deleting = new StandaloneConsumer(getConnection(),
                     new JettyMessageConsumer().withPath(deleteServletPath));
             reporting = new StandaloneConsumer(getConnection(),
-                    new JettyMessageConsumer().withPath(reportingEndpoint()));
+                    reportingConsumer);
             gettingStacktrace = new StandaloneConsumer(getConnection(),
                     new JettyMessageConsumer().withPath(stackTraceServletPath));
 
@@ -377,6 +380,11 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
         return StringUtils.defaultIfBlank(getStackTraceHttpMethod(), HTTP_STACKTRACE_METHOD);
     }
 
+    String includeErrorMessageFlagMetadataKey() {
+        return StringUtils.defaultIfBlank(getIncludeErrorMessageFlagMetadataKey(),
+            DEFAULT_INCLUDE_ERROR_MESSAGE_FLAG_METADATA_KEY);
+    }
+
     protected static void executeQuietly(Service service, AdaptrisMessage msg) {
         try {
             service.doService(msg);
@@ -466,11 +474,11 @@ public class RetryFromJetty extends FailedMessageRetrierImp {
             String httpCode = HTTP_ERROR;
             boolean includeErrorMessage = true;
 
-            if (jettyMsg.getMetadata(includeErrorMessageFlagMetadataKey) != null && jettyMsg.getMetadataValue(includeErrorMessageFlagMetadataKey) != null) {
-                includeErrorMessage = Boolean.parseBoolean(jettyMsg.getMetadataValue(includeErrorMessageFlagMetadataKey));
-            }
-
             try {
+                if (jettyMsg.getMetadata(includeErrorMessageFlagMetadataKey()) != null && jettyMsg.getMetadataValue(includeErrorMessageFlagMetadataKey()) != null) {
+                    includeErrorMessage = Boolean.parseBoolean(jettyMsg.getMetadataValue(includeErrorMessageFlagMetadataKey()));
+                }
+
                 getReportBuilder().build(getRetryStore().report(includeErrorMessage), jettyMsg);
                 httpCode = HTTP_OK;
             } catch (Exception e) {

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStore.java
@@ -19,7 +19,7 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
    *
    * @implNote The default implementation just returns an empty list.
    */
-  default Iterable<RemoteBlob> report() throws InterlokException {
+  default Iterable<RemoteBlob> report(boolean includeErrorMessage) throws InterlokException {
     return Collections.emptyList();
   }
 
@@ -51,7 +51,6 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
       throws InterlokException {
     return buildForRetry(msgId, metadata, null);
   }
-
 
   /**
    * Build the message for retrying from the store.
@@ -172,4 +171,17 @@ public interface RetryStore extends ComponentLifecycle, ComponentLifecycleExtens
    * @throws InterlokException if the stack trace cannot be retrieved
    */
   String getStackTrace(String msgId) throws InterlokException;
+
+  /**
+   * Retrieve the first line of the stack trace for a given message ID.
+   *
+   * @param msgId the message ID
+   * @return the first line of the stack trace as a String
+   * @throws InterlokException if the stack trace cannot be retrieved
+  */
+  default String getStacktraceFirstLine(String msgId) throws InterlokException {
+    String stackTrace = getStackTrace(msgId);
+    return stackTrace.split("\\R", 2)[0];
+  }
+
 }

--- a/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreListService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/http/jetty/retry/RetryStoreListService.java
@@ -1,5 +1,6 @@
 package com.adaptris.core.http.jetty.retry;
 
+import com.adaptris.annotation.AdvancedConfig;
 import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -34,10 +35,21 @@ public class RetryStoreListService extends RetryStoreServiceImpl {
   @Setter
   private BlobListRenderer reportRenderer;
 
+  @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
+  private String includeErrorMessageFlagMetadataKey = "includeErrorMessage";
+
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     try {
-      renderer().render(getRetryStore().report(), msg);
+      boolean includeErrorMessage = true;
+        String includeErrorMessageValue = getMetadataIfExists(msg, includeErrorMessageFlagMetadataKey);
+      if (includeErrorMessageValue != null) {
+        includeErrorMessage = Boolean.parseBoolean(includeErrorMessageValue);
+      }
+
+      renderer().render(getRetryStore().report(includeErrorMessage), msg);
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
     }
@@ -46,5 +58,12 @@ public class RetryStoreListService extends RetryStoreServiceImpl {
 
   private BlobListRenderer renderer() {
     return ObjectUtils.defaultIfNull(getReportRenderer(), new BlobListRenderer() {});
+  }
+
+  private String getMetadataIfExists(AdaptrisMessage msg, String metadataKey) {
+      if (msg.getMetadata(metadataKey) != null && msg.getMetadataValue(metadataKey) != null) {
+          return msg.getMetadataValue(metadataKey);
+      }
+      return null;
   }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jdbc/retry/JdbcRetryStore.java
@@ -216,7 +216,7 @@ public class JdbcRetryStore implements RetryStore {
   }
 
   @Override
-  public Iterable<RemoteBlob> report() throws InterlokException {
+  public Iterable<RemoteBlob> report(boolean includeErrorMessage) throws InterlokException {
     return Collections.EMPTY_LIST;
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
@@ -187,7 +187,7 @@ public class FilesystemRetryStoreTest {
       LifecycleHelper.initAndStart(store);
       AdaptrisMessage msg = new DefaultMessageFactory().newMessage("hello");
       store.write(msg);
-      assertTrue(store.report().iterator().hasNext());
+      assertTrue(store.report(false).iterator().hasNext());
     } finally {
       LifecycleHelper.stopAndClose(store);
     }
@@ -201,11 +201,34 @@ public class FilesystemRetryStoreTest {
       try {
         LifecycleHelper.initAndStart(store);
         new DefaultMessageFactory().newMessage("hello");
-        store.report();
+        store.report(false);
       } finally {
         LifecycleHelper.stopAndClose(store);
       }
     });
+  }
+
+  @Test
+  public void testReport_IncludesErrorMessageLine() throws Exception {
+    FilesystemRetryStore store = new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(FilesystemRetryStoreTest.TEST_BASE_URL));
+    try {
+      LifecycleHelper.initAndStart(store);
+      AdaptrisMessage msg = new DefaultMessageFactory().newMessage("payload");
+      msg.addObjectHeader(Exception.class.getName(), new Exception("Test error line"));
+      store.write(msg);
+
+      Iterable<RemoteBlob> blobs = store.report(true);
+      boolean found = false;
+      for (RemoteBlob blob : blobs) {
+        if (blob.getName().contains(FilesystemRetryStore.NAME_ERROR_LINE_SEPERATOR)) {
+          found = true;
+          break;
+        }
+      }
+      assertTrue(found, "Blob name should include error message line");
+    } finally {
+      LifecycleHelper.stopAndClose(store);
+    }
   }
 
   @Test
@@ -248,13 +271,13 @@ public class FilesystemRetryStoreTest {
       File retryStoreDir = FsHelper.toFile(BaseCase.getConfiguration(TEST_BASE_URL));
       File storedMsgDir = new File(retryStoreDir, msg.getUniqueId());
 
-      RemoteBlob blob = FilesystemRetryStore.createForReport(storedMsgDir);
+      RemoteBlob blob = FilesystemRetryStore.createForReport(storedMsgDir, null);
       assertNotNull(blob);
       assertEquals("hello".length(), blob.getSize());
 
       File randomDir = TempFileUtils.createTrackedDir(store);
-      assertNull(FilesystemRetryStore.createForReport(randomDir));
-      assertNull(FilesystemRetryStore.createForReport(null));
+      assertNull(FilesystemRetryStore.createForReport(randomDir, null));
+      assertNull(FilesystemRetryStore.createForReport(null, null));
     } finally {
       LifecycleHelper.stopAndClose(store);
     }

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/FilesystemRetryStoreTest.java
@@ -231,6 +231,29 @@ public class FilesystemRetryStoreTest {
     }
   }
 
+    @Test
+    public void testReport_DoesNotIncludesErrorMessageLine() throws Exception {
+        FilesystemRetryStore store = new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(FilesystemRetryStoreTest.TEST_BASE_URL));
+        try {
+            LifecycleHelper.initAndStart(store);
+            AdaptrisMessage msg = new DefaultMessageFactory().newMessage("payload");
+            msg.addObjectHeader(Exception.class.getName(), new Exception("Test error line"));
+            store.write(msg);
+
+            Iterable<RemoteBlob> blobs = store.report(false);
+            boolean found = false;
+            for (RemoteBlob blob : blobs) {
+                if (blob.getName().contains(FilesystemRetryStore.NAME_ERROR_LINE_SEPERATOR)) {
+                    found = true;
+                    break;
+                }
+            }
+            assertFalse(found, "Blob name should not include error message line");
+        } finally {
+            LifecycleHelper.stopAndClose(store);
+        }
+    }
+
   @Test
   public void testDelete() throws Exception {
     FilesystemRetryStore store = new FilesystemRetryStore().withBaseUrl(BaseCase.getConfiguration(TEST_BASE_URL));

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/InMemoryRetryStore.java
@@ -12,6 +12,8 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.cloud.RemoteBlob;
 
+import static com.adaptris.core.http.jetty.retry.FilesystemRetryStore.NAME_ERROR_LINE_SEPERATOR;
+
 // While it's perfectly reasonable to "mock" an in memory one isn't an awful choice for testing.
 // However, it's of *no use in real life*.
 public class InMemoryRetryStore implements RetryStore {
@@ -47,12 +49,27 @@ public class InMemoryRetryStore implements RetryStore {
   }
 
   @Override
-  public Iterable<RemoteBlob> report() throws InterlokException {
+  public Iterable<RemoteBlob> report(boolean includeErrorMessage) throws InterlokException {
     return STORE.entrySet().stream()
-        .map((e) -> new RemoteBlob.Builder().setBucket("bucket")
-            .setLastModified(System.currentTimeMillis()).setName(e.getKey())
-            .setSize(e.getValue().getSize()).build())
-        .collect(Collectors.toList());
+      .map((e) -> {
+        String name = e.getKey();
+        if (includeErrorMessage) {
+          String stacktraceFirstLine = null;
+          try {
+            stacktraceFirstLine = getStacktraceFirstLine(e.getKey());
+          } catch (InterlokException ignored) {
+          }
+            name += NAME_ERROR_LINE_SEPERATOR + stacktraceFirstLine;
+        }
+        return new RemoteBlob.Builder()
+          .setBucket("bucket")
+          .setLastModified(System.currentTimeMillis())
+          .setName(name)
+          .setSize(e.getValue()
+          .getSize())
+          .build();
+      })
+      .collect(Collectors.toList());
   }
 
   public static void removeAll() {

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -2,9 +2,7 @@ package com.adaptris.core.http.jetty.retry;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -173,16 +171,17 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
   }
 
   @Test
-  public void testReportListener_IncludeErrorMessageFalse() {
+  public void testReportListener_DoNotIncludeErrorMessage() {
     RetryFromJetty retrier = new RetryFromJetty();
       retrier.setRetryStore(new InMemoryRetryStore());
     RetryFromJetty.ReportListener listener = retrier.new ReportListener();
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    msg.addMetadata(retrier.getIncludeErrorMessageFlagMetadataKey(), "false");
+    msg.addMetadata(retrier.includeErrorMessageFlagMetadataKey(), "false");
 
     listener.onAdaptrisMessage(msg, m -> {}, m -> {});
 
     assertEquals(RetryFromJetty.HTTP_OK, msg.getMetadataValue(RetryFromJetty.HTTP_STATUS_KEY));
+    assertFalse(Boolean.parseBoolean(msg.getMetadataValue(retrier.includeErrorMessageFlagMetadataKey())));
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryFromJettyTest.java
@@ -161,6 +161,31 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
   }
 
   @Test
+  public void testReportListener_DefaultIncludeErrorMessage() {
+    RetryFromJetty retrier = new RetryFromJetty();
+    retrier.setRetryStore(new InMemoryRetryStore());
+    RetryFromJetty.ReportListener listener = retrier.new ReportListener();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+
+    listener.onAdaptrisMessage(msg, m -> {}, m -> {});
+
+    assertEquals(RetryFromJetty.HTTP_OK, msg.getMetadataValue(RetryFromJetty.HTTP_STATUS_KEY));
+  }
+
+  @Test
+  public void testReportListener_IncludeErrorMessageFalse() {
+    RetryFromJetty retrier = new RetryFromJetty();
+      retrier.setRetryStore(new InMemoryRetryStore());
+    RetryFromJetty.ReportListener listener = retrier.new ReportListener();
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata(retrier.getIncludeErrorMessageFlagMetadataKey(), "false");
+
+    listener.onAdaptrisMessage(msg, m -> {}, m -> {});
+
+    assertEquals(RetryFromJetty.HTTP_OK, msg.getMetadataValue(RetryFromJetty.HTTP_STATUS_KEY));
+  }
+
+  @Test
   public void testRetry() throws Exception {
     RetryFromJetty retrier = create();
     StandardWorkflow workflow = createWorkflow();
@@ -346,156 +371,82 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
     }
   }
 
-    @Test
-    public void testStackTrace() throws Exception {
-        RetryFromJetty retrier = create();
-        try {
-            start(retrier);
-            AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            try {
-                throw new Exception("Test Exception");
-            } catch (Exception e) {
-                baseMsg.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, e);
-            }
-            retryStore.write(baseMsg);
-            assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+  @Test
+  public void testStackTrace() throws Exception {
+      RetryFromJetty retrier = create();
+      try {
+          start(retrier);
+          AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+          try {
+              throw new Exception("Test Exception");
+          } catch (Exception e) {
+              baseMsg.addObjectHeader(CoreConstants.OBJ_METADATA_EXCEPTION, e);
+          }
+          retryStore.write(baseMsg);
+          assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
 
-            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_PREFIX + baseMsg.getUniqueId());
-            StandardHttpProducer http = buildProducer(url);
-            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
-            http.setIgnoreServerResponseCode(true);
-            triggerMsg.addMetadata(RetryFromJetty.MSG_ID_KEY, baseMsg.getUniqueId());
+          AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+          String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_PREFIX + baseMsg.getUniqueId());
+          StandardHttpProducer http = buildProducer(url);
+          http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+          http.setIgnoreServerResponseCode(true);
+          triggerMsg.addMetadata(RetryFromJetty.MSG_ID_KEY, baseMsg.getUniqueId());
 
-            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+          ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
 
-            assertEquals(RetryFromJetty.HTTP_OK,
-                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
-            assertNotNull(triggerMsg.getContent());
-        } finally {
-            stop(retrier);
-        }
-    }
+          assertEquals(RetryFromJetty.HTTP_OK,
+                  triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+          assertNotNull(triggerMsg.getContent());
+      } finally {
+          stop(retrier);
+      }
+  }
 
-    @Test
-    public void testStackTrace_BadRequest() throws Exception {
-        RetryFromJetty retrier = create();
-        try {
-            start(retrier);
-            AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            retryStore.write(baseMsg);
-            assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
+  @Test
+  public void testStackTrace_BadRequest() throws Exception {
+      RetryFromJetty retrier = create();
+      try {
+          start(retrier);
+          AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+          retryStore.write(baseMsg);
+          assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
 
-            // Test with invalid URL
-            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl("/invalid/path/" + baseMsg.getUniqueId());
-            StandardHttpProducer http = buildProducer(url);
-            http.setIgnoreServerResponseCode(true);
-            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+          // Test with invalid URL
+          AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+          String url = jettyHelper.buildUrl("/invalid/path/" + baseMsg.getUniqueId());
+          StandardHttpProducer http = buildProducer(url);
+          http.setIgnoreServerResponseCode(true);
+          http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
 
-            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+          ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
 
-            assertEquals(RetryFromJetty.HTTP_NOT_FOUND,
-                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
-        } finally {
-            stop(retrier);
-        }
-    }
+          assertEquals(RetryFromJetty.HTTP_NOT_FOUND,
+                  triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+      } finally {
+          stop(retrier);
+      }
+  }
 
-    @Test
-    public void testStackTrace_Error() throws Exception {
-        RetryFromJetty retrier = create();
-        try {
-            retrier.setRetryStore(new BrokenRetryStore());
-            start(retrier);
+  @Test
+  public void testStackTrace_Error() throws Exception {
+      RetryFromJetty retrier = create();
+      try {
+          retrier.setRetryStore(new BrokenRetryStore());
+          start(retrier);
 
-            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_PREFIX + triggerMsg.getUniqueId());
-            StandardHttpProducer http = buildProducer(url);
-            http.setIgnoreServerResponseCode(true);
-            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
+          AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+          String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_PREFIX + triggerMsg.getUniqueId());
+          StandardHttpProducer http = buildProducer(url);
+          http.setIgnoreServerResponseCode(true);
+          http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
 
-            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
-            assertEquals(RetryFromJetty.HTTP_ERROR,
-                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
-        } finally {
-            stop(retrier);
-        }
-    }
-
-    @Test
-    public void testStackTraceFirstLine() throws Exception {
-        RetryFromJetty retrier = create();
-        try {
-            start(retrier);
-            AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            retryStore.write(baseMsg);
-            assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
-
-            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_FIRST_LINE_PREFIX + baseMsg.getUniqueId());
-            StandardHttpProducer http = buildProducer(url);
-            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
-            http.setIgnoreServerResponseCode(true);
-            triggerMsg.addMetadata(RetryFromJetty.MSG_ID_KEY, baseMsg.getUniqueId());
-
-            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
-
-            assertEquals(RetryFromJetty.HTTP_OK,
-                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
-            assertNotNull(triggerMsg.getContent());
-            assertEquals(1, triggerMsg.getContent().split("\n").length);
-        } finally {
-            stop(retrier);
-        }
-    }
-
-    @Test
-    public void testStackTraceFirstLine_BadRequest() throws Exception {
-        RetryFromJetty retrier = create();
-        try {
-            start(retrier);
-            AdaptrisMessage baseMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            retryStore.write(baseMsg);
-            assertNotNull(retryStore.getMetadata(baseMsg.getUniqueId()));
-
-            // Test with invalid URL
-            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl("/invalid/path/" + baseMsg.getUniqueId());
-            StandardHttpProducer http = buildProducer(url);
-            http.setIgnoreServerResponseCode(true);
-            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
-
-            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
-
-            assertEquals(RetryFromJetty.HTTP_NOT_FOUND,
-                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
-        } finally {
-            stop(retrier);
-        }
-    }
-
-    @Test
-    public void testStackTraceFirstLine_Error() throws Exception {
-        RetryFromJetty retrier = create();
-        try {
-            retrier.setRetryStore(new BrokenRetryStore());
-            start(retrier);
-
-            AdaptrisMessage triggerMsg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-            String url = jettyHelper.buildUrl(RetryFromJetty.DEFAULT_STACKTRACE_FIRST_LINE_PREFIX + triggerMsg.getUniqueId());
-            StandardHttpProducer http = buildProducer(url);
-            http.setIgnoreServerResponseCode(true);
-            http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.GET));
-
-            ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
-            assertEquals(RetryFromJetty.HTTP_ERROR,
-                    triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
-        } finally {
-            stop(retrier);
-        }
-    }
-
+          ExampleServiceCase.execute(new StandaloneRequestor(http), triggerMsg);
+          assertEquals(RetryFromJetty.HTTP_ERROR,
+                  triggerMsg.getMetadataValue(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE));
+      } finally {
+          stop(retrier);
+      }
+  }
 
   private StandardHttpProducer buildProducer(String url) {
     StandardHttpProducer producer = new StandardHttpProducer().withURL(url);
@@ -559,7 +510,7 @@ public class RetryFromJettyTest extends FailedMessageRetrierCase {
     }
 
     @Override
-    public Iterable<RemoteBlob> report() throws InterlokException {
+    public Iterable<RemoteBlob> report(boolean includeErrorMessage) throws InterlokException {
       throw new UnsupportedOperationException();
     }
 

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreListServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreListServiceTest.java
@@ -1,0 +1,88 @@
+package com.adaptris.core.http.jetty.retry;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.MetadataElement;
+import com.adaptris.interlok.cloud.BlobListRenderer;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class RetryStoreListServiceTest {
+    private static final String METADATA_KEY= "includeErrorMessage";
+
+    private RetryStoreListService service;
+    private BlobListRenderer renderer;
+    private AdaptrisMessage message;
+    private InMemoryRetryStore retryStore;
+    private Iterable<RemoteBlob> reportResult;
+
+    @BeforeEach
+    void setUp() {
+        service = new RetryStoreListService();
+        renderer = mock(BlobListRenderer.class);
+        message = mock(AdaptrisMessage.class);
+        retryStore = mock(InMemoryRetryStore.class);
+        reportResult = Collections.emptyList();
+        service.setReportRenderer(renderer);
+        service.setRetryStore(retryStore);
+    }
+
+    @Test
+    void test_includeErrorMessageTrue() throws Exception {
+        when(message.getMetadataValue(METADATA_KEY)).thenReturn("true");
+        when(retryStore.report(true)).thenReturn(reportResult);
+
+        service.doService(message);
+
+        verify(renderer).render(eq(reportResult), eq(message));
+    }
+
+    @Test
+    void test_includeErrorMessageFalse() throws Exception {
+        when(message.getMetadataValue(METADATA_KEY)).thenReturn("false");
+        when(retryStore.report(false)).thenReturn(reportResult);
+
+        service.doService(message);
+
+        verify(renderer).render(eq(reportResult), eq(message));
+    }
+
+    @Test
+    void test_includeErrorMessageValueNotNull() throws Exception {
+        // Both metadata and metadataValue are non-null
+        when(message.getMetadata(METADATA_KEY)).thenReturn(
+            new MetadataElement(METADATA_KEY, "true"));
+        when(message.getMetadataValue(METADATA_KEY)).thenReturn("true");
+        when(retryStore.report(true)).thenReturn(reportResult);
+
+        service.doService(message);
+
+        verify(renderer).render(eq(reportResult), eq(message));
+    }
+
+    @Test
+    void test_includeErrorMessageNotPresent_defaultsTrue() throws Exception {
+        when(message.getMetadataValue(METADATA_KEY)).thenReturn(null);
+        when(retryStore.report(true)).thenReturn(reportResult);
+
+        service.doService(message);
+
+        verify(renderer).render(eq(reportResult), eq(message));
+    }
+
+    @Test
+    void test_errorScenario_throwsServiceException() throws Exception {
+        when(message.getMetadataValue("includeErrorMessage")).thenReturn("true");
+        when(retryStore.report(true)).thenThrow(new RuntimeException("Simulated error"));
+
+        org.junit.jupiter.api.Assertions.assertThrows(
+            com.adaptris.core.ServiceException.class,
+            () -> service.doService(message)
+        );
+    }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/http/jetty/retry/RetryStoreTest.java
@@ -58,7 +58,7 @@ public class RetryStoreTest implements RetryStore {
 
   @Test
   public void testDefaultReport() throws Exception {
-    assertFalse(report().iterator().hasNext());
+    assertFalse(report(false).iterator().hasNext());
   }
 
   @Override


### PR DESCRIPTION
## Modification

This change refactors the latest retry endpoints to remove the method that gets only the first line of the stack trace. The first line error message will now be included in the report endpoint as default behaviour and can be excluded with a customisable http parameter. The default parameter name is includeErrorMessage.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

The users will start seeing the error messages as default when listing the failed messages. Depending on the component specific implementation, it may look something like this - ' id123 - Exception: NullPointer'. This will differ between components, for example, the aws retry store implementation returns json.

## Testing

Set up a local adapter using the build from this branch and a global retry-via-jetty component. This will then expose the default endpoints (and can be configured). These endpoints can be interrogated using Postman. Sample xml for the retry component:

```
<retry-via-jetty>
  <unique-id>adoring-easley</unique-id>
  <connection class="jetty-embedded-connection">
    <unique-id>naughty-nobel</unique-id>
  </connection>
  <report-builder/>
  <retry-store class="retry-store-filesystem">
    <base-url>C:/Adaptris/retryStore</base-url>
  </retry-store>
</retry-via-jetty>
```
