### PR TITLE
Initialize _connectionErrorWaitDuration to 60 seconds

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -44,7 +44,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
 
     protected Integer connectionErrorThreshold;
     protected String connectionErrorWaitDuration;
-    protected Duration _connectionErrorWaitDuration;
+    protected Duration _connectionErrorWaitDuration = Duration.ofSeconds(60);
     protected Integer connectionErrors = 0;
 
     @Getter
@@ -54,7 +54,6 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     @Override
     public void prepare() throws CoreException {
         super.prepare();
-        setConnectionErrorWaitDuration(connectionErrorWaitDuration);
     }
 
     public Integer getConnectionErrorThreshold() {

--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -78,7 +78,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     }
 
     public Duration connectionErrorWaitDuration() {
-        if (_connectionErrorWaitDuration == null && connectionErrorWaitDuration != null) {
+        if (connectionErrorWaitDuration != null) {
             setConnectionErrorWaitDuration(connectionErrorWaitDuration);
         }
         return _connectionErrorWaitDuration;


### PR DESCRIPTION
Set default value for _connectionErrorWaitDuration to 60 seconds. This would avoid a NullPointerException in the prepare method

## Motivation

To resolve the java.lang.NullPointerException

	java.base/java.util.Objects.requireNonNull(Objects.java:235)
	java.base/java.time.Duration.parse(Duration.java:391)
	com.adaptris.core.ChannelUnavailableConnectionErrorHandlingProducer.setConnectionErrorWaitDuration(ChannelUnavailableConnectionErrorHandlingProducer.java:73)
	com.adaptris.core.ChannelUnavailableConnectionErrorHandlingProducer.prepare(ChannelUnavailableConnectionErrorHandlingProducer.java:57)

## Modification

added default to the _connectionErrorWaitDuration 
