### PR TITLE
extending support for HmacMD5 in MetadataHashingService

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -289,15 +289,21 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-    CVE-2025-1948: False positive for Jetty 10.0.24. CVE-2025-1948 only affects Jetty versions 12.0.0 to 12.0.16.
-	CVE-2024-6763: Jetty 10.0.24 is the highest version 10 we can go to.
-	CVE-2025-11143: Remediation requires a major Jetty upgrade from 10.x to 12.x, which is not possible yet.
+    CVE-2025-1948: False positive for Jetty 10.x. CVE-2025-1948 only affects Jetty versions 12.0.0 to 12.0.16.
+	CVE-2024-6763: MEDIUM - URI parsing of invalid authority. Impact is limited to direct use of HttpURI class;
+	  Jetty's internal usage is not vulnerable. We are on Jetty 10.0.26 (10.0.x is EOL); full fix requires Jetty 12.x.
+	CVE-2025-11143: LOW - Differential URI parsing. Patches for 10.0.x are only available via TuxCare/HeroDevs (commercial).
+	  Remediation requires a major Jetty upgrade from 10.x to 12.x, which is not possible yet.
 	CVE-2026-5795: Remediation also requires a Jetty 12.x upgrade, which is currently not viable.
+	CVE-2026-2332: HIGH - HTTP Request Smuggling via Chunked Extension Quoted-String Parsing.
+	  No patch available for Jetty 10.0.x (EOL). Fix requires upgrade to Jetty 12.1.7+, which is not viable yet.
+	  10.0.28 does not build; 10.0.26 is the highest working Jetty 10.x version.
     ]]></notes>
     <cve>CVE-2025-1948</cve>
 	<cve>CVE-2024-6763</cve>
 	<cve>CVE-2025-11143</cve>
 	<cve>CVE-2026-5795</cve>
+	<cve>CVE-2026-2332</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -330,4 +336,38 @@
 	<cve>CVE-2022-41966</cve>
 	<cve>CVE-2021-39140</cve>
   </suppress>   
