### PR TITLE
Add connection monitoring

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnection.java
@@ -134,7 +134,7 @@ public interface AdaptrisConnection extends AdaptrisComponent, ComponentLifecycl
    * Returns whether this connection should be exposed as a runtime component.
    */
   default Boolean getRuntimeComponent() {
-    return null;
+    return Boolean.FALSE;
   }
 
   /**

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnection.java
@@ -109,6 +109,41 @@ public interface AdaptrisConnection extends AdaptrisComponent, ComponentLifecycl
   ConnectionErrorHandler connectionErrorHandler();
 
   /**
+   * Sets the {@link ConnectionStateHandler} to use.
+   */
+  default void setConnectionStateHandler(ConnectionStateHandler handler) {
+  }
+
+  /**
+   * Returns the configured {@link ConnectionStateHandler}.
+   */
+  default ConnectionStateHandler getConnectionStateHandler() {
+    return null;
+  }
+
+  /**
+   * Returns the currently active {@link ConnectionStateHandler}.
+   *
+   * @return the active {@link ConnectionStateHandler}, which may not be the same as the configured one.
+   */
+  default ConnectionStateHandler connectionStateHandler() {
+    return null;
+  }
+
+  /**
+   * Returns whether this connection should be exposed as a runtime component.
+   */
+  default Boolean getRuntimeComponent() {
+    return null;
+  }
+
+  /**
+   * Sets whether this connection should be exposed as a runtime component.
+   */
+  default void setRuntimeComponent(Boolean runtimeComponent) {
+  }
+
+  /**
    * Return the connection as represented by this connection
    *
    * @param type the type of connection

--- a/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/AdaptrisConnectionImp.java
@@ -16,6 +16,8 @@
 
 package com.adaptris.core;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -28,6 +30,13 @@ import org.slf4j.LoggerFactory;
 
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.runtime.AdapterManager;
+import com.adaptris.core.runtime.ChannelManager;
+import com.adaptris.core.runtime.ConnectionMonitor;
+import com.adaptris.core.runtime.ParentRuntimeInfoComponent;
+import com.adaptris.core.runtime.RuntimeInfoComponent;
+import com.adaptris.core.runtime.RuntimeInfoComponentFactory;
+import com.adaptris.core.runtime.WorkflowManager;
 import com.adaptris.core.util.LifecycleHelper;
 
 /**
@@ -38,14 +47,24 @@ import com.adaptris.core.util.LifecycleHelper;
 public abstract class AdaptrisConnectionImp implements AdaptrisConnection, StateManagedComponent {
   // protected transient Log log = LogFactory.getLog(this.getClass().getName());
 
+  static {
+    RuntimeInfoComponentFactory.registerComponentFactory(new JmxFactory());
+  }
+
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
   @AdvancedConfig
   @Valid
   private ConnectionErrorHandler connectionErrorHandler;
   @AdvancedConfig(rare = true)
+  @Valid
+  private ConnectionStateHandler connectionStateHandler;
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "false")
   private Boolean workersFirstOnShutdown;
+  @AdvancedConfig(rare = true)
+  @InputFieldDefault(value = "false")
+  private Boolean runtimeComponent;
   private String uniqueId;
 
   private transient Object lock = new Object();
@@ -77,9 +96,10 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
         prepare();
       }
       initConnection();
-      // Intentionly after initialising the connection as the connection error
-      // handler will almost certainly use it.
+      // Intentionally after initialising the connection as the connection error
+      // handler and state handler will almost certainly use it.
       LifecycleHelper.init(connectionErrorHandler());
+      LifecycleHelper.init(connectionStateHandler());
     }
   }
 
@@ -87,6 +107,9 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
   public final void prepare() throws CoreException {
     if (connectionErrorHandler() != null) {
       connectionErrorHandler().registerConnection(this);
+    }
+    if (connectionStateHandler() != null) {
+      connectionStateHandler().registerConnection(this);
     }
     prepareConnection();
     prepared = true;
@@ -102,6 +125,7 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
     synchronized (lock) {
       startConnection();
       LifecycleHelper.start(connectionErrorHandler());
+      LifecycleHelper.start(connectionStateHandler());
     }
   }
 
@@ -124,6 +148,7 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
         }
       }
       LifecycleHelper.close(connectionErrorHandler());
+      LifecycleHelper.close(connectionStateHandler());
       closeConnection();
     }
   }
@@ -146,6 +171,7 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
         }
       }
       LifecycleHelper.stop(connectionErrorHandler());
+      LifecycleHelper.stop(connectionStateHandler());
       stopConnection();
     }
   }
@@ -242,6 +268,21 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
     return connectionErrorHandler;
   }
 
+  @Override
+  public void setConnectionStateHandler(ConnectionStateHandler handler) {
+    connectionStateHandler = handler;
+  }
+
+  @Override
+  public ConnectionStateHandler getConnectionStateHandler() {
+    return connectionStateHandler;
+  }
+
+  @Override
+  public ConnectionStateHandler connectionStateHandler() {
+    return getConnectionStateHandler();
+  }
+
   /**
    * @return the workerLifecycleFirstOnShutdown
    */
@@ -295,6 +336,16 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
   }
 
   @Override
+  public Boolean getRuntimeComponent() {
+    return runtimeComponent;
+  }
+
+  @Override
+  public void setRuntimeComponent(Boolean b) {
+    runtimeComponent = b;
+  }
+
+  @Override
   public void changeState(ComponentState s) {
     state = s;
   }
