### PR TITLE
Session restart channel and auto configure refactor

### DIFF
--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 ext {
   componentName="Interlok Core/Base"
   componentDesc="The Core Interlok framework component; this is your must have"
-  activeMqVersion="5.18.7"
+  activeMqVersion="5.19.2"
   bouncyCastleVersion="1.80"
   mysqlDriverVersion="8.0.33"
   slf4jVersion = "2.0.17"
@@ -126,7 +126,10 @@ dependencies {
   api ("com.zaxxer:HikariCP:6.2.1")
   api ("net.sf.saxon:Saxon-HE:12.6")
   api ("xerces:xercesImpl:2.12.2")
-  api ("com.mchange:c3p0:0.9.5.5")
+  api ("com.mchange:c3p0:0.9.5.5") {
+    exclude group: "com.mchange", module: "mchange-commons-java"
+  }
+  api ("com.mchange:mchange-commons-java:0.3.0")
   api ("org.apache-extras.beanshell:bsh:2.0b6")
 
   api ("org.slf4j:slf4j-api:$slf4jVersion")

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -129,7 +129,7 @@ dependencies {
   api ("com.mchange:c3p0:0.9.5.5") {
     exclude group: "com.mchange", module: "mchange-commons-java"
   }
-  api ("com.mchange:mchange-commons-java:0.3.0")
+  api ("com.mchange:mchange-commons-java:0.4.0")
   api ("org.apache-extras.beanshell:bsh:2.0b6")
 
   api ("org.slf4j:slf4j-api:$slf4jVersion")

--- a/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ChannelUnavailableConnectionErrorHandlingProducer.java
@@ -154,6 +154,7 @@ public class ChannelUnavailableConnectionErrorHandlingProducer extends Connectio
                     public void run() {
                         try {
                             toggleChannelAvailability(true);
+                            setConnectionErrors(0);
                             ChannelUnavailableConnectionErrorHandlingProducer.super.handleConnectionException();
                         } catch (CoreException e) {
                             log.warn(e.getMessage(), e);

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -123,24 +123,22 @@ public class JmsProducer extends JmsProducerImpl {
 
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest, boolean refreshSessionIfProduceException)
       throws JMSException, CoreException {
-    setupSession(msg, !refreshSessionIfProduceException);
-    Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());
+    Message jmsMsg = null;
+    setupSession(msg);
     try {
-      if (!perMessageProperties()) {
-        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg);
-      } else {
-        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg,
-                calculateDeliveryMode(msg, jmsDest.deliveryMode()),
-                calculatePriority(msg, jmsDest.priority()),
-                calculateTimeToLive(msg, jmsDest.timeToLive()));
-      }
+        jmsMsg = sendMessage(msg, jmsDest);
     } catch (JMSException ex) {
       currentLogger().debug("Caught exception while producing", ex);
       if (refreshSessionIfProduceException) {
         currentLogger().info("Handling exception by retrying with new session. Exception: {}", ex.getMessage());
-        // don't refresh session on this call, instead throw
-        doProduce(msg, jmsDest, false);
-        return;
+        // force recreate a session if we get an exception, and try again. If it fails again, then we throw the original exception.
+        setupSession(msg, refreshSessionIfProduceException);
+        try {
+            jmsMsg = sendMessage(msg, jmsDest);
+        } catch (JMSException ex1) {
+            currentLogger().debug("Caught exception while producing with force recreation of session", ex1);
+            throw ex1;
+        }
       } else throw ex;
     }
     captureOutgoingMessageDetails(jmsMsg, msg);
@@ -259,6 +257,19 @@ public class JmsProducer extends JmsProducerImpl {
   public <T extends JmsProducer> T withEndpoint(String s) {
     setEndpoint(s);
     return (T) this;
+  }
+
+  private Message sendMessage(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException {
+      Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());
+      if (!perMessageProperties()) {
+          producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg);
+      } else {
+          producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg,
+                  calculateDeliveryMode(msg, jmsDest.deliveryMode()),
+                  calculatePriority(msg, jmsDest.priority()),
+                  calculateTimeToLive(msg, jmsDest.timeToLive()));
+      }
+      return jmsMsg;
   }
 
   protected class MyJmsDestination implements JmsDestination {

--- a/interlok-core/src/test/java/com/adaptris/core/ExceptionMatchingChannelRestartConnectionErrorHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ExceptionMatchingChannelRestartConnectionErrorHandlerTest.java
@@ -115,13 +115,13 @@ public class ExceptionMatchingChannelRestartConnectionErrorHandlerTest extends c
       // after the connection error wait duration, the channel is available
       Thread.sleep((producer.connectionErrorWaitDuration().getSeconds()+1)*1000);
       assertTrue(channel.isAvailable());
-      assertEquals(5, producer.getConnectionErrors());
+      assertEquals(0, producer.getConnectionErrors());
 
       assertThrows(ProduceException.class, () -> producer.produce(msg));
       assertThrows(ProduceException.class, () -> producer.request(msg));
       assertThrows(ProduceException.class, () -> producer.request(msg, 1000));
-      assertFalse(channel.isAvailable());
-      assertEquals(8, producer.getConnectionErrors());
+      assertTrue(channel.isAvailable());
+      assertEquals(3, producer.getConnectionErrors());
 
       // after a successful produce, the channel is available and error count is reset
       DefaultMessageFactory factory = new DefaultMessageFactory();


### PR DESCRIPTION
## Motivation

https://telusagriculture.atlassian.net/browse/INTERLOK-4723

## Modification

Modified boolean check to enable JMS Session auto-refresh session on exception and reset connection error counts on auto-configure channel unavailable restart

## PR Checklist

- [x] been self-reviewed.
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Channel should restart and not close immediately for ChannelUnavailableConnectionErrorHandlingProducer

## Testing

The Interlok adapter configuration needs to have metadata present with key "JMSRefreshSessionOnException" to refresh JMS jession on exception . By default, if missing this setting is true

disable-session-refresh-on-exception JMSRefreshSessionOnException true jms-producer jms:queue:QueueName PERSISTENT
The interlok adapter configuration needs to have metadata present with key "autoConfigureConnection" set to true for automatically configure connection

jms-consumer AUTO_ACKNOWLEDGE InputQueue-1 workflow-services set-auto-configure-connection-true autoConfigureConnection true
