### PR TITLE
Fix to remove Duration field from ChannelUnavailableConnectionErrorHa…

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -42,9 +42,16 @@ import org.apache.commons.lang3.BooleanUtils;
 public class ChannelUnavailableConnectionErrorHandlingProducer extends ConnectionErrorHandlingProducer {
     protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
+    @Getter
+    @Setter
     protected Integer connectionErrorThreshold;
-    protected String connectionErrorWaitDuration;
-    protected Duration _connectionErrorWaitDuration = Duration.ofSeconds(60);
+
+    @Getter
+    @Setter
+    protected Integer connectionErrorWaitDuration = 60;
+
+    @Getter
+    @Setter
     protected Integer connectionErrors = 0;
 
     @Getter
@@ -54,42 +61,6 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
     @Override
     public void prepare() throws CoreException {
         super.prepare();
-    }
-
-    public Integer getConnectionErrorThreshold() {
-        return connectionErrorThreshold;
-    }
-
-    public void setConnectionErrorThreshold(Integer connectionErrorThreshold) {
-        this.connectionErrorThreshold = connectionErrorThreshold;
-    }
-
-    public String getConnectionErrorWaitDuration() {
-        return connectionErrorWaitDuration;
-    }
-
-    public void setConnectionErrorWaitDuration(String connectionErrorWaitDuration) {
-        setConnectionErrorWaitDuration(Duration.parse(connectionErrorWaitDuration));
-        this.connectionErrorWaitDuration = connectionErrorWaitDuration;
-    }
-
-    public void setConnectionErrorWaitDuration(Duration connectionErrorWaitDuration) {
-        this._connectionErrorWaitDuration =connectionErrorWaitDuration;
-    }
-
-    public Duration connectionErrorWaitDuration() {
-        if (connectionErrorWaitDuration != null) {
-            setConnectionErrorWaitDuration(connectionErrorWaitDuration);
-        }
-        return _connectionErrorWaitDuration;
-    }
-
-    public Integer getConnectionErrors() {
-        return connectionErrors;
-    }
-
-    protected void setConnectionErrors(Integer connectionErrors) {
-        this.connectionErrors = connectionErrors;
     }
 
     @Override
@@ -159,7 +130,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
                             log.warn(e.getMessage(), e);
                         }
                     }
-                }, connectionErrorWaitDuration().toMillis());
+                }, getConnectionErrorWaitDuration()*1000);
             }
         }
     }

--- a/interlok-core/src/test/java/com/adaptris/core/ExceptionMatchingChannelRestartConnectionErrorHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExceptionMatchingChannelRestartConnectionErrorHandlerTest.java
@@ -64,7 +64,7 @@ public class ExceptionMatchingChannelRestartConnectionErrorHandlerTest extends c
       channel.setProduceConnection(connection);
 
       ChannelUnavailableConnectionErrorHandlingProducer producer = new ChannelUnavailableConnectionErrorHandlingProducer();
-      producer.setConnectionErrorWaitDuration("PT10S");
+      producer.setConnectionErrorWaitDuration(5);
       CustomisableProducer producerDelegateSuccess = new CustomisableProducer(
               (msg, dest1, dest2) -> {},
               (msg, dest1, dest2) -> { return msg; }
@@ -78,7 +78,7 @@ public class ExceptionMatchingChannelRestartConnectionErrorHandlerTest extends c
 
       producer.setDelegate(producerDelegateFailure);
       producer.setConnectionErrorThreshold(5);
-//      producer.setConnectionErrorWaitDuration(Duration.ofSeconds(10));
+      producer.setConnectionErrorWaitDuration(5);
 
       WorkflowList workflowList = new WorkflowList();
       StandardWorkflow workflow = new StandardWorkflow();
@@ -95,7 +95,7 @@ public class ExceptionMatchingChannelRestartConnectionErrorHandlerTest extends c
       assertTrue(handler.allowedInConjunctionWith(delegate));
 
       assertEquals(0, producer.getConnectionErrors());
-      assertEquals("PT10S", producer.getConnectionErrorWaitDuration());
+      assertEquals(5, producer.getConnectionErrorWaitDuration());
       assertTrue(channel.isAvailable());
       assertThrows(ProduceException.class, () -> producer.produce(msg));
 
@@ -113,7 +113,7 @@ public class ExceptionMatchingChannelRestartConnectionErrorHandlerTest extends c
       assertFalse(channel.isAvailable());
 
       // after the connection error wait duration, the channel is available
-      Thread.sleep((producer.connectionErrorWaitDuration().getSeconds()+1)*1000);
+      Thread.sleep((producer.getConnectionErrorWaitDuration()+1)*1000);
       assertTrue(channel.isAvailable());
       assertEquals(5, producer.getConnectionErrors());
 


### PR DESCRIPTION
## Motivation

Setting the field type for connectionErrorWaitDuration to simple Integer from Duration since it gives error on interlokVerifyConfig gradle task for ngn projects

## Modification

Changed type to Integer from Duration for connectionErrorWaitDuration field

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

The ChannelUnavailableConnectionErrorHandlingProducer works as expected as before and accepts integer values for connectionErrorWaitDuration field

## Testing

Run interlokVerifyConfigCheck for ngn projects
