### PR TITLE
S3 write patch

### DIFF
--- a/gradle/owasp-exclude.xml
+++ b/gradle/owasp-exclude.xml
@@ -401,4 +401,13 @@
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty(\.http2|\.websocket)?/.+@10\.0\.[0-9]+$</packageUrl>
     <cve>CVE-2026-6790</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+      CVE-2026-10050: Affects Jetty 10.0.x (EOL). No patched release exists in the Jetty 10.x line;
+      10.0.26 is the final Jetty 10.x release on Maven Central. Remediation requires upgrading to
+      Jetty 12.x which is outside the current Java 17 / Jetty 10 constraints.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty(\.http2|\.websocket)?/.+@10\.0\.[0-9]+$</packageUrl>
+    <cve>CVE-2026-10050</cve>
+  </suppress>
 </suppressions>

--- a/interlok-core/build.gradle
+++ b/interlok-core/build.gradle
@@ -4,7 +4,7 @@ ext {
   componentName="Interlok Core/Base"
   componentDesc="The Core Interlok framework component; this is your must have"
   activeMqVersion="5.19.9"
-  bouncyCastleVersion="1.84"
+  bouncyCastleVersion="1.85"
   mysqlDriverVersion="8.0.33"
   slf4jVersion = "2.0.17"
   mockitoVersion = "4.9.0"

--- a/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
+++ b/interlok-core/src/test/java/com/adaptris/core/AdaptrisConnectionTest.java
@@ -18,22 +18,21 @@ package com.adaptris.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.awaitility.Awaitility;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import com.adaptris.core.stubs.MockConnection;
@@ -49,9 +48,6 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
   private static final String START = "start";
   private static final String INIT = "init";
 
-  public AdaptrisConnectionTest() {
-  }
-
   @Test
   public void testConnectionErrorHandler() throws Exception {
     MockConnection mc = new MockConnection();
@@ -66,37 +62,43 @@ public class AdaptrisConnectionTest extends com.adaptris.interlok.junit.scaffold
   public void testConcurrentListenerRegistration() throws Exception {
     int threadCount = 100;
     final MockConnection connection = new MockConnection();
-    
-    ThreadFactory tf = new ThreadFactory() {
-      @Override
-      public Thread newThread(Runnable r) {
-        return new Thread(r);
-      }
-    };
-    ExecutorService newFixedThreadPool = Executors.newFixedThreadPool(threadCount, tf);
-    
-    List<Callable<Boolean>> callables = new ArrayList<>();
-    for(int index = 0; index < threadCount; index ++) {
+
+    CountDownLatch startGate = new CountDownLatch(1);
+    CountDownLatch doneGate = new CountDownLatch(threadCount);
+    ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+    List<Future<Boolean>> futures = new ArrayList<>();
+    for (int index = 0; index < threadCount; index++) {
       Callable<Boolean> call = () -> {
-        StateManagedComponent comp = new ServiceList();
-        AdaptrisMessageConsumer consumer = new MockConsumer();
-        AdaptrisMessageProducer producer = new MockProducer();
-        connection.addExceptionListener(comp);
-        connection.addMessageConsumer(consumer);
-        connection.addMessageProducer(producer);
-        return true;
+        try {
+          startGate.await();
+          StateManagedComponent comp = new ServiceList();
+          AdaptrisMessageConsumer consumer = new MockConsumer();
+          AdaptrisMessageProducer producer = new MockProducer();
+          connection.addExceptionListener(comp);
+          connection.addMessageConsumer(consumer);
+          connection.addMessageProducer(producer);
+          return true;
+        }
+        finally {
+          doneGate.countDown();
+        }
       };
-      callables.add(call);
+      futures.add(pool.submit(call));
     }
-    
-    newFixedThreadPool.invokeAll(callables);
-    
-    Awaitility
-      .await()
-      .atMost(Duration.ofSeconds(20))
-      .with()
-      .pollInterval(Duration.ofMillis(100))
-      .untilTrue(new AtomicBoolean(connection.retrieveExceptionListeners().size() == threadCount));
+
+    startGate.countDown();
+    assertTrue(doneGate.await(20, TimeUnit.SECONDS), "Timed out waiting for concurrent registration tasks to finish");
+
+    for (Future<Boolean> future : futures) {
+      assertTrue(future.get(), "Concurrent registration task did not complete successfully");
+    }
+
+    assertEquals(threadCount, connection.retrieveExceptionListeners().size());
+    assertEquals(threadCount, connection.retrieveMessageConsumers().size());
+    assertEquals(threadCount, connection.retrieveMessageProducers().size());
+
+    pool.shutdownNow();
   }
 
   @Test


### PR DESCRIPTION
This pull request introduces several dependency updates and enhances the `RetryStoreWriteService` to ensure the workflow ID is consistently added to message metadata. The main logic change ensures that the workflow ID is set from the message lifecycle event or fallback sources, but does not overwrite an existing value. Comprehensive tests have been added to verify this behavior.

**Enhancements to RetryStoreWriteService:**

* [`RetryStoreWriteService`](diffhunk://#diff-eaf7d1f98862f3c6fb19736244af28ed329fb724c957c88a28cf92d25ddc9ba9R30-R51): Added logic to enrich messages with the workflow ID from the message lifecycle event or fallback metadata, but only if the workflow ID is not already present.
* [`RetryStoreWriteTest`](diffhunk://#diff-8eeebd8d02c5d652d2776968182fd6cc8f43ac1782248fe90c68a216f00abe0bR50-R91): Added tests to verify that the workflow ID is added when missing and that existing workflow ID metadata is not overwritten.

**Dependency updates:**

* Updated `log4j2Version` to `2.25.5` in `interlok-common/build.gradle`, `interlok-client/build.gradle`, `interlok-client-jmx/build.gradle`, and `interlok-logging/build.gradle`. [[1]](diffhunk://#diff-e2e6efec445b4481d5ab924dc155ef531ea18253bd42683f124c14b26d45eccdL10-R10) [[2]](diffhunk://#diff-3f32610cba31d81eafe9d9dc15f8359b7dce938e6b540a5faa85db1f43eb024aL5-R5) [[3]](diffhunk://#diff-d68f0da501d33cf5eebc4137bfe6f9fbf8872421881268b24b4ad34a893b0615L5-R5) [[4]](diffhunk://#diff-1515e7cbcb0d91a495505a0aa9d34eb305034b4eb08e14bc5c6f9d780058c413L5-R5)
* Updated `activeMqVersion` to `5.19.9` in `interlok-core/build.gradle`.

**Security/maintenance:**

* Updated OWASP suppression rules to include CVE-2026-6790 for Jetty 10.0.x, documenting the EOL status and temporary mitigation.