### PR TITLE
INTERLOK-4684: Implement recovery when JMS session is closed

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/DefaultProducerSessionFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/DefaultProducerSessionFactory.java
@@ -49,4 +49,10 @@ public class DefaultProducerSessionFactory extends ProducerSessionFactoryImpl {
     return session;
   }
 
+
+  @Override
+  public void close() {
+    super.close();
+    session = null;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -109,17 +109,32 @@ public class JmsProducer extends JmsProducerImpl {
     }
   }
 
-    protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
+  protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
+     throws JMSException, CoreException {
+    doProduce(msg, jmsDest, true);
+  }
+
+  protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest, boolean refreshSessionIfProduceException)
       throws JMSException, CoreException {
-    setupSession(msg);
+    setupSession(msg, !refreshSessionIfProduceException);
     Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());
-    if (!perMessageProperties()) {
-      producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg);
-    } else {
-      producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg,
-          calculateDeliveryMode(msg, jmsDest.deliveryMode()),
-          calculatePriority(msg, jmsDest.priority()),
-          calculateTimeToLive(msg, jmsDest.timeToLive()));
+    try {
+      if (!perMessageProperties()) {
+        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg);
+      } else {
+        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg,
+                calculateDeliveryMode(msg, jmsDest.deliveryMode()),
+                calculatePriority(msg, jmsDest.priority()),
+                calculateTimeToLive(msg, jmsDest.timeToLive()));
+      }
+    } catch (JMSException ex) {
+      currentLogger().debug("Caught exception while producing", ex);
+      if (refreshSessionIfProduceException) {
+        currentLogger().info("Handling exception by retrying with new session. Exception: {}", ex.getMessage());
+        // don't refresh session on this call, instead throw
+        doProduce(msg, jmsDest, false);
+        return;
+      } else throw ex;
     }
     captureOutgoingMessageDetails(jmsMsg, msg);
     log.info("msg produced to destination [{}]", jmsDest);

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducerImpl.java
@@ -200,6 +200,16 @@ public abstract class JmsProducerImpl extends RequestReplyProducerBase implement
 
 
   protected ProducerSession setupSession(AdaptrisMessage msg) throws JMSException {
+    return setupSession(msg, false);
+  }
+
+  protected ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) throws JMSException {
+    if (forceRecreate && producerSession != null) {
+      getSessionFactory().close();
+
+      producerSession = null;
+    }
+
     if (!msg.getUniqueId().equals(CURRENT_MESSAGE_ID) || producerSession == null) {
       producerSession = getSessionFactory().createProducerSession(this, msg);
       configuredMessageTranslator().registerSession(producerSession.getSession());

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
@@ -18,26 +18,18 @@ package com.adaptris.core.jms;
 
 import static com.adaptris.interlok.junit.scaffolding.jms.JmsConfig.DEFAULT_PAYLOAD;
 import static com.adaptris.interlok.junit.scaffolding.jms.JmsConfig.MESSAGE_TRANSLATOR_LIST;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.Queue;
-import javax.jms.Session;
+import javax.jms.*;
 
+import com.adaptris.core.*;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -47,13 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceException;
-import com.adaptris.core.ServiceList;
-import com.adaptris.core.StandaloneConsumer;
-import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.StandaloneRequestor;
 import com.adaptris.core.jms.BasicJmsProducerCase.Loopback;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
@@ -566,6 +551,72 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
     } finally {
       stop(standaloneProducer, standaloneConsumer);
     }
+  }
+
+  @Test
+  public void testRefreshSessionIfException() throws Exception {
+    String rfc6167 = "jms:queue:" + getName() + "";
+    JmsConsumerImpl consumer = createConsumer(getName());
+    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
+    MockMessageListener jms = new MockMessageListener();
+    JmsProducer producer = spy(createProducer(rfc6167));
+    ProducerSessionFactory psf = spy(new DefaultProducerSessionFactory());
+    producer.setSessionFactory(psf);
+    standaloneConsumer.registerAdaptrisMessageListener(jms);
+    MessageProducer throwsExceptionProducer = mock(MessageProducer.class);
+    doAnswer(args -> {
+      throw new JMSException("The Session is closed");
+    }).when(throwsExceptionProducer).send(isA(Destination.class), any(), anyInt(), anyInt(), anyLong());
+
+    doReturn(new ProducerSession() {
+      @Override
+      public Session getSession() {
+        ProducerSession existingProducerSession = producer.producerSession();
+        return existingProducerSession.getSession();
+      }
+
+      @Override
+      public MessageProducer getProducer() {
+        return throwsExceptionProducer;
+      }
+    }).when(producer).producerSession();
+
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
+    assertThrows(ServiceException.class, () -> {
+      try {
+        start(standaloneConsumer, standaloneProducer);
+
+        standaloneProducer.doService(createMessage());
+
+      } finally {
+        stop(standaloneProducer, standaloneConsumer);
+      }
+    });
+
+    verify(producer, times(2)).setupSession(any(), eq(false));
+    verify(producer).setupSession(any(), eq(true));
+  }
+
+  @Test
+  public void testSetupSession() throws Exception {
+    String rfc6167 = "jms:queue:" + getName() + "";
+    JmsProducer producer = createProducer(rfc6167);
+    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
+    ProducerSessionFactory psf = new DefaultProducerSessionFactory();
+    producer.setSessionFactory(psf);
+    try {
+      start(standaloneProducer);
+      ProducerSession session1 = producer.setupSession(createMessage(), false);
+      ProducerSession session2 = producer.setupSession(createMessage(), false);
+      assertEquals(session1, session2);
+      ProducerSession session3 = producer.setupSession(createMessage(), true);
+      assertNotEquals(session1, session3);
+      assertNotEquals(session2, session3);
+    } finally {
+      stop(standaloneProducer);
+    }
+
   }
 
   @Test


### PR DESCRIPTION
## Motivation

https://telusagriculture.atlassian.net/browse/INTERLOK-4684

## Modification

JmsProducer.doProduce() will now attempt to refresh the JMS session if it encounters a JMSException while sending.

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Clients should not need to worry about transient stale JMS sessions as when sending, a refresh will occur. However if it is not a transient issue then the exception will be thrown.

## Testing

No config changes are required, use the latest snapshot JAR.
