### PR TITLE
NWK-2895 Saxon Extensions

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -283,9 +283,11 @@
     <notes><![CDATA[
     CVE-2025-1948: False positive for Jetty 10.0.24. CVE-2025-1948 only affects Jetty versions 12.0.0 to 12.0.16.
 	CVE-2024-6763: Jetty 10.0.24 is the highest version 10 we can go to.
+	CVE-2025-11143: Remediation requires a major Jetty upgrade from 10.x to 12.x, which is not possible yet.
     ]]></notes>
     <cve>CVE-2025-1948</cve>
 	<cve>CVE-2024-6763</cve>
+	<cve>CVE-2025-11143</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[

--- a/interlok-client-jmx/build.gradle
+++ b/interlok-client-jmx/build.gradle
@@ -2,7 +2,7 @@ ext {
   componentName='Interlok Core/JMX Client'
   componentDesc="JMX implementation of the Interlok Client API"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  log4j2Version = "2.24.3"
+  log4j2Version = "2.25.3"
   mockitoVersion = '4.9.0'
 }
 

--- a/interlok-client/build.gradle
+++ b/interlok-client/build.gradle
@@ -2,7 +2,7 @@ ext {
   componentName='Interlok Core/Client'
   componentDesc="Interlok client API; allows you to programatically submit messages to an Interlok workflow"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  log4j2Version = "2.24.3"
+  log4j2Version = "2.25.3"
   mockitoVersion = '4.9.0'
 }
 

--- a/interlok-common/build.gradle
+++ b/interlok-common/build.gradle
@@ -7,7 +7,7 @@ ext {
   maxThreads = project.hasProperty("junit.threads") ? project.getProperty("junit.threads") : 1
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
   slf4jVersion = "2.0.17"
-  log4j2Version = "2.24.3"
+  log4j2Version = "2.25.3"
   mockitoVersion = "4.9.0"
   jettyVersion= "10.0.26"
 }

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 ext {
   componentName="Interlok Core/Base"
   componentDesc="The Core Interlok framework component; this is your must have"
-  activeMqVersion="5.18.7"
+  activeMqVersion="5.19.2"
   bouncyCastleVersion="1.80"
   mysqlDriverVersion="8.0.33"
   slf4jVersion = "2.0.17"

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -126,19 +126,10 @@ dependencies {
   api ("com.zaxxer:HikariCP:6.2.1")
   api ("net.sf.saxon:Saxon-HE:12.6")
   api ("xerces:xercesImpl:2.12.2")
-<<<<<<< feature/NWK-2895-saxon-extensions
-  api ("com.mchange:c3p0:0.12.0")
-  constraints {
-    api("com.mchange:mchange-commons-java:0.4.0") {
-      because "CVE-2026-27727: Remote Code Execution via JNDI Reference Resolution - upgrade to 0.4.0+ to gate remote factoryClassLocation lookups"
-    }
-  }
-=======
   api ("com.mchange:c3p0:0.9.5.5") {
     exclude group: "com.mchange", module: "mchange-commons-java"
   }
   api ("com.mchange:mchange-commons-java:0.4.0")
->>>>>>> develop
   api ("org.apache-extras.beanshell:bsh:2.0b6")
 
   api ("org.slf4j:slf4j-api:$slf4jVersion")

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -126,7 +126,12 @@ dependencies {
   api ("com.zaxxer:HikariCP:6.2.1")
   api ("net.sf.saxon:Saxon-HE:12.6")
   api ("xerces:xercesImpl:2.12.2")
-  api ("com.mchange:c3p0:0.9.5.5")
+  api ("com.mchange:c3p0:0.12.0")
+  constraints {
+    api("com.mchange:mchange-commons-java:0.4.0") {
+      because "CVE-2026-27727: Remote Code Execution via JNDI Reference Resolution - upgrade to 0.4.0+ to gate remote factoryClassLocation lookups"
+    }
+  }
   api ("org.apache-extras.beanshell:bsh:2.0b6")
 
   api ("org.slf4j:slf4j-api:$slf4jVersion")

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/NoExtensions.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/NoExtensions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.util.text.xml;
 
 import net.sf.saxon.Configuration;

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/NoExtensions.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/NoExtensions.java
@@ -1,0 +1,14 @@
+package com.adaptris.util.text.xml;
+
+import net.sf.saxon.Configuration;
+
+/**
+ * Null implementation of {@link SaxonExtensionRegistrar} that performs no operations.
+ */
+public class NoExtensions implements SaxonExtensionRegistrar {
+
+    @Override
+    public void register(Configuration config) {
+        // No-op implementation
+    }
+}

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/SaxonExtensionRegistrar.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/SaxonExtensionRegistrar.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.util.text.xml;
 
 import net.sf.saxon.Configuration;

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/SaxonExtensionRegistrar.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/SaxonExtensionRegistrar.java
@@ -1,0 +1,9 @@
+package com.adaptris.util.text.xml;
+
+import net.sf.saxon.Configuration;
+
+public interface SaxonExtensionRegistrar {
+    /** Register Saxon extension functions with the given configuration.
+     * @param config the Saxon Configuration to register extensions with **/
+    void register(Configuration config);
+}

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -137,7 +137,7 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
   }
 
   public SaxonExtensionRegistrar getExtensionRegistrar() {
-    return StringUtils.isNotEmpty(getExtensionRegistrarImplementation())
+    return StringUtils.isNotBlank(getExtensionRegistrarImplementation())
         ? loadExtensionRegistrar(getExtensionRegistrarImplementation())
         : new NoExtensions();
   }
@@ -151,8 +151,11 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
       } else {
         log.warn("Class {} does not implement SaxonExtensionRegistrar", className);
       }
-    } catch (Exception e) {
-      log.warn("Failed to load SaxonExtensionRegistrar implementation: {}", className, e);
+    } catch (Throwable t) {
+      if (t instanceof  InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      log.warn("Failed to load SaxonExtensionRegistrar implementation: {}", className, t);
     }
     return new NoExtensions();
   }

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -41,15 +41,29 @@ import net.sf.saxon.Configuration;
 import net.sf.saxon.TransformerFactoryImpl;
 
 /**
+ * An {@link XmlTransformerFactory} implementation that creates XSLT {@link Transformer} instances.
+ *
  * <p>
- * The XsltTransformerFactory is responsible for creating the {@link Transformer}.
+ * By default, the JDK's built-in {@link TransformerFactory} is used. You can override this by
+ * setting {@code transformerFactoryImpl} to the fully-qualified class name of an alternative
+ * {@link TransformerFactory} implementation — for example, Saxon's
+ * {@code net.sf.saxon.TransformerFactoryImpl} for XSLT 2.0/3.0 support.
  * </p>
+ *
  * <p>
- * The {@link Transformer} is used to actually perform a document transformation.
+ * When a Saxon {@link TransformerFactory} is detected, optional Saxon extension functions can be
+ * registered via a {@link SaxonExtensionRegistrar} implementation. Specify the fully-qualified
+ * class name of your {@link SaxonExtensionRegistrar} via {@code extensionRegistrarImplementation}.
+ * If not set, no extensions are registered.
+ * </p>
+ *
+ * <p>
+ * This factory also overrides the URL-based transformer creation to parse the XSL stylesheet
+ * directly from its URL as a DOM {@link Document}, preserving file location context so that
+ * relative {@code xsl:import} and {@code xsl:include} paths resolve correctly.
  * </p>
  *
  * @config xslt-transformer-factory
- *
  * @author amcgrath
  */
 

--- a/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
+++ b/interlok-core/src/main/java/com/adaptris/util/text/xml/XsltTransformerFactory.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.util.text.xml;
 
+import java.util.Optional;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -23,6 +25,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
@@ -30,6 +34,11 @@ import org.xml.sax.InputSource;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.DisplayOrder;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.sf.saxon.Configuration;
+import net.sf.saxon.TransformerFactoryImpl;
 
 /**
  * <p>
@@ -45,11 +54,20 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 
 @XStreamAlias("xslt-transformer-factory")
-@DisplayOrder(order = { "transformerFactoryImpl", "failOnRecoverableError" })
+@DisplayOrder(order = { "transformerFactoryImpl", "extensionRegistrarImplementation", "failOnRecoverableError" })
 public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
 
+  private transient final Logger log = LoggerFactory.getLogger(this.getClass());
+
+  @Getter
+  @Setter
   @AdvancedConfig
   private String transformerFactoryImpl;
+
+  @Getter
+  @Setter
+  @AdvancedConfig
+  private String extensionRegistrarImplementation;
 
   public XsltTransformerFactory() {
     super();
@@ -75,31 +93,53 @@ public class XsltTransformerFactory extends XmlTransformerFactoryImpl {
     return configure(newInstance()).newTransformer(new DOMSource(xmlDoc, url));
   }
 
-    /**
-   * @return the transformerFactoryImpl
-   */
-  public String getTransformerFactoryImpl() {
-    return transformerFactoryImpl;
-  }
-
-  /**
-   * Specify the transformer factory that will be used.
-   * <p>
-   * If you have both saxon and xalan (for instance) available on the classpath; and you want to explicitly use the xalan implementation
-   * then you could put {@code org.apache.xalan.processor.TransformerFactoryImpl} here to force it to use Xalan or
-   * {@code net.sf.saxon.TransformerFactoryImpl} to force it to use Saxon.
-   * <p>
-   *
-   * @param s
-   *          he transformerFactoryImpl to set, if not specified the JVM default is used {@link TransformerFactory#newInstance()}.
-   */
-  public void setTransformerFactoryImpl(String s) {
-    transformerFactoryImpl = s;
-  }
-
+  @Override
   protected TransformerFactory newInstance() {
-    return StringUtils.isEmpty(getTransformerFactoryImpl()) ? TransformerFactory.newInstance()
+    TransformerFactory tf = StringUtils.isEmpty(getTransformerFactoryImpl())
+        ? TransformerFactory.newInstance()
         : TransformerFactory.newInstance(getTransformerFactoryImpl(), null);
+
+    getSaxonConfiguration(tf).ifPresent(config -> {
+      log.debug("Registering Saxon extensions with config: {}", config);
+      getExtensionRegistrar().register(config);
+    });
+
+    return tf;
   }
 
+  protected Optional<Configuration> getSaxonConfiguration(TransformerFactory tf) {
+    log.debug("Getting SaxonConfiguration if applicable");
+
+    if (tf == null) {
+      return Optional.empty();
+    }
+
+    // Saxon-HE and Saxon-EE factories both derive from TransformerFactoryImpl.
+    if (tf instanceof TransformerFactoryImpl) {
+      log.debug("Retrieving Saxon Configuration from {}", tf.getClass().getName());
+      return Optional.of(((TransformerFactoryImpl) tf).getConfiguration());
+    }
+    return Optional.empty();
+  }
+
+  public SaxonExtensionRegistrar getExtensionRegistrar() {
+    return StringUtils.isNotEmpty(getExtensionRegistrarImplementation())
+        ? loadExtensionRegistrar(getExtensionRegistrarImplementation())
+        : new NoExtensions();
+  }
+
+  private SaxonExtensionRegistrar loadExtensionRegistrar(String className) {
+    try {
+      Class<?> clazz = Class.forName(className);
+      if (SaxonExtensionRegistrar.class.isAssignableFrom(clazz)) {
+        log.debug("Found SaxonExtensionRegistrar implementation class: {}", className);
+        return (SaxonExtensionRegistrar) clazz.getDeclaredConstructor().newInstance();
+      } else {
+        log.warn("Class {} does not implement SaxonExtensionRegistrar", className);
+      }
+    } catch (Exception e) {
+      log.warn("Failed to load SaxonExtensionRegistrar implementation: {}", className, e);
+    }
+    return new NoExtensions();
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/util/text/xml/XsltTransformerFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/xml/XsltTransformerFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.adaptris.util.text.xml;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/interlok-core/src/test/java/com/adaptris/util/text/xml/XsltTransformerFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/xml/XsltTransformerFactoryTest.java
@@ -1,0 +1,277 @@
+package com.adaptris.util.text.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.xml.transform.ErrorListener;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.TransformerFactoryImpl;
+
+class XsltTransformerFactoryTest {
+
+  private static final String SAXON_FACTORY_IMPL = "net.sf.saxon.TransformerFactoryImpl";
+
+  @BeforeEach
+  void resetState() {
+    TestRegistrar.invocationCount.set(0);
+    TestRegistrar.lastConfig = null;
+  }
+
+  @Test
+  void constructorsWork() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    assertNull(factory.getTransformerFactoryImpl());
+
+    XsltTransformerFactory factoryWithImpl = new XsltTransformerFactory(SAXON_FACTORY_IMPL);
+    assertEquals(SAXON_FACTORY_IMPL, factoryWithImpl.getTransformerFactoryImpl());
+  }
+
+  @Test
+  void getSaxonConfigurationReturnsEmptyOnNullFactory() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    assertTrue(factory.getSaxonConfiguration(null).isEmpty());
+  }
+
+  @Test
+  void getSaxonConfigurationReturnsPresentForSaxonFactory() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    assertTrue(factory.getSaxonConfiguration(new TransformerFactoryImpl()).isPresent());
+  }
+
+  @Test
+  void getSaxonConfigurationReturnsEmptyForNonSaxonFactory() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    assertTrue(factory.getSaxonConfiguration(new NonSaxonTransformerFactory()).isEmpty());
+  }
+
+  @Test
+  void getExtensionRegistrarDefaultsToNoExtensions() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    assertInstanceOf(NoExtensions.class, factory.getExtensionRegistrar());
+
+    factory.setExtensionRegistrarImplementation("");
+    assertInstanceOf(NoExtensions.class, factory.getExtensionRegistrar());
+  }
+
+  @Test
+  void getExtensionRegistrarLoadsValidImplementation() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    factory.setExtensionRegistrarImplementation(TestRegistrar.class.getName());
+
+    assertInstanceOf(TestRegistrar.class, factory.getExtensionRegistrar());
+  }
+
+  @Test
+  void getExtensionRegistrarFallsBackWhenClassIsNotAssignable() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    factory.setExtensionRegistrarImplementation(String.class.getName());
+
+    assertInstanceOf(NoExtensions.class, factory.getExtensionRegistrar());
+  }
+
+  @Test
+  void getExtensionRegistrarFallsBackWhenClassCannotBeLoaded() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    factory.setExtensionRegistrarImplementation("com.adaptris.missing.DoesNotExist");
+
+    assertInstanceOf(NoExtensions.class, factory.getExtensionRegistrar());
+  }
+
+  @Test
+  void newInstanceRegistersExtensionsWhenFactoryIsSaxon() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    factory.setTransformerFactoryImpl(SAXON_FACTORY_IMPL);
+    factory.setExtensionRegistrarImplementation(TestRegistrar.class.getName());
+
+    TransformerFactory tf = factory.newInstance();
+
+    assertInstanceOf(TransformerFactoryImpl.class, tf);
+    assertEquals(1, TestRegistrar.invocationCount.get());
+    assertNotNull(TestRegistrar.lastConfig);
+  }
+
+  @Test
+  void newInstanceDoesNotRegisterExtensionsWhenFactoryIsNotSaxon() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    factory.setTransformerFactoryImpl(NonSaxonTransformerFactory.class.getName());
+    factory.setExtensionRegistrarImplementation(TestRegistrar.class.getName());
+
+    TransformerFactory tf = factory.newInstance();
+
+    assertInstanceOf(NonSaxonTransformerFactory.class, tf);
+    assertEquals(0, TestRegistrar.invocationCount.get());
+    assertNull(TestRegistrar.lastConfig);
+  }
+
+  @Test
+  void newInstanceWorksWithDefaultTransformerFactory() {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    TransformerFactory tf = factory.newInstance();
+    assertNotNull(tf);
+  }
+
+  @Test
+  void createTransformerFromUrlWithoutEntityResolver() throws Exception {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    factory.setTransformerFactoryImpl(SAXON_FACTORY_IMPL);
+
+    String xsl = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">"
+        + "<xsl:template match=\"/\"><out>ok</out></xsl:template>"
+        + "</xsl:stylesheet>";
+
+    Path xslFile = Files.createTempFile("xslt-transformer-factory-", ".xsl");
+    Files.writeString(xslFile, xsl, StandardCharsets.UTF_8);
+
+    try {
+      Transformer transformer = factory.createTransformerFromUrl(xslFile.toUri().toString(), null);
+      assertNotNull(transformer);
+    } finally {
+      Files.deleteIfExists(xslFile);
+    }
+  }
+
+  @Test
+  void createTransformerFromUrlUsesEntityResolverWhenProvided() throws Exception {
+    XsltTransformerFactory factory = new XsltTransformerFactory();
+    factory.setTransformerFactoryImpl(SAXON_FACTORY_IMPL);
+    factory.setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder.newLenientInstance());
+
+    String xsl = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<!DOCTYPE xsl:stylesheet [<!ENTITY ext SYSTEM \"urn:test-entity\">]>\n"
+        + "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n"
+        + "  <xsl:template match=\"/\">\n"
+        + "    <out>&ext;</out>\n"
+        + "  </xsl:template>\n"
+        + "</xsl:stylesheet>";
+
+    Path xslFile = Files.createTempFile("xslt-transformer-factory-entity-", ".xsl");
+    Files.writeString(xslFile, xsl, StandardCharsets.UTF_8);
+
+    AtomicInteger resolverCalls = new AtomicInteger(0);
+    EntityResolver resolver = (publicId, systemId) -> {
+      resolverCalls.incrementAndGet();
+      if ("urn:test-entity".equals(systemId)) {
+        return new InputSource(new StringReader("resolved-value"));
+      }
+      return null;
+    };
+
+    try {
+      Transformer transformer = factory.createTransformerFromUrl(xslFile.toUri().toString(), resolver);
+      StringWriter output = new StringWriter();
+      transformer.transform(new StreamSource(new StringReader("<root/>")), new StreamResult(output));
+
+      assertTrue(resolverCalls.get() > 0);
+      assertTrue(output.toString().contains("resolved-value"));
+    } finally {
+      Files.deleteIfExists(xslFile);
+    }
+  }
+
+  public static class TestRegistrar implements SaxonExtensionRegistrar {
+    static final AtomicInteger invocationCount = new AtomicInteger(0);
+    static volatile Configuration lastConfig;
+
+    @Override
+    public void register(Configuration config) {
+      invocationCount.incrementAndGet();
+      lastConfig = config;
+    }
+  }
+
+  public static class NonSaxonTransformerFactory extends TransformerFactory {
+
+    private URIResolver resolver;
+    private ErrorListener errorListener;
+
+    @Override
+    public Transformer newTransformer(Source source) {
+      throw new UnsupportedOperationException("Not used in this test");
+    }
+
+    @Override
+    public Transformer newTransformer() {
+      throw new UnsupportedOperationException("Not used in this test");
+    }
+
+    @Override
+    public Templates newTemplates(Source source) {
+      throw new UnsupportedOperationException("Not used in this test");
+    }
+
+    @Override
+    public Source getAssociatedStylesheet(Source source, String media, String title, String charset) {
+      throw new UnsupportedOperationException("Not used in this test");
+    }
+
+    @Override
+    public void setURIResolver(URIResolver resolver) {
+      this.resolver = resolver;
+    }
+
+    @Override
+    public URIResolver getURIResolver() {
+      return resolver;
+    }
+
+    @Override
+    public void setFeature(String name, boolean value) throws TransformerConfigurationException {
+      // No-op for test-only factory implementation.
+    }
+
+    @Override
+    public boolean getFeature(String name) {
+      return false;
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+      // No-op for test-only factory implementation.
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+      return null;
+    }
+
+    @Override
+    public void setErrorListener(ErrorListener listener) {
+      this.errorListener = listener;
+    }
+
+    @Override
+    public ErrorListener getErrorListener() {
+      return errorListener;
+    }
+  }
+}
+

--- a/interlok-core/src/test/java/com/adaptris/util/text/xml/XsltTransformerFactoryTest.java
+++ b/interlok-core/src/test/java/com/adaptris/util/text/xml/XsltTransformerFactoryTest.java
@@ -1,7 +1,6 @@
 package com.adaptris.util.text.xml;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -19,7 +18,6 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamResult;

--- a/interlok-logging/build.gradle
+++ b/interlok-logging/build.gradle
@@ -2,7 +2,7 @@ ext {
   componentName='Interlok Core/Logging'
   componentDesc="Custom JMX Logger for Interlok for use with the UI"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  log4j2Version = "2.24.3"
+  log4j2Version = "2.25.3"
 }
 
 // In this section you declare the dependencies for your production and test code


### PR DESCRIPTION
## Motivation

Enabling Saxon extension functionaility with Saxon in interlok xsl transformations.

## Modification

Updated XsltTransformerFactory to get the configuration object from the transformer factory and then use the new SaxonExtensionRegistrar to register saxon extensions to the same config object.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Now able to use Saxon extensions when using a XsltTransformerFactory in the XML Transform Service.