### PR TITLE
ConfigurableEventHandler - Fix State management

### DIFF
--- a/interlok-core/src/main/java/com/adaptris/core/ConfigurableEventHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfigurableEventHandler.java
@@ -93,9 +93,8 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   @Override
   protected void eventHandlerInit() throws CoreException {
     super.eventHandlerInit();
-    for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null)
-          LifecycleHelper.init(rule.getStandaloneProducer());
+    for (Rule rule : rules) {
+      if (rule.getStandaloneProducer() != null) LifecycleHelper.init(rule.getStandaloneProducer());
     }
   }
 
@@ -103,9 +102,8 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   @Override
   protected void eventHandlerStart() throws CoreException {
     super.eventHandlerStart();
-    for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null)
-          LifecycleHelper.start(rule.getStandaloneProducer());
+    for (Rule rule : rules) {
+      if (rule.getStandaloneProducer() != null) LifecycleHelper.start(rule.getStandaloneProducer());
     }
   }
 
@@ -113,9 +111,8 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   @Override
   protected void eventHandlerStop() {
     super.eventHandlerStop();
-    for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null)
-          LifecycleHelper.stop(rule.getStandaloneProducer());
+    for (Rule rule : rules) {
+      if (rule.getStandaloneProducer() != null) LifecycleHelper.stop(rule.getStandaloneProducer());
     }
   }
 
@@ -123,21 +120,19 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   @Override
   protected void eventHandlerClose() {
     super.eventHandlerClose();
-    for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null)
-          LifecycleHelper.close(rule.getStandaloneProducer());
+    for (Rule rule : rules) {
+      if (rule.getStandaloneProducer() != null) LifecycleHelper.close(rule.getStandaloneProducer());
     }
   }
 
   @Override
   public void prepare() throws CoreException {
     super.prepare();
-    for(Rule rule : rules) {
+    for (Rule rule : rules) {
       if (rule.getStandaloneProducer() != null)
         LifecycleHelper.prepare(rule.getStandaloneProducer());
     }
   }
-
 
   @AllArgsConstructor
   @AdapterComponent

--- a/interlok-core/src/main/java/com/adaptris/core/ConfigurableEventHandler.java
+++ b/interlok-core/src/main/java/com/adaptris/core/ConfigurableEventHandler.java
@@ -19,6 +19,7 @@ package com.adaptris.core;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import lombok.AllArgsConstructor;
@@ -93,7 +94,8 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   protected void eventHandlerInit() throws CoreException {
     super.eventHandlerInit();
     for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null) rule.getStandaloneProducer().init();
+      if (rule.getStandaloneProducer() != null)
+          LifecycleHelper.init(rule.getStandaloneProducer());
     }
   }
 
@@ -102,7 +104,8 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   protected void eventHandlerStart() throws CoreException {
     super.eventHandlerStart();
     for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null) rule.getStandaloneProducer().start();
+      if (rule.getStandaloneProducer() != null)
+          LifecycleHelper.start(rule.getStandaloneProducer());
     }
   }
 
@@ -111,7 +114,8 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   protected void eventHandlerStop() {
     super.eventHandlerStop();
     for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null) rule.getStandaloneProducer().stop();
+      if (rule.getStandaloneProducer() != null)
+          LifecycleHelper.stop(rule.getStandaloneProducer());
     }
   }
 
@@ -120,7 +124,8 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   protected void eventHandlerClose() {
     super.eventHandlerClose();
     for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null) rule.getStandaloneProducer().close();
+      if (rule.getStandaloneProducer() != null)
+          LifecycleHelper.close(rule.getStandaloneProducer());
     }
   }
 
