### PR TITLE
INTERLOK-4696-Boolean flag for auto configure and auto refresh

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -113,7 +113,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         } finally {
             if (failed == null) {
                 setConnectionErrors(0);
-                toggleChannelAvailability(BooleanUtils.toBooleanDefaultIfNull(autoConfigureConnection));
+                toggleChannelAvailability(BooleanUtils.toBooleanDefaultIfNull(Boolean.valueOf(autoConfigureConnection), false));
             }
         }
     }
@@ -130,7 +130,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         } finally {
             if (failed == null) {
                 setConnectionErrors(0);
-                toggleChannelAvailability(BooleanUtils.toBooleanDefaultIfNull(autoConfigureConnection));
+                toggleChannelAvailability(BooleanUtils.toBooleanDefaultIfNull(Boolean.valueOf(autoConfigureConnection), false));
             }
         }
     }

--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 /**
  * <p>
  * A decorator for <code>AdaptrisMessageProducer</code> which will handle connection errors
@@ -102,6 +104,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     @Override
     public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
         ProduceException failed = null;
+        String autoConfigureConnection = msg.getMetadataValue(CoreConstants.AUTO_CONFIGURATION_KEY);
         try {
             return super.request(msg, timeout);
         } catch (ProduceException ex) {
@@ -110,7 +113,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         } finally {
             if (failed == null) {
                 setConnectionErrors(0);
-                toggleChannelAvailability(true);
+                toggleChannelAvailability(BooleanUtils.toBooleanDefaultIfNull(autoConfigureConnection));
             }
         }
     }
@@ -118,6 +121,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     @Override
     public void produce(AdaptrisMessage msg) throws ProduceException {
         ProduceException failed = null;
+        String autoConfigureConnection = msg.getMetadataValue(CoreConstants.AUTO_CONFIGURATION_KEY);
         try {
             super.produce(msg);
         } catch (ProduceException ex) {
@@ -126,7 +130,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         } finally {
             if (failed == null) {
                 setConnectionErrors(0);
-                toggleChannelAvailability(true);
+                toggleChannelAvailability(BooleanUtils.toBooleanDefaultIfNull(autoConfigureConnection));
             }
         }
     }

--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -16,6 +16,7 @@ package com.adaptris.core;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,6 +106,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
         ProduceException failed = null;
         String autoConfigureConnection = msg.getMetadataValue(CoreConstants.AUTO_CONFIGURATION_KEY);
+        Boolean isAutoConfigureConnection = StringUtils.isNotEmpty(autoConfigureConnection)? Boolean.valueOf(autoConfigureConnection): Boolean.TRUE;
         try {
             return super.request(msg, timeout);
         } catch (ProduceException ex) {
@@ -113,7 +115,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         } finally {
             if (failed == null) {
                 setConnectionErrors(0);
-                toggleChannelAvailability(BooleanUtils.toBooleanDefaultIfNull(Boolean.valueOf(autoConfigureConnection), false));
+                toggleChannelAvailability(isAutoConfigureConnection);
             }
         }
     }
@@ -122,6 +124,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     public void produce(AdaptrisMessage msg) throws ProduceException {
         ProduceException failed = null;
         String autoConfigureConnection = msg.getMetadataValue(CoreConstants.AUTO_CONFIGURATION_KEY);
+        Boolean isAutoConfigureConnection = StringUtils.isEmpty(autoConfigureConnection)? Boolean.TRUE:Boolean.valueOf(autoConfigureConnection);
         try {
             super.produce(msg);
         } catch (ProduceException ex) {
@@ -130,7 +133,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         } finally {
             if (failed == null) {
                 setConnectionErrors(0);
-                toggleChannelAvailability(BooleanUtils.toBooleanDefaultIfNull(Boolean.valueOf(autoConfigureConnection), false));
+                toggleChannelAvailability(isAutoConfigureConnection);
             }
         }
     }

--- a/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/CoreConstants.java
@@ -180,6 +180,13 @@ public abstract class CoreConstants {
   public static final String RETRY_COUNT_KEY = "previousretrycount";
 
   /**
+   * <p>
+   * Metadta key for auto configuration of connection.
+   * </p>
+   */
+  public static final String AUTO_CONFIGURATION_KEY = "autoConfigureConnection";
+
+  /**
    * Metadata key specifying that security has been encrypted using v1 encryption compability mode.
    */
   public static final String SECURITY_V1_COMPATIBILITY = "v1encryption" + "compatibility";

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConstants.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConstants.java
@@ -110,4 +110,12 @@ public final class JmsConstants {
    */
   public static final String JMS_ASYNC_STATIC_REPLY_TO = "JMSAsyncStaticReplyTo";
 
+  /**
+   * Key used to refresh session on encountering exception when using a producer.
+   * <p>
+   * If this metadata key is populated, then it will be used to refresh a session if an exception is encountered whenever a message is produced to JMS.
+   * </p>
+   *
+   */
+  public static final String JMS_AUTO_REFRESH_SESSION_ON_EXCEPTION = "JMSRefreshSessionOnException";
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -45,6 +45,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * JMS Producer implementation that can target queues or topics via an RFC6167 style destination.
@@ -113,7 +114,8 @@ public class JmsProducer extends JmsProducerImpl {
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
      throws JMSException, CoreException {
     String refreshSessionIfProduceException = msg.getMetadataValue(JMS_AUTO_REFRESH_SESSION_ON_EXCEPTION);
-    doProduce(msg, jmsDest, BooleanUtils.toBooleanDefaultIfNull(Boolean.valueOf(refreshSessionIfProduceException), true));
+    Boolean isRefreshSessionIfProduceException = StringUtils.isNotEmpty(refreshSessionIfProduceException)? Boolean.valueOf(refreshSessionIfProduceException):Boolean.TRUE;
+    doProduce(msg, jmsDest, isRefreshSessionIfProduceException);
   }
 
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest, boolean refreshSessionIfProduceException)

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -18,6 +18,7 @@ package com.adaptris.core.jms;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static com.adaptris.core.jms.JmsConstants.JMS_ASYNC_STATIC_REPLY_TO;
+import static com.adaptris.core.jms.JmsConstants.JMS_AUTO_REFRESH_SESSION_ON_EXCEPTION;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.util.Optional;
@@ -111,7 +112,8 @@ public class JmsProducer extends JmsProducerImpl {
 
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
      throws JMSException, CoreException {
-    doProduce(msg, jmsDest, true);
+    String refreshSessionIfProduceException = msg.getMetadataValue(JMS_AUTO_REFRESH_SESSION_ON_EXCEPTION);
+    doProduce(msg, jmsDest, BooleanUtils.toBooleanDefaultIfNull(refreshSessionIfProduceException));
   }
 
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest, boolean refreshSessionIfProduceException)

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -113,7 +113,7 @@ public class JmsProducer extends JmsProducerImpl {
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
      throws JMSException, CoreException {
     String refreshSessionIfProduceException = msg.getMetadataValue(JMS_AUTO_REFRESH_SESSION_ON_EXCEPTION);
-    doProduce(msg, jmsDest, BooleanUtils.toBooleanDefaultIfNull(refreshSessionIfProduceException));
+    doProduce(msg, jmsDest, BooleanUtils.toBooleanDefaultIfNull(Boolean.valueOf(refreshSessionIfProduceException), true));
   }
 
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest, boolean refreshSessionIfProduceException)

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
@@ -553,6 +553,55 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
     }
   }
 
