### PR TITLE
Updated changes to move the boolean check to configuration

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -43,6 +43,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     protected String connectionErrorWaitDuration;
     protected Duration _connectionErrorWaitDuration;
     protected Integer connectionErrors = 0;
+    private Boolean autoConfigureConnection = Boolean.TRUE;
 
     @Override
     public void prepare() throws CoreException {
@@ -86,6 +87,14 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         this.connectionErrors = connectionErrors;
     }
 
+    public Boolean getAutoConfigureConnection() {
+        return autoConfigureConnection;
+    }
+
+    public void setAutoConfigureConnection(Boolean autoConfigureConnection) {
+        this.autoConfigureConnection = autoConfigureConnection;
+    }
+
     @Override
     public AdaptrisMessage request(AdaptrisMessage msg) throws ProduceException {
         ProduceException failed = null;
@@ -95,7 +104,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
             failed = ex;
             throw ex;
         } finally {
-            if (failed == null) {
+            if (getAutoConfigureConnection() && failed == null) {
                 setConnectionErrors(0);
                 toggleChannelAvailability(true);
             }
@@ -105,17 +114,15 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     @Override
     public AdaptrisMessage request(AdaptrisMessage msg, long timeout) throws ProduceException {
         ProduceException failed = null;
-        String autoConfigureConnection = msg.getMetadataValue(CoreConstants.AUTO_CONFIGURATION_KEY);
-        Boolean isAutoConfigureConnection = StringUtils.isNotEmpty(autoConfigureConnection)? Boolean.valueOf(autoConfigureConnection): Boolean.TRUE;
         try {
             return super.request(msg, timeout);
         } catch (ProduceException ex) {
             failed = ex;
             throw ex;
         } finally {
-            if (failed == null) {
+            if (getAutoConfigureConnection() && failed == null) {
                 setConnectionErrors(0);
-                toggleChannelAvailability(isAutoConfigureConnection);
+                toggleChannelAvailability(true);
             }
         }
     }
@@ -123,17 +130,15 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     @Override
     public void produce(AdaptrisMessage msg) throws ProduceException {
         ProduceException failed = null;
-        String autoConfigureConnection = msg.getMetadataValue(CoreConstants.AUTO_CONFIGURATION_KEY);
-        Boolean isAutoConfigureConnection = StringUtils.isEmpty(autoConfigureConnection)? Boolean.TRUE:Boolean.valueOf(autoConfigureConnection);
         try {
             super.produce(msg);
         } catch (ProduceException ex) {
             failed = ex;
             throw ex;
         } finally {
-            if (failed == null) {
+            if (getAutoConfigureConnection() && failed == null) {
                 setConnectionErrors(0);
-                toggleChannelAvailability(isAutoConfigureConnection);
+                toggleChannelAvailability(true);
             }
         }
     }
@@ -143,7 +148,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         if (connectionErrors == null) setConnectionErrors(0);
         setConnectionErrors(connectionErrors + 1);
         log.debug("Consecutive connection errors encountered: {} threshold: {}", getConnectionErrors(), getConnectionErrorThreshold());
-        if (getConnectionErrors() >= getConnectionErrorThreshold()) {
+        if (getAutoConfigureConnection() && getConnectionErrors() >= getConnectionErrorThreshold()) {
             toggleChannelAvailability(false);
             new Timer().schedule(new TimerTask() {
                 @Override

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -18,7 +18,7 @@ package com.adaptris.core.jms;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static com.adaptris.core.jms.JmsConstants.JMS_ASYNC_STATIC_REPLY_TO;
-import static com.adaptris.core.jms.JmsConstants.JMS_AUTO_REFRESH_SESSION_ON_EXCEPTION;
+import org.apache.commons.lang3.BooleanUtils;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.util.Optional;
@@ -28,8 +28,6 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.validation.constraints.NotBlank;
-
-import org.apache.commons.lang3.BooleanUtils;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
@@ -45,7 +43,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * JMS Producer implementation that can target queues or topics via an RFC6167 style destination.
@@ -83,6 +80,14 @@ import org.apache.commons.lang3.StringUtils;
 public class JmsProducer extends JmsProducerImpl {
 
   /**
+   * If true, the producer will refresh the JMS session on a produce exception.
+   * Defaults to true for backward compatibility.
+   */
+  @Getter
+  @Setter
+  private Boolean refreshSessionIfProduceException = Boolean.TRUE;
+
+  /**
    * The JMS Endpoint defined in an RFC6167 manner.
    */
   @InputFieldHint(expression = true)
@@ -113,9 +118,7 @@ public class JmsProducer extends JmsProducerImpl {
 
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
      throws JMSException, CoreException {
-    String refreshSessionIfProduceException = msg.getMetadataValue(JMS_AUTO_REFRESH_SESSION_ON_EXCEPTION);
-    Boolean isRefreshSessionIfProduceException = StringUtils.isNotEmpty(refreshSessionIfProduceException)? Boolean.valueOf(refreshSessionIfProduceException):Boolean.TRUE;
-    doProduce(msg, jmsDest, isRefreshSessionIfProduceException);
+    doProduce(msg, jmsDest, refreshSessionIfProduceException);
   }
 
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest, boolean refreshSessionIfProduceException)

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
@@ -602,50 +602,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
       verify(producer, times(1)).setupSession(any(), eq(true));
   }
 
-  @Test
-  public void testRefreshSessionIfException() throws Exception {
-    String rfc6167 = "jms:queue:" + getName() + "";
-    JmsConsumerImpl consumer = createConsumer(getName());
-    consumer.setAcknowledgeMode("AUTO_ACKNOWLEDGE");
-    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(activeMqBroker.getJmsConnection(), consumer);
-    MockMessageListener jms = new MockMessageListener();
-    JmsProducer producer = spy(createProducer(rfc6167));
-    ProducerSessionFactory psf = spy(new DefaultProducerSessionFactory());
-    producer.setSessionFactory(psf);
-    standaloneConsumer.registerAdaptrisMessageListener(jms);
-    MessageProducer throwsExceptionProducer = mock(MessageProducer.class);
-    doAnswer(args -> {
-      throw new JMSException("The Session is closed");
-    }).when(throwsExceptionProducer).send(isA(Destination.class), any(), anyInt(), anyInt(), anyLong());
 
-    doReturn(new ProducerSession() {
-      @Override
-      public Session getSession() {
-        ProducerSession existingProducerSession = producer.producerSession();
-        return existingProducerSession.getSession();
-      }
-
-      @Override
-      public MessageProducer getProducer() {
-        return throwsExceptionProducer;
-      }
-    }).when(producer).producerSession();
-
-    StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
-    assertThrows(ServiceException.class, () -> {
-      try {
-        start(standaloneConsumer, standaloneProducer);
-
-        standaloneProducer.doService(createMessage());
-
-      } finally {
-        stop(standaloneProducer, standaloneConsumer);
-      }
-    });
-
-    verify(producer, times(2)).setupSession(any(), eq(false));
-    verify(producer).setupSession(any(), eq(true));
-  }
 
   @Test
   public void testSetupSession() throws Exception {
@@ -918,6 +875,61 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
         stop(serviceList);
       }
     });
+  }
+
+  @Test
+  public void testDoProduce_RefreshSessionIfProduceException_ConfigTrue() throws Exception {
+    JmsProducer producer = spy(createProducer("producer1"));
+    producer.setRefreshSessionIfProduceException(true);
+    producer.setSessionFactory(mockSessionFactory);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("test");
+    JmsDestination mockJmsDestination = mock(JmsDestination.class);
+    javax.jms.MessageProducer mockMsgProducer = mock(javax.jms.MessageProducer.class);
+    ProducerSession mockProducerSession = mock(ProducerSession.class);
+    when(mockSessionFactory.createProducerSession(any(), any())).thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession()).thenReturn(mockSession);
+    when(mockProducerSession.getProducer()).thenReturn(mockMsgProducer);
+    when(mockJmsDestination.getDestination()).thenReturn(mock(Destination.class));
+    when(mockJmsDestination.getReplyToDestination()).thenReturn(null);
+    doReturn(mock(Message.class)).when(producer).translate(any(), any());
+    doReturn(true).when(producer).perMessageProperties();
+    doReturn(1).when(producer).calculateDeliveryMode(any(), any());
+    doReturn(1).when(producer).calculatePriority(any(), any());
+    doReturn(1L).when(producer).calculateTimeToLive(any(), any());
+    // First call throws, second call does not
+    doThrow(new JMSException("fail")).doNothing().when(mockMsgProducer)
+      .send(any(Destination.class), any(Message.class), anyInt(), anyInt(), anyLong());
+    // Should not throw because retry will succeed
+    assertDoesNotThrow(() -> producer.doProduce(msg, mockJmsDestination));
+    // Should have called send twice (retry)
+    verify(mockMsgProducer, times(2)).send(any(Destination.class), any(Message.class), anyInt(), anyInt(), anyLong());
+  }
+
+  @Test
+  public void testDoProduce_RefreshSessionIfProduceException_ConfigFalse() throws Exception {
+    JmsProducer producer = spy(createProducer("producer2"));
+    producer.setRefreshSessionIfProduceException(false);
+    producer.setSessionFactory(mockSessionFactory);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("test");
+    JmsDestination mockJmsDestination = mock(JmsDestination.class);
+    javax.jms.MessageProducer mockMsgProducer = mock(javax.jms.MessageProducer.class);
+    ProducerSession mockProducerSession = mock(ProducerSession.class);
+    when(mockSessionFactory.createProducerSession(any(), any())).thenReturn(mockProducerSession);
+    when(mockProducerSession.getSession()).thenReturn(mockSession);
+    when(mockProducerSession.getProducer()).thenReturn(mockMsgProducer);
+    when(mockJmsDestination.getDestination()).thenReturn(mock(Destination.class));
+    when(mockJmsDestination.getReplyToDestination()).thenReturn(null);
+    doReturn(mock(Message.class)).when(producer).translate(any(), any());
+    doReturn(true).when(producer).perMessageProperties();
+    doReturn(1).when(producer).calculateDeliveryMode(any(), any());
+    doReturn(1).when(producer).calculatePriority(any(), any());
+    doReturn(1L).when(producer).calculateTimeToLive(any(), any());
+    doThrow(new JMSException("fail")).when(mockMsgProducer)
+      .send(any(Destination.class), any(Message.class), anyInt(), anyInt(), anyLong());
+    // Should throw because no retry
+    assertThrows(JMSException.class, () -> producer.doProduce(msg, mockJmsDestination));
+    // Should have called send only once (no retry)
+    verify(mockMsgProducer, times(1)).send(any(Destination.class), any(Message.class), anyInt(), anyInt(), anyLong());
   }
 
   @Override


### PR DESCRIPTION
## Motivation

https://telusagriculture.atlassian.net/browse/INTERLOK-4696

## Modification

Added boolean metadata as configuration to enable JMS Session auto-refresh session on exception and auto-configure channel unavailable restart

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Boolean configurations made available to enable JMS Session auto-refresh session on exception and auto-configure channel unavailable restart

## Testing

The change can be tested on adapter by placing the below snippets - 
<producer class="channel-unavailable-connection-error-handling-producer">
  <connection-error-threshold>5</connection-error-threshold>
  <connection-error-wait-duration>${durationBetweenRestarts}</connection-error-wait-duration>
  <auto-configure-connection>true</auto-configure-connection>
  <delegate class="standard-http-producer">
    <unique-id>trigger-upgrade-all</unique-id>
    <method-provider class="http-configured-request-method">
      <method>GET</method>
    </method-provider>
    <content-type-provider class="http-configured-content-type-provider">
      <mime-type>text/plain</mime-type>
    </content-type-provider>
    <response-header-handler class="http-discard-response-headers"/>
    <request-header-provider class="http-no-request-headers"/>
    <ignore-server-response-code>false</ignore-server-response-code>
    <url>%message{targetUrl}</url>
    <authenticator class="http-no-authentication"/>
  </delegate>
</producer>

And for producer as - 
<producer class="jms-producer">
  <endpoint>jms:queue:MyQueue</endpoint>
  <refresh-session-if-produce-exception>false</refresh-session-if-produce-exception>
</producer>
