### PR TITLE
Feature/interlok 4720 backward compatiiblity jms connection and producers

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -150,6 +150,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         log.debug("Consecutive connection errors encountered: {} threshold: {}", getConnectionErrors(), getConnectionErrorThreshold());
         if (getConnectionErrors() >= getConnectionErrorThreshold()) {
             toggleChannelAvailability(false);
+            // If autoconfigured, then make channel available after the wait duration has expired.
             if(getAutoConfigureConnection()) {
                 new Timer().schedule(new TimerTask() {
                     @Override

--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -15,7 +15,10 @@
 package com.adaptris.core;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +46,9 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     protected String connectionErrorWaitDuration;
     protected Duration _connectionErrorWaitDuration;
     protected Integer connectionErrors = 0;
+
+    @Getter
+    @Setter
     private Boolean autoConfigureConnection = Boolean.TRUE;
 
     @Override
@@ -85,14 +91,6 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
 
     protected void setConnectionErrors(Integer connectionErrors) {
         this.connectionErrors = connectionErrors;
-    }
-
-    public Boolean getAutoConfigureConnection() {
-        return autoConfigureConnection;
-    }
-
-    public void setAutoConfigureConnection(Boolean autoConfigureConnection) {
-        this.autoConfigureConnection = autoConfigureConnection;
     }
 
     @Override

--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -104,7 +104,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
             failed = ex;
             throw ex;
         } finally {
-            if (getAutoConfigureConnection() && failed == null) {
+            if (failed == null) {
                 setConnectionErrors(0);
                 toggleChannelAvailability(true);
             }
@@ -120,7 +120,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
             failed = ex;
             throw ex;
         } finally {
-            if (getAutoConfigureConnection() && failed == null) {
+            if (failed == null) {
                 setConnectionErrors(0);
                 toggleChannelAvailability(true);
             }
@@ -136,7 +136,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
             failed = ex;
             throw ex;
         } finally {
-            if (getAutoConfigureConnection() && failed == null) {
+            if (failed == null) {
                 setConnectionErrors(0);
                 toggleChannelAvailability(true);
             }
@@ -148,19 +148,21 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
         if (connectionErrors == null) setConnectionErrors(0);
         setConnectionErrors(connectionErrors + 1);
         log.debug("Consecutive connection errors encountered: {} threshold: {}", getConnectionErrors(), getConnectionErrorThreshold());
-        if (getAutoConfigureConnection() && getConnectionErrors() >= getConnectionErrorThreshold()) {
+        if (getConnectionErrors() >= getConnectionErrorThreshold()) {
             toggleChannelAvailability(false);
-            new Timer().schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    try {
-                        toggleChannelAvailability(true);
-                        ChannelUnavailableConnectionErrorHandlingProducer.super.handleConnectionException();
-                    } catch (CoreException e) {
-                        log.warn(e.getMessage(), e);
+            if(getAutoConfigureConnection()) {
+                new Timer().schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        try {
+                            toggleChannelAvailability(true);
+                            ChannelUnavailableConnectionErrorHandlingProducer.super.handleConnectionException();
+                        } catch (CoreException e) {
+                            log.warn(e.getMessage(), e);
+                        }
                     }
-                }
-            }, connectionErrorWaitDuration().toMillis());
+                }, connectionErrorWaitDuration().toMillis());
+            }
         }
     }
 

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -85,7 +85,7 @@ public class JmsProducer extends JmsProducerImpl {
    */
   @Getter
   @Setter
-  private Boolean refreshSessionIfProduceException = Boolean.TRUE;
+  private Boolean refreshSessionIfProduceException = Boolean.FALSE;
 
   /**
    * The JMS Endpoint defined in an RFC6167 manner.

--- a/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
@@ -107,5 +107,4 @@ public class ConnectionErrorHandlingProducerTest extends com.adaptris.interlok.j
       verify(p, times(1)).handleConnectionException();
 
     }
-
 }

--- a/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.core;
 
@@ -20,94 +20,91 @@ import com.adaptris.core.stubs.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
-import java.util.Collections;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class ConnectionErrorHandlingProducerTest extends com.adaptris.interlok.junit.scaffolding.BaseCase {
 
-  public ConnectionErrorHandlingProducerTest() {
-
-  }
-
-  @Test
-  public void testDelegate() throws Exception {
-    ConnectionErrorHandlingProducer a = new ConnectionErrorHandlingProducer();
-    NullMessageProducer p = spy(new NullMessageProducer());
-    a.setDelegate(p);
-    assertEquals(p, a.getDelegate());
-
-    a.setEncoder(mock(AdaptrisMessageEncoder.class));
-    a.setMessageFactory(mock(AdaptrisMessageFactory.class));
-    p.setUniqueId("id");
-    p.setIsTrackingEndpoint(true);
-
-    assertEquals(p.getEncoder(), a.getEncoder());
-    assertEquals(p.getMessageFactory(), a.getMessageFactory());
-    assertEquals(p.getUniqueId(), a.getUniqueId());
-    assertEquals(p.isTrackingEndpoint(), a.isTrackingEndpoint());
-    assertEquals(p.createName(), a.createName());
-    assertEquals(p.createQualifier(), a.createQualifier());
-
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    byte[] bytes = new byte[0];
-    a.decode(bytes);
-    verify(p).decode(ArgumentMatchers.eq(bytes));
-
-    a.encode(msg);
-    verify(p).encode((ArgumentMatchers.eq(msg)));
-
-    AdaptrisConnection c = mock(AdaptrisConnection.class);
-    a.registerConnection(c);
-    assertEquals(p.retrieveConnection(AdaptrisConnection.class), a.retrieveConnection(AdaptrisConnection.class));
-
-    a.request(msg);
-    verify(p).request(ArgumentMatchers.eq(msg));
-
-    a.produce(msg);
-    verify(p).produce(ArgumentMatchers.eq(msg));
-
-    CustomisableProducer exceptionProducer = new CustomisableProducer(
-      (msg1, dest1, dest) -> { throw new ProduceException(); },
-      (msg1, dest1, timeout) -> { throw new ProduceException(); });
-
-    a.setDelegate(exceptionProducer);
-
-    assertThrows(ProduceException.class, () -> a.request(msg));
-    assertThrows(ProduceException.class, () -> a.request(msg, 1000));
-    assertThrows(ProduceException.class, () -> a.produce(msg));
-  }
-
-    @Test
-    public void testMaybeHandleException() throws Exception {
-      ConnectionErrorHandlingProducer a = new ConnectionErrorHandlingProducer();
-      NullMessageProducer p = spy(new NullMessageProducer());
-      a.setDelegate(p);
-      AdaptrisConnection con = new NullConnection();
-      ConnectionErrorHandler eh = mock(ConnectionErrorHandler.class);
-      con.setConnectionErrorHandler(eh);
-
-      ProduceException ex = new ProduceException();
-      a.maybeHandleException(ex);
-      verify(p, times(0)).handleConnectionException();
-
-      when(eh.canHandleException(any())).thenReturn(false);
-      a.maybeHandleException(ex);
-      verify(p, times(0)).handleConnectionException();
-
-      when(eh.canHandleException(any())).thenReturn(true);
-      a.maybeHandleException(ex);
-      verify(p, times(0)).handleConnectionException();
-
-      a.registerConnection(con);
-      assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
-      verify(p, times(1)).handleConnectionException();
-
-      when(eh.canHandleException(any())).thenReturn(false);
-      assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
-      verify(p, times(1)).handleConnectionException();
+    public ConnectionErrorHandlingProducerTest() {
 
     }
 
+    @Test
+    public void testDelegate() throws Exception {
+        ConnectionErrorHandlingProducer a = new ConnectionErrorHandlingProducer();
+        NullMessageProducer p = spy(new NullMessageProducer());
+        a.setDelegate(p);
+        assertEquals(p, a.getDelegate());
+
+        a.setEncoder(mock(AdaptrisMessageEncoder.class));
+        a.setMessageFactory(mock(AdaptrisMessageFactory.class));
+        p.setUniqueId("id");
+        p.setIsTrackingEndpoint(true);
+
+        assertEquals(p.getEncoder(), a.getEncoder());
+        assertEquals(p.getMessageFactory(), a.getMessageFactory());
+        assertEquals(p.getUniqueId(), a.getUniqueId());
+        assertEquals(p.isTrackingEndpoint(), a.isTrackingEndpoint());
+        assertEquals(p.createName(), a.createName());
+        assertEquals(p.createQualifier(), a.createQualifier());
+
+        AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+        byte[] bytes = new byte[0];
+        a.decode(bytes);
+        verify(p).decode(ArgumentMatchers.eq(bytes));
+
+        a.encode(msg);
+        verify(p).encode((ArgumentMatchers.eq(msg)));
+
+        AdaptrisConnection c = mock(AdaptrisConnection.class);
+        a.registerConnection(c);
+        assertEquals(p.retrieveConnection(AdaptrisConnection.class), a.retrieveConnection(AdaptrisConnection.class));
+
+        a.request(msg);
+        verify(p).request(ArgumentMatchers.eq(msg));
+
+        a.produce(msg);
+        verify(p).produce(ArgumentMatchers.eq(msg));
+
+        CustomisableProducer exceptionProducer = new CustomisableProducer(
+                (msg1, dest1, dest) -> { throw new ProduceException(); },
+                (msg1, dest1, timeout) -> { throw new ProduceException(); });
+
+        a.setDelegate(exceptionProducer);
+
+        assertThrows(ProduceException.class, () -> a.request(msg));
+        assertThrows(ProduceException.class, () -> a.request(msg, 1000));
+        assertThrows(ProduceException.class, () -> a.produce(msg));
+    }
+
+    @Test
+    public void testMaybeHandleException() throws Exception {
+        ConnectionErrorHandlingProducer a = new ConnectionErrorHandlingProducer();
+        NullMessageProducer p = spy(new NullMessageProducer());
+        a.setDelegate(p);
+        AdaptrisConnection con = new NullConnection();
+        ConnectionErrorHandler eh = mock(ConnectionErrorHandler.class);
+        con.setConnectionErrorHandler(eh);
+
+        ProduceException ex = new ProduceException();
+        a.maybeHandleException(ex);
+        verify(p, times(0)).handleConnectionException();
+
+        when(eh.canHandleException(any())).thenReturn(false);
+        a.maybeHandleException(ex);
+        verify(p, times(0)).handleConnectionException();
+
+        when(eh.canHandleException(any())).thenReturn(true);
+        a.maybeHandleException(ex);
+        verify(p, times(0)).handleConnectionException();
+
+        a.registerConnection(con);
+        assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
+        verify(p, times(1)).handleConnectionException();
+
+        when(eh.canHandleException(any())).thenReturn(false);
+        assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
+        verify(p, times(1)).handleConnectionException();
+
+    }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
@@ -20,6 +20,8 @@ import com.adaptris.core.stubs.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -106,5 +108,28 @@ public class ConnectionErrorHandlingProducerTest extends com.adaptris.interlok.j
       assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
       verify(p, times(1)).handleConnectionException();
 
+    }
+
+    @Test
+    public void testToggleChannelAvailability() {
+        ChannelUnavailableConnectionErrorHandlingProducer producer = spy(new ChannelUnavailableConnectionErrorHandlingProducer());
+        AdaptrisConnection connection = mock(AdaptrisConnection.class);
+        Channel channel = mock(Channel.class);
+        StateManagedComponent otherComponent = mock(StateManagedComponent.class);
+
+        // Mock retrieveExceptionListeners to return a Channel and another component
+        when(connection.retrieveExceptionListeners()).thenReturn(Collections.singleton(channel));
+        // Mock retrieveConnection to return our mocked connection
+        doReturn(connection).when(producer).retrieveConnection(AdaptrisConnection.class);
+
+        // Call toggleChannelAvailability(true)
+        producer.toggleChannelAvailability(true);
+        // Verify Channel.toggleAvailability(true) is called
+        verify(channel, times(1)).toggleAvailability(true);
+
+        // Call toggleChannelAvailability(false)
+        producer.toggleChannelAvailability(false);
+        // Verify Channel.toggleAvailability(false) is called
+        verify(channel, times(1)).toggleAvailability(false);
     }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
@@ -110,19 +110,4 @@ public class ConnectionErrorHandlingProducerTest extends com.adaptris.interlok.j
 
     }
 
-    @Test
-        when(connection.retrieveExceptionListeners()).thenReturn(Collections.singleton(channel));
-        // Mock retrieveConnection to return our mocked connection
-        doReturn(connection).when(producer).retrieveConnection(AdaptrisConnection.class);
-
-        // Call toggleChannelAvailability(true)
-        producer.toggleChannelAvailability(true);
-        // Verify Channel.toggleAvailability(true) is called
-        verify(channel, times(1)).toggleAvailability(true);
-
-        // Call toggleChannelAvailability(false)
-        producer.toggleChannelAvailability(false);
-        // Verify Channel.toggleAvailability(false) is called
-        verify(channel, times(1)).toggleAvailability(false);
-    }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
@@ -111,13 +111,6 @@ public class ConnectionErrorHandlingProducerTest extends com.adaptris.interlok.j
     }
 
     @Test
-    public void testToggleChannelAvailability() {
-        ChannelUnavailableConnectionErrorHandlingProducer producer = spy(new ChannelUnavailableConnectionErrorHandlingProducer());
-        AdaptrisConnection connection = mock(AdaptrisConnection.class);
-        Channel channel = mock(Channel.class);
-        StateManagedComponent otherComponent = mock(StateManagedComponent.class);
-
-        // Mock retrieveExceptionListeners to return a Channel and another component
         when(connection.retrieveExceptionListeners()).thenReturn(Collections.singleton(channel));
         // Mock retrieveConnection to return our mocked connection
         doReturn(connection).when(producer).retrieveConnection(AdaptrisConnection.class);

--- a/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConnectionErrorHandlingProducerTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 package com.adaptris.core;
 
@@ -25,86 +25,87 @@ import static org.mockito.Mockito.*;
 
 public class ConnectionErrorHandlingProducerTest extends com.adaptris.interlok.junit.scaffolding.BaseCase {
 
-    public ConnectionErrorHandlingProducerTest() {
+  public ConnectionErrorHandlingProducerTest() {
 
-    }
+  }
 
-    @Test
-    public void testDelegate() throws Exception {
-        ConnectionErrorHandlingProducer a = new ConnectionErrorHandlingProducer();
-        NullMessageProducer p = spy(new NullMessageProducer());
-        a.setDelegate(p);
-        assertEquals(p, a.getDelegate());
+  @Test
+  public void testDelegate() throws Exception {
+    ConnectionErrorHandlingProducer a = new ConnectionErrorHandlingProducer();
+    NullMessageProducer p = spy(new NullMessageProducer());
+    a.setDelegate(p);
+    assertEquals(p, a.getDelegate());
 
-        a.setEncoder(mock(AdaptrisMessageEncoder.class));
-        a.setMessageFactory(mock(AdaptrisMessageFactory.class));
-        p.setUniqueId("id");
-        p.setIsTrackingEndpoint(true);
+    a.setEncoder(mock(AdaptrisMessageEncoder.class));
+    a.setMessageFactory(mock(AdaptrisMessageFactory.class));
+    p.setUniqueId("id");
+    p.setIsTrackingEndpoint(true);
 
-        assertEquals(p.getEncoder(), a.getEncoder());
-        assertEquals(p.getMessageFactory(), a.getMessageFactory());
-        assertEquals(p.getUniqueId(), a.getUniqueId());
-        assertEquals(p.isTrackingEndpoint(), a.isTrackingEndpoint());
-        assertEquals(p.createName(), a.createName());
-        assertEquals(p.createQualifier(), a.createQualifier());
+    assertEquals(p.getEncoder(), a.getEncoder());
+    assertEquals(p.getMessageFactory(), a.getMessageFactory());
+    assertEquals(p.getUniqueId(), a.getUniqueId());
+    assertEquals(p.isTrackingEndpoint(), a.isTrackingEndpoint());
+    assertEquals(p.createName(), a.createName());
+    assertEquals(p.createQualifier(), a.createQualifier());
 
-        AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-        byte[] bytes = new byte[0];
-        a.decode(bytes);
-        verify(p).decode(ArgumentMatchers.eq(bytes));
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    byte[] bytes = new byte[0];
+    a.decode(bytes);
+    verify(p).decode(ArgumentMatchers.eq(bytes));
 
-        a.encode(msg);
-        verify(p).encode((ArgumentMatchers.eq(msg)));
+    a.encode(msg);
+    verify(p).encode((ArgumentMatchers.eq(msg)));
 
-        AdaptrisConnection c = mock(AdaptrisConnection.class);
-        a.registerConnection(c);
-        assertEquals(p.retrieveConnection(AdaptrisConnection.class), a.retrieveConnection(AdaptrisConnection.class));
+    AdaptrisConnection c = mock(AdaptrisConnection.class);
+    a.registerConnection(c);
+    assertEquals(p.retrieveConnection(AdaptrisConnection.class), a.retrieveConnection(AdaptrisConnection.class));
 
-        a.request(msg);
-        verify(p).request(ArgumentMatchers.eq(msg));
+    a.request(msg);
+    verify(p).request(ArgumentMatchers.eq(msg));
 
-        a.produce(msg);
-        verify(p).produce(ArgumentMatchers.eq(msg));
+    a.produce(msg);
+    verify(p).produce(ArgumentMatchers.eq(msg));
 
-        CustomisableProducer exceptionProducer = new CustomisableProducer(
-                (msg1, dest1, dest) -> { throw new ProduceException(); },
-                (msg1, dest1, timeout) -> { throw new ProduceException(); });
+    CustomisableProducer exceptionProducer = new CustomisableProducer(
+      (msg1, dest1, dest) -> { throw new ProduceException(); },
+      (msg1, dest1, timeout) -> { throw new ProduceException(); });
 
-        a.setDelegate(exceptionProducer);
+    a.setDelegate(exceptionProducer);
 
-        assertThrows(ProduceException.class, () -> a.request(msg));
-        assertThrows(ProduceException.class, () -> a.request(msg, 1000));
-        assertThrows(ProduceException.class, () -> a.produce(msg));
-    }
+    assertThrows(ProduceException.class, () -> a.request(msg));
+    assertThrows(ProduceException.class, () -> a.request(msg, 1000));
+    assertThrows(ProduceException.class, () -> a.produce(msg));
+  }
 
     @Test
     public void testMaybeHandleException() throws Exception {
-        ConnectionErrorHandlingProducer a = new ConnectionErrorHandlingProducer();
-        NullMessageProducer p = spy(new NullMessageProducer());
-        a.setDelegate(p);
-        AdaptrisConnection con = new NullConnection();
-        ConnectionErrorHandler eh = mock(ConnectionErrorHandler.class);
-        con.setConnectionErrorHandler(eh);
+      ConnectionErrorHandlingProducer a = new ConnectionErrorHandlingProducer();
+      NullMessageProducer p = spy(new NullMessageProducer());
+      a.setDelegate(p);
+      AdaptrisConnection con = new NullConnection();
+      ConnectionErrorHandler eh = mock(ConnectionErrorHandler.class);
+      con.setConnectionErrorHandler(eh);
 
-        ProduceException ex = new ProduceException();
-        a.maybeHandleException(ex);
-        verify(p, times(0)).handleConnectionException();
+      ProduceException ex = new ProduceException();
+      a.maybeHandleException(ex);
+      verify(p, times(0)).handleConnectionException();
 
-        when(eh.canHandleException(any())).thenReturn(false);
-        a.maybeHandleException(ex);
-        verify(p, times(0)).handleConnectionException();
+      when(eh.canHandleException(any())).thenReturn(false);
+      a.maybeHandleException(ex);
+      verify(p, times(0)).handleConnectionException();
 
-        when(eh.canHandleException(any())).thenReturn(true);
-        a.maybeHandleException(ex);
-        verify(p, times(0)).handleConnectionException();
+      when(eh.canHandleException(any())).thenReturn(true);
+      a.maybeHandleException(ex);
+      verify(p, times(0)).handleConnectionException();
 
-        a.registerConnection(con);
-        assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
-        verify(p, times(1)).handleConnectionException();
+      a.registerConnection(con);
+      assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
+      verify(p, times(1)).handleConnectionException();
 
-        when(eh.canHandleException(any())).thenReturn(false);
-        assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
-        verify(p, times(1)).handleConnectionException();
+      when(eh.canHandleException(any())).thenReturn(false);
+      assertThrows(ProduceException.class, () -> a.maybeHandleException(ex));
+      verify(p, times(1)).handleConnectionException();
 
     }
+
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsProducerTest.java
@@ -506,6 +506,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
     JmsProducer producer = createProducer(rfc6167);
     TimedInactivityProducerSessionFactory psf = new TimedInactivityProducerSessionFactory(new TimeInterval(10L, TimeUnit.MILLISECONDS));
     producer.setSessionFactory(psf);
+    producer.setRefreshSessionIfProduceException(true);
     standaloneConsumer.registerAdaptrisMessageListener(jms);
 
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
@@ -535,6 +536,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
     JmsProducer producer = createProducer(rfc6167);
     TimedInactivityProducerSessionFactory psf = new TimedInactivityProducerSessionFactory();
     producer.setSessionFactory(psf);
+    producer.setRefreshSessionIfProduceException(true);
     standaloneConsumer.registerAdaptrisMessageListener(jms);
 
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
@@ -564,6 +566,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
       JmsProducer producer = spy(createProducer(rfc6167));
       ProducerSessionFactory psf = spy(new DefaultProducerSessionFactory());
       producer.setSessionFactory(psf);
+      producer.setRefreshSessionIfProduceException(true);
       standaloneConsumer.registerAdaptrisMessageListener(jms);
 
       MessageProducer throwsExceptionProducer = mock(MessageProducer.class);
@@ -635,7 +638,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
     JmsProducer producer = createProducer(rfc6167);
     MessageCountProducerSessionFactory psf = new MessageCountProducerSessionFactory(1);
     producer.setSessionFactory(psf);
-
+    producer.setRefreshSessionIfProduceException(true);
     standaloneConsumer.registerAdaptrisMessageListener(jms);
 
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
@@ -665,7 +668,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
     JmsProducer producer = createProducer(rfc6167);
     MessageCountProducerSessionFactory psf = new MessageCountProducerSessionFactory();
     producer.setSessionFactory(psf);
-
+    producer.setRefreshSessionIfProduceException(true);
     standaloneConsumer.registerAdaptrisMessageListener(jms);
 
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
@@ -722,7 +725,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
     JmsProducer producer = createProducer(rfc6167);
     MessageSizeProducerSessionFactory psf = new MessageSizeProducerSessionFactory();
     producer.setSessionFactory(psf);
-
+    producer.setRefreshSessionIfProduceException(true);
     standaloneConsumer.registerAdaptrisMessageListener(jms);
 
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
@@ -749,7 +752,7 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
     JmsProducer producer = createProducer(rfc6167);
     MetadataProducerSessionFactory psf = new MetadataProducerSessionFactory(getName());
     producer.setSessionFactory(psf);
-
+    producer.setRefreshSessionIfProduceException(true);
     standaloneConsumer.registerAdaptrisMessageListener(jms);
 
     StandaloneProducer standaloneProducer = new StandaloneProducer(activeMqBroker.getJmsConnection(), producer);
@@ -803,9 +806,11 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
   @Test
   public void testMultipleRequestorWithSession() throws Exception {
     String rfc6167 = "jms:queue:" + getName() + "";
+    JmsProducer producer = createProducer(rfc6167);
+    producer.setRefreshSessionIfProduceException(true);
     ServiceList serviceList = new ServiceList(
-        new StandaloneRequestor(activeMqBroker.getJmsConnection(), createProducer(rfc6167), new TimeInterval(1L, TimeUnit.SECONDS)),
-        new StandaloneRequestor(activeMqBroker.getJmsConnection(), createProducer(rfc6167), new TimeInterval(1L, TimeUnit.SECONDS)));
+        new StandaloneRequestor(activeMqBroker.getJmsConnection(), producer, new TimeInterval(1L, TimeUnit.SECONDS)),
+        new StandaloneRequestor(activeMqBroker.getJmsConnection(), producer, new TimeInterval(1L, TimeUnit.SECONDS)));
     Loopback echo = createLoopback(activeMqBroker, getName());
     try {
       echo.start();
@@ -825,7 +830,9 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
   @Test
   public void testRequest_AsyncReplyTo_Metadata() throws Exception {
     String rfc6167 = "jms:queue:" + getName() + "";
-    StandaloneRequestor serviceList = new StandaloneRequestor(activeMqBroker.getJmsConnection(), createProducer(rfc6167),
+    JmsProducer producer = createProducer(rfc6167);
+    producer.setRefreshSessionIfProduceException(true);
+    StandaloneRequestor serviceList = new StandaloneRequestor(activeMqBroker.getJmsConnection(), producer,
         new TimeInterval(1L, TimeUnit.SECONDS));
     Loopback echo = createLoopback(activeMqBroker, getName());
     try {
@@ -844,7 +851,9 @@ public class JmsProducerTest extends com.adaptris.interlok.junit.scaffolding.jms
   @Test
   public void testRequest_DefinedReplyTo() throws Exception {
     String rfc6167 = String.format("jms:queue:%1$s?replyToName=%1$s_reply", getName());
-    StandaloneRequestor serviceList = new StandaloneRequestor(activeMqBroker.getJmsConnection(), createProducer(rfc6167),
+    JmsProducer producer = createProducer(rfc6167);
+    producer.setRefreshSessionIfProduceException(true);
+    StandaloneRequestor serviceList = new StandaloneRequestor(activeMqBroker.getJmsConnection(), producer,
         new TimeInterval(1L, TimeUnit.SECONDS));
     Loopback echo = createLoopback(activeMqBroker, getName());
     try {


### PR DESCRIPTION
## Motivation

[Why am I doing this](https://telusagriculture.atlassian.net/browse/INTERLOK-4720)

## Modification

Modified boolean configurations to default in line with backward compatibility uses for JMS Session auto-refresh session on exception and auto-configure channel unavailable restart

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Boolean configurations with backward compatible default values are made available to enable JMS Session auto-refresh session on exception and auto-configure channel unavailable restart

## Testing

The change can be tested on adapter by placing the below snippets - 
<producer class="channel-unavailable-connection-error-handling-producer">
  <connection-error-threshold>5</connection-error-threshold>
  <connection-error-wait-duration>${durationBetweenRestarts}</connection-error-wait-duration>
  <auto-configure-connection>true</auto-configure-connection>
  <delegate class="standard-http-producer">
    <unique-id>trigger-upgrade-all</unique-id>
    <method-provider class="http-configured-request-method">
      <method>GET</method>
    </method-provider>
    <content-type-provider class="http-configured-content-type-provider">
      <mime-type>text/plain</mime-type>
    </content-type-provider>
    <response-header-handler class="http-discard-response-headers"/>
    <request-header-provider class="http-no-request-headers"/>
    <ignore-server-response-code>false</ignore-server-response-code>
    <url>%message{targetUrl}</url>
    <authenticator class="http-no-authentication"/>
  </delegate>
</producer>

And for producer as - 
<producer class="jms-producer">
  <endpoint>jms:queue:MyQueue</endpoint>
  <refresh-session-if-produce-exception>true</refresh-session-if-produce-exception>
</producer>