+
+  @Test
+  public void testRefreshSessionIfException_MetadataTrue() throws Exception {
+      String rfc6167 = "jms:queue:" + getName();
+      JmsConsumerImpl consumer = createConsumer(getName());
+      consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
+      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
+      MockMessageListener jms = new MockMessageListener();
+      JmsProducer producer = spy(createProducer(rfc6167));
+      ProducerSessionFactory psf = spy(new DefaultProducerSessionFactory());
+      producer.setSessionFactory(psf);
+      standaloneConsumer.registerAdaptrisMessageListener(jms);
+
+      MessageProducer throwsExceptionProducer = mock(MessageProducer.class);
+      doAnswer(args -> {
+          throw new JMSException("The Session is closed");
+      }).when(throwsExceptionProducer).send(isA(Destination.class), any(), anyInt(), anyInt(), anyLong());
+
+      doReturn(new ProducerSession() {
+          @Override
+          public Session getSession() {
+                return producer.producerSession().getSession();
+            }
+
+          @Override
+          public MessageProducer getProducer() {
+                return throwsExceptionProducer;
+            }
+      }).when(producer).producerSession();
+
+      StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
+
+      // Explicitly set JMSRefreshSessionOnException = "true"
+      AdaptrisMessage msg = createMessage();
+      msg.addMetadata(JmsConstants.JMS_AUTO_REFRESH_SESSION_ON_EXCEPTION, "true");
+
+      assertThrows(ServiceException.class, () -> {
+          try {
+              start(standaloneConsumer, standaloneProducer);
+              standaloneProducer.doService(msg);
+          } finally {
+              stop(standaloneProducer, standaloneConsumer);
+          }
+      });
+
+      verify(producer, times(2)).setupSession(any(), eq(false));
+      verify(producer, times(1)).setupSession(any(), eq(true));
+  }
+
   @Test
   public void testRefreshSessionIfException() throws Exception {
     String rfc6167 = "jms:queue:" + getName() + "";


### PR DESCRIPTION
## Motivation

Why am I doing this

https://telusagriculture.atlassian.net/browse/INTERLOK-4696

What did I change

Added boolean metadata to enable JMS Session auto-refresh session on exception and auto-configure channel unavailable restart

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user

## Testing

How can I test this if I'm reviewing this.

The Interlok adapter configuration needs to have metadata present with key "JMSRefreshSessionOnException" to refresh JMS jession on exception . By default, if missing this setting is true

<service-collection class="service-list">
  <services>
      <add-metadata-service>
        <unique-id>disable-session-refresh-on-exception</unique-id>
        <metadata-element>
         <key>JMSRefreshSessionOnException</key>
         <value>true</value>
        </metadata-element>
    </add-metadata-service>
    <producer class="jms-producer">
      <unique-id>jms-producer</unique-id>
      <endpoint>jms:queue:QueueName</endpoint>
      <message-translator class="bytes-message-translator"/>
      <delivery-mode>PERSISTENT</delivery-mode>
    </producer>
  </services>
</service-collection>

The interlok adapter configuration needs to have metadata present with key "autoConfigureConnection" set to true for automatically configure connection

<workflow-list>
        <standard-workflow>
          <consumer class="jms-queue-consumer">
            <unique-id>jms-consumer</unique-id>
            <acknowledge-mode>AUTO_ACKNOWLEDGE</acknowledge-mode>
            <queue>InputQueue-1</queue>
          </consumer>
          <service-collection class="service-list">
            <unique-id>workflow-services</unique-id>
            <services>
              <add-metadata-service>
                <unique-id>set-auto-configure-connection-true</unique-id>
                <metadata-element>
                  <key>autoConfigureConnection</key>
                  <value>true</value>
                </metadata-element>
              </add-metadata-service>
            </services>
          </service-collection>
       </standard-workflow>
</workflow-list>