@@ -128,7 +133,8 @@ public class ConfigurableEventHandler extends DefaultEventHandler {
   public void prepare() throws CoreException {
     super.prepare();
     for(Rule rule : rules) {
-      if (rule.getStandaloneProducer() != null) rule.getStandaloneProducer().prepare();
+      if (rule.getStandaloneProducer() != null)
+        LifecycleHelper.prepare(rule.getStandaloneProducer());
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/ConfigurableEventHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConfigurableEventHandlerTest.java
@@ -270,7 +270,7 @@ public class ConfigurableEventHandlerTest
 
   @Test
   public void testComponentStates() throws Exception {
-    ConfigurableEventHandler evh = applyConfiguration(newEventHandler("testResolveEventSender"));
+    ConfigurableEventHandler evh = applyConfiguration(newEventHandler("testComponentStates"));
     evh.getRules().add(new ConfigurableEventHandler.Rule(
             Mockito.mock(EventMatcher.class),
             Mockito.mock(StandaloneProducer.class)
@@ -287,10 +287,10 @@ public class ConfigurableEventHandlerTest
       LifecycleHelper.stop(evh);
       evh.getRules().forEach(rule -> {
         try {
-          Mockito.verify(rule.getStandaloneProducer()).init();
+          Mockito.verify(rule.getStandaloneProducer()).requestInit();
           Mockito.verify(rule.getStandaloneProducer()).prepare();
-          Mockito.verify(rule.getStandaloneProducer()).start();
-          Mockito.verify(rule.getStandaloneProducer()).stop();
+          Mockito.verify(rule.getStandaloneProducer()).requestStart();
+          Mockito.verify(rule.getStandaloneProducer()).requestStop();
         } catch (CoreException e) {
           throw new RuntimeException(e);
         }
@@ -299,8 +299,72 @@ public class ConfigurableEventHandlerTest
     finally {
       LifecycleHelper.close(evh);
       evh.getRules().forEach(rule -> {
-        Mockito.verify(rule.getStandaloneProducer()).close();
+        Mockito.verify(rule.getStandaloneProducer()).requestClose();
       });
+    }
+  }
+
+  @Test
+  void testRuleStandaloneProducerStateTransitions() throws Exception {
+    ConfigurableEventHandler evh = applyConfiguration(newEventHandler("testRuleStandaloneProducerStateTransitions"));
+    StandaloneProducer ruleProducer1 = new StandaloneProducer();
+    StandaloneProducer ruleProducer2 = new StandaloneProducer();
+    evh.getRules().add(new ConfigurableEventHandler.Rule(new NullEventMatcher(), ruleProducer1));
+    evh.getRules().add(new ConfigurableEventHandler.Rule(new NullEventMatcher(), ruleProducer2));
+
+    // Before lifecycle, producers should be in ClosedState
+    assertEquals(ClosedState.getInstance(), ruleProducer1.retrieveComponentState());
+    assertEquals(ClosedState.getInstance(), ruleProducer2.retrieveComponentState());
+
+    try {
+      LifecycleHelper.prepare(evh);
+      LifecycleHelper.init(evh);
+      assertEquals(InitialisedState.getInstance(), ruleProducer1.retrieveComponentState());
+      assertEquals(InitialisedState.getInstance(), ruleProducer2.retrieveComponentState());
+
+      LifecycleHelper.start(evh);
+      assertEquals(StartedState.getInstance(), ruleProducer1.retrieveComponentState());
+      assertEquals(StartedState.getInstance(), ruleProducer2.retrieveComponentState());
+
+      LifecycleHelper.stop(evh);
+      assertEquals(StoppedState.getInstance(), ruleProducer1.retrieveComponentState());
+      assertEquals(StoppedState.getInstance(), ruleProducer2.retrieveComponentState());
+    }
+    finally {
+      LifecycleHelper.close(evh);
+    }
+
+    assertEquals(ClosedState.getInstance(), ruleProducer1.retrieveComponentState());
+    assertEquals(ClosedState.getInstance(), ruleProducer2.retrieveComponentState());
+  }
+
+  @Test
+  void testRuleStandaloneProducersRegisteredAsExceptionListeners() throws Exception {
+    ConfigurableEventHandler evh = applyConfiguration(newEventHandler("testRuleStandaloneProducersRegisteredAsExceptionListeners"));
+    NullConnection sharedConnection = new NullConnection();
+    StandaloneProducer ruleProducer1 = new StandaloneProducer(sharedConnection, new NullMessageProducer());
+    StandaloneProducer ruleProducer2 = new StandaloneProducer(sharedConnection, new NullMessageProducer());
+    evh.getRules().add(new ConfigurableEventHandler.Rule(new NullEventMatcher(), ruleProducer1));
+    evh.getRules().add(new ConfigurableEventHandler.Rule(new NullEventMatcher(), ruleProducer2));
+
+    try {
+      LifecycleHelper.prepare(evh);
+      LifecycleHelper.init(evh);
+      LifecycleHelper.start(evh);
+
+      // Rule producers should be registered as exception listeners on the shared connection
+      Set<StateManagedComponent> listeners = sharedConnection.retrieveExceptionListeners();
+      assertTrue(listeners.contains(ruleProducer1), "Rule producer 1 should be an exception listener");
+      assertTrue(listeners.contains(ruleProducer2), "Rule producer 2 should be an exception listener");
+
+      // They should be in StartedState so that ConnectionErrorHandlerImp.filter() includes them
+      for (StateManagedComponent listener : listeners) {
+        assertEquals(StartedState.getInstance(), listener.retrieveComponentState(),
+            "Listener " + listener.getUniqueId() + " should be in StartedState for error handler recovery");
+      }
+    }
+    finally {
+      LifecycleHelper.close(evh);
     }
   }
 

--- a/interlok-core/src/test/java/com/adaptris/core/ConfigurableEventHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConfigurableEventHandlerTest.java
@@ -368,6 +368,30 @@ public class ConfigurableEventHandlerTest
     }
   }
 
+  @Test
+  void testRuleWithNullStandaloneProducerSkipsLifecycle() throws Exception {
+    ConfigurableEventHandler evh = applyConfiguration(newEventHandler("testRuleWithNullStandaloneProducerSkipsLifecycle"));
+    ConfigurableEventHandler.Rule ruleWithNull = new ConfigurableEventHandler.Rule(new NullEventMatcher(), null);
+    evh.getRules().add(ruleWithNull);
+    // Also add a real rule to ensure the loop continues past the null one
+    StandaloneProducer realProducer = new StandaloneProducer();
+    evh.getRules().add(new ConfigurableEventHandler.Rule(new NullEventMatcher(), realProducer));
+
+    try {
+      LifecycleHelper.prepare(evh);
+      LifecycleHelper.init(evh);
+      LifecycleHelper.start(evh);
+      // Real producer still transitions correctly despite a null sibling
+      assertEquals(StartedState.getInstance(), realProducer.retrieveComponentState());
+      LifecycleHelper.stop(evh);
+      assertEquals(StoppedState.getInstance(), realProducer.retrieveComponentState());
+    }
+    finally {
+      LifecycleHelper.close(evh);
+    }
+    assertEquals(ClosedState.getInstance(), realProducer.retrieveComponentState());
+  }
+
     /**
      * @see ExampleConfigCase#retrieveObjectForSampleConfig()
      */

--- a/interlok-core/src/test/java/com/adaptris/core/ConfigurableEventHandlerTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/ConfigurableEventHandlerTest.java
@@ -281,14 +281,14 @@ public class ConfigurableEventHandlerTest
     ));
 
     try {
-      LifecycleHelper.init(evh);
       LifecycleHelper.prepare(evh);
+      LifecycleHelper.init(evh);
       LifecycleHelper.start(evh);
       LifecycleHelper.stop(evh);
       evh.getRules().forEach(rule -> {
         try {
-          Mockito.verify(rule.getStandaloneProducer()).requestInit();
           Mockito.verify(rule.getStandaloneProducer()).prepare();
+          Mockito.verify(rule.getStandaloneProducer()).requestInit();
           Mockito.verify(rule.getStandaloneProducer()).requestStart();
           Mockito.verify(rule.getStandaloneProducer()).requestStop();
         } catch (CoreException e) {


### PR DESCRIPTION
## Motivation

ConfigurableEventHandler calls init(), start(), stop(), and close() directly on its rule StandaloneProducers instead of using LifecycleHelper, which means the StandaloneProducers' internal serviceState never changes from ClosedState.

This means that the StandaloneProducers, though registered as an exception listener on the connection, won't be restarted on connection errors because the ConnectionErrorHandler filters for components which are in a `started state` (https://github.com/adaptris/interlok/blob/develop/interlok-core/src/main/java/com/adaptris/core/ConnectionErrorHandlerImp.java#L145).

## Modification

Used LifecycleHelper methods to handle state transition which actually updates the state of the component

## PR Checklist

- [x] been self-reviewed.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked the display of the component in the UI

## Result

ConfigurableEventHandler will be restarted when a ConnectionErrorHandler restarts affected components.

## Testing

This can be observed on usage of ConfigurableEventHandler, in conjunction with a Solace connection with a JmsExceptionHandler. When a Solace container is stopped, the ConnectionErrorHandler kicks in, and in the logs you can see components that use the connection are restarted, but not the ConfigurableEventHandler.