@@ -332,6 +383,33 @@ public abstract class AdaptrisConnectionImp implements AdaptrisConnection, State
   public AdaptrisConnection cloneForTesting() throws CoreException {
     AdaptrisMarshaller m = DefaultMarshaller.getDefaultMarshaller();
     return (AdaptrisConnection) m.unmarshal(m.marshal(this));
+  }
+
+  private static class JmxFactory extends RuntimeInfoComponentFactory {
+
+    @Override
+    protected boolean isSupported(AdaptrisComponent component) {
+      return component instanceof AdaptrisConnection;
+    }
+
+    @Override
+    protected RuntimeInfoComponent createComponent(ParentRuntimeInfoComponent parent, AdaptrisComponent component)
+        throws Exception {
+      if (!(parent instanceof AdapterManager || parent instanceof ChannelManager || parent instanceof WorkflowManager)) {
+        return null;
+      }
+      AdaptrisConnection connection = (AdaptrisConnection) component;
+      if (connection instanceof SharedConnection) {
+        return null;
+      }
+      if (!Boolean.TRUE.equals(connection.getRuntimeComponent())) {
+        return null;
+      }
+      if (isEmpty(connection.getUniqueId())) {
+        return null;
+      }
+      return new ConnectionMonitor(parent, connection);
+    }
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/ConnectionStateHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConnectionStateHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core;
+
+/**
+ * Lifecycle extension point for reacting to connection state transitions.
+ * <p>
+ * Implementations are attached to an {@link AdaptrisConnection} and are invoked by the
+ * standard connection lifecycle ({@link #init()}, {@link #start()}, {@link #stop()}, {@link #close()}).
+ * This lets a handler observe external signals (for example reconnecting/reconnected events)
+ * and update connection state via {@link StateManagedComponent#changeState(ComponentState)} when appropriate.
+ * </p>
+ */
+public interface ConnectionStateHandler extends ComponentLifecycle {
+
+  /**
+   * Register the owning connection instance before lifecycle methods are invoked.
+   *
+   * @param connection the connection that owns this handler
+   */
+  void registerConnection(AdaptrisConnection connection);
+
+  /**
+   * Return the registered connection as the requested type.
+   *
+   * @param type the expected connection type
+   * @param <T> target type
+   * @return the registered connection cast to {@code type}
+   */
+  <T> T retrieveConnection(Class<T> type);
+}

--- a/interlok-core/src/main/java/com/adaptris/core/ConnectionStateHandlerImp.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConnectionStateHandlerImp.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core;
+
+import com.adaptris.core.util.Args;
+
+/**
+ * Common behaviour for {@link ConnectionStateHandler} implementations.
+ */
+public abstract class ConnectionStateHandlerImp implements ConnectionStateHandler {
+
+  private transient AdaptrisConnection adaptrisConnection;
+
+  @Override
+  public void registerConnection(AdaptrisConnection connection) {
+    adaptrisConnection = Args.notNull(connection, "connection");
+  }
+
+  @Override
+  public <T> T retrieveConnection(Class<T> type) {
+    return (T) adaptrisConnection;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/SharedConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/SharedConnection.java
@@ -164,6 +164,31 @@ public class SharedConnection extends SharedComponent implements AdaptrisConnect
     return getProxiedConnection().connectionErrorHandler();
   }
 
+  @Override
+  public void setConnectionStateHandler(ConnectionStateHandler handler) {
+    getProxiedConnection().setConnectionStateHandler(handler);
+  }
+
+  @Override
+  public ConnectionStateHandler getConnectionStateHandler() {
+    return getProxiedConnection().getConnectionStateHandler();
+  }
+
+  @Override
+  public ConnectionStateHandler connectionStateHandler() {
+    return getProxiedConnection().connectionStateHandler();
+  }
+
+  @Override
+  public Boolean getRuntimeComponent() {
+    return getProxiedConnection().getRuntimeComponent();
+  }
+
+  @Override
+  public void setRuntimeComponent(Boolean runtimeComponent) {
+    getProxiedConnection().setRuntimeComponent(runtimeComponent);
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public <T> T retrieveConnection(Class<T> type) {

--- a/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnection.java
+++ b/interlok-core/src/main/java/com/adaptris/core/jms/JmsConnection.java
@@ -32,6 +32,7 @@ import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMarshaller;
 import com.adaptris.core.AllowsRetriesConnection;
 import com.adaptris.core.ConnectionErrorHandler;
+import com.adaptris.core.ConnectionStateHandler;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.jms.jndi.StandardJndiImplementation;
@@ -220,6 +221,11 @@ public class JmsConnection extends AllowsRetriesConnection implements JmsConnect
   @Override
   protected void prepareConnection() throws CoreException {
     getVendorImplementation().prepare();
+  }
+
+  @Override
+  public ConnectionStateHandler connectionStateHandler() {
+    return getConnectionStateHandler();
   }
 
 

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterComponentMBean.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterComponentMBean.java
@@ -98,6 +98,12 @@ public interface AdapterComponentMBean extends BaseComponentMBean {
   String JMX_CHANNEL_TYPE = JMX_DOMAIN_NAME + ":type=Channel";
 
   /**
+   * The standard JMX Prefix for connections which resolves to {@value}
+   *
+   */
+  String JMX_CONNECTION_TYPE = JMX_DOMAIN_NAME + ":type=Connection";
+
+  /**
    * The standard JMX Prefix for a given Message Error Digest exposed via JMX which resolves to {@value}
    *
    */
@@ -177,6 +183,18 @@ public interface AdapterComponentMBean extends BaseComponentMBean {
    *
    */
   String NOTIF_TYPE_CHANNEL_CONFIG = "adaptris.jmx.channel.config";
+
+  /**
+   * Notification type for connection lifecycle notifications '{@value} '
+   *
+   */
+  String NOTIF_TYPE_CONNECTION_LIFECYCLE = "adaptris.jmx.connection.lifecycle";
+
+  /**
+   * Notification type for connection config update notifications '{@value} '
+   *
+   */
+  String NOTIF_TYPE_CONNECTION_CONFIG = "adaptris.jmx.connection.config";
   /**
    * Notification type for adapter config update notifications '{@value} '
    *

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
@@ -17,6 +17,7 @@
 package com.adaptris.core.runtime;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -25,12 +26,15 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.lang.management.ManagementFactory;
+
 import javax.management.MBeanNotificationInfo;
 import javax.management.MalformedObjectNameException;
 import javax.management.Notification;
 import javax.management.ObjectName;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdapterLifecycleEvent;
 import com.adaptris.core.AdaptrisComponent;
@@ -47,6 +51,7 @@ import com.adaptris.core.Service;
 import com.adaptris.core.StartedState;
 import com.adaptris.core.StoppedState;
 import com.adaptris.core.management.VersionReport;
+import com.adaptris.core.util.JmxHelper;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.core.util.ManagedThreadFactory;
 
@@ -149,7 +154,7 @@ public class AdapterManager extends ComponentManagerImpl<Adapter> implements Ada
   }
 
   private boolean isJmxRegistered() {
-    return ManagementFactory.getPlatformMBeanServer().isRegistered(myObjectName);
+    return JmxHelper.findMBeanServer().isRegistered(myObjectName);
   }
 
   private ConnectionMonitor findSharedConnectionMonitor(String id) {

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
@@ -17,7 +17,6 @@
 package com.adaptris.core.runtime;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -25,16 +24,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.lang.management.ManagementFactory;
-
 import javax.management.MBeanNotificationInfo;
 import javax.management.MalformedObjectNameException;
 import javax.management.Notification;
 import javax.management.ObjectName;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import com.adaptris.core.Adapter;
 import com.adaptris.core.AdapterLifecycleEvent;
 import com.adaptris.core.AdaptrisComponent;

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
@@ -159,8 +159,8 @@ public class AdapterManager extends ComponentManagerImpl<Adapter> implements Ada
 
   private ConnectionMonitor findSharedConnectionMonitor(String id) {
     for (ChildRuntimeInfoComponent cmb : childRuntimeInfoComponents) {
-      if (cmb instanceof ConnectionMonitor && id.equals(((ConnectionMonitor) cmb).connectionId())) {
-        return (ConnectionMonitor) cmb;
+      if (cmb instanceof ConnectionMonitor connectionMonitor && id.equals(connectionMonitor.connectionId())) {
+        return connectionMonitor;
       }
     }
     return null;

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.lang.management.ManagementFactory;
 import javax.management.MBeanNotificationInfo;
 import javax.management.MalformedObjectNameException;
 import javax.management.Notification;
@@ -83,6 +84,9 @@ public class AdapterManager extends ComponentManagerImpl<Adapter> implements Ada
         addChild(new ChannelManager(c, this, true), true);
       }
     }
+    for (AdaptrisConnection c : adapter.getSharedComponents().getConnections()) {
+      registerChildRuntime(c);
+    }
     registerChildRuntime(adapter.getMessageErrorDigester());
     registerChildRuntime(adapter.getFailedMessageRetrier());
     registerChildRuntime(adapter.getMessageErrorHandler());
@@ -130,6 +134,36 @@ public class AdapterManager extends ComponentManagerImpl<Adapter> implements Ada
       result.add(cmb.createObjectName());
     }
     return result;
+  }
+
+  boolean addSharedConnectionMonitor(AdaptrisConnection connection) throws CoreException {
+    ChildRuntimeInfoComponent info = (ChildRuntimeInfoComponent) RuntimeInfoComponentFactory.create(this, connection);
+    if (!(info instanceof ConnectionMonitor)) {
+      return false;
+    }
+    boolean added = addChildJmxComponent(info);
+    if (added && isJmxRegistered()) {
+      info.registerMBean();
+    }
+    return added;
+  }
+
+  private boolean isJmxRegistered() {
+    try {
+      return ManagementFactory.getPlatformMBeanServer().isRegistered(createObjectName());
+    }
+    catch (MalformedObjectNameException e) {
+      return false;
+    }
+  }
+
+  private ConnectionMonitor findSharedConnectionMonitor(String id) {
+    for (ChildRuntimeInfoComponent cmb : childRuntimeInfoComponents) {
+      if (cmb instanceof ConnectionMonitor && id.equals(((ConnectionMonitor) cmb).connectionId())) {
+        return (ConnectionMonitor) cmb;
+      }
+    }
+    return null;
   }
 
   @Override
@@ -285,6 +319,7 @@ public class AdapterManager extends ComponentManagerImpl<Adapter> implements Ada
     AdaptrisConnection comp = (AdaptrisConnection) DefaultMarshaller.getDefaultMarshaller().unmarshal(xmlString);
     boolean result = getWrappedComponent().getSharedComponents().addConnection(comp);
     if (result) {
+      addSharedConnectionMonitor(comp);
       marshalAndSendNotification();
     }
     return result;
@@ -296,6 +331,7 @@ public class AdapterManager extends ComponentManagerImpl<Adapter> implements Ada
     AdaptrisConnection comp = (AdaptrisConnection) DefaultMarshaller.getDefaultMarshaller().unmarshal(xmlString);
     boolean result = getWrappedComponent().getSharedComponents().addConnection(comp);
     if (result) {
+      addSharedConnectionMonitor(comp);
       getWrappedComponent().getSharedComponents().bindJNDI(comp.getUniqueId());
       marshalAndSendNotification();
     }
@@ -308,6 +344,11 @@ public class AdapterManager extends ComponentManagerImpl<Adapter> implements Ada
     Collection<AdaptrisConnection> c = getWrappedComponent().getSharedComponents().removeConnection(connectionId);
     boolean result = c.size() > 0;
     if (result) {
+      ConnectionMonitor mgr = findSharedConnectionMonitor(connectionId);
+      if (mgr != null) {
+        mgr.unregisterMBean();
+        removeChildJmxComponent(mgr);
+      }
       marshalAndSendNotification();
     }
     return result;

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/AdapterManager.java
@@ -141,20 +141,15 @@ public class AdapterManager extends ComponentManagerImpl<Adapter> implements Ada
     if (!(info instanceof ConnectionMonitor)) {
       return false;
     }
-    boolean added = addChildJmxComponent(info);
-    if (added && isJmxRegistered()) {
+    addChildJmxComponent(info);
+    if (isJmxRegistered()) {
       info.registerMBean();
     }
-    return added;
+    return true;
   }
 
   private boolean isJmxRegistered() {
-    try {
-      return ManagementFactory.getPlatformMBeanServer().isRegistered(createObjectName());
-    }
-    catch (MalformedObjectNameException e) {
-      return false;
-    }
+    return ManagementFactory.getPlatformMBeanServer().isRegistered(myObjectName);
   }
 
   private ConnectionMonitor findSharedConnectionMonitor(String id) {

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ChannelManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ChannelManager.java
@@ -285,8 +285,8 @@ public class ChannelManager extends ComponentManagerImpl<Channel> implements Cha
   }
 
   private ChildRuntimeInfoComponent withConnectionSuffix(ChildRuntimeInfoComponent comp, String suffix) {
-    if (comp instanceof ConnectionMonitor) {
-      ((ConnectionMonitor) comp).appendObjectNameSuffix(suffix);
+    if (comp instanceof ConnectionMonitor connectionMonitor) {
+      connectionMonitor.appendObjectNameSuffix(suffix);
     }
     return comp;
   }

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ChannelManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ChannelManager.java
@@ -49,6 +49,8 @@ public class ChannelManager extends ComponentManagerImpl<Channel> implements Cha
   private transient Set<WorkflowRuntimeManager> workflowManagers;
   private transient ObjectName myObjectName = null;
   private transient Set<ChildRuntimeInfoComponent> childRuntimeInfoComponents;
+  private static final String CONSUME_CONNECTION_SUFFIX = "-consume-connection";
+  private static final String PRODUCE_CONNECTION_SUFFIX = "-produce-connection";
   private transient String autoStart;
 
   private ChannelManager() {
@@ -84,6 +86,12 @@ public class ChannelManager extends ComponentManagerImpl<Channel> implements Cha
         addChild(new WorkflowManager(c, this, true), true);
       }
     }
+    addChildJmxComponentQuietly(withConnectionSuffix(
+        (ChildRuntimeInfoComponent) RuntimeInfoComponentFactory.create(this, channel.getConsumeConnection()),
+        CONSUME_CONNECTION_SUFFIX));
+    addChildJmxComponentQuietly(withConnectionSuffix(
+        (ChildRuntimeInfoComponent) RuntimeInfoComponentFactory.create(this, channel.getProduceConnection()),
+        PRODUCE_CONNECTION_SUFFIX));
     addChildJmxComponentQuietly(
         (ChildRuntimeInfoComponent) RuntimeInfoComponentFactory.create(this, channel.getMessageErrorHandler()));
     marshalConfig();
@@ -274,6 +282,13 @@ public class ChannelManager extends ComponentManagerImpl<Channel> implements Cha
       return addChildJmxComponent(comp);
     }
     return false;
+  }
+
+  private ChildRuntimeInfoComponent withConnectionSuffix(ChildRuntimeInfoComponent comp, String suffix) {
+    if (comp instanceof ConnectionMonitor) {
+      ((ConnectionMonitor) comp).appendObjectNameSuffix(suffix);
+    }
+    return comp;
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ConnectionMonitor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ConnectionMonitor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package com.adaptris.core.runtime;
 
 import static com.adaptris.core.runtime.AdapterComponentMBean.JMX_CONNECTION_TYPE;
@@ -7,7 +23,7 @@ import com.adaptris.core.ComponentState;
 
 public class ConnectionMonitor extends ChildRuntimeInfoComponentImpl implements ConnectionMonitorMBean {
 
-  private transient RuntimeInfoComponent parent;
+  private transient ParentRuntimeInfoComponent parent;
   private transient AdaptrisConnection wrappedComponent;
   private transient String objectNameId;
 
@@ -15,7 +31,7 @@ public class ConnectionMonitor extends ChildRuntimeInfoComponentImpl implements 
     super();
   }
 
-  public ConnectionMonitor(RuntimeInfoComponent owner, AdaptrisConnection component) {
+  public ConnectionMonitor(ParentRuntimeInfoComponent owner, AdaptrisConnection component) {
     this();
     parent = owner;
     wrappedComponent = component;
@@ -33,7 +49,7 @@ public class ConnectionMonitor extends ChildRuntimeInfoComponentImpl implements 
   }
 
   @Override
-  public RuntimeInfoComponent getParentRuntimeInfoComponent() {
+  public ParentRuntimeInfoComponent getParentRuntimeInfoComponent() {
     return parent;
   }
 

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ConnectionMonitor.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ConnectionMonitor.java
@@ -1,0 +1,57 @@
+package com.adaptris.core.runtime;
+
+import static com.adaptris.core.runtime.AdapterComponentMBean.JMX_CONNECTION_TYPE;
+
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.ComponentState;
+
+public class ConnectionMonitor extends ChildRuntimeInfoComponentImpl implements ConnectionMonitorMBean {
+
+  private transient RuntimeInfoComponent parent;
+  private transient AdaptrisConnection wrappedComponent;
+  private transient String objectNameId;
+
+  private ConnectionMonitor() {
+    super();
+  }
+
+  public ConnectionMonitor(RuntimeInfoComponent owner, AdaptrisConnection component) {
+    this();
+    parent = owner;
+    wrappedComponent = component;
+    objectNameId = wrappedComponent.getUniqueId();
+  }
+
+  @Override
+  protected String getType() {
+    return JMX_CONNECTION_TYPE;
+  }
+
+  @Override
+  protected String uniqueId() {
+    return objectNameId;
+  }
+
+  @Override
+  public RuntimeInfoComponent getParentRuntimeInfoComponent() {
+    return parent;
+  }
+
+  @Override
+  public ComponentState getComponentState() {
+    return wrappedComponent.retrieveComponentState();
+  }
+
+  @Override
+  public String getUniqueId() {
+    return wrappedComponent.getUniqueId();
+  }
+
+  String connectionId() {
+    return wrappedComponent.getUniqueId();
+  }
+
+  void appendObjectNameSuffix(String suffix) {
+    objectNameId = wrappedComponent.getUniqueId() + suffix;
+  }
+}

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ConnectionMonitorMBean.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ConnectionMonitorMBean.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package com.adaptris.core.runtime;
 
 import com.adaptris.core.ComponentState;

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/ConnectionMonitorMBean.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/ConnectionMonitorMBean.java
@@ -1,0 +1,13 @@
+package com.adaptris.core.runtime;
+
+import com.adaptris.core.ComponentState;
+
+/**
+ * Read-only runtime information for a connection.
+ */
+public interface ConnectionMonitorMBean extends ChildRuntimeInfoComponentMBean {
+
+  String getUniqueId();
+
+  ComponentState getComponentState();
+}

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/WorkflowManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/WorkflowManager.java
@@ -33,8 +33,10 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import com.adaptris.core.AdaptrisComponent;
+import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ComponentState;
+import com.adaptris.core.ConnectedService;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultSerializableMessageTranslator;
 import com.adaptris.core.NullProcessingExceptionHandler;
@@ -42,8 +44,12 @@ import com.adaptris.core.PoolingWorkflow;
 import com.adaptris.core.ProcessingExceptionHandler;
 import com.adaptris.core.SerializableAdaptrisMessage;
 import com.adaptris.core.SerializableMessageTranslator;
+import com.adaptris.core.Service;
+import com.adaptris.core.ServiceCollection;
+import com.adaptris.core.ServiceWrapper;
 import com.adaptris.core.Workflow;
 import com.adaptris.core.WorkflowInterceptor;
+import com.adaptris.core.WorkflowImp;
 import com.adaptris.core.http.jetty.BasicJettyConsumer;
 import com.adaptris.core.http.jetty.JettyPoolingWorkflowInterceptor;
 import com.adaptris.core.http.jetty.JettyWorkflowInterceptorImpl;
@@ -61,6 +67,7 @@ import com.adaptris.util.TimeInterval;
 public class WorkflowManager extends ComponentManagerImpl<Workflow>implements WorkflowManagerMBean, WorkflowRuntimeManager {
 
   private static final TimeInterval MAX_REPLY_WAIT = new TimeInterval(1L, TimeUnit.MINUTES);
+  private static final String CONNECTED_SERVICE_CONNECTION_SUFFIX = "-connected-service-";
   private transient Workflow managedWorkflow;
   private transient ChannelManager parent;
   private transient ObjectName myObjectName = null;
@@ -102,7 +109,43 @@ public class WorkflowManager extends ComponentManagerImpl<Workflow>implements Wo
     for (AdaptrisComponent c : runtimeCandidates) {
       addChildJmxComponentQuietly((ChildRuntimeInfoComponent) RuntimeInfoComponentFactory.create(this, c));
     }
+    for (WorkflowConnectedService connection : serviceConnections(managedWorkflow)) {
+      addChildJmxComponentQuietly(withConnectedServiceSuffix(
+          (ChildRuntimeInfoComponent) RuntimeInfoComponentFactory.create(this, connection.connection),
+          connection.serviceId));
+    }
     marshalConfig();
+  }
+
+  private static Collection<WorkflowConnectedService> serviceConnections(Workflow workflow) {
+    Set<WorkflowConnectedService> result = new HashSet<>();
+    if (workflow instanceof WorkflowImp) {
+      ServiceCollection services = ((WorkflowImp) workflow).getServiceCollection();
+      collectConnections(services, result);
+    }
+    return result;
+  }
+
+  private static void collectConnections(Service service, Set<WorkflowConnectedService> connections) {
+    if (service == null) {
+      return;
+    }
+    if (service instanceof ConnectedService) {
+      AdaptrisConnection connection = ((ConnectedService) service).getConnection();
+      if (connection != null) {
+        connections.add(new WorkflowConnectedService(connection, service.getUniqueId()));
+      }
+    }
+    if (service instanceof ServiceCollection) {
+      for (Service nested : ((ServiceCollection) service).getServices()) {
+        collectConnections(nested, connections);
+      }
+    }
+    if (service instanceof ServiceWrapper) {
+      for (Service nested : ((ServiceWrapper) service).wrappedServices()) {
+        collectConnections(nested, connections);
+      }
+    }
   }
 
   @Override
@@ -275,6 +318,40 @@ public class WorkflowManager extends ComponentManagerImpl<Workflow>implements Wo
       return addChildJmxComponent(comp);
     }
     return false;
+  }
+
+  private ChildRuntimeInfoComponent withConnectedServiceSuffix(ChildRuntimeInfoComponent comp, String serviceId) {
+    if (comp instanceof ConnectionMonitor) {
+      ((ConnectionMonitor) comp).appendObjectNameSuffix(CONNECTED_SERVICE_CONNECTION_SUFFIX + serviceId);
+    }
+    return comp;
+  }
+
+  private static class WorkflowConnectedService {
+    private final AdaptrisConnection connection;
+    private final String serviceId;
+
+    private WorkflowConnectedService(AdaptrisConnection connection, String serviceId) {
+      this.connection = connection;
+      this.serviceId = serviceId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof WorkflowConnectedService)) {
+        return false;
+      }
+      WorkflowConnectedService other = (WorkflowConnectedService) obj;
+      return new EqualsBuilder().append(connection, other.connection).append(serviceId, other.serviceId).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+      return new HashCodeBuilder(17, 31).append(connection).append(serviceId).toHashCode();
+    }
   }
 
   @Override

--- a/interlok-core/src/main/java/com/adaptris/core/runtime/WorkflowManager.java
+++ b/interlok-core/src/main/java/com/adaptris/core/runtime/WorkflowManager.java
@@ -119,8 +119,8 @@ public class WorkflowManager extends ComponentManagerImpl<Workflow>implements Wo
 
   private static Collection<WorkflowConnectedService> serviceConnections(Workflow workflow) {
     Set<WorkflowConnectedService> result = new HashSet<>();
-    if (workflow instanceof WorkflowImp) {
-      ServiceCollection services = ((WorkflowImp) workflow).getServiceCollection();
+    if (workflow instanceof WorkflowImp workflowImp) {
+      ServiceCollection services = workflowImp.getServiceCollection();
       collectConnections(services, result);
     }
     return result;
@@ -130,19 +130,19 @@ public class WorkflowManager extends ComponentManagerImpl<Workflow>implements Wo
     if (service == null) {
       return;
     }
-    if (service instanceof ConnectedService) {
-      AdaptrisConnection connection = ((ConnectedService) service).getConnection();
+    if (service instanceof ConnectedService connectedService) {
+      AdaptrisConnection connection = connectedService.getConnection();
       if (connection != null) {
         connections.add(new WorkflowConnectedService(connection, service.getUniqueId()));
       }
     }
-    if (service instanceof ServiceCollection) {
-      for (Service nested : ((ServiceCollection) service).getServices()) {
+    if (service instanceof ServiceCollection serviceCollection) {
+      for (Service nested : serviceCollection.getServices()) {
         collectConnections(nested, connections);
       }
     }
-    if (service instanceof ServiceWrapper) {
-      for (Service nested : ((ServiceWrapper) service).wrappedServices()) {
+    if (service instanceof ServiceWrapper serviceWrapper) {
+      for (Service nested : serviceWrapper.wrappedServices()) {
         collectConnections(nested, connections);
       }
     }
@@ -321,8 +321,8 @@ public class WorkflowManager extends ComponentManagerImpl<Workflow>implements Wo
   }
 
   private ChildRuntimeInfoComponent withConnectedServiceSuffix(ChildRuntimeInfoComponent comp, String serviceId) {
-    if (comp instanceof ConnectionMonitor) {
-      ((ConnectionMonitor) comp).appendObjectNameSuffix(CONNECTED_SERVICE_CONNECTION_SUFFIX + serviceId);
+    if (comp instanceof ConnectionMonitor connectionMonitor) {
+      connectionMonitor.appendObjectNameSuffix(CONNECTED_SERVICE_CONNECTION_SUFFIX + serviceId);
     }
     return comp;
   }

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
@@ -192,7 +192,7 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
   }
 
   @Test
-  public void testConnectionStateHandler() throws Exception {
+  void testConnectionStateHandler() {
     MockConnection mc = new MockConnection();
     assertNull(mc.getConnectionStateHandler());
     ConnectionStateHandler csh = new ConnectionStateHandlerImp(){};
@@ -201,7 +201,7 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
   }
 
   @Test
-  public void testConnectionStateHandlerRegisteredOnPrepare() throws Exception {
+  void testConnectionStateHandlerRegisteredOnPrepare() throws Exception {
     MockConnection connection = new MockConnection();
     ConnectionStateHandler handler = mock(ConnectionStateHandler.class);
     connection.setConnectionStateHandler(handler);
@@ -212,7 +212,7 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
   }
 
   @Test
-  public void testInterfaceDefaultMethods() throws Exception {
+  void testInterfaceDefaultMethods() {
     AdaptrisConnection connection = new DefaultMethodConnection();
 
     // Default implementation is no-op and does not retain the handler.
@@ -277,10 +277,12 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
 
     @Override
     public void addExceptionListener(StateManagedComponent comp) {
+      //test only
     }
 
     @Override
     public void addMessageProducer(AdaptrisMessageProducer producer) throws CoreException {
+      //test only
     }
 
     @Override
@@ -290,6 +292,7 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
 
     @Override
     public void addMessageConsumer(AdaptrisMessageConsumer consumer) throws CoreException {
+      //test only
     }
 
     @Override
@@ -299,6 +302,7 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
 
     @Override
     public void setConnectionErrorHandler(ConnectionErrorHandler handler) {
+      //test only
     }
 
     @Override
@@ -333,26 +337,32 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
 
     @Override
     public void changeState(ComponentState newState) {
+      //test only
     }
 
     @Override
     public void requestInit() throws CoreException {
+      //test only
     }
 
     @Override
     public void requestStart() throws CoreException {
+      //test only
     }
 
     @Override
     public void requestStop() {
+      //test only
     }
 
     @Override
     public void requestClose() {
+      //test only
     }
 
     @Override
     public void prepare() throws CoreException {
+      //test only
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
@@ -15,7 +15,9 @@
 */
 
 package com.adaptris.core;
-t static org.junit.jupiter.api.Assertions.assertNull;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
@@ -16,8 +16,11 @@
 
 package com.adaptris.core;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
 import java.time.Duration;
@@ -195,6 +198,17 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
     ConnectionStateHandler csh = new ConnectionStateHandlerImp(){};
     mc.setConnectionStateHandler(csh);
     assertEquals(csh, mc.getConnectionStateHandler());
+  }
+
+  @Test
+  public void testConnectionStateHandlerRegisteredOnPrepare() throws Exception {
+    MockConnection connection = new MockConnection();
+    ConnectionStateHandler handler = mock(ConnectionStateHandler.class);
+    connection.setConnectionStateHandler(handler);
+
+    connection.prepare();
+
+    verify(handler).registerConnection(connection);
   }
 
   private void assertState(List list, ComponentState state) {

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
@@ -15,9 +15,7 @@
 */
 
 package com.adaptris.core;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+t static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
@@ -16,7 +16,6 @@
 
 package com.adaptris.core;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
@@ -25,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
@@ -211,6 +211,22 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
     verify(handler).registerConnection(connection);
   }
 
+  @Test
+  public void testInterfaceDefaultMethods() throws Exception {
+    AdaptrisConnection connection = new DefaultMethodConnection();
+
+    // Default implementation is no-op and does not retain the handler.
+    connection.setConnectionStateHandler(new ConnectionStateHandlerImp() {
+    });
+    assertNull(connection.getConnectionStateHandler());
+    assertNull(connection.connectionStateHandler());
+
+    // Default runtime component setting is FALSE and setter is no-op.
+    assertEquals(Boolean.FALSE, connection.getRuntimeComponent());
+    connection.setRuntimeComponent(Boolean.TRUE);
+    assertEquals(Boolean.FALSE, connection.getRuntimeComponent());
+  }
+
   private void assertState(List list, ComponentState state) {
     for (Object c : list) {
       assertEquals(state, ((StateManagedComponent) c).retrieveComponentState(), "" + state);
@@ -250,6 +266,94 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
       throw new Exception(methodName + " not found");
     }
     return;
+  }
+
+  private static class DefaultMethodConnection implements AdaptrisConnection {
+
+    @Override
+    public java.util.Set<StateManagedComponent> retrieveExceptionListeners() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public void addExceptionListener(StateManagedComponent comp) {
+    }
+
+    @Override
+    public void addMessageProducer(AdaptrisMessageProducer producer) throws CoreException {
+    }
+
+    @Override
+    public java.util.Set<AdaptrisMessageProducer> retrieveMessageProducers() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public void addMessageConsumer(AdaptrisMessageConsumer consumer) throws CoreException {
+    }
+
+    @Override
+    public java.util.Set<AdaptrisMessageConsumer> retrieveMessageConsumers() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public void setConnectionErrorHandler(ConnectionErrorHandler handler) {
+    }
+
+    @Override
+    public ConnectionErrorHandler getConnectionErrorHandler() {
+      return null;
+    }
+
+    @Override
+    public ConnectionErrorHandler connectionErrorHandler() {
+      return null;
+    }
+
+    @Override
+    public <T> T retrieveConnection(Class<T> type) {
+      return null;
+    }
+
+    @Override
+    public AdaptrisConnection cloneForTesting() throws CoreException {
+      return this;
+    }
+
+    @Override
+    public String getUniqueId() {
+      return "default-method-connection";
+    }
+
+    @Override
+    public ComponentState retrieveComponentState() {
+      return ClosedState.getInstance();
+    }
+
+    @Override
+    public void changeState(ComponentState newState) {
+    }
+
+    @Override
+    public void requestInit() throws CoreException {
+    }
+
+    @Override
+    public void requestStart() throws CoreException {
+    }
+
+    @Override
+    public void requestStop() {
+    }
+
+    @Override
+    public void requestClose() {
+    }
+
+    @Override
+    public void prepare() throws CoreException {
+    }
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
@@ -188,6 +188,15 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
     assertEquals(MockConnection.class, mc.cloneForTesting().getClass());
   }
 
+  @Test
+  public void testConnectionStateHandler() throws Exception {
+    MockConnection mc = new MockConnection();
+    assertNull(mc.getConnectionStateHandler());
+    ConnectionStateHandler csh = new ConnectionStateHandlerImp(){};
+    mc.setConnectionStateHandler(csh);
+    assertEquals(csh, mc.getConnectionStateHandler());
+  }
+
   private void assertState(List list, ComponentState state) {
     for (Object c : list) {
       assertEquals(state, ((StateManagedComponent) c).retrieveComponentState(), "" + state);

--- a/interlok-core/src/test/java/com/adaptris/core/ConnectionStateHandlerImpTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConnectionStateHandlerImpTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.adaptris.core.stubs.MockConnection;
 
-public class ConnectionStateHandlerImpTest {
+class ConnectionStateHandlerImpTest {
 
   /**
    * Concrete test implementation of abstract ConnectionStateHandlerImp.
@@ -33,7 +33,7 @@ public class ConnectionStateHandlerImpTest {
   }
 
   @Test
-  public void testRegisterConnection() throws Exception {
+  void testRegisterConnection() {
     ConnectionStateHandler handler = new TestConnectionStateHandler();
     MockConnection connection = new MockConnection();
 
@@ -43,7 +43,7 @@ public class ConnectionStateHandlerImpTest {
   }
 
   @Test
-  public void testRegisterConnectionNull() throws Exception {
+  void testRegisterConnectionNull() {
     ConnectionStateHandler handler = new TestConnectionStateHandler();
 
     assertThrows(IllegalArgumentException.class, () -> handler.registerConnection(null),
@@ -51,7 +51,7 @@ public class ConnectionStateHandlerImpTest {
   }
 
   @Test
-  public void testRetrieveConnectionBeforeRegistration() throws Exception {
+  void testRetrieveConnectionBeforeRegistration() {
     ConnectionStateHandler handler = new TestConnectionStateHandler();
 
     assertNull(handler.retrieveConnection(AdaptrisConnection.class),
@@ -59,7 +59,7 @@ public class ConnectionStateHandlerImpTest {
   }
 
   @Test
-  public void testRetrieveConnectionWithCasting() throws Exception {
+  void testRetrieveConnectionWithCasting() {
     ConnectionStateHandler handler = new TestConnectionStateHandler();
     MockConnection connection = new MockConnection();
     handler.registerConnection(connection);
@@ -71,7 +71,7 @@ public class ConnectionStateHandlerImpTest {
   }
 
   @Test
-  public void testRegisterConnectionMultipleTimes() throws Exception {
+  void testRegisterConnectionMultipleTimes() {
     ConnectionStateHandler handler = new TestConnectionStateHandler();
     MockConnection connection1 = new MockConnection();
     MockConnection connection2 = new MockConnection();

--- a/interlok-core/src/test/java/com/adaptris/core/ConnectionStateHandlerImpTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConnectionStateHandlerImpTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.adaptris.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.stubs.MockConnection;
+
+public class ConnectionStateHandlerImpTest {
+
+  /**
+   * Concrete test implementation of abstract ConnectionStateHandlerImp.
+   */
+  private static class TestConnectionStateHandler extends ConnectionStateHandlerImp {
+  }
+
+  @Test
+  public void testRegisterConnection() throws Exception {
+    ConnectionStateHandler handler = new TestConnectionStateHandler();
+    MockConnection connection = new MockConnection();
+
+    handler.registerConnection(connection);
+
+    assertEquals(connection, handler.retrieveConnection(AdaptrisConnection.class));
+  }
+
+  @Test
+  public void testRegisterConnectionNull() throws Exception {
+    ConnectionStateHandler handler = new TestConnectionStateHandler();
+
+    assertThrows(IllegalArgumentException.class, () -> handler.registerConnection(null),
+        "registerConnection() should reject null connection");
+  }
+
+  @Test
+  public void testRetrieveConnectionBeforeRegistration() throws Exception {
+    ConnectionStateHandler handler = new TestConnectionStateHandler();
+
+    assertNull(handler.retrieveConnection(AdaptrisConnection.class),
+        "retrieveConnection() should return null before registerConnection() is called");
+  }
+
+  @Test
+  public void testRetrieveConnectionWithCasting() throws Exception {
+    ConnectionStateHandler handler = new TestConnectionStateHandler();
+    MockConnection connection = new MockConnection();
+    handler.registerConnection(connection);
+
+    MockConnection retrieved = handler.retrieveConnection(MockConnection.class);
+
+    assertEquals(connection, retrieved);
+    assertEquals(MockConnection.class, retrieved.getClass());
+  }
+
+  @Test
+  public void testRegisterConnectionMultipleTimes() throws Exception {
+    ConnectionStateHandler handler = new TestConnectionStateHandler();
+    MockConnection connection1 = new MockConnection();
+    MockConnection connection2 = new MockConnection();
+
+    handler.registerConnection(connection1);
+    assertEquals(connection1, handler.retrieveConnection(AdaptrisConnection.class));
+
+    // Subsequent registration overwrites the previous one
+    handler.registerConnection(connection2);
+    assertEquals(connection2, handler.retrieveConnection(AdaptrisConnection.class));
+  }
+
+}

--- a/interlok-core/src/test/java/com/adaptris/core/SharedConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/SharedConnectionTest.java
@@ -170,6 +170,48 @@ public class SharedConnectionTest {
   }
 
   @Test
+  public void testConnectionStateHandler() throws Exception {
+    Adapter a = createAndStart();
+    NullConnection nc = (NullConnection) a.getSharedComponents().getConnections().get(0);
+    SharedConnection c = new SharedConnection(nc.getUniqueId());
+    try {
+      LifecycleHelper.initAndStart(c);
+      ConnectionStateHandler csh = new ConnectionStateHandlerImp() {
+      };
+
+      c.setConnectionStateHandler(csh);
+      assertEquals(csh, c.getConnectionStateHandler());
+      assertEquals(csh, nc.getConnectionStateHandler());
+      assertEquals(csh, c.connectionStateHandler());
+    }
+    finally {
+      LifecycleHelper.stopAndClose(a);
+      LifecycleHelper.stopAndClose(c);
+    }
+  }
+
+  @Test
+  public void testRuntimeComponentDelegation() throws Exception {
+    Adapter a = createAndStart();
+    NullConnection nc = (NullConnection) a.getSharedComponents().getConnections().get(0);
+    SharedConnection c = new SharedConnection(nc.getUniqueId());
+    try {
+      LifecycleHelper.initAndStart(c);
+      c.setRuntimeComponent(Boolean.TRUE);
+      assertEquals(Boolean.TRUE, c.getRuntimeComponent());
+      assertEquals(Boolean.TRUE, nc.getRuntimeComponent());
+
+      c.setRuntimeComponent(Boolean.FALSE);
+      assertEquals(Boolean.FALSE, c.getRuntimeComponent());
+      assertEquals(Boolean.FALSE, nc.getRuntimeComponent());
+    }
+    finally {
+      LifecycleHelper.stopAndClose(a);
+      LifecycleHelper.stopAndClose(c);
+    }
+  }
+
+  @Test
   public void testConnection() throws Exception {
     Adapter a = createAndStart();
     NullConnection nc = (NullConnection) a.getSharedComponents().getConnections().get(0);

--- a/interlok-core/src/test/java/com/adaptris/core/SharedConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/SharedConnectionTest.java
@@ -170,7 +170,7 @@ public class SharedConnectionTest {
   }
 
   @Test
-  public void testConnectionStateHandler() throws Exception {
+  void testConnectionStateHandler() throws Exception {
     Adapter a = createAndStart();
     NullConnection nc = (NullConnection) a.getSharedComponents().getConnections().get(0);
     SharedConnection c = new SharedConnection(nc.getUniqueId());
@@ -191,7 +191,7 @@ public class SharedConnectionTest {
   }
 
   @Test
-  public void testRuntimeComponentDelegation() throws Exception {
+  void testRuntimeComponentDelegation() throws Exception {
     Adapter a = createAndStart();
     NullConnection nc = (NullConnection) a.getSharedComponents().getConnections().get(0);
     SharedConnection c = new SharedConnection(nc.getUniqueId());

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterManagerTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -916,6 +917,68 @@ public class AdapterManagerTest extends ComponentManagerCase {
     assertFalse(adapterManager.removeChildJmxComponent(child2));
     // Just the componentChecker left.
     assertEquals(1, adapterManager.getChildRuntimeInfoComponents().size());
+  }
+
+  @Test
+  public void testRuntimeInfoFactory_CreateConnectionMonitor() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager parent = new AdapterManager(adapter);
+    NullConnection connection = new NullConnection(getName());
+    connection.setRuntimeComponent(Boolean.TRUE);
+
+    RuntimeInfoComponent result = RuntimeInfoComponentFactory.create(parent, connection);
+
+    assertNotNull(result);
+    assertTrue(result instanceof ConnectionMonitor);
+  }
+
+  @Test
+  public void testRuntimeInfoFactory_NoConnectionMonitor_WhenRuntimeComponentNotTrue() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager parent = new AdapterManager(adapter);
+    NullConnection connection = new NullConnection(getName());
+
+    RuntimeInfoComponent result = RuntimeInfoComponentFactory.create(parent, connection);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void testRuntimeInfoFactory_NoConnectionMonitor_WhenUniqueIdMissing() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager parent = new AdapterManager(adapter);
+    NullConnection connection = new NullConnection();
+    connection.setRuntimeComponent(Boolean.TRUE);
+
+    RuntimeInfoComponent result = RuntimeInfoComponentFactory.create(parent, connection);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void testRuntimeInfoFactory_NoConnectionMonitor_ForSharedConnection() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager parent = new AdapterManager(adapter);
+    SharedConnection shared = new SharedConnection(getName());
+
+    RuntimeInfoComponent result = RuntimeInfoComponentFactory.create(parent, shared);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void testRuntimeInfoFactory_NoConnectionMonitor_WhenParentUnsupported() throws Exception {
+    NullConnection connection = new NullConnection(getName());
+    connection.setRuntimeComponent(Boolean.TRUE);
+    StubChannelManager unsupportedParent = new StubChannelManager();
+
+    RuntimeInfoComponent result = RuntimeInfoComponentFactory.create(unsupportedParent, connection);
+
+    assertNull(result);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterManagerTest.java
@@ -920,7 +920,7 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testRuntimeInfoFactory_CreateConnectionMonitor() throws Exception {
+  void testRuntimeInfoFactory_CreateConnectionMonitor() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager parent = new AdapterManager(adapter);
@@ -934,7 +934,7 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testRuntimeInfoFactory_NoConnectionMonitor_WhenRuntimeComponentNotTrue() throws Exception {
+  void testRuntimeInfoFactory_NoConnectionMonitor_WhenRuntimeComponentNotTrue() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager parent = new AdapterManager(adapter);
@@ -946,7 +946,7 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testRuntimeInfoFactory_NoConnectionMonitor_WhenUniqueIdMissing() throws Exception {
+  void testRuntimeInfoFactory_NoConnectionMonitor_WhenUniqueIdMissing() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager parent = new AdapterManager(adapter);
@@ -959,7 +959,7 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testRuntimeInfoFactory_NoConnectionMonitor_ForSharedConnection() throws Exception {
+  void testRuntimeInfoFactory_NoConnectionMonitor_ForSharedConnection() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager parent = new AdapterManager(adapter);
@@ -971,7 +971,7 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testRuntimeInfoFactory_NoConnectionMonitor_WhenParentUnsupported() throws Exception {
+  void testRuntimeInfoFactory_NoConnectionMonitor_WhenParentUnsupported() throws Exception {
     NullConnection connection = new NullConnection(getName());
     connection.setRuntimeComponent(Boolean.TRUE);
     StubChannelManager unsupportedParent = new StubChannelManager();
@@ -1441,7 +1441,7 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testAddSharedConnectionMonitor_ConnectionMonitor_NotJmxRegistered() throws Exception {
+  void testAddSharedConnectionMonitor_ConnectionMonitor_NotJmxRegistered() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager adapterManager = new AdapterManager(adapter);
@@ -1454,7 +1454,7 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testAddSharedConnectionMonitor_ConnectionMonitor_JmxRegistered() throws Exception {
+  void testAddSharedConnectionMonitor_ConnectionMonitor_JmxRegistered() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager adapterManager = new AdapterManager(adapter);
@@ -1463,18 +1463,15 @@ public class AdapterManagerTest extends ComponentManagerCase {
     List<BaseComponentMBean> mBeans = new ArrayList<BaseComponentMBean>();
     mBeans.add(adapterManager);
     mBeans.addAll(adapterManager.getAllDescendants());
-    try {
-      register(mBeans);
-      // Adapter IS JMX-registered, so isJmxRegistered() returns true and info.registerMBean() is called
-      boolean result = adapterManager.addSharedConnectionMonitor(connection);
-      assertTrue(result);
-    }
-    finally {
-    }
+
+    register(mBeans);
+    // Adapter IS JMX-registered, so isJmxRegistered() returns true and info.registerMBean() is called
+    boolean result = adapterManager.addSharedConnectionMonitor(connection);
+    assertTrue(result);
   }
 
   @Test
-  public void testMBean_RemoveSharedConnection_WithConnectionMonitor() throws Exception {
+  void testMBean_RemoveSharedConnection_WithConnectionMonitor() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     NullConnection connection = new NullConnection(getName());
@@ -1498,7 +1495,7 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testMBean_RemoveSharedConnection_ConnectionMonitorIdMismatch() throws Exception {
+  void testMBean_RemoveSharedConnection_ConnectionMonitorIdMismatch() throws Exception {
     // Covers the false branch of: cmb instanceof ConnectionMonitor cm && id.equals(cm.connectionId())
     // A ConnectionMonitor exists for "conn-A" but we remove "conn-B" — IDs don't match, returns null
     String adapterName = this.getClass().getSimpleName() + "." + getName();
@@ -1512,23 +1509,21 @@ public class AdapterManagerTest extends ComponentManagerCase {
     AdapterManager adapterManager = new AdapterManager(adapter);
     ObjectName adapterObj = adapterManager.createObjectName();
     AdaptrisMarshaller m = DefaultMarshaller.getDefaultMarshaller();
-    try {
-      adapterManager.registerMBean();
-      // Add a ConnectionMonitor only for connA
-      adapterManager.addSharedConnectionMonitor(connA);
-      AdapterManagerMBean amp = JMX.newMBeanProxy(mBeanServer, adapterObj, AdapterManagerMBean.class);
-      // Remove connB: findSharedConnectionMonitor iterates, finds connA's monitor but IDs differ → returns null
-      assertTrue(amp.removeSharedConnection(getName() + "_B"));
-      Adapter marshalledAdapter = (Adapter) m.unmarshal(amp.getConfiguration());
-      assertEquals(1, marshalledAdapter.getSharedComponents().getConnections().size());
-      assertEquals(getName() + "_A", marshalledAdapter.getSharedComponents().getConnections().get(0).getUniqueId());
-    }
-    finally {
-    }
+
+    adapterManager.registerMBean();
+    // Add a ConnectionMonitor only for connA
+    adapterManager.addSharedConnectionMonitor(connA);
+    AdapterManagerMBean amp = JMX.newMBeanProxy(mBeanServer, adapterObj, AdapterManagerMBean.class);
+    // Remove connB: findSharedConnectionMonitor iterates, finds connA's monitor but IDs differ → returns null
+    assertTrue(amp.removeSharedConnection(getName() + "_B"));
+    Adapter marshalledAdapter = (Adapter) m.unmarshal(amp.getConfiguration());
+    assertEquals(1, marshalledAdapter.getSharedComponents().getConnections().size());
+    assertEquals(getName() + "_A", marshalledAdapter.getSharedComponents().getConnections().get(0).getUniqueId());
+
   }
 
   @Test
-  public void testMBean_AddChannel() throws Exception {
+  void testMBean_AddChannel() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager adapterManager = new AdapterManager(adapter);
@@ -1537,23 +1532,21 @@ public class AdapterManagerTest extends ComponentManagerCase {
     List<BaseComponentMBean> mBeans = new ArrayList<BaseComponentMBean>();
     mBeans.add(adapterManager);
     mBeans.addAll(adapterManager.getAllDescendants());
-    try {
-      register(mBeans);
-      AdapterManagerMBean adapterManagerProxy = JMX.newMBeanProxy(mBeanServer, adapterObj, AdapterManagerMBean.class);
-      ObjectName channelObj = adapterManagerProxy.addChannel(DefaultMarshaller.getDefaultMarshaller().marshal(newChannel));
-      assertNotNull(channelObj);
-      ChannelManagerMBean channelManagerProxy = JMX.newMBeanProxy(mBeanServer, channelObj, ChannelManagerMBean.class);
-      assertEquals(ClosedState.getInstance(), channelManagerProxy.getComponentState());
-      Adapter marshalledAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(
-          adapterManagerProxy.getConfiguration());
-      assertEquals(1, marshalledAdapter.getChannelList().size());
-    }
-    finally {
-    }
+
+    register(mBeans);
+    AdapterManagerMBean adapterManagerProxy = JMX.newMBeanProxy(mBeanServer, adapterObj, AdapterManagerMBean.class);
+    ObjectName channelObj = adapterManagerProxy.addChannel(DefaultMarshaller.getDefaultMarshaller().marshal(newChannel));
+    assertNotNull(channelObj);
+    ChannelManagerMBean channelManagerProxy = JMX.newMBeanProxy(mBeanServer, channelObj, ChannelManagerMBean.class);
+    assertEquals(ClosedState.getInstance(), channelManagerProxy.getComponentState());
+    Adapter marshalledAdapter = (Adapter) DefaultMarshaller.getDefaultMarshaller().unmarshal(
+        adapterManagerProxy.getConfiguration());
+    assertEquals(1, marshalledAdapter.getChannelList().size());
+
   }
 
   @Test
-  public void testMBean_AddChannel_WhileStarted() throws Exception {
+  void testMBean_AddChannel_WhileStarted() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager adapterManager = new AdapterManager(adapter);

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/AdapterManagerTest.java
@@ -1441,6 +1441,93 @@ public class AdapterManagerTest extends ComponentManagerCase {
   }
 
   @Test
+  public void testAddSharedConnectionMonitor_ConnectionMonitor_NotJmxRegistered() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager adapterManager = new AdapterManager(adapter);
+    NullConnection connection = new NullConnection(getName());
+    connection.setRuntimeComponent(Boolean.TRUE);
+    // Adapter is NOT JMX-registered, so isJmxRegistered() returns false
+    // but the ConnectionMonitor is still added to childRuntimeInfoComponents
+    boolean result = adapterManager.addSharedConnectionMonitor(connection);
+    assertTrue(result);
+  }
+
+  @Test
+  public void testAddSharedConnectionMonitor_ConnectionMonitor_JmxRegistered() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager adapterManager = new AdapterManager(adapter);
+    NullConnection connection = new NullConnection(getName());
+    connection.setRuntimeComponent(Boolean.TRUE);
+    List<BaseComponentMBean> mBeans = new ArrayList<BaseComponentMBean>();
+    mBeans.add(adapterManager);
+    mBeans.addAll(adapterManager.getAllDescendants());
+    try {
+      register(mBeans);
+      // Adapter IS JMX-registered, so isJmxRegistered() returns true and info.registerMBean() is called
+      boolean result = adapterManager.addSharedConnectionMonitor(connection);
+      assertTrue(result);
+    }
+    finally {
+    }
+  }
+
+  @Test
+  public void testMBean_RemoveSharedConnection_WithConnectionMonitor() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    NullConnection connection = new NullConnection(getName());
+    connection.setRuntimeComponent(Boolean.TRUE);
+    adapter.getSharedComponents().addConnection(connection);
+    AdapterManager adapterManager = new AdapterManager(adapter);
+    ObjectName adapterObj = adapterManager.createObjectName();
+    AdaptrisMarshaller m = DefaultMarshaller.getDefaultMarshaller();
+    try {
+      adapterManager.registerMBean();
+      // Add a ConnectionMonitor to childRuntimeInfoComponents for this connection
+      adapterManager.addSharedConnectionMonitor(connection);
+      AdapterManagerMBean amp = JMX.newMBeanProxy(mBeanServer, adapterObj, AdapterManagerMBean.class);
+      // removeSharedConnection calls findSharedConnectionMonitor, which should find and return the monitor
+      assertTrue(amp.removeSharedConnection(getName()));
+      Adapter marshalledAdapter = (Adapter) m.unmarshal(amp.getConfiguration());
+      assertEquals(0, marshalledAdapter.getSharedComponents().getConnections().size());
+    }
+    finally {
+    }
+  }
+
+  @Test
+  public void testMBean_RemoveSharedConnection_ConnectionMonitorIdMismatch() throws Exception {
+    // Covers the false branch of: cmb instanceof ConnectionMonitor cm && id.equals(cm.connectionId())
+    // A ConnectionMonitor exists for "conn-A" but we remove "conn-B" — IDs don't match, returns null
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    NullConnection connA = new NullConnection(getName() + "_A");
+    connA.setRuntimeComponent(Boolean.TRUE);
+    NullConnection connB = new NullConnection(getName() + "_B");
+    // connB has no RuntimeComponent flag, so no ConnectionMonitor will be created for it
+    adapter.getSharedComponents().addConnection(connA);
+    adapter.getSharedComponents().addConnection(connB);
+    AdapterManager adapterManager = new AdapterManager(adapter);
+    ObjectName adapterObj = adapterManager.createObjectName();
+    AdaptrisMarshaller m = DefaultMarshaller.getDefaultMarshaller();
+    try {
+      adapterManager.registerMBean();
+      // Add a ConnectionMonitor only for connA
+      adapterManager.addSharedConnectionMonitor(connA);
+      AdapterManagerMBean amp = JMX.newMBeanProxy(mBeanServer, adapterObj, AdapterManagerMBean.class);
+      // Remove connB: findSharedConnectionMonitor iterates, finds connA's monitor but IDs differ → returns null
+      assertTrue(amp.removeSharedConnection(getName() + "_B"));
+      Adapter marshalledAdapter = (Adapter) m.unmarshal(amp.getConfiguration());
+      assertEquals(1, marshalledAdapter.getSharedComponents().getConnections().size());
+      assertEquals(getName() + "_A", marshalledAdapter.getSharedComponents().getConnections().get(0).getUniqueId());
+    }
+    finally {
+    }
+  }
+
+  @Test
   public void testMBean_AddChannel() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
@@ -623,7 +623,7 @@ public class ChannelManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testChannelManager_ConnectionMonitorSuffixes() throws Exception {
+  void testChannelManager_ConnectionMonitorSuffixes() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
 
     Adapter adapter = createAdapter(adapterName);

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
@@ -52,6 +52,7 @@ import com.adaptris.core.ComponentState;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMarshaller;
 import com.adaptris.core.InitialisedState;
+import com.adaptris.core.NullConnection;
 import com.adaptris.core.PoolingWorkflow;
 import com.adaptris.core.RetryMessageErrorHandler;
 import com.adaptris.core.RetryMessageErrorHandlerMonitorMBean;
@@ -619,6 +620,31 @@ public class ChannelManagerTest extends ComponentManagerCase {
     finally {
       adapter.requestClose();
     }
+  }
+
+  @Test
+  public void testChannelManager_ConnectionMonitorSuffixes() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager adapterManager = new AdapterManager(adapter);
+    Channel channel = createChannel(getName() + "_withConnectionSuffix");
+
+    NullConnection consumeConnection = new NullConnection(getName() + "-consume");
+    consumeConnection.setRuntimeComponent(Boolean.TRUE);
+    channel.setConsumeConnection(consumeConnection);
+
+    NullConnection produceConnection = new NullConnection(getName() + "-produce");
+    produceConnection.setRuntimeComponent(Boolean.TRUE);
+    channel.setProduceConnection(produceConnection);
+
+    ChannelManager channelManager = new ChannelManager(channel, adapterManager);
+    Collection<ObjectName> children = channelManager.getChildRuntimeInfoComponents();
+
+    assertTrue(children.stream().anyMatch(
+        o -> o.toString().contains(consumeConnection.getUniqueId() + "-consume-connection")));
+    assertTrue(children.stream().anyMatch(
+        o -> o.toString().contains(produceConnection.getUniqueId() + "-produce-connection")));
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
@@ -1805,29 +1805,3 @@ public class ChannelManagerTest extends ComponentManagerCase {
     }
   }
 }
-
-    ChannelChild(ChannelManager wm) {
-      myParent = wm;
-    }
-
-    @Override
-    public ObjectName getParentObjectName() throws MalformedObjectNameException {
-      return myParent.createObjectName();
-    }
-
-    @Override
-    public String getParentId() {
-      return myParent.getUniqueId();
-    }
-
-    @Override
-    public ObjectName createObjectName() throws MalformedObjectNameException {
-      return ObjectName.getInstance("Dummy:type=" + uid);
-    }
-
-    @Override
-    public RuntimeInfoComponent getParentRuntimeInfoComponent() {
-      return myParent;
-    }
-  }
-}

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/ChannelManagerTest.java
@@ -1805,3 +1805,29 @@ public class ChannelManagerTest extends ComponentManagerCase {
     }
   }
 }
+
+    ChannelChild(ChannelManager wm) {
+      myParent = wm;
+    }
+
+    @Override
+    public ObjectName getParentObjectName() throws MalformedObjectNameException {
+      return myParent.createObjectName();
+    }
+
+    @Override
+    public String getParentId() {
+      return myParent.getUniqueId();
+    }
+
+    @Override
+    public ObjectName createObjectName() throws MalformedObjectNameException {
+      return ObjectName.getInstance("Dummy:type=" + uid);
+    }
+
+    @Override
+    public RuntimeInfoComponent getParentRuntimeInfoComponent() {
+      return myParent;
+    }
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/ConnectionMonitorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/ConnectionMonitorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Adaptris Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adaptris.core.runtime;
+
+import static com.adaptris.core.runtime.AdapterComponentMBean.JMX_CONNECTION_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.StartedState;
+import com.adaptris.core.stubs.MockConnection;
+
+public class ConnectionMonitorTest {
+
+  @Test
+  public void testType() {
+    RuntimeInfoComponent parent = new RuntimeInfoComponent() {
+    };
+    MockConnection connection = new MockConnection("conn-1");
+    ConnectionMonitor monitor = new ConnectionMonitor(parent, connection);
+
+    assertEquals(JMX_CONNECTION_TYPE, monitor.getType());
+  }
+
+  @Test
+  public void testUniqueIdAndSuffix() {
+    RuntimeInfoComponent parent = new RuntimeInfoComponent() {
+    };
+    MockConnection connection = new MockConnection("conn-1");
+    ConnectionMonitor monitor = new ConnectionMonitor(parent, connection);
+
+    assertEquals("conn-1", monitor.uniqueId());
+    assertEquals("conn-1", monitor.connectionId());
+    assertEquals("conn-1", monitor.getUniqueId());
+
+    monitor.appendObjectNameSuffix("-suffix");
+
+    assertEquals("conn-1-suffix", monitor.uniqueId());
+    assertEquals("conn-1", monitor.connectionId());
+    assertEquals("conn-1", monitor.getUniqueId());
+  }
+
+  @Test
+  public void testParentAndState() {
+    RuntimeInfoComponent parent = new RuntimeInfoComponent() {
+    };
+    MockConnection connection = new MockConnection("conn-1");
+    connection.changeState(StartedState.getInstance());
+    ConnectionMonitor monitor = new ConnectionMonitor(parent, connection);
+
+    assertSame(parent, monitor.getParentRuntimeInfoComponent());
+    assertSame(StartedState.getInstance(), monitor.getComponentState());
+  }
+}

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/ConnectionMonitorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/ConnectionMonitorTest.java
@@ -20,17 +20,20 @@ import static com.adaptris.core.runtime.AdapterComponentMBean.JMX_CONNECTION_TYP
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import org.junit.jupiter.api.Test;
-
+import com.adaptris.core.Adapter;
+import com.adaptris.core.Channel;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.StandardWorkflow;
 import com.adaptris.core.StartedState;
 import com.adaptris.core.stubs.MockConnection;
+import javax.management.MalformedObjectNameException;
+import org.junit.jupiter.api.Test;
 
 public class ConnectionMonitorTest {
 
   @Test
-  public void testType() {
-    RuntimeInfoComponent parent = new RuntimeInfoComponent() {
-    };
+  public void testType() throws MalformedObjectNameException, CoreException {
+    ParentRuntimeInfoComponent parent = new AdapterManager(createAdapter("adapter-1"));
     MockConnection connection = new MockConnection("conn-1");
     ConnectionMonitor monitor = new ConnectionMonitor(parent, connection);
 
@@ -38,9 +41,10 @@ public class ConnectionMonitorTest {
   }
 
   @Test
-  public void testUniqueIdAndSuffix() {
-    RuntimeInfoComponent parent = new RuntimeInfoComponent() {
-    };
+  public void testUniqueIdAndSuffix() throws MalformedObjectNameException, CoreException {
+    ParentRuntimeInfoComponent parent =
+        new ChannelManager(
+            createChannel("channel-1"), new AdapterManager(createAdapter("adapter-1")));
     MockConnection connection = new MockConnection("conn-1");
     ConnectionMonitor monitor = new ConnectionMonitor(parent, connection);
 
@@ -56,14 +60,35 @@ public class ConnectionMonitorTest {
   }
 
   @Test
-  public void testParentAndState() {
-    RuntimeInfoComponent parent = new RuntimeInfoComponent() {
-    };
+  public void testParentAndState() throws MalformedObjectNameException, CoreException {
+    ParentRuntimeInfoComponent parent =
+        new WorkflowManager(
+            createWorkflow("workflow-1"),
+            new ChannelManager(
+                createChannel("channel-1"), new AdapterManager(createAdapter("adapter-1"))));
     MockConnection connection = new MockConnection("conn-1");
     connection.changeState(StartedState.getInstance());
     ConnectionMonitor monitor = new ConnectionMonitor(parent, connection);
 
     assertSame(parent, monitor.getParentRuntimeInfoComponent());
     assertSame(StartedState.getInstance(), monitor.getComponentState());
+  }
+
+  protected Adapter createAdapter(String uid) {
+    Adapter adapter = new Adapter();
+    adapter.setUniqueId(uid);
+    return adapter;
+  }
+
+  protected Channel createChannel(String uid) {
+    Channel c = new Channel();
+    c.setUniqueId(uid);
+    return c;
+  }
+
+  protected StandardWorkflow createWorkflow(String uid) {
+    StandardWorkflow wf = new StandardWorkflow();
+    wf.setUniqueId(uid);
+    return wf;
   }
 }

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/ConnectionMonitorTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/ConnectionMonitorTest.java
@@ -29,10 +29,10 @@ import com.adaptris.core.stubs.MockConnection;
 import javax.management.MalformedObjectNameException;
 import org.junit.jupiter.api.Test;
 
-public class ConnectionMonitorTest {
+class ConnectionMonitorTest {
 
   @Test
-  public void testType() throws MalformedObjectNameException, CoreException {
+  void testType() throws MalformedObjectNameException, CoreException {
     ParentRuntimeInfoComponent parent = new AdapterManager(createAdapter("adapter-1"));
     MockConnection connection = new MockConnection("conn-1");
     ConnectionMonitor monitor = new ConnectionMonitor(parent, connection);
@@ -41,7 +41,7 @@ public class ConnectionMonitorTest {
   }
 
   @Test
-  public void testUniqueIdAndSuffix() throws MalformedObjectNameException, CoreException {
+  void testUniqueIdAndSuffix() throws MalformedObjectNameException, CoreException {
     ParentRuntimeInfoComponent parent =
         new ChannelManager(
             createChannel("channel-1"), new AdapterManager(createAdapter("adapter-1")));
@@ -60,7 +60,7 @@ public class ConnectionMonitorTest {
   }
 
   @Test
-  public void testParentAndState() throws MalformedObjectNameException, CoreException {
+  void testParentAndState() throws MalformedObjectNameException, CoreException {
     ParentRuntimeInfoComponent parent =
         new WorkflowManager(
             createWorkflow("workflow-1"),

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/WorkflowManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/WorkflowManagerTest.java
@@ -22,22 +22,11 @@ import static com.adaptris.core.runtime.AdapterComponentMBean.NOTIF_MSG_INITIALI
 import static com.adaptris.core.runtime.AdapterComponentMBean.NOTIF_MSG_STARTED;
 import static com.adaptris.core.runtime.AdapterComponentMBean.NOTIF_MSG_STOPPED;
 import static com.adaptris.core.runtime.AdapterComponentMBean.NOTIF_TYPE_WORKFLOW_LIFECYCLE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.JMX;
@@ -213,7 +202,7 @@ public class WorkflowManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testConstructor_WithConnectedServiceConnection_SuffixApplied() throws Exception {
+  void testConstructor_WithConnectedServiceConnection_SuffixApplied() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager adapterManager = new AdapterManager(adapter);
@@ -234,7 +223,7 @@ public class WorkflowManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testConstructor_WithConnectedServiceInsideWrapper_SuffixApplied() throws Exception {
+  void testConstructor_WithConnectedServiceInsideWrapper_SuffixApplied() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager adapterManager = new AdapterManager(adapter);
@@ -257,7 +246,7 @@ public class WorkflowManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testWorkflowConnectedServiceEqualityAndHashCode() throws Exception {
+  void testWorkflowConnectedServiceEqualityAndHashCode() throws Exception {
     Class<?> connectedServiceClass = Class.forName("com.adaptris.core.runtime.WorkflowManager$WorkflowConnectedService");
     var ctor = connectedServiceClass.getDeclaredConstructor(com.adaptris.core.AdaptrisConnection.class, String.class);
     ctor.setAccessible(true);
@@ -267,15 +256,14 @@ public class WorkflowManagerTest extends ComponentManagerCase {
     Object b = ctor.newInstance(c1, "svc-1");
     Object c = ctor.newInstance(c1, "svc-2");
 
-    assertTrue(a.equals(a));
-    assertFalse(a.equals("not-a-workflow-connected-service"));
-    assertTrue(a.equals(b));
-    assertFalse(a.equals(c));
+    assertNotEquals("not-a-workflow-connected-service", a);
+    assertEquals(a, b);
+    assertNotEquals(a, c);
     assertEquals(a.hashCode(), b.hashCode());
   }
   
   @Test
-  public void testServiceConnections_WhenWorkflowIsNotWorkflowImp_ReturnsEmpty() throws Exception {
+  void testServiceConnections_WhenWorkflowIsNotWorkflowImp_ReturnsEmpty() throws Exception {
     Method serviceConnections = WorkflowManager.class.getDeclaredMethod("serviceConnections", Workflow.class);
     serviceConnections.setAccessible(true);
 
@@ -283,12 +271,12 @@ public class WorkflowManagerTest extends ComponentManagerCase {
     Object result = serviceConnections.invoke(null, notWorkflowImp);
 
     assertNotNull(result);
-    assertTrue(result instanceof java.util.Collection);
+    assertInstanceOf(Collection.class, result);
     assertEquals(0, ((java.util.Collection<?>) result).size());
   }
 
   @Test
-  public void testCollectConnections_WhenServiceNull_DoesNothing() throws Exception {
+  void testCollectConnections_WhenServiceNull_DoesNothing() throws Exception {
     Method collectConnections = WorkflowManager.class.getDeclaredMethod("collectConnections", com.adaptris.core.Service.class,
         Set.class);
     collectConnections.setAccessible(true);
@@ -303,7 +291,7 @@ public class WorkflowManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testCollectConnections_WhenConnectedServiceHasNullConnection_DoesNotAdd() throws Exception {
+  void testCollectConnections_WhenConnectedServiceHasNullConnection_DoesNotAdd() throws Exception {
     Method collectConnections = WorkflowManager.class.getDeclaredMethod("collectConnections", com.adaptris.core.Service.class,
         Set.class);
     collectConnections.setAccessible(true);
@@ -317,7 +305,7 @@ public class WorkflowManagerTest extends ComponentManagerCase {
   }
 
   @Test
-  public void testWithConnectedServiceSuffix_NonConnectionMonitor_Unchanged() throws Exception {
+  void testWithConnectedServiceSuffix_NonConnectionMonitor_Unchanged() throws Exception {
     String adapterName = this.getClass().getSimpleName() + "." + getName();
     Adapter adapter = createAdapter(adapterName);
     AdapterManager adapterManager = new AdapterManager(adapter);
@@ -333,7 +321,7 @@ public class WorkflowManagerTest extends ComponentManagerCase {
 
     Object result = withConnectedServiceSuffix.invoke(workflowManager, child, "svc-id");
 
-    assertTrue(result == child);
+    assertSame(result, child);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/WorkflowManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/WorkflowManagerTest.java
@@ -24,14 +24,19 @@ import static com.adaptris.core.runtime.AdapterComponentMBean.NOTIF_MSG_STOPPED;
 import static com.adaptris.core.runtime.AdapterComponentMBean.NOTIF_TYPE_WORKFLOW_LIFECYCLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.management.InstanceAlreadyExistsException;
@@ -49,10 +54,12 @@ import com.adaptris.core.ClosedState;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.InitialisedState;
 import com.adaptris.core.MetadataElement;
+import com.adaptris.core.NullConnection;
 import com.adaptris.core.PoolingWorkflow;
 import com.adaptris.core.RetryMessageErrorHandler;
 import com.adaptris.core.RetryMessageErrorHandlerMonitorMBean;
 import com.adaptris.core.SerializableAdaptrisMessage;
+import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.StandardWorkflow;
 import com.adaptris.core.StartedState;
 import com.adaptris.core.StoppedState;
@@ -64,6 +71,7 @@ import com.adaptris.core.interceptor.InFlightWorkflowInterceptor;
 import com.adaptris.core.interceptor.MessageMetricsInterceptor;
 import com.adaptris.core.interceptor.ThrottlingInterceptor;
 import com.adaptris.core.services.metadata.AddMetadataService;
+import com.adaptris.core.services.StatelessServiceWrapper;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.stubs.StubSerializableMessage;
 import com.adaptris.interlok.management.MessageProcessor;
@@ -202,6 +210,130 @@ public class WorkflowManagerTest extends ComponentManagerCase {
     workflow.getInterceptors().add(new ThrottlingInterceptor());
     WorkflowManager workflowManager = new WorkflowManager(workflow, channelManager);
     assertEquals(0, workflowManager.getChildRuntimeInfoComponents().size());
+  }
+
+  @Test
+  public void testConstructor_WithConnectedServiceConnection_SuffixApplied() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager adapterManager = new AdapterManager(adapter);
+    Channel channel = createChannel("c1");
+    ChannelManager channelManager = new ChannelManager(channel, adapterManager);
+
+    StandardWorkflow workflow = createWorkflow("w1");
+    NullConnection serviceConnection = new NullConnection(getName() + "-conn");
+    serviceConnection.setRuntimeComponent(Boolean.TRUE);
+    StandaloneProducer connectedService = new StandaloneProducer(serviceConnection, new MockMessageProducer());
+    connectedService.setUniqueId(getName() + "-service");
+    workflow.getServiceCollection().add(connectedService);
+
+    WorkflowManager workflowManager = new WorkflowManager(workflow, channelManager);
+
+    String expectedSuffix = serviceConnection.getUniqueId() + "-connected-service-" + connectedService.getUniqueId();
+    assertTrue(workflowManager.getChildRuntimeInfoComponents().stream().anyMatch(o -> o.toString().contains(expectedSuffix)));
+  }
+
+  @Test
+  public void testConstructor_WithConnectedServiceInsideWrapper_SuffixApplied() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager adapterManager = new AdapterManager(adapter);
+    Channel channel = createChannel("c1");
+    ChannelManager channelManager = new ChannelManager(channel, adapterManager);
+
+    StandardWorkflow workflow = createWorkflow("w1");
+    NullConnection serviceConnection = new NullConnection(getName() + "-wrapped-conn");
+    serviceConnection.setRuntimeComponent(Boolean.TRUE);
+    StandaloneProducer nestedConnectedService = new StandaloneProducer(serviceConnection, new MockMessageProducer());
+    nestedConnectedService.setUniqueId(getName() + "-nested-service");
+    StatelessServiceWrapper wrapper = new StatelessServiceWrapper(nestedConnectedService);
+    wrapper.setUniqueId(getName() + "-wrapper");
+    workflow.getServiceCollection().add(wrapper);
+
+    WorkflowManager workflowManager = new WorkflowManager(workflow, channelManager);
+
+    String expectedSuffix = serviceConnection.getUniqueId() + "-connected-service-" + nestedConnectedService.getUniqueId();
+    assertTrue(workflowManager.getChildRuntimeInfoComponents().stream().anyMatch(o -> o.toString().contains(expectedSuffix)));
+  }
+
+  @Test
+  public void testWorkflowConnectedServiceEqualityAndHashCode() throws Exception {
+    Class<?> connectedServiceClass = Class.forName("com.adaptris.core.runtime.WorkflowManager$WorkflowConnectedService");
+    var ctor = connectedServiceClass.getDeclaredConstructor(com.adaptris.core.AdaptrisConnection.class, String.class);
+    ctor.setAccessible(true);
+
+    NullConnection c1 = new NullConnection("c1");
+    Object a = ctor.newInstance(c1, "svc-1");
+    Object b = ctor.newInstance(c1, "svc-1");
+    Object c = ctor.newInstance(c1, "svc-2");
+
+    assertTrue(a.equals(a));
+    assertFalse(a.equals("not-a-workflow-connected-service"));
+    assertTrue(a.equals(b));
+    assertFalse(a.equals(c));
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+  
+  @Test
+  public void testServiceConnections_WhenWorkflowIsNotWorkflowImp_ReturnsEmpty() throws Exception {
+    Method serviceConnections = WorkflowManager.class.getDeclaredMethod("serviceConnections", Workflow.class);
+    serviceConnections.setAccessible(true);
+
+    Workflow notWorkflowImp = mock(Workflow.class);
+    Object result = serviceConnections.invoke(null, notWorkflowImp);
+
+    assertNotNull(result);
+    assertTrue(result instanceof java.util.Collection);
+    assertEquals(0, ((java.util.Collection<?>) result).size());
+  }
+
+  @Test
+  public void testCollectConnections_WhenServiceNull_DoesNothing() throws Exception {
+    Method collectConnections = WorkflowManager.class.getDeclaredMethod("collectConnections", com.adaptris.core.Service.class,
+        Set.class);
+    collectConnections.setAccessible(true);
+
+    Set<Object> connections = new HashSet<>();
+    connections.add(new Object());
+    int before = connections.size();
+
+    collectConnections.invoke(null, null, connections);
+
+    assertEquals(before, connections.size());
+  }
+
+  @Test
+  public void testCollectConnections_WhenConnectedServiceHasNullConnection_DoesNotAdd() throws Exception {
+    Method collectConnections = WorkflowManager.class.getDeclaredMethod("collectConnections", com.adaptris.core.Service.class,
+        Set.class);
+    collectConnections.setAccessible(true);
+
+    com.adaptris.core.ConnectedService connectedService = mock(com.adaptris.core.ConnectedService.class);
+    Set<Object> connections = new HashSet<>();
+
+    collectConnections.invoke(null, connectedService, connections);
+
+    assertEquals(0, connections.size());
+  }
+
+  @Test
+  public void testWithConnectedServiceSuffix_NonConnectionMonitor_Unchanged() throws Exception {
+    String adapterName = this.getClass().getSimpleName() + "." + getName();
+    Adapter adapter = createAdapter(adapterName);
+    AdapterManager adapterManager = new AdapterManager(adapter);
+    Channel channel = createChannel("c1");
+    ChannelManager channelManager = new ChannelManager(channel, adapterManager);
+    Workflow workflow = createWorkflow("w1");
+    WorkflowManager workflowManager = new WorkflowManager(workflow, channelManager);
+    WorkflowChild child = new WorkflowChild(workflowManager);
+
+    Method withConnectedServiceSuffix = WorkflowManager.class.getDeclaredMethod("withConnectedServiceSuffix",
+        ChildRuntimeInfoComponent.class, String.class);
+    withConnectedServiceSuffix.setAccessible(true);
+
+    Object result = withConnectedServiceSuffix.invoke(workflowManager, child, "svc-id");
+
+    assertTrue(result == child);
   }
 
   @Test

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/WorkflowManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/WorkflowManagerTest.java
@@ -256,7 +256,8 @@ public class WorkflowManagerTest extends ComponentManagerCase {
     Object b = ctor.newInstance(c1, "svc-1");
     Object c = ctor.newInstance(c1, "svc-2");
 
-    assertNotEquals("not-a-workflow-connected-service", a);
+    assertEquals(a, a);
+    assertNotEquals(a, "not-a-workflow-connected-service");
     assertEquals(a, b);
     assertNotEquals(a, c);
     assertEquals(a.hashCode(), b.hashCode());

--- a/interlok-core/src/test/java/com/adaptris/core/runtime/WorkflowManagerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/runtime/WorkflowManagerTest.java
@@ -257,7 +257,7 @@ public class WorkflowManagerTest extends ComponentManagerCase {
     Object c = ctor.newInstance(c1, "svc-2");
 
     assertEquals(a, a);
-    assertNotEquals(a, "not-a-workflow-connected-service");
+    assertNotEquals("not-a-workflow-connected-service", a);
     assertEquals(a, b);
     assertNotEquals(a, c);
     assertEquals(a.hashCode(), b.hashCode());


### PR DESCRIPTION
## Motivation

Add runtime connection state monitoring via JMX to the Interlok framework. Currently, you can only monitor whether adapters, channels, and workflows are started/stopped — but connections (JMS brokers, databases, etc.) were invisible at the JMX layer. If a connection goes down, the only signal is the ConnectionErrorHandler firing; there was no way to query "is my JMS connection up?" through the standard health-check infrastructure.

This PR makes connections runtime observable components, so external tools like the REST health-check endpoint (see https://github.com/adaptris/interlok-workflow-rest-services/pull/988 ) can detect connection state.

## Modification

What did I change

- Connections opt in to be registered as runtime components (JMX Mbeans) with `runtimeComponent=true`
  - Registers adapter shared connections  
  - Registers channel consume and produce connections with a suffix in the object name, as these can have duplicate unique IDs
  - Registers workflow `ConnectedService` (standalone producer) with a suffix as these can have duplicate unique IDs
  - Registers deeply nested `ConnectedService` connections (ServiceList within ServiceList within ServiceList (and so on) with Standalone Producer)
- Connections have a new `ConnectionStateHandler` extension point for reacting to connection lifecycle transitions. This allows JMS Solace connections to consume Solace connection `reconnect events` and update the state of the connection. See https://github.com/adaptris/interlok-solace/pull/529

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

New connection JMX Mbean objects which can be interrogated for connection state to determine adapter health

## Testing

### Interlok Config

<details>

```xml
<adapter>
  <unique-id>test-adapter</unique-id>
  <start-up-event-imp>com.adaptris.core.event.StandardAdapterStartUpEvent</start-up-event-imp>
  <heartbeat-event-imp>com.adaptris.core.HeartbeatEvent</heartbeat-event-imp>
  <shared-components>
    <connections>
      <jetty-embedded-connection>
        <unique-id>embedded-jetty-connection</unique-id>
      </jetty-embedded-connection>
      <jms-connection>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </jms-connection>
      <jms-connection>
        <connection-state-handler class="solace-connection-state-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection-2</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </jms-connection>
      <jms-connection>
        <connection-state-handler class="solace-connection-state-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection 2</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </jms-connection>
      <jms-connection>
        <connection-state-handler class="solace-connection-state-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection 3</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </jms-connection>
    </connections>
    <services>
      <standalone-producer>
        <unique-id>solace-jms 3</unique-id>
        <connection class="jms-connection">
          <connection-state-handler class="solace-connection-state-handler"/>
          <runtime-component>true</runtime-component>
          <unique-id>solace-jms-connection-3</unique-id>
          <connection-attempts>-1</connection-attempts>
          <user-name>default</user-name>
          <password>admin</password>
          <client-id>local_client</client-id>
          <vendor-implementation class="advanced-solace-implementation">
            <broker-url>tcp://localhost:55555</broker-url>
            <message-vpn>default</message-vpn>
            <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
            <delivery-mode>PERSISTENT</delivery-mode>
            <solace-keepalive>
              <keep-alives>true</keep-alives>
              <keep-alive-count-max>5</keep-alive-count-max>
              <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
            </solace-keepalive>
            <solace-connection-tuning>
              <connect-retries>-1</connect-retries>
              <reconnect-retries>-1</reconnect-retries>
            </solace-connection-tuning>
            <properties/>
          </vendor-implementation>
        </connection>
        <producer class="null-message-producer">
          <unique-id>affectionate-shirley</unique-id>
        </producer>
      </standalone-producer>
      <standalone-producer>
        <unique-id>solace-jms 4</unique-id>
        <connection class="jms-connection">
          <connection-state-handler class="solace-connection-state-handler"/>
          <runtime-component>true</runtime-component>
          <unique-id>solace-jms-connection-3</unique-id>
          <connection-attempts>-1</connection-attempts>
          <user-name>default</user-name>
          <password>admin</password>
          <client-id>local_client</client-id>
          <vendor-implementation class="advanced-solace-implementation">
            <broker-url>tcp://localhost:55555</broker-url>
            <message-vpn>default</message-vpn>
            <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
            <delivery-mode>PERSISTENT</delivery-mode>
            <solace-keepalive>
              <keep-alives>true</keep-alives>
              <keep-alive-count-max>5</keep-alive-count-max>
              <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
            </solace-keepalive>
            <solace-connection-tuning>
              <connect-retries>-1</connect-retries>
              <reconnect-retries>-1</reconnect-retries>
            </solace-connection-tuning>
            <properties/>
          </vendor-implementation>
        </connection>
        <producer class="null-message-producer">
          <unique-id>affectionate-shirley</unique-id>
        </producer>
      </standalone-producer>
    </services>
  </shared-components>
  <event-handler class="configurable-event-handler">
    <unique-id>ConfigurableEventHandler</unique-id>
    <connection class="null-connection">
      <unique-id>default-null-connection</unique-id>
    </connection>
    <producer class="null-message-producer">
      <unique-id>default-null-message-producer</unique-id>
    </producer>
    <rule>
      <matcher class="regex-event-matcher">
        <regex>com\.adaptris\.core\.MessageLifecycleEvent</regex>
        <match-type>TYPE</match-type>
      </matcher>
      <standalone-producer>
        <unique-id>match-MessageLifecycleEvent</unique-id>
        <connection class="shared-connection">
          <lookup-name>solace-jms-connection</lookup-name>
        </connection>
        <producer class="jms-producer">
          <unique-id>produce-MessageLifecycleEvent</unique-id>
          <acknowledge-mode>CLIENT_ACKNOWLEDGE</acknowledge-mode>
          <message-translator class="text-message-translator">
            <metadata-filter class="remove-all-metadata-filter"/>
          </message-translator>
          <delivery-mode>PERSISTENT</delivery-mode>
          <session-factory class="jms-default-producer-session"/>
          <refresh-session-if-produce-exception>false</refresh-session-if-produce-exception>
          <endpoint>mle/topic</endpoint>
        </producer>
      </standalone-producer>
    </rule>
    <rule>
      <matcher class="regex-event-matcher">
        <regex>com\.adaptris\.core\.HeartbeatEvent</regex>
        <match-type>TYPE</match-type>
      </matcher>
      <standalone-producer>
        <unique-id>match-HeartbeatEvent</unique-id>
        <connection class="shared-connection">
          <lookup-name>solace-jms-connection</lookup-name>
        </connection>
        <producer class="jms-producer">
          <unique-id>produce-HeartbeatEvent</unique-id>
          <acknowledge-mode>CLIENT_ACKNOWLEDGE</acknowledge-mode>
          <message-translator class="text-message-translator">
            <metadata-filter class="remove-all-metadata-filter"/>
          </message-translator>
          <delivery-mode>PERSISTENT</delivery-mode>
          <session-factory class="jms-default-producer-session"/>
          <refresh-session-if-produce-exception>false</refresh-session-if-produce-exception>
          <endpoint>ale/topic</endpoint>
        </producer>
      </standalone-producer>
    </rule>
  </event-handler>
  <heartbeat-event-interval>
    <unit>MINUTES</unit>
    <interval>15</interval>
  </heartbeat-event-interval>
  <message-error-handler class="null-processing-exception-handler">
    <unique-id>null-processing-exception-handle</unique-id>
  </message-error-handler>
  <failed-message-retrier class="no-retries">
    <unique-id>no-retries</unique-id>
  </failed-message-retrier>
  <channel-list>
    <channel>
      <consume-connection class="shared-connection">
        <lookup-name>embedded-jetty-connection</lookup-name>
      </consume-connection>
      <produce-connection class="null-connection">
        <unique-id>ecstatic-lumiere</unique-id>
      </produce-connection>
      <workflow-list>
        <standard-workflow>
          <consumer class="jetty-message-consumer">
            <unique-id>send-message-to-destination</unique-id>
            <path>/send-to-jms-destination</path>
            <methods>POST</methods>
            <parameter-handler class="jetty-http-parameters-as-metadata">
              <parameter-prefix>param_</parameter-prefix>
            </parameter-handler>
            <header-handler class="jetty-http-headers-as-object-metadata"/>
          </consumer>
          <service-collection class="service-list">
            <unique-id>sharp-kowalevski</unique-id>
            <services>
              <if-then-otherwise>
                <unique-id>if-jmsDestination-is-empty-return-bad-request</unique-id>
                <condition class="metadata">
                  <operator class="is-empty"/>
                  <metadata-key>param_jmsDestination</metadata-key>
                </condition>
                <then>
                  <service class="service-list">
                    <unique-id>jmsDestination-is-empty</unique-id>
                    <services>
                      <payload-from-template>
                        <unique-id>set-error-message</unique-id>
                        <metadata-tokens/>
                        <template>{"errorDescription":"jmsDestination parameter cannot be empty"}</template>
                      </payload-from-template>
                      <jetty-response-service>
                        <unique-id>return-400-bad-request</unique-id>
                        <http-status>400</http-status>
                        <content-type>application/json</content-type>
                        <response-header-provider class="jetty-no-response-headers"/>
                      </jetty-response-service>
                      <stop-processing-service>
                        <unique-id>stop-processing</unique-id>
                      </stop-processing-service>
                    </services>
                  </service>
                </then>
                <otherwise>
                  <service class="null-service">
                    <unique-id>jmsDestination-not-empty-do-nothing</unique-id>
                  </service>
                </otherwise>
              </if-then-otherwise>
              <metadata-filter-service>
                <unique-id>remove-metadata</unique-id>
                <filter class="regex-metadata-filter">
                  <include-pattern>param_jmsDestination</include-pattern>
                </filter>
              </metadata-filter-service>
              <clone-message-service-list>
                <unique-id>get-metadata-from-payload</unique-id>
                <services>
                  <service-list>
                    <unique-id>get-and-set-metadata</unique-id>
                    <services>
                      <json-path-service>
                        <unique-id>get-metadata</unique-id>
                        <json-path-execution>
                          <source class="constant-data-input-parameter">
                            <value>$.metadata</value>
                          </source>
                          <target class="string-payload-data-output-parameter"/>
                        </json-path-execution>
                        <source class="string-payload-data-input-parameter"/>
                      </json-path-service>
                      <json-to-metadata>
                        <unique-id>set-metadata</unique-id>
                      </json-to-metadata>
                    </services>
                  </service-list>
                </services>
                <override-metadata-filter class="regex-metadata-filter">
                  <include-pattern>^.*$</include-pattern>
                </override-metadata-filter>
                <new-unique-id-per-message>false</new-unique-id-per-message>
              </clone-message-service-list>
              <json-path-service>
                <unique-id>get-payload</unique-id>
                <json-path-execution>
                  <source class="constant-data-input-parameter">
                    <value>$.payload</value>
                  </source>
                  <target class="string-payload-data-output-parameter"/>
                </json-path-execution>
                <source class="string-payload-data-input-parameter"/>
              </json-path-service>
              <if-then-otherwise>
                <unique-id>set-message-unique-id-if-present</unique-id>
                <condition class="metadata">
                  <operator class="not-empty"/>
                  <metadata-key>messageuniqueid</metadata-key>
                </condition>
                <then>
                  <service class="service-list">
                    <unique-id>set-unique-id</unique-id>
                    <services>
                      <if-then-otherwise>
                        <unique-id>if-unique-id-contains-spaces-return-bad-request</unique-id>
                        <condition class="function">
                          <definition>function evaluateScript(message) {
  return /\s/g.test(message.getMetadataValue("messageuniqueid"));
}</definition>
                        </condition>
                        <then>
                          <service class="service-list">
                            <unique-id>unqiue-id-contains-whitespace</unique-id>
                            <services>
                              <payload-from-template>
                                <unique-id>set-error-message</unique-id>
                                <metadata-tokens/>
                                <template>{"errorDescription":"$.metadata.messageuniqueid cannot contain any whitespace"}</template>
                              </payload-from-template>
                              <jetty-response-service>
                                <unique-id>return-400-bad-request</unique-id>
                                <http-status>400</http-status>
                                <content-type>application/json</content-type>
                                <response-header-provider class="jetty-no-response-headers"/>
                              </jetty-response-service>
                              <stop-processing-service>
                                <unique-id>stop-processing</unique-id>
                              </stop-processing-service>
                            </services>
                          </service>
                        </then>
                        <otherwise>
                          <service class="null-service">
                            <unique-id>unqiue-id-does-not-contains-whitespace-do-nothing</unique-id>
                          </service>
                        </otherwise>
                      </if-then-otherwise>
                      <embedded-scripting-service>
                        <unique-id>set-unique-id</unique-id>
                        <language>javascript</language>
                        <script>message.setUniqueId(message.getMetadataValue("messageuniqueid"));</script>
                      </embedded-scripting-service>
                      <metadata-filter-service>
                        <unique-id>remove-unique-id-metadata</unique-id>
                        <filter class="regex-metadata-filter">
                          <exclude-pattern>^messageuniqueid$</exclude-pattern>
                        </filter>
                      </metadata-filter-service>
                    </services>
                  </service>
                </then>
                <otherwise>
                  <service class="service-list">
                    <unique-id>do-nothing</unique-id>
                    <services/>
                  </service>
                </otherwise>
              </if-then-otherwise>
              <add-metadata-service>
                <unique-id>add-destination-metadata</unique-id>
                <metadata-element>
                  <key>produceDestination</key>
                  <value>%message{param_jmsDestination}</value>
                </metadata-element>
              </add-metadata-service>
              <standalone-producer>
                <unique-id>send-to-destination</unique-id>
                <connection class="shared-connection">
                  <lookup-name>solace-jms-connection</lookup-name>
                </connection>
                <producer class="jms-producer">
                  <unique-id>produce-to-destination</unique-id>
                  <acknowledge-mode>CLIENT_ACKNOWLEDGE</acknowledge-mode>
                  <message-translator class="text-message-translator"/>
                  <delivery-mode>PERSISTENT</delivery-mode>
                  <session-factory class="jms-default-producer-session"/>
                  <refresh-session-if-produce-exception>false</refresh-session-if-produce-exception>
                  <endpoint>%message{produceDestination}</endpoint>
                </producer>
              </standalone-producer>
            </services>
          </service-collection>
          <producer class="null-message-producer">
            <unique-id>tiny-borg</unique-id>
          </producer>
          <send-events>false</send-events>
          <unique-id>send-message-to-destination</unique-id>
          <message-metrics-interceptor>
            <unique-id>send-message-to-destination-MessageMetrics</unique-id>
            <timeslice-duration>
              <unit>MINUTES</unit>
              <interval>5</interval>
            </timeslice-duration>
            <timeslice-history-count>12</timeslice-history-count>
          </message-metrics-interceptor>
          <in-flight-workflow-interceptor>
            <unique-id>send-message-to-destination-InFlight</unique-id>
          </in-flight-workflow-interceptor>
        </standard-workflow>
      </workflow-list>
      <message-error-handler class="null-processing-exception-handler">
        <unique-id>null-exception-handler</unique-id>
      </message-error-handler>
      <unique-id>test-inbound</unique-id>
    </channel>
    <channel>
      <consume-connection class="jms-connection">
        <connection-error-handler class="jms-connection-error-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection-2</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </consume-connection>
      <produce-connection class="jms-connection">
        <connection-error-handler class="null-connection-error-handler"/>
        <runtime-component>true</runtime-component>
        <unique-id>solace-jms-connection-2</unique-id>
        <connection-attempts>-1</connection-attempts>
        <user-name>default</user-name>
        <password>admin</password>
        <client-id>local_client</client-id>
        <vendor-implementation class="advanced-solace-implementation">
          <broker-url>tcp://localhost:55555</broker-url>
          <message-vpn>default</message-vpn>
          <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
          <delivery-mode>PERSISTENT</delivery-mode>
          <solace-keepalive>
            <keep-alives>true</keep-alives>
            <keep-alive-count-max>5</keep-alive-count-max>
            <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
          </solace-keepalive>
          <solace-connection-tuning>
            <connect-retries>-1</connect-retries>
            <reconnect-retries>-1</reconnect-retries>
          </solace-connection-tuning>
          <properties/>
        </vendor-implementation>
      </produce-connection>
      <workflow-list>
        <standard-workflow>
          <consumer class="null-message-consumer">
            <unique-id>awesome-golick</unique-id>
          </consumer>
          <service-collection class="service-list">
            <unique-id>boring-hoover</unique-id>
            <services>
              <service-list>
                <unique-id>solace-jms-2</unique-id>
                <services/>
              </service-list>
              <null-service>
                <unique-id>solace-jms-2 2</unique-id>
              </null-service>
              <standalone-producer>
                <unique-id>solace-jms</unique-id>
                <connection class="jms-connection">
                  <connection-state-handler class="solace-connection-state-handler"/>
                  <runtime-component>true</runtime-component>
                  <unique-id>solace-jms-connection-2</unique-id>
                  <connection-attempts>-1</connection-attempts>
                  <user-name>default</user-name>
                  <password>admin</password>
                  <client-id>local_client</client-id>
                  <vendor-implementation class="advanced-solace-implementation">
                    <broker-url>tcp://localhost:55555</broker-url>
                    <message-vpn>default</message-vpn>
                    <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
                    <delivery-mode>PERSISTENT</delivery-mode>
                    <solace-keepalive>
                      <keep-alives>true</keep-alives>
                      <keep-alive-count-max>5</keep-alive-count-max>
                      <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
                    </solace-keepalive>
                    <solace-connection-tuning>
                      <connect-retries>-1</connect-retries>
                      <reconnect-retries>-1</reconnect-retries>
                    </solace-connection-tuning>
                    <properties/>
                  </vendor-implementation>
                </connection>
                <producer class="null-message-producer">
                  <unique-id>affectionate-shirley</unique-id>
                </producer>
              </standalone-producer>
              <standalone-producer>
                <unique-id>solace-jms 2</unique-id>
                <connection class="jms-connection">
                  <connection-state-handler class="solace-connection-state-handler"/>
                  <runtime-component>true</runtime-component>
                  <unique-id>solace-jms-connection-2</unique-id>
                  <connection-attempts>-1</connection-attempts>
                  <user-name>default</user-name>
                  <password>admin</password>
                  <client-id>local_client</client-id>
                  <vendor-implementation class="advanced-solace-implementation">
                    <broker-url>tcp://localhost:55555</broker-url>
                    <message-vpn>default</message-vpn>
                    <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
                    <delivery-mode>PERSISTENT</delivery-mode>
                    <solace-keepalive>
                      <keep-alives>true</keep-alives>
                      <keep-alive-count-max>5</keep-alive-count-max>
                      <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
                    </solace-keepalive>
                    <solace-connection-tuning>
                      <connect-retries>-1</connect-retries>
                      <reconnect-retries>-1</reconnect-retries>
                    </solace-connection-tuning>
                    <properties/>
                  </vendor-implementation>
                </connection>
                <producer class="null-message-producer">
                  <unique-id>affectionate-shirley</unique-id>
                </producer>
              </standalone-producer>
              <standalone-producer>
                <unique-id>solace-jms 3</unique-id>
                <connection class="jms-connection">
                  <connection-state-handler class="solace-connection-state-handler"/>
                  <runtime-component>true</runtime-component>
                  <unique-id>solace-jms-connection-3</unique-id>
                  <connection-attempts>-1</connection-attempts>
                  <user-name>default</user-name>
                  <password>admin</password>
                  <client-id>local_client</client-id>
                  <vendor-implementation class="advanced-solace-implementation">
                    <broker-url>tcp://localhost:55555</broker-url>
                    <message-vpn>default</message-vpn>
                    <authentication-scheme>AUTHENTICATION_SCHEME_BASIC</authentication-scheme>
                    <delivery-mode>PERSISTENT</delivery-mode>
                    <solace-keepalive>
                      <keep-alives>true</keep-alives>
                      <keep-alive-count-max>5</keep-alive-count-max>
                      <keep-alive-interval-in-millis>1000</keep-alive-interval-in-millis>
                    </solace-keepalive>
                    <solace-connection-tuning>
                      <connect-retries>-1</connect-retries>
                      <reconnect-retries>-1</reconnect-retries>
                    </solace-connection-tuning>
                    <properties/>
                  </vendor-implementation>
                </connection>
                <producer class="null-message-producer">
                  <unique-id>affectionate-shirley</unique-id>
                </producer>
              </standalone-producer>
            </services>
          </service-collection>
          <producer class="null-message-producer">
            <unique-id>elegant-bell</unique-id>
          </producer>
          <unique-id>test-channel-2-workflow-1</unique-id>
          <message-metrics-interceptor>
            <unique-id>trusting-mcclintock-MessageMetrics</unique-id>
            <timeslice-duration>
              <unit>MINUTES</unit>
              <interval>5</interval>
            </timeslice-duration>
            <timeslice-history-count>12</timeslice-history-count>
          </message-metrics-interceptor>
          <in-flight-workflow-interceptor>
            <unique-id>trusting-mcclintock-InFlight</unique-id>
          </in-flight-workflow-interceptor>
        </standard-workflow>
      </workflow-list>
      <unique-id>test-channel-2</unique-id>
    </channel>
  </channel-list>
  <message-error-digester class="standard-message-error-digester">
    <unique-id>standard-message-error-digester</unique-id>
    <digest-max-size>100</digest-max-size>
  </message-error-digester>
</adapter>
```

</details>

### Solace Container

<details>

```yaml
services:
  solace:
    image: solace/solace-pubsub-standard:latest
    container_name: solace
    volumes:
      - "storage-group:/var/lib/solace"
    shm_size: 1g
    ulimits:
      core: -1
      nofile:
        soft: 1048576
        hard: 1048576
    deploy:
      restart_policy:
        condition: on-failure
        max_attempts: 1
    ports:
      - '8080:8080'
      - '55555:55555'
      - '8008:8008'
      - '9001:9000'
    environment:
      - username_admin_globalaccesslevel=admin
      - username_admin_password=admin
      - system_scaling_maxconnectioncount=100
    healthcheck:
      test: [ "CMD", "curl", "-f", "http://localhost:8080" ]
volumes:
  storage-group:
```

</details>

- Run Solace Container `docker compose up -d`
- Run Interlok with above config
- Use JConsole (or other tools) to see new JMX Mbeans