+  <suppress>
+    <notes><![CDATA[
+    file name: c3p0-0.9.5.5.jar
+    CVE-2026-27830 and CVE-2026-55223 are fixed in c3p0 0.12.0. However, upgrading to 0.12.0
+    requires a code change: the method setUsesTraditionalReflectiveProxies() was removed from
+    ComboPooledDataSource and is called in PooledConnectionProperties.java.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.mchange/c3p0@.*$</packageUrl>
+    <cve>CVE-2026-27830</cve>
+    <cve>CVE-2026-55223</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: mchange-commons-java-0.4.0.jar
+    CVE-2026-55153 is fixed in a newer mchange-commons-java release. However, upgrading
+    mchange-commons-java independently of c3p0 0.9.5.5 risks runtime incompatibility since
+    c3p0 0.9.5.5 was compiled against an older mchange-commons-java API. A safe upgrade of
+    mchange-commons-java also requires upgrading c3p0, which in turn requires code changes
+    (see c3p0 suppression above). Suppressed until the c3p0 upgrade is scheduled.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.mchange/mchange\-commons\-java@.*$</packageUrl>
+    <cve>CVE-2026-55153</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+    file name: xercesImpl-2.12.2.jar
+    CVE-2017-7503 affects xerces:xercesImpl. Version 2.12.2 is the latest release available on
+    Maven Central in the 2.x line; no patched version exists within the same major version.
+    Upgrading to a different XML parser would require code changes to Validator.java and
+    XmlHelper.java which directly reference Xerces-specific classes.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
+    <cve>CVE-2017-7503</cve>
+  </suppress>
 </suppressions>

--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -274,20 +274,18 @@
   <suppress>
     <notes><![CDATA[
       file name: spring-boot-loader-2.7.18.jar
-	  Suppress because we are not impacted as not checking nested jar signature and also there is no 2.x fix verions
+      CVEs flagged against spring-boot-loader 2.7.18 where suggested 2.7.x remediations are not
+      available via Maven Central for this project. We cannot update this component further on
+      Spring Boot 2.x; remediation will be addressed when we move to Spring Boot v3.
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring-boot-loader@.*$</packageUrl>
-    <vulnerabilityName>CVE-2024-38807</vulnerabilityName>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      file name: spring-boot-loader-2.7.18.jar
-      Temporary suppression for CVE-2026-22733. Spring guidance indicates remediation in 2.7.32,
-      but that version is not available in Maven Central yet. Upgrading to Spring Boot 3.x is
-      not currently viable for this project.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring-boot-loader@.*$</packageUrl>
+    <cve>CVE-2024-38807</cve>
     <cve>CVE-2026-22733</cve>
+    <cve>CVE-2026-40972</cve>
+    <cve>CVE-2026-40973</cve>
+    <cve>CVE-2026-40974</cve>
+    <cve>CVE-2026-40975</cve>
+    <cve>CVE-2026-40977</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -3,8 +3,8 @@ import org.apache.tools.ant.taskdefs.condition.Os
 ext {
   componentName="Interlok Core/Base"
   componentDesc="The Core Interlok framework component; this is your must have"
-  activeMqVersion="5.19.6"
-  bouncyCastleVersion="1.80"
+  activeMqVersion="5.19.8"
+  bouncyCastleVersion="1.84"
   mysqlDriverVersion="8.0.33"
   slf4jVersion = "2.0.17"
   mockitoVersion = "4.9.0"

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java
@@ -16,9 +16,11 @@
 
 package com.adaptris.core.services.metadata;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -48,7 +50,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("metadata-hashing-service")
 @AdapterComponent
 @ComponentProfile(summary = "Hash a metadata value, and store it", tag = "service,metadata")
-@DisplayOrder(order = {"metadataKeyRegexp", "hashAlgorithm", "byteTranslator", "metadataLogger"})
+@DisplayOrder(order = {"metadataKeyRegexp", "hashAlgorithm", "hmacKey", "byteTranslator", "metadataLogger"})
 public class MetadataHashingService extends ReformatMetadata {
   private static final String DEFAULT_HASH_ALG = "SHA1";
   @NotBlank
@@ -58,6 +60,7 @@ public class MetadataHashingService extends ReformatMetadata {
   @Valid
   @AutoPopulated
   private ByteTranslator byteTranslator;
+  private String hmacKey;
 
   public MetadataHashingService() {
     super();
@@ -81,7 +84,11 @@ public class MetadataHashingService extends ReformatMetadata {
   @Override
   protected void initService() throws CoreException {
     try {
-      MessageDigest.getInstance(getHashAlgorithm());
+      if (isHmacConfigured()) {
+        Mac.getInstance(getHashAlgorithm());
+      } else {
+        MessageDigest.getInstance(getHashAlgorithm());
+      }
       super.initService();
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
@@ -91,7 +98,14 @@ public class MetadataHashingService extends ReformatMetadata {
 
   @Override
   public String reformat(String s, String charEncoding) throws Exception {
-    return getByteTranslator().translate(MessageDigest.getInstance(getHashAlgorithm()).digest(toBytes(s, charEncoding)));
+    byte[] data = toBytes(s, charEncoding);
+    if (isHmacConfigured()) {
+      SecretKeySpec key = new SecretKeySpec(toBytes(getHmacKey(), charEncoding), getHashAlgorithm());
+      Mac mac = Mac.getInstance(getHashAlgorithm());
+      mac.init(key);
+      return getByteTranslator().translate(mac.doFinal(data));
+    }
+    return getByteTranslator().translate(MessageDigest.getInstance(getHashAlgorithm()).digest(data));
   }
 
   public final String getHashAlgorithm() {
@@ -103,7 +117,7 @@ public class MetadataHashingService extends ReformatMetadata {
   }
 
   private byte[] toBytes(String metadataValue, String charset) throws UnsupportedEncodingException {
-    if (!isEmpty(charset)) {
+    if (!isBlank(charset)) {
       return metadataValue.getBytes(charset);
     }
     return metadataValue.getBytes();
@@ -114,12 +128,39 @@ public class MetadataHashingService extends ReformatMetadata {
   }
 
   /**
+   * Specify an optional key to enable HMAC mode.
+   * <p>
+   * If this is blank or null, then {@link MessageDigest} based hashing is used.
+   * If this is configured, then {@link Mac} based hashing is used and {@link #getHashAlgorithm()}
+   * should be a valid Mac algorithm such as {@code HmacMD5}.
+   * </p>
+   *
+   * @return the HMAC key.
+   */
+  public String getHmacKey() {
+    return hmacKey;
+  }
+
+  /**
+   * Specify an optional key to enable HMAC mode.
+   *
+   * @param key the HMAC key.
+   */
+  public void setHmacKey(String key) {
+    this.hmacKey = key;
+  }
+
+  /**
    * Specify how to translate the resulting byte array from the hash into a String.
    * 
    * @param translator the translator;
    */
   public final void setByteTranslator(ByteTranslator translator) {
-    this.byteTranslator = Args.notNull(translator, "byteTranslator");;
+    this.byteTranslator = Args.notNull(translator, "byteTranslator");
+  }
+
+  private boolean isHmacConfigured() {
+    return !isBlank(getHmacKey());
   }
 
 }

--- a/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java
+++ b/interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java
@@ -18,6 +18,7 @@ package com.adaptris.core.services.metadata;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -28,7 +29,10 @@ import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.CoreException;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.security.password.Password;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.util.text.Base64ByteTranslator;
@@ -60,6 +64,7 @@ public class MetadataHashingService extends ReformatMetadata {
   @Valid
   @AutoPopulated
   private ByteTranslator byteTranslator;
+  @InputFieldHint(style = "PASSWORD", external = true)
   private String hmacKey;
 
   public MetadataHashingService() {
@@ -100,7 +105,7 @@ public class MetadataHashingService extends ReformatMetadata {
   public String reformat(String s, String charEncoding) throws Exception {
     byte[] data = toBytes(s, charEncoding);
     if (isHmacConfigured()) {
-      SecretKeySpec key = new SecretKeySpec(toBytes(getHmacKey(), charEncoding), getHashAlgorithm());
+      SecretKeySpec key = new SecretKeySpec(hmacKeyBytes(), getHashAlgorithm());
       Mac mac = Mac.getInstance(getHashAlgorithm());
       mac.init(key);
       return getByteTranslator().translate(mac.doFinal(data));
@@ -161,6 +166,12 @@ public class MetadataHashingService extends ReformatMetadata {
 
   private boolean isHmacConfigured() {
     return !isBlank(getHmacKey());
+  }
+
+  private byte[] hmacKeyBytes() throws Exception {
+    String resolved = ExternalResolver.resolve(getHmacKey());
+    String decoded = Password.decode(resolved);
+    return decoded.getBytes(StandardCharsets.UTF_8);
   }
 
 }

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataHashingTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataHashingTest.java
@@ -26,6 +26,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.security.password.Password;
 import com.adaptris.util.text.Base64ByteTranslator;
 import com.adaptris.util.text.HexStringByteTranslator;
 
@@ -124,6 +125,15 @@ public class MetadataHashingTest extends MetadataServiceExample {
   public void testService_HmacMd5() throws Exception {
     MetadataHashingService service = new MetadataHashingService(METADATA_KEY, "HmacMD5", new HexStringByteTranslator());
     service.setHmacKey(HMAC_KEY);
+    AdaptrisMessage msg = createMessage(null);
+    execute(service, msg);
+    assertEquals(METADATA_HMAC_MD5, msg.getMetadataValue(METADATA_KEY));
+  }
+
+  @Test
+  public void testService_HmacMd5_EncodedHmacKey() throws Exception {
+    MetadataHashingService service = new MetadataHashingService(METADATA_KEY, "HmacMD5", new HexStringByteTranslator());
+    service.setHmacKey(Password.encode(HMAC_KEY, Password.PORTABLE_PASSWORD));
     AdaptrisMessage msg = createMessage(null);
     execute(service, msg);
     assertEquals(METADATA_HMAC_MD5, msg.getMetadataValue(METADATA_KEY));

--- a/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataHashingTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataHashingTest.java
@@ -34,6 +34,8 @@ public class MetadataHashingTest extends MetadataServiceExample {
   private static final String METADATA_KEY = "key";
   private static final String METADATA_VALUE = "2104913203";
   private static final String METADATA_HASH_MD5 = "fff9f3d8d4ec2726e0b2422116b20dd2";
+  private static final String METADATA_HMAC_MD5 = "2d1a7ab865997f3fd6d66c7c8bca44ac";
+  private static final String HMAC_KEY = "secret";
 
 
   private AdaptrisMessage createMessage(String encoding) throws Exception {
@@ -66,6 +68,15 @@ public class MetadataHashingTest extends MetadataServiceExample {
     catch (CoreException expected) {
 
     }
+  }
+
+  @Test
+  public void testSetHmacKey() {
+    MetadataHashingService service = new MetadataHashingService();
+    service.setHmacKey(HMAC_KEY);
+    assertEquals(HMAC_KEY, service.getHmacKey());
+    service.setHmacKey(null);
+    assertEquals(null, service.getHmacKey());
   }
 
   @Test
@@ -107,6 +118,36 @@ public class MetadataHashingTest extends MetadataServiceExample {
     AdaptrisMessage msg = createMessage("UTF-8");
     execute(service, msg);
     assertEquals(METADATA_HASH_MD5, msg.getMetadataValue(METADATA_KEY));
+  }
+
+  @Test
+  public void testService_HmacMd5() throws Exception {
+    MetadataHashingService service = new MetadataHashingService(METADATA_KEY, "HmacMD5", new HexStringByteTranslator());
+    service.setHmacKey(HMAC_KEY);
+    AdaptrisMessage msg = createMessage(null);
+    execute(service, msg);
+    assertEquals(METADATA_HMAC_MD5, msg.getMetadataValue(METADATA_KEY));
+  }
+
+  @Test
+  public void testService_BlankHmacKey_DisablesHmacMode() throws Exception {
+    MetadataHashingService service = new MetadataHashingService(METADATA_KEY, "MD5", new HexStringByteTranslator());
+    service.setHmacKey("   ");
+    AdaptrisMessage msg = createMessage(null);
+    execute(service, msg);
+    assertEquals(METADATA_HASH_MD5, msg.getMetadataValue(METADATA_KEY));
+  }
+
+  @Test
+  public void testInit_HmacMode_RequiresMacAlgorithm() {
+    MetadataHashingService service = new MetadataHashingService(METADATA_KEY, "MD5", new HexStringByteTranslator());
+    service.setHmacKey(HMAC_KEY);
+    try {
+      LifecycleHelper.init(service);
+      fail();
+    }
+    catch (CoreException expected) {
+    }
   }
 
   @Override


### PR DESCRIPTION
This pull request adds support for HMAC-based hashing to the `MetadataHashingService`, allowing users to specify an HMAC key and use MAC algorithms (e.g., `HmacMD5`) for hashing metadata values. The changes include updates to the service logic, configuration, and corresponding tests.

**Enhancements to Metadata Hashing:**

* Added support for HMAC-based hashing in `MetadataHashingService` by introducing a new `hmacKey` property and logic to use `Mac` when the key is configured. If `hmacKey` is blank or null, the service continues to use standard `MessageDigest` hashing. (`interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java`) [[1]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fL19-R23) [[2]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fL51-R53) [[3]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fR63) [[4]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fR87-R91) [[5]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fL94-R108) [[6]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fL106-R120) [[7]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fR130-R163)

**API and Configuration Changes:**

* Updated the `DisplayOrder` annotation to include `hmacKey`, and added getter/setter for the new property with appropriate documentation. (`interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java`) [[1]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fL51-R53) [[2]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fR130-R163)

**Improvements and Additions to Testing:**

* Added comprehensive tests for HMAC functionality, including validation of correct HMAC hash output, disabling HMAC mode with a blank key, and ensuring an exception is thrown if an invalid MAC algorithm is used. (`interlok-core/src/test/java/com/adaptris/core/services/metadata/MetadataHashingTest.java`) [[1]](diffhunk://#diff-6b377ba3b39f7c08ddca9742464730cd55bbc666e4fc215df83980ef96aa7a89R37-R38) [[2]](diffhunk://#diff-6b377ba3b39f7c08ddca9742464730cd55bbc666e4fc215df83980ef96aa7a89R73-R81) [[3]](diffhunk://#diff-6b377ba3b39f7c08ddca9742464730cd55bbc666e4fc215df83980ef96aa7a89R123-R152)

**Code Quality and Consistency:**

* Replaced usage of `StringUtils.isEmpty` with `StringUtils.isBlank` for improved handling of whitespace-only strings. (`interlok-core/src/main/java/com/adaptris/core/services/metadata/MetadataHashingService.java`) [[1]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fL19-R23) [[2]](diffhunk://#diff-30a080bb3a10562bc2ad1b7523adbff952f06cbd1c2cb8c7a4bda473482c409fL106-R120)

These changes make the hashing service more flexible and secure by supporting both traditional and HMAC-based algorithms, and ensure robust test coverage for the new functionality.