### PR TITLE
Update refreshSessionIfProduceException for JMS Queue and Topic producer

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
@@ -85,15 +85,22 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
   }
 
   protected void doProduce(AdaptrisMessage msg, Destination destination, Destination replyTo) throws JMSException, CoreException {
+    Message jmsMsg = null;
     setupSession(msg);
-    Message jmsMsg = translate(msg, replyTo);
-    if (!perMessageProperties()) {
-      producerSession().getProducer().send(destination, jmsMsg);
-    }
-    else {
-      producerSession().getProducer().send(destination, jmsMsg,
-          calculateDeliveryMode(msg, getDeliveryMode()),
-          calculatePriority(msg, getPriority()), calculateTimeToLive(msg, timeToLive()));
+    try {
+      jmsMsg = sendMessage(msg, destination, replyTo);
+    } catch (JMSException ex) {
+       currentLogger().debug("Caught JMS exception while producing", ex);
+       if (refreshSessionIfProduceException) {
+           currentLogger().info("Handling exception by retrying with new session. Exception: {}", ex.getMessage());
+           setupSession(msg, refreshSessionIfProduceException);
+           try {
+               jmsMsg = sendMessage(msg, destination, replyTo);
+           } catch (JMSException exc) {
+               currentLogger().debug("Caught JMS exception while producing with force recreation of session", exc);
+               throw exc;
+           }
+       }
     }
     captureOutgoingMessageDetails(jmsMsg, msg);
     log.info("msg produced to destination [{}]", destination);
@@ -140,4 +147,16 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
 
   protected abstract Destination createTemporaryDestination() throws JMSException;
 
+  private Message sendMessage(AdaptrisMessage msg, Destination destination, Destination replyTo) throws JMSException {
+    Message jmsMsg = translate(msg, replyTo);
+    if (!perMessageProperties()) {
+      producerSession().getProducer().send(destination, jmsMsg);
+    } else {
+      producerSession().getProducer().send(destination, jmsMsg,
+          calculateDeliveryMode(msg, getDeliveryMode()),
+          calculatePriority(msg, getPriority()),
+          calculateTimeToLive(msg, timeToLive()));
+      }
+      return jmsMsg;
+    }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
@@ -91,14 +91,14 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
       jmsMsg = sendMessage(msg, destination, replyTo);
     } catch (JMSException ex) {
        currentLogger().debug("Caught JMS exception while producing", ex);
-       if (refreshSessionIfProduceException) {
+       if (refreshSessionIfProduceException == true) {
            currentLogger().info("Handling exception by retrying with new session. Exception: {}", ex.getMessage());
            setupSession(msg, refreshSessionIfProduceException);
            try {
                jmsMsg = sendMessage(msg, destination, replyTo);
            } catch (JMSException exc) {
                currentLogger().debug("Caught JMS exception while producing with force recreation of session", exc);
-               throw exc;
+               throw new JMSException("Failed to produce message after session refresh: " + exc.getMessage());
            }
        }
     }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
@@ -147,7 +147,6 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
 
   protected abstract Destination createTemporaryDestination() throws JMSException;
 
-  private Message sendMessage(AdaptrisMessage msg, Destination destination, Destination replyTo) throws JMSException {
     Message jmsMsg = translate(msg, replyTo);
     if (!perMessageProperties()) {
       producerSession().getProducer().send(destination, jmsMsg);

--- a/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
@@ -147,6 +147,7 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
 
   protected abstract Destination createTemporaryDestination() throws JMSException;
 
+  protected Message sendMessage(AdaptrisMessage msg, Destination destination, Destination replyTo) throws JMSException {
     Message jmsMsg = translate(msg, replyTo);
     if (!perMessageProperties()) {
       producerSession().getProducer().send(destination, jmsMsg);

--- a/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/DefinedJmsProducer.java
@@ -86,19 +86,19 @@ public abstract class DefinedJmsProducer extends JmsProducerImpl {
 
   protected void doProduce(AdaptrisMessage msg, Destination destination, Destination replyTo) throws JMSException, CoreException {
     Message jmsMsg = null;
+    boolean refreshSessionIfProduceException = this.refreshSessionIfProduceException.booleanValue();
     setupSession(msg);
     try {
       jmsMsg = sendMessage(msg, destination, replyTo);
     } catch (JMSException ex) {
        currentLogger().debug("Caught JMS exception while producing", ex);
-       if (refreshSessionIfProduceException == true) {
+       if (refreshSessionIfProduceException) {
            currentLogger().info("Handling exception by retrying with new session. Exception: {}", ex.getMessage());
            setupSession(msg, refreshSessionIfProduceException);
            try {
                jmsMsg = sendMessage(msg, destination, replyTo);
            } catch (JMSException exc) {
-               currentLogger().debug("Caught JMS exception while producing with force recreation of session", exc);
-               throw new JMSException("Failed to produce message after session refresh: " + exc.getMessage());
+               throw new JMSException("Failed to produce message with force recreation of session: " + exc.getMessage());
            }
        }
     }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -54,22 +54,7 @@ public class JmsAsyncProducer extends JmsProducer {
       Message jmsMsg = null;
       try {
           setupSession(msg);
-          try {
-              jmsMsg = sendMessageWithEventHandler(msg, jmsDest);
-          } catch (JMSException e) {
-              currentLogger().debug("Caught exception while producing", e);
-              if (refreshSessionIfProduceException) {
-                  currentLogger().info("Handling exception by retrying with new session. Exception: {}", e.getMessage());
-                  // force recreate a session if we get an exception, and try again. If it fails again, then we throw the original exception.
-                  setupSession(msg, refreshSessionIfProduceException);
-                  try {
-                      jmsMsg = sendMessageWithEventHandler(msg, jmsDest);
-                  } catch (JMSException exc) {
-                      currentLogger().debug("Caught exception while producing with force recreation of session", exc);
-                      throw new JMSException("Failed to produce message force recreation of session: " + exc.getMessage());
-                  }
-              } else throw e;
-          }
+          jmsMsg = sendMessageWithRetry(msg, jmsDest);
           // in real time speed JMSMessageID may not yet be set, therefore we set a header.
           getEventHandler().addUnAckedMessage(jmsMsg.getStringProperty(ID_HEADER), msg);
           // Standard workflow will attempt to execute this after the produce,
@@ -83,7 +68,8 @@ public class JmsAsyncProducer extends JmsProducer {
           ExceptionHelper.rethrowProduceException(ex);
       }
   }
-  
+
+
   @Override
   public void init() throws CoreException {
     super.init();
@@ -105,4 +91,31 @@ public class JmsAsyncProducer extends JmsProducer {
     }
     return jmsMsg;
   }
+
+    private Message sendMessageWithRetry(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException {
+        Message jmsMsg;
+        boolean refreshSessionIfProduceException = this.refreshSessionIfProduceException.booleanValue();
+        try {
+            jmsMsg = sendMessageWithEventHandler(msg, jmsDest);
+        } catch (JMSException e) {
+            currentLogger().debug("Caught exception while producing", e);
+            if (refreshSessionIfProduceException) {
+                currentLogger().info("Handling exception by retrying with new session. Exception: {}", e.getMessage());
+                // force recreate a session if we get an exception, and try again. If it fails again, then we throw the original exception.
+                setupSession(msg, refreshSessionIfProduceException);
+                jmsMsg = sendMessageWithNoRetry(msg, jmsDest);
+            } else throw e;
+        }
+        return jmsMsg;
+    }
+
+    private Message sendMessageWithNoRetry(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException {
+        Message jmsMsg;
+        try {
+            jmsMsg = sendMessageWithEventHandler(msg, jmsDest);
+        } catch (JMSException exc) {
+            throw new JMSException("Failed to produce message force recreation of session: " + exc.getMessage());
+        }
+        return jmsMsg;
+    }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -66,7 +66,7 @@ public class JmsAsyncProducer extends JmsProducer {
                       jmsMsg = sendMessageWithEventHandler(msg, jmsDest);
                   } catch (JMSException exc) {
                       currentLogger().debug("Caught exception while producing with force recreation of session", exc);
-                      throw exc;
+                      throw new JMSException("Failed to produce message force recreation of session: " + exc.getMessage());
                   }
               } else throw e;
           }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -51,32 +51,37 @@ public class JmsAsyncProducer extends JmsProducer {
   
   @Override
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException, CoreException {
-    try {
-      setupSession(msg);
-      Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());
-      jmsMsg.setStringProperty(ID_HEADER, msg.getUniqueId());
-      
-      if (!perMessageProperties()) {
-        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg, getEventHandler());
-      } else {
-        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg,
-            calculateDeliveryMode(msg, jmsDest.deliveryMode()),
-            calculatePriority(msg, jmsDest.priority()),
-            calculateTimeToLive(msg, jmsDest.timeToLive()),
-            getEventHandler());
+      Message jmsMsg = null;
+      try {
+          setupSession(msg);
+          try {
+              jmsMsg = sendMessage(msg, jmsDest);
+          } catch (JMSException e) {
+              currentLogger().debug("Caught exception while producing", e);
+              if (refreshSessionIfProduceException) {
+                  currentLogger().info("Handling exception by retrying with new session. Exception: {}", e.getMessage());
+                  // force recreate a session if we get an exception, and try again. If it fails again, then we throw the original exception.
+                  setupSession(msg, refreshSessionIfProduceException);
+                  try {
+                      jmsMsg = sendMessage(msg, jmsDest);
+                  } catch (JMSException exc) {
+                      currentLogger().debug("Caught exception while producing with force recreation of session", exc);
+                      throw exc;
+                  }
+              } else throw e;
+          }
+          // in real time speed JMSMessageID may not yet be set, therefore we set a header.
+          getEventHandler().addUnAckedMessage(jmsMsg.getStringProperty(ID_HEADER), msg);
+          // Standard workflow will attempt to execute this after the produce,
+          // let's remove them so it's handled by our async event handler.
+          msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK);
+          msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK);
+
+          captureOutgoingMessageDetails(jmsMsg, msg);
+          log.info("msg produced to destination [{}]", jmsDest);
+      } catch (Throwable ex) {
+          ExceptionHelper.rethrowProduceException(ex);
       }
-      // in real time speed JMSMessageID may not yet be set, therefore we set a header.
-      getEventHandler().addUnAckedMessage(jmsMsg.getStringProperty(ID_HEADER), msg);
-      // Standard workflow will attempt to execute this after the produce, 
-      // let's remove them so it's handled by our async event handler.
-      msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK);
-      msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK);
-      
-      captureOutgoingMessageDetails(jmsMsg, msg);
-      log.info("msg produced to destination [{}]", jmsDest);
-    } catch (Throwable ex) {
-      ExceptionHelper.rethrowProduceException(ex);
-    }
   }
   
   @Override
@@ -85,4 +90,20 @@ public class JmsAsyncProducer extends JmsProducer {
     getEventHandler().init();
   }
 
+  private Message sendMessage(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException {
+    Message jmsMsg;
+    jmsMsg = translate(msg, jmsDest.getReplyToDestination());
+    jmsMsg.setStringProperty(ID_HEADER, msg.getUniqueId());
+
+    if (!perMessageProperties()) {
+        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg, getEventHandler());
+    } else {
+        producerSession().getProducer().send(jmsDest.getDestination(), jmsMsg,
+                calculateDeliveryMode(msg, jmsDest.deliveryMode()),
+                calculatePriority(msg, jmsDest.priority()),
+                calculateTimeToLive(msg, jmsDest.timeToLive()),
+                getEventHandler());
+    }
+    return jmsMsg;
+  }
 }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsAsyncProducer.java
@@ -55,7 +55,7 @@ public class JmsAsyncProducer extends JmsProducer {
       try {
           setupSession(msg);
           try {
-              jmsMsg = sendMessage(msg, jmsDest);
+              jmsMsg = sendMessageWithEventHandler(msg, jmsDest);
           } catch (JMSException e) {
               currentLogger().debug("Caught exception while producing", e);
               if (refreshSessionIfProduceException) {
@@ -63,7 +63,7 @@ public class JmsAsyncProducer extends JmsProducer {
                   // force recreate a session if we get an exception, and try again. If it fails again, then we throw the original exception.
                   setupSession(msg, refreshSessionIfProduceException);
                   try {
-                      jmsMsg = sendMessage(msg, jmsDest);
+                      jmsMsg = sendMessageWithEventHandler(msg, jmsDest);
                   } catch (JMSException exc) {
                       currentLogger().debug("Caught exception while producing with force recreation of session", exc);
                       throw exc;
@@ -90,9 +90,8 @@ public class JmsAsyncProducer extends JmsProducer {
     getEventHandler().init();
   }
 
-  private Message sendMessage(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException {
-    Message jmsMsg;
-    jmsMsg = translate(msg, jmsDest.getReplyToDestination());
+  private Message sendMessageWithEventHandler(AdaptrisMessage msg, JmsDestination jmsDest) throws JMSException {
+    Message jmsMsg = translate(msg, jmsDest.getReplyToDestination());
     jmsMsg.setStringProperty(ID_HEADER, msg.getUniqueId());
 
     if (!perMessageProperties()) {

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -80,14 +80,6 @@ import lombok.Setter;
 public class JmsProducer extends JmsProducerImpl {
 
   /**
-   * If true, the producer will refresh the JMS session on a produce exception.
-   * Defaults to true for backward compatibility.
-   */
-  @Getter
-  @Setter
-  private Boolean refreshSessionIfProduceException = Boolean.FALSE;
-
-  /**
    * The JMS Endpoint defined in an RFC6167 manner.
    */
   @InputFieldHint(expression = true)
@@ -118,11 +110,6 @@ public class JmsProducer extends JmsProducerImpl {
 
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
      throws JMSException, CoreException {
-    doProduce(msg, jmsDest, refreshSessionIfProduceException);
-  }
-
-  protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest, boolean refreshSessionIfProduceException)
-      throws JMSException, CoreException {
     Message jmsMsg = null;
     setupSession(msg);
     try {
@@ -135,9 +122,9 @@ public class JmsProducer extends JmsProducerImpl {
         setupSession(msg, refreshSessionIfProduceException);
         try {
             jmsMsg = sendMessage(msg, jmsDest);
-        } catch (JMSException ex1) {
-            currentLogger().debug("Caught exception while producing with force recreation of session", ex1);
-            throw ex1;
+        } catch (JMSException exc) {
+            currentLogger().debug("Caught exception while producing with force recreation of session", exc);
+            throw exc;
         }
       } else throw ex;
     }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -124,7 +124,7 @@ public class JmsProducer extends JmsProducerImpl {
             jmsMsg = sendMessage(msg, jmsDest);
         } catch (JMSException exc) {
             currentLogger().debug("Caught exception while producing with force recreation of session", exc);
-            throw exc;
+            throw new JMSException("Failed to produce message with force recreation of session: " + exc.getMessage());
         }
       } else throw ex;
     }

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducer.java
@@ -111,6 +111,7 @@ public class JmsProducer extends JmsProducerImpl {
   protected void doProduce(AdaptrisMessage msg, JmsDestination jmsDest)
      throws JMSException, CoreException {
     Message jmsMsg = null;
+    boolean refreshSessionIfProduceException = this.refreshSessionIfProduceException.booleanValue();
     setupSession(msg);
     try {
         jmsMsg = sendMessage(msg, jmsDest);
@@ -123,7 +124,6 @@ public class JmsProducer extends JmsProducerImpl {
         try {
             jmsMsg = sendMessage(msg, jmsDest);
         } catch (JMSException exc) {
-            currentLogger().debug("Caught exception while producing with force recreation of session", exc);
             throw new JMSException("Failed to produce message with force recreation of session: " + exc.getMessage());
         }
       } else throw ex;

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducerImpl.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsProducerImpl.java
@@ -39,6 +39,8 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -110,9 +112,14 @@ public abstract class JmsProducerImpl extends RequestReplyProducerBase implement
   @AdvancedConfig
   private ProducerSessionFactory sessionFactory;
 
-
+  /**
+   * If true, the producer will refresh the JMS session on a produce exception.
+   * Defaults to true for backward compatibility.
+   */
+  @Getter
+  @Setter
+  protected Boolean refreshSessionIfProduceException = Boolean.FALSE;
   private transient ProducerSession producerSession;
-
   private transient Boolean transactedSession;
   private transient long rollbackTimeout = 30000;
 

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,10 +16,10 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageProducer;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -269,6 +271,19 @@ public class JmsAsyncProducerTest
     } finally {
       LifecycleHelper.stopAndClose(standaloneProducer);
     }
+  }
+
+  @Test
+  public void testDoProduceWithSessionRefresh() throws Exception {
+    // Arrange: first call to send throws, second call succeeds
+    producer.refreshSessionIfProduceException = true; // set directly since setter is protected
+    // First call to 6-arg send throws, second call does nothing (succeeds)
+    doThrow(new JMSException("expected")).doNothing()
+      .when(mockMessageProducer).send(any(), eq(mockMessage), anyInt(), anyInt(), anyLong(), any(CompletionListener.class));
+
+    // Act & Assert: should not throw, should call send twice (6-arg version)
+    producer.doProduce(adaptrisMessage, mockJmsDestination);
+    verify(mockMessageProducer, times(2)).send(any(), eq(mockMessage), anyInt(), anyInt(), anyLong(), any(CompletionListener.class));
   }
 
   @Override

--- a/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/JmsAsyncProducerTest.java
@@ -274,14 +274,13 @@ public class JmsAsyncProducerTest
   }
 
   @Test
-  public void testDoProduceWithSessionRefresh() throws Exception {
+  void testDoProduceWithSessionRefresh() throws Exception {
     // Arrange: first call to send throws, second call succeeds
-    producer.refreshSessionIfProduceException = true; // set directly since setter is protected
-    // First call to 6-arg send throws, second call does nothing (succeeds)
+    producer.refreshSessionIfProduceException = true;
+
     doThrow(new JMSException("expected")).doNothing()
       .when(mockMessageProducer).send(any(), eq(mockMessage), anyInt(), anyInt(), anyLong(), any(CompletionListener.class));
 
-    // Act & Assert: should not throw, should call send twice (6-arg version)
     producer.doProduce(adaptrisMessage, mockJmsDestination);
     verify(mockMessageProducer, times(2)).send(any(), eq(mockMessage), anyInt(), anyInt(), anyLong(), any(CompletionListener.class));
   }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -88,7 +88,6 @@ public class PasProducerTest extends BasicJmsProducerCase {
       start(standaloneProducer);
       AdaptrisMessage msg = DefaultMessageFactory.getDefaultInstance().newMessage("Hello JMS Topic");
       producer.doProduce(msg, topicName);
-      Thread.sleep(500);
       assertEquals(1, listener.getMessages().size(), "Message should be received on topic");
       assertEquals("Hello JMS Topic", listener.getMessages().get(0).getContent(), "Message content should match");
       stop(standaloneProducer);
@@ -125,7 +124,7 @@ public class PasProducerTest extends BasicJmsProducerCase {
       // Always return a dummy message, never call super
       return new org.apache.activemq.command.ActiveMQTextMessage();
     }
-    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) { /* No implementation */ }
+    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) { return; }
     @Override protected void logLinkedException(String prefix, Exception e) { throw new UnsupportedOperationException(); }
     @Override public void rollback() { throw new UnsupportedOperationException(); }
     @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
@@ -141,7 +140,7 @@ public class PasProducerTest extends BasicJmsProducerCase {
     protected javax.jms.Message sendMessage(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
       throw new javax.jms.JMSException("Simulated failure");
     }
-    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) { /* No implementation */ }
+    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) { return; }
     @Override protected void logLinkedException(String prefix, Exception e) { throw new UnsupportedOperationException(); }
     @Override public void rollback() { throw new UnsupportedOperationException(); }
     @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -24,8 +24,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.adaptris.core.stubs.MockMessageListener;
 
-import javax.jms.JMSException;
-
 public class PasProducerTest extends BasicJmsProducerCase {
 
   /**
@@ -100,6 +98,22 @@ public class PasProducerTest extends BasicJmsProducerCase {
     }
   }
 
+  @Test
+  public void testDefinedJmsProducer_RetryLogic() {
+      RetryOnceDefinedJmsProducer producer = new RetryOnceDefinedJmsProducer();
+      producer.refreshSessionIfProduceException = true;
+      assertDoesNotThrow(() -> producer.doProduce(new com.adaptris.core.DefaultMessageFactory().newMessage(), (javax.jms.Destination) null, (javax.jms.Destination) null));
+  }
+
+  @Test
+  public void testDefinedJmsProducer_RetryLogic_BothAttemptsFail() {
+      AlwaysFailingDefinedJmsProducer producer = new AlwaysFailingDefinedJmsProducer();
+      producer.refreshSessionIfProduceException = true;
+      assertThrows(javax.jms.JMSException.class, () ->
+            producer.doProduce(new com.adaptris.core.DefaultMessageFactory().newMessage(), (javax.jms.Destination) null, (javax.jms.Destination) null)
+      );
+  }
+
   // Test double that simulates retry logic by overriding sendMessage only
   static class RetryOnceDefinedJmsProducer extends DefinedJmsProducer {
     private boolean first = true;
@@ -122,10 +136,19 @@ public class PasProducerTest extends BasicJmsProducerCase {
     @Override public String endpoint(AdaptrisMessage msg) { return null; }
   }
 
-  @Test
-  public void testDefinedJmsProducer_RetryLogic_CoversLines93to103() {
-    RetryOnceDefinedJmsProducer producer = new RetryOnceDefinedJmsProducer();
-    producer.refreshSessionIfProduceException = true;
-    assertDoesNotThrow(() -> producer.doProduce(new com.adaptris.core.DefaultMessageFactory().newMessage(), (javax.jms.Destination) null, (javax.jms.Destination) null));
+  // Test double that always fails sendMessage to cover retry catch block
+  static class AlwaysFailingDefinedJmsProducer extends DefinedJmsProducer {
+    protected javax.jms.Message sendMessage(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
+      throw new javax.jms.JMSException("Simulated failure");
+    }
+    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) {}
+    @Override protected void logLinkedException(String prefix, Exception e) {}
+    @Override public void rollback() {}
+    @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
+    @Override public ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) { return null; }
+    protected void log(String s, Object... args) {}
+    @Override protected javax.jms.Destination createDestination(String dest) { return null; }
+    @Override protected javax.jms.Destination createTemporaryDestination() { return null; }
+    @Override public String endpoint(AdaptrisMessage msg) { return null; }
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -16,9 +16,13 @@
 
 package com.adaptris.core.jms;
 
-import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.*;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
 import com.adaptris.core.jms.activemq.EmbeddedActiveMq;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.adaptris.core.stubs.MockMessageListener;
 
 public class PasProducerTest extends BasicJmsProducerCase {
 
@@ -61,9 +65,7 @@ public class PasProducerTest extends BasicJmsProducerCase {
 
   @Override
   protected JmsConsumerImpl createConsumer(String dest) {
-    PasConsumer pas = new PasConsumer();
-    pas.setTopic(dest);
-    return pas;
+    return new PasConsumer().withTopic(dest);
   }
 
   @Override
@@ -71,4 +73,29 @@ public class PasProducerTest extends BasicJmsProducerCase {
     return new TopicLoopback(mq, dest);
   }
 
+  @Test
+  public void testDoProduce() throws Exception {
+    String topicName = "testDoProduceTopic";
+    EmbeddedActiveMq broker = new EmbeddedActiveMq();
+    broker.start();
+    try {
+      PasProducer producer = new PasProducer().withTopic(topicName);
+      StandaloneProducer standaloneProducer = new StandaloneProducer(broker.getJmsConnection(), producer);
+      PasConsumer consumer = new PasConsumer().withTopic(topicName);
+      StandaloneConsumer standaloneConsumer = new StandaloneConsumer(broker.getJmsConnection(), consumer);
+      MockMessageListener listener = new MockMessageListener();
+      standaloneConsumer.registerAdaptrisMessageListener(listener);
+      start(standaloneConsumer);
+      start(standaloneProducer);
+      AdaptrisMessage msg = DefaultMessageFactory.getDefaultInstance().newMessage("Hello JMS Topic");
+      producer.doProduce(msg, topicName);
+      Thread.sleep(500);
+      assertEquals(1, listener.getMessages().size(), "Message should be received on topic");
+      assertEquals("Hello JMS Topic", listener.getMessages().get(0).getContent(), "Message content should match");
+      stop(standaloneProducer);
+      stop(standaloneConsumer);
+    } finally {
+      broker.destroy();
+    }
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -24,9 +24,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.adaptris.core.stubs.MockMessageListener;
 
+import javax.jms.JMSException;
+
 public class PasProducerTest extends BasicJmsProducerCase {
-
-
+    
   /**
    * @see com.adaptris.core.ExampleConfigCase#retrieveObjectForSampleConfig()
    */
@@ -98,4 +99,48 @@ public class PasProducerTest extends BasicJmsProducerCase {
       broker.destroy();
     }
   }
+
+  // Simple test to cover retry logic in DefinedJmsProducer (lines 92-102)
+
+  @Test
+  public void testDefinedJmsProducer_SimpleRetry() throws Exception {
+    SimpleRetryDefinedJmsProducer producer = new SimpleRetryDefinedJmsProducer();
+    producer.refreshSessionIfProduceException = true;
+    // Should succeed on retry (first call fails, second succeeds)
+    assertDoesNotThrow(() -> producer.doProduce(new com.adaptris.core.DefaultMessageFactory().newMessage(), (javax.jms.Destination) null, (javax.jms.Destination) null));
+  }
+
+    static class SimpleRetryDefinedJmsProducer extends DefinedJmsProducer {
+        private boolean first = true;
+        protected javax.jms.Message sendMessage(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
+            if (first && Boolean.TRUE.equals(refreshSessionIfProduceException)) {
+                first = false;
+                throw new javax.jms.JMSException("Simulated failure");
+            }
+            // Always return a dummy message, never call super
+            return new org.apache.activemq.command.ActiveMQTextMessage();
+        }
+        @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) {}
+        @Override protected void logLinkedException(String prefix, Exception e) {}
+        @Override public void rollback() {}
+        @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
+        @Override public ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) { return null; }
+        protected void log(String s, Object... args) {}
+        @Override protected javax.jms.Destination createDestination(String dest) { return null; }
+        @Override protected javax.jms.Destination createTemporaryDestination() { return null; }
+        @Override public String endpoint(AdaptrisMessage msg) { return null; }
+        @Override
+        protected void doProduce(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
+            try {
+                sendMessage(msg, destination, replyTo);
+            } catch (JMSException ex) {
+                if (refreshSessionIfProduceException) {
+                    // Simulate session refresh and retry
+                    sendMessage(msg, destination, replyTo);
+                } else {
+                    throw ex;
+                }
+            }
+        }
+    }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -125,12 +125,12 @@ public class PasProducerTest extends BasicJmsProducerCase {
       // Always return a dummy message, never call super
       return new org.apache.activemq.command.ActiveMQTextMessage();
     }
-    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) {}
-    @Override protected void logLinkedException(String prefix, Exception e) {}
-    @Override public void rollback() {}
+    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) { /* No implementation */ }
+    @Override protected void logLinkedException(String prefix, Exception e) { /* No implementation */ }
+    @Override public void rollback() { /* No implementation */ }
     @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
     @Override public ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) { return null; }
-    protected void log(String s, Object... args) {}
+    protected void log(String s, Object... args) { /* No implementation */ }
     @Override protected javax.jms.Destination createDestination(String dest) { return null; }
     @Override protected javax.jms.Destination createTemporaryDestination() { return null; }
     @Override public String endpoint(AdaptrisMessage msg) { return null; }
@@ -141,12 +141,12 @@ public class PasProducerTest extends BasicJmsProducerCase {
     protected javax.jms.Message sendMessage(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
       throw new javax.jms.JMSException("Simulated failure");
     }
-    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) {}
-    @Override protected void logLinkedException(String prefix, Exception e) {}
-    @Override public void rollback() {}
+    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) { /* No implementation */ }
+    @Override protected void logLinkedException(String prefix, Exception e) { /* No implementation */ }
+    @Override public void rollback() { /* No implementation */ }
     @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
     @Override public ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) { return null; }
-    protected void log(String s, Object... args) {}
+    protected void log(String s, Object... args) { /* No implementation */ }
     @Override protected javax.jms.Destination createDestination(String dest) { return null; }
     @Override protected javax.jms.Destination createTemporaryDestination() { return null; }
     @Override public String endpoint(AdaptrisMessage msg) { return null; }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -88,6 +88,7 @@ public class PasProducerTest extends BasicJmsProducerCase {
       start(standaloneProducer);
       AdaptrisMessage msg = DefaultMessageFactory.getDefaultInstance().newMessage("Hello JMS Topic");
       producer.doProduce(msg, topicName);
+      Thread.sleep(500);
       assertEquals(1, listener.getMessages().size(), "Message should be received on topic");
       assertEquals("Hello JMS Topic", listener.getMessages().get(0).getContent(), "Message content should match");
       stop(standaloneProducer);

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.adaptris.core.stubs.MockMessageListener;
 
-public class PasProducerTest extends BasicJmsProducerCase {
+class PasProducerTest extends BasicJmsProducerCase {
 
   /**
    * @see com.adaptris.core.ExampleConfigCase#retrieveObjectForSampleConfig()
@@ -73,7 +73,7 @@ public class PasProducerTest extends BasicJmsProducerCase {
   }
 
   @Test
-  public void testDoProduce() throws Exception {
+  void testDoProduce() throws Exception {
     String topicName = "testDoProduceTopic";
     EmbeddedActiveMq broker = new EmbeddedActiveMq();
     broker.start();
@@ -99,14 +99,14 @@ public class PasProducerTest extends BasicJmsProducerCase {
   }
 
   @Test
-  public void testDefinedJmsProducer_RetryLogic() {
+  void testDefinedJmsProducer_RetryLogic() {
       RetryOnceDefinedJmsProducer producer = new RetryOnceDefinedJmsProducer();
       producer.refreshSessionIfProduceException = true;
       assertDoesNotThrow(() -> producer.doProduce(new com.adaptris.core.DefaultMessageFactory().newMessage(), (javax.jms.Destination) null, (javax.jms.Destination) null));
   }
 
   @Test
-  public void testDefinedJmsProducer_RetryLogic_BothAttemptsFail() {
+  void testDefinedJmsProducer_RetryLogic_BothAttemptsFail() {
       AlwaysFailingDefinedJmsProducer producer = new AlwaysFailingDefinedJmsProducer();
       producer.refreshSessionIfProduceException = true;
       assertThrows(javax.jms.JMSException.class, () ->
@@ -117,6 +117,7 @@ public class PasProducerTest extends BasicJmsProducerCase {
   // Test double that simulates retry logic by overriding sendMessage only
   static class RetryOnceDefinedJmsProducer extends DefinedJmsProducer {
     private boolean first = true;
+    @Override
     protected javax.jms.Message sendMessage(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
       if (first) {
         first = false;
@@ -138,6 +139,7 @@ public class PasProducerTest extends BasicJmsProducerCase {
 
   // Test double that always fails sendMessage to cover retry catch block
   static class AlwaysFailingDefinedJmsProducer extends DefinedJmsProducer {
+    @Override
     protected javax.jms.Message sendMessage(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
       throw new javax.jms.JMSException("Simulated failure");
     }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -27,7 +27,7 @@ import com.adaptris.core.stubs.MockMessageListener;
 import javax.jms.JMSException;
 
 public class PasProducerTest extends BasicJmsProducerCase {
-    
+
   /**
    * @see com.adaptris.core.ExampleConfigCase#retrieveObjectForSampleConfig()
    */
@@ -100,47 +100,32 @@ public class PasProducerTest extends BasicJmsProducerCase {
     }
   }
 
-  // Simple test to cover retry logic in DefinedJmsProducer (lines 92-102)
-
-  @Test
-  public void testDefinedJmsProducer_SimpleRetry() throws Exception {
-    SimpleRetryDefinedJmsProducer producer = new SimpleRetryDefinedJmsProducer();
-    producer.refreshSessionIfProduceException = true;
-    // Should succeed on retry (first call fails, second succeeds)
-    assertDoesNotThrow(() -> producer.doProduce(new com.adaptris.core.DefaultMessageFactory().newMessage(), (javax.jms.Destination) null, (javax.jms.Destination) null));
+  // Test double that simulates retry logic by overriding sendMessage only
+  static class RetryOnceDefinedJmsProducer extends DefinedJmsProducer {
+    private boolean first = true;
+    protected javax.jms.Message sendMessage(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
+      if (first) {
+        first = false;
+        throw new javax.jms.JMSException("Simulated failure");
+      }
+      // Always return a dummy message, never call super
+      return new org.apache.activemq.command.ActiveMQTextMessage();
+    }
+    @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) {}
+    @Override protected void logLinkedException(String prefix, Exception e) {}
+    @Override public void rollback() {}
+    @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
+    @Override public ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) { return null; }
+    protected void log(String s, Object... args) {}
+    @Override protected javax.jms.Destination createDestination(String dest) { return null; }
+    @Override protected javax.jms.Destination createTemporaryDestination() { return null; }
+    @Override public String endpoint(AdaptrisMessage msg) { return null; }
   }
 
-    static class SimpleRetryDefinedJmsProducer extends DefinedJmsProducer {
-        private boolean first = true;
-        protected javax.jms.Message sendMessage(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
-            if (first && Boolean.TRUE.equals(refreshSessionIfProduceException)) {
-                first = false;
-                throw new javax.jms.JMSException("Simulated failure");
-            }
-            // Always return a dummy message, never call super
-            return new org.apache.activemq.command.ActiveMQTextMessage();
-        }
-        @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) {}
-        @Override protected void logLinkedException(String prefix, Exception e) {}
-        @Override public void rollback() {}
-        @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
-        @Override public ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) { return null; }
-        protected void log(String s, Object... args) {}
-        @Override protected javax.jms.Destination createDestination(String dest) { return null; }
-        @Override protected javax.jms.Destination createTemporaryDestination() { return null; }
-        @Override public String endpoint(AdaptrisMessage msg) { return null; }
-        @Override
-        protected void doProduce(AdaptrisMessage msg, javax.jms.Destination destination, javax.jms.Destination replyTo) throws javax.jms.JMSException {
-            try {
-                sendMessage(msg, destination, replyTo);
-            } catch (JMSException ex) {
-                if (refreshSessionIfProduceException) {
-                    // Simulate session refresh and retry
-                    sendMessage(msg, destination, replyTo);
-                } else {
-                    throw ex;
-                }
-            }
-        }
-    }
+  @Test
+  public void testDefinedJmsProducer_RetryLogic_CoversLines93to103() {
+    RetryOnceDefinedJmsProducer producer = new RetryOnceDefinedJmsProducer();
+    producer.refreshSessionIfProduceException = true;
+    assertDoesNotThrow(() -> producer.doProduce(new com.adaptris.core.DefaultMessageFactory().newMessage(), (javax.jms.Destination) null, (javax.jms.Destination) null));
+  }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/jms/PasProducerTest.java
@@ -126,11 +126,11 @@ public class PasProducerTest extends BasicJmsProducerCase {
       return new org.apache.activemq.command.ActiveMQTextMessage();
     }
     @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) { /* No implementation */ }
-    @Override protected void logLinkedException(String prefix, Exception e) { /* No implementation */ }
-    @Override public void rollback() { /* No implementation */ }
+    @Override protected void logLinkedException(String prefix, Exception e) { throw new UnsupportedOperationException(); }
+    @Override public void rollback() { throw new UnsupportedOperationException(); }
     @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
     @Override public ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) { return null; }
-    protected void log(String s, Object... args) { /* No implementation */ }
+    protected void log(String s, Object... args) { throw new UnsupportedOperationException(); }
     @Override protected javax.jms.Destination createDestination(String dest) { return null; }
     @Override protected javax.jms.Destination createTemporaryDestination() { return null; }
     @Override public String endpoint(AdaptrisMessage msg) { return null; }
@@ -142,11 +142,11 @@ public class PasProducerTest extends BasicJmsProducerCase {
       throw new javax.jms.JMSException("Simulated failure");
     }
     @Override protected void captureOutgoingMessageDetails(javax.jms.Message jmsMsg, AdaptrisMessage msg) { /* No implementation */ }
-    @Override protected void logLinkedException(String prefix, Exception e) { /* No implementation */ }
-    @Override public void rollback() { /* No implementation */ }
+    @Override protected void logLinkedException(String prefix, Exception e) { throw new UnsupportedOperationException(); }
+    @Override public void rollback() { throw new UnsupportedOperationException(); }
     @Override public ProducerSession setupSession(AdaptrisMessage msg) { return null; }
     @Override public ProducerSession setupSession(AdaptrisMessage msg, boolean forceRecreate) { return null; }
-    protected void log(String s, Object... args) { /* No implementation */ }
+    protected void log(String s, Object... args) { throw new UnsupportedOperationException(); }
     @Override protected javax.jms.Destination createDestination(String dest) { return null; }
     @Override protected javax.jms.Destination createTemporaryDestination() { return null; }
     @Override public String endpoint(AdaptrisMessage msg) { return null; }


### PR DESCRIPTION
## Motivation

https://telusagriculture.atlassian.net/browse/INTERLOK-4723

## Modification

Changes for adding refreshSessionIfProduceException for Queue and Topic Message Producer

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

refreshSessionIfProduceException option works for Queue and Topic Message Producer

## Testing

Unit tests and Testing will be performed in integration with Proagrica Network
