### PR TITLE
INTERLOK-4656: Extend FindAndReplaceService for special characters

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/services/findreplace/AbstractReplacementSource.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/findreplace/AbstractReplacementSource.java
@@ -26,12 +26,29 @@ public abstract class AbstractReplacementSource implements ReplacementSource {
   @NotNull
   private String value;
 
+  @NotNull
+  private Mode mode = Mode.LITERAL;
+
+  @Override
+  public Mode getMode() {
+    return mode;
+  }
+
+  public void setMode(Mode mode) {
+    this.mode = mode;
+  }
+
   public String getValue() {
     return value;
   }
 
   public void setValue(String value) {
     this.value = value;
+  }
+
+  public AbstractReplacementSource mode(Mode mode) {
+      setMode(mode);
+      return this;
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/findreplace/AbstractReplacementSource.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/findreplace/AbstractReplacementSource.java
@@ -27,28 +27,27 @@ public abstract class AbstractReplacementSource implements ReplacementSource {
   private String value;
 
   @NotNull
-  private Mode mode = Mode.LITERAL;
+  private String mode = Mode.LITERAL.name();
 
-  @Override
-  public Mode getMode() {
-    return mode;
+  public AbstractReplacementSource mode(Mode mode) {
+      setMode(mode.name());
+      return this;
   }
 
-  public void setMode(Mode mode) {
-    this.mode = mode;
-  }
+    public String getMode() {
+        return mode;
+    }
 
-  public String getValue() {
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    public String getValue() {
     return value;
   }
 
   public void setValue(String value) {
     this.value = value;
-  }
-
-  public AbstractReplacementSource mode(Mode mode) {
-      setMode(mode);
-      return this;
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/findreplace/AbstractReplacementSource.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/findreplace/AbstractReplacementSource.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.findreplace;
 
 import javax.validation.constraints.NotNull;
 
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 
 public abstract class AbstractReplacementSource implements ReplacementSource {
@@ -26,7 +27,9 @@ public abstract class AbstractReplacementSource implements ReplacementSource {
   @NotNull
   private String value;
 
+  @InputFieldDefault("LITERAL")
   @NotNull
+  @InputFieldHint(expression=true)
   private String mode = Mode.LITERAL.name();
 
   public AbstractReplacementSource mode(Mode mode) {

--- a/interlok-core/src/main/java/com/adaptris/core/services/findreplace/FindAndReplaceService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/findreplace/FindAndReplaceService.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.findreplace;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 
 import javax.validation.Valid;
 
@@ -76,7 +77,9 @@ public class FindAndReplaceService extends ServiceImp {
       String find = unit.getFind().obtainValue(msg);
       String replace = unit.getReplace().obtainValue(msg);
       log.trace("replacing [" + find + "] with [" + replace + "]");
-      doReplace(msg, find, replace);
+      String findModified = unit.getFind().getMode().modify(find);
+      String replaceModified = unit.getReplace().getMode().modify(replace);
+      doReplace(msg, findModified, replaceModified);
     }
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/services/findreplace/FindAndReplaceService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/findreplace/FindAndReplaceService.java
@@ -18,7 +18,6 @@ package com.adaptris.core.services.findreplace;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 
 import javax.validation.Valid;
 
@@ -77,8 +76,12 @@ public class FindAndReplaceService extends ServiceImp {
       String find = unit.getFind().obtainValue(msg);
       String replace = unit.getReplace().obtainValue(msg);
       log.trace("replacing [" + find + "] with [" + replace + "]");
-      String findModified = unit.getFind().getMode().modify(find);
-      String replaceModified = unit.getReplace().getMode().modify(replace);
+      String findModeStr = msg.resolve(unit.getFind().getMode());
+      ReplacementSource.Mode findMode = ReplacementSource.Mode.valueOf(findModeStr);
+      String findModified = findMode.modify(find);
+      String replaceModeStr = msg.resolve(unit.getReplace().getMode());
+      ReplacementSource.Mode replaceMode = ReplacementSource.Mode.valueOf(replaceModeStr);
+      String replaceModified = replaceMode.modify(replace);
       doReplace(msg, findModified, replaceModified);
     }
   }

--- a/interlok-core/src/main/java/com/adaptris/core/services/findreplace/ReplacementSource.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/findreplace/ReplacementSource.java
@@ -37,7 +37,7 @@ public interface ReplacementSource {
    */
   String obtainValue(AdaptrisMessage msg) throws ServiceException;
 
-  Mode getMode();
+  String getMode();
 
   enum Mode {
     LITERAL(Matcher::quoteReplacement),
@@ -45,7 +45,7 @@ public interface ReplacementSource {
     ;
 
     private final Function<String, String> modifier;
-    
+
     Mode(Function<String, String> modifier) {
         this.modifier = modifier;
     }

--- a/interlok-core/src/main/java/com/adaptris/core/services/findreplace/ReplacementSource.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/findreplace/ReplacementSource.java
@@ -19,6 +19,9 @@ package com.adaptris.core.services.findreplace;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
 
+import java.util.function.Function;
+import java.util.regex.Matcher;
+
 /**
  * Interface for handling how find and replace operations occur for {@link FindAndReplaceService}.
  */
@@ -33,4 +36,22 @@ public interface ReplacementSource {
    * @return the String to be used as the replacement.
    */
   String obtainValue(AdaptrisMessage msg) throws ServiceException;
+
+  Mode getMode();
+
+  enum Mode {
+    LITERAL(Matcher::quoteReplacement),
+    FULL_REGEX(val -> val)
+    ;
+
+    private final Function<String, String> modifier;
+    
+    Mode(Function<String, String> modifier) {
+        this.modifier = modifier;
+    }
+
+    public String modify(String value) {
+        return modifier.apply(value);
+    }
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/findreplace/FindAndReplaceServiceTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/findreplace/FindAndReplaceServiceTest.java
@@ -21,12 +21,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.GeneralServiceExample;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class FindAndReplaceServiceTest extends GeneralServiceExample {
 
@@ -160,8 +164,8 @@ public class FindAndReplaceServiceTest extends GeneralServiceExample {
     FindAndReplaceService service = new FindAndReplaceService();
     service.setReplaceFirstOnly(true);
     service.getFindAndReplaceUnits().add(
-        new FindAndReplaceUnit(new ConfiguredReplacementSource(REGEXP_FIND_WITH_MATCHGROUP), new ConfiguredReplacementSource(
-            REGEXP_REPLACE_USE_MATCHGROUP)));
+        new FindAndReplaceUnit(new ConfiguredReplacementSource(REGEXP_FIND_WITH_MATCHGROUP).mode(ReplacementSource.Mode.FULL_REGEX), new ConfiguredReplacementSource(
+            REGEXP_REPLACE_USE_MATCHGROUP).mode(ReplacementSource.Mode.FULL_REGEX)));
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(REGEXP_PAYLOAD);
     execute(service, msg);
     assertEquals(REGEXP_PAYLOAD_EXPECTED, msg.getContent());
@@ -180,8 +184,8 @@ public class FindAndReplaceServiceTest extends GeneralServiceExample {
     FindAndReplaceService service = new FindAndReplaceService();
     service.setReplaceFirstOnly(false);
     service.getFindAndReplaceUnits().add(
-        new FindAndReplaceUnit(new ConfiguredReplacementSource(REGEXP_FIND_WITH_MATCHGROUP), new ConfiguredReplacementSource(
-            REGEXP_REPLACE_USE_MATCHGROUP)));
+        new FindAndReplaceUnit(new ConfiguredReplacementSource(REGEXP_FIND_WITH_MATCHGROUP).mode(ReplacementSource.Mode.FULL_REGEX), new ConfiguredReplacementSource(
+            REGEXP_REPLACE_USE_MATCHGROUP).mode(ReplacementSource.Mode.FULL_REGEX)));
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(REGEXP_PAYLOAD);
     execute(service, msg);
     assertEquals(REGEXP_PAYLOAD_EXPECTED, msg.getContent());
@@ -222,6 +226,28 @@ public class FindAndReplaceServiceTest extends GeneralServiceExample {
     execute(service, msg);
     assertTrue(msg.getContent().equals(PAYLOAD_REPLACED_ALL_HEX));
   }
+
+    @ParameterizedTest
+    @MethodSource("specialCharactersFindReplace")
+    public void testReplaceAll_ConfiguredSpecialCharacters(String find, String replace, String before, String after) throws Exception {
+        FindAndReplaceService service = new FindAndReplaceService();
+        service.setReplaceFirstOnly(false);
+        service.getFindAndReplaceUnits().add(
+                new FindAndReplaceUnit(new ConfiguredReplacementSource(find), new ConfiguredReplacementSource(
+                        replace)));
+        AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(before);
+        execute(service, msg);
+        assertEquals(after, msg.getContent());
+    }
+
+    private static Stream<Arguments> specialCharactersFindReplace() {
+        return Stream.of(
+                Arguments.of("\n", "\n\n", "some text before\nthen after\n", "some text before\n\nthen after\n\n"),
+                Arguments.of("\r", "\r\r", "some text before\rthen after\r", "some text before\r\rthen after\r\r"),
+                Arguments.of("\t", "\t\t", "some text before\tthen after\t", "some text before\t\tthen after\t\t"),
+                Arguments.of("\\", "\\\\", "some text before\\then after\\", "some text before\\\\then after\\\\")
+        );
+    }
 
   private FindAndReplaceService createServiceForTests(ReplacementSourceImpl impl, boolean replaceFirst) {
     FindAndReplaceService service = new FindAndReplaceService();


### PR DESCRIPTION
## Motivation

https://telusagriculture.atlassian.net/browse/INTERLOK-4656

## Modification

Made FindAndReplaceService support a 'mode' which distinguishes literal character replacement and regex support.


## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

FindAndReplaceService now supports a mode at the replacement source level, which controls whether literal or full regex is applied.

## Testing

sample adapter and inputs in the comments of the ticket: https://telusagriculture.atlassian.net/browse/INTERLOK-4